### PR TITLE
Implementing Android notification channels

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -38,6 +38,11 @@ class MessagingService : FirebaseMessagingService() {
         const val TITLE = "title"
         const val MESSAGE = "message"
         const val IMAGE_URL = "image"
+
+        // special action constants
+        const val REQUEST_LOCATION_UPDATE = "request_location_update"
+        const val CLEAR_NOTIFICATION = "clear_notification"
+        const val REMOVE_CHANNEL = "remove_channel"
     }
 
     @Inject
@@ -66,14 +71,20 @@ class MessagingService : FirebaseMessagingService() {
         remoteMessage.data.let {
             Log.d(TAG, "Message data payload: " + remoteMessage.data)
 
-            if (it[MESSAGE] == "request_location_update") {
-                Log.d(TAG, "Request location update")
-                requestAccurateLocationUpdate()
-            } else if (it[MESSAGE] == "clear_notification" && !it["tag"].isNullOrBlank()) {
-                Log.d(TAG, "Clearing notification with tag: ${it["tag"]}")
-                clearNotification(it["tag"]!!)
-            } else {
-                mainScope.launch {
+            when {
+                it[MESSAGE] == REQUEST_LOCATION_UPDATE -> {
+                    Log.d(TAG, "Request location update")
+                    requestAccurateLocationUpdate()
+                }
+                it[MESSAGE] == CLEAR_NOTIFICATION && !it["tag"].isNullOrBlank() -> {
+                    Log.d(TAG, "Clearing notification with tag: ${it["tag"]}")
+                    clearNotification(it["tag"]!!)
+                }
+                it[MESSAGE] == REMOVE_CHANNEL && !it["channel"].isNullOrBlank() -> {
+                    Log.d(TAG, "Removing Notification channel ${it["tag"]}")
+                    removeNotificationChannel(it["channel"]!!)
+                }
+                else -> mainScope.launch {
                     Log.d(TAG, "Creating notification with following data: $it")
                     sendNotification(it)
                 }
@@ -94,6 +105,17 @@ class MessagingService : FirebaseMessagingService() {
         val messageId = tag.hashCode()
 
         notificationManager.cancel(tag, messageId)
+    }
+
+    private fun removeNotificationChannel(channelName: String) {
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val channelID: String = createChannelID(channelName)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationManager.deleteNotificationChannel(channelID)
+        }
     }
 
     /**
@@ -276,24 +298,33 @@ class MessagingService : FirebaseMessagingService() {
         data: Map<String, String>
     ): String {
         // Define some values for a default channel
-        var channelId = "default"
+        var channelID = "default"
         var channelName = "Default Channel"
 
         if (data.containsKey("channel")) {
-            channelId = data["channel"].toString().trim().replace(" ", "_")
+            channelID = createChannelID(data["channel"].toString())
             channelName = data["channel"].toString().trim()
         }
 
         // Since android Oreo notification channel is needed.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
-                channelId,
+                channelID,
                 channelName,
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             notificationManager.createNotificationChannel(channel)
         }
-        return channelId
+        return channelID
+    }
+
+    private fun createChannelID(
+        channelName: String
+    ): String {
+        return channelName
+            .trim()
+            .toLowerCase()
+            .replace(" ", "_")
     }
 
     /**

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -110,7 +110,7 @@ class MessagingService : FirebaseMessagingService() {
         val notificationManager =
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
-        val channelId = handleChannel(notificationManager)
+        val channelId = handleChannel(notificationManager, data)
 
         val notificationBuilder = NotificationCompat.Builder(this, channelId)
             .setContentIntent(pendingIntent)
@@ -272,15 +272,23 @@ class MessagingService : FirebaseMessagingService() {
     }
 
     private fun handleChannel(
-        notificationManager: NotificationManager
+        notificationManager: NotificationManager,
+        data: Map<String, String>
     ): String {
-        // TODO: implement channels
-        val channelId = "default"
+        // Define some values for a default channel
+        var channelId = "default"
+        var channelName = "Default Channel"
+
+        if (data.containsKey("channel")) {
+            channelId = data["channel"].toString().trim().replace(" ", "_")
+            channelName = data["channel"].toString().trim()
+        }
+
         // Since android Oreo notification channel is needed.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(
                 channelId,
-                "Default Channel",
+                channelName,
                 NotificationManager.IMPORTANCE_DEFAULT
             )
             notificationManager.createNotificationChannel(channel)


### PR DESCRIPTION
Hi,
I am new here.

Had a quick go on notification channels in android. The solution is quite simple. 
I am checking a cannel parameter in the payload data. 
```
{
  message: "something important",
  channel: "Important"
}
```

This allows users to define channels in their automation. Then they are able to configure them with different sounds and priorities on their phones.

Still testing it, tough. Sofar I just implemented it and send a few test messages to the android emulator from the firebase console. That however worked already.
I am also still working on a way to remove channels.
Anyway, wanted to let you know I am working on this and looking forward to your feedback.

KR

**Update 1:**
Removing notification channels is working aswell. It requires a message like this:
```
{
  message: "remove_channel",
  channel: "Important"
}
```

**Update 2:**
I now tested this in the emulator and on my phone with a custom rest client to send the messages.
Is there a way to rig a test instance of Homeassistant with my server key to do that aswell?
However, so far all tests are successful. And I observed the following on my Samsung:

- The device reports the deleted channels (categories).
- After removing a channel. If a new message arrives with the removed channel name, it is recreated with the same settings configured before deletion.
- Once the channel is created I can configure:
  - Style: Silent/Sound/Popup ...
  - Sound
  - Vibration
  - Light (not the color tough)
  - Badges
  - Lock Screen Appearance
  - Ignore disturb mode

_*Note this is Samsung specific, it will be different on other phones_

I will set this to review now, but still need to update the docs in the Companion Documentation.

![Screenshot_1588434371](https://user-images.githubusercontent.com/63962343/80868768-e13ed680-8c9c-11ea-885b-752086d8a287.png)
