### PR TITLE
Disable setting if get_panels is not available or fails

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -96,7 +96,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
             onChangeBiometricValidator
 
         val shortcuts = findPreference<Preference>("shortcuts")
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && presenter.getPanels().isNotEmpty()) {
             shortcuts?.onPreferenceClickListener =
                 onClickShortcuts
         } else {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -1,9 +1,11 @@
 package io.homeassistant.companion.android.settings
 
 import androidx.preference.PreferenceDataStore
+import io.homeassistant.companion.android.domain.integration.Panel
 
 interface SettingsPresenter {
     fun getPreferenceDataStore(): PreferenceDataStore
     fun onCreate()
     fun onFinish()
+    fun getPanels(): Array<Panel>
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -6,7 +6,6 @@ import io.homeassistant.companion.android.domain.authentication.AuthenticationUs
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import io.homeassistant.companion.android.domain.integration.Panel
 import io.homeassistant.companion.android.domain.url.UrlUseCase
-import io.homeassistant.companion.android.settings.shortcuts.ShortcutsPresenterImpl
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -4,7 +4,9 @@ import android.util.Log
 import androidx.preference.PreferenceDataStore
 import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import io.homeassistant.companion.android.domain.integration.Panel
 import io.homeassistant.companion.android.domain.url.UrlUseCase
+import io.homeassistant.companion.android.settings.shortcuts.ShortcutsPresenterImpl
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -121,6 +123,18 @@ class SettingsPresenterImpl @Inject constructor(
             urlUseCase.saveUrl("", true)
         } else {
             settingsView.enableInternalConnection()
+        }
+    }
+
+    override fun getPanels(): Array<Panel> {
+        return runBlocking {
+            var panels = arrayOf<Panel>()
+            try {
+                panels = integrationUseCase.getPanels()
+            } catch (e: Exception) {
+                Log.e(SettingsPresenterImpl.TAG, "Issue getting panels.", e)
+            }
+            panels
         }
     }
 }


### PR DESCRIPTION
Checks if panels are empty. This can be removed after core PR https://github.com/home-assistant/core/pull/34445 is merged and released to stable

Issue Ref https://github.com/home-assistant/android/issues/559#issuecomment-623579395