### PR TITLE
Fix widget service calls with numbers (#640)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,7 @@ dependencies {
     }
 
     implementation(Config.Dependency.Misc.lokalize)
+    implementation(Config.Dependency.Misc.jackson)
 
     implementation(Config.Dependency.Play.location)
     implementation(Config.Dependency.Firebase.core)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidget.kt
@@ -10,7 +10,8 @@ import android.os.Handler
 import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
-import com.google.gson.Gson
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
@@ -168,9 +169,9 @@ class ButtonWidget : AppWidgetProvider() {
             } else {
                 // If everything loaded correctly, package the service data and attempt the call
                 try {
+
                     // Convert JSON to HashMap
-                    val serviceDataMap =
-                        Gson().fromJson(serviceDataJson, HashMap<String, Any>()::class.java)
+                    val serviceDataMap: HashMap<String, Any> = jacksonObjectMapper().readValue(serviceDataJson)
 
                     integrationUseCase.callService(domain, service, serviceDataMap)
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/ButtonWidgetConfigureActivity.kt
@@ -14,7 +14,7 @@ import android.widget.AutoCompleteTextView
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.google.gson.Gson
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.Entity
@@ -86,7 +86,7 @@ class ButtonWidgetConfigureActivity : Activity() {
 
         intent.putExtra(
             ButtonWidget.EXTRA_SERVICE_DATA,
-            Gson().toJson(serviceDataMap)
+            jacksonObjectMapper().writeValueAsString(serviceDataMap)
         )
 
         context.sendBroadcast(intent)


### PR DESCRIPTION
Fixes #640 

Widget service calls will fail, if a number for any field is used.
Because the GSON parser will parse every integer to a double.
This is especially a problem on the service alarm_control_panel.alarm_disarm
which needs a code to disarm the alarm panel.
So every code will be converted to .0 (eg. 1234 would be 1234.0)
Solution: Use Jackson instead of gson
Jackson parses integers correctly

GSON problem described here:
https://github.com/google/gson/issues/1084