### PR TITLE
Correct accuracy for location tracking

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/background/LocationBroadcastReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/background/LocationBroadcastReceiver.kt
@@ -202,7 +202,7 @@ class LocationBroadcastReceiver : LocationBroadcastReceiverBase() {
                             TAG,
                             "Got single accurate location update: ${locationResult?.lastLocation}"
                         )
-                        if (locationResult != null && locationResult.lastLocation.accuracy <= 1) {
+                        if (locationResult != null && locationResult.lastLocation.accuracy <= MINIMUM_ACCURACY)) {
                             Log.d(TAG, "Location accurate enough, all done with high accuracy.")
                             runBlocking { sendLocationUpdate(locationResult.lastLocation) }
                             LocationServices.getFusedLocationProviderClient(context)

--- a/app/src/full/java/io/homeassistant/companion/android/background/LocationBroadcastReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/background/LocationBroadcastReceiver.kt
@@ -202,7 +202,7 @@ class LocationBroadcastReceiver : LocationBroadcastReceiverBase() {
                             TAG,
                             "Got single accurate location update: ${locationResult?.lastLocation}"
                         )
-                        if (locationResult != null && locationResult.lastLocation.accuracy <= MINIMUM_ACCURACY)) {
+                        if (locationResult != null && locationResult.lastLocation.accuracy <= MINIMUM_ACCURACY) {
                             Log.d(TAG, "Location accurate enough, all done with high accuracy.")
                             runBlocking { sendLocationUpdate(locationResult.lastLocation) }
                             LocationServices.getFusedLocationProviderClient(context)


### PR DESCRIPTION
It was mentioned in https://github.com/home-assistant/android/issues/703#issuecomment-669636182 that we should be using `MINIMUM_ACCURACY` in place of `1` so just switching it back to what was previously expected.  Possibly introduced in #682 at least from what I can tell. This isn't tested but the accuracy of `<= 1` is probably a bit extreme 😆 