### PR TITLE
Auto detect device dark theme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -148,6 +148,7 @@ dependencies {
 
     implementation(Config.Dependency.AndroidX.workManager)
     implementation(Config.Dependency.AndroidX.biometric)
+    implementation(Config.Dependency.AndroidX.webKit)
 
     testImplementation(Config.Dependency.Testing.spek2Jvm)
     testImplementation(Config.Dependency.Testing.spek2JUnit)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -93,7 +93,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private var resourceURL: String = ""
     private var unlocked = false
 
-    @SuppressLint("SetJavaScriptEnabled", "RestrictedApi")
+    @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_webview)
@@ -336,10 +336,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             }, "externalApp")
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
                 WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
-            }
         }
 
         val cookieManager = CookieManager.getInstance()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -37,9 +37,9 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.room.Room
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
-import androidx.room.Room
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.DaggerPresenterComponent

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.webview
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PictureInPictureParams
 import android.content.Context
@@ -9,7 +10,6 @@ import android.content.pm.ShortcutManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.graphics.drawable.Icon
-import android.Manifest
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -37,8 +37,8 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import androidx.webkit.WebViewFeature
 import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import androidx.room.Room
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.webview
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PictureInPictureParams
 import android.content.Context
@@ -36,6 +37,8 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.webkit.WebViewFeature
+import androidx.webkit.WebSettingsCompat
 import androidx.room.Room
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig
@@ -129,6 +132,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         webView.apply {
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
+
             webViewClient = object : WebViewClient() {
                 override fun onReceivedError(
                     view: WebView?,
@@ -222,26 +226,26 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                             if (it == PermissionRequest.RESOURCE_VIDEO_CAPTURE) {
                                 if (PermissionManager.hasPermission(
                                         context,
-                                        android.Manifest.permission.CAMERA
+                                        Manifest.permission.CAMERA
                                     )
                                 ) {
                                     request.grant(arrayOf(it))
                                 } else {
                                     requestPermissions(
-                                        arrayOf(android.Manifest.permission.CAMERA),
+                                        arrayOf(Manifest.permission.CAMERA),
                                         CAMERA_REQUEST_CODE
                                     )
                                 }
                             } else if (it == PermissionRequest.RESOURCE_AUDIO_CAPTURE) {
                                 if (PermissionManager.hasPermission(
                                         context,
-                                        android.Manifest.permission.RECORD_AUDIO
+                                        Manifest.permission.RECORD_AUDIO
                                     )
                                 ) {
                                     request.grant(arrayOf(it))
                                 } else {
                                     requestPermissions(
-                                        arrayOf(android.Manifest.permission.RECORD_AUDIO),
+                                        arrayOf(Manifest.permission.RECORD_AUDIO),
                                         AUDIO_REQUEST_CODE
                                     )
                                 }
@@ -332,6 +336,12 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             }, "externalApp")
         }
 
+        if (Build.VERSION.SDK_INT >= 29) {
+            webView.isForceDarkAllowed = true
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_AUTO)
+            }
+        }
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
         cookieManager.setAcceptThirdPartyCookies(webView, true)
@@ -547,7 +557,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         val viewPassword = dialogLayout.findViewById<ImageView>(R.id.viewPassword)
         var autoAuth = false
 
-        viewPassword.setOnClickListener() {
+        viewPassword.setOnClickListener {
             if (password.transformationMethod == PasswordTransformationMethod.getInstance()) {
                 password.transformationMethod = HideReturnsTransformationMethod.getInstance()
                 viewPassword.setImageResource(R.drawable.ic_visibility_off)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.webview
 
-import android.Manifest
 import android.annotation.SuppressLint
 import android.app.PictureInPictureParams
 import android.content.Context
@@ -10,6 +9,7 @@ import android.content.pm.ShortcutManager
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.graphics.drawable.Icon
+import android.Manifest
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -337,8 +337,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if(WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
-                WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY);
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+                WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -337,11 +337,11 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            webView.isForceDarkAllowed = true
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
                 WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_AUTO)
             }
         }
+
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
         cookieManager.setAcceptThirdPartyCookies(webView, true)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -93,7 +93,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private var resourceURL: String = ""
     private var unlocked = false
 
-    @SuppressLint("SetJavaScriptEnabled")
+    @SuppressLint("SetJavaScriptEnabled", "RestrictedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_webview)
@@ -337,8 +337,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-                WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_AUTO)
+            if(WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+                WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY);
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -336,7 +336,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             }, "externalApp")
         }
 
-        if (Build.VERSION.SDK_INT >= 29) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             webView.isForceDarkAllowed = true
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
                 WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_AUTO)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -337,7 +337,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         }
 
         if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
-                WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
+            WebSettingsCompat.setForceDarkStrategy(webView.getSettings(), WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
         }
 
         val cookieManager = CookieManager.getInstance()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -10,6 +10,8 @@ import io.homeassistant.companion.android.domain.integration.Panel
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.util.UrlHandler
 import java.net.URL
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -59,7 +61,7 @@ class WebViewPresenterImpl @Inject constructor(
             }
 
             try {
-                view.setStatusBarColor(Color.parseColor(integrationUseCase.getThemeColor()))
+                view.setStatusBarColor(parseColorWithRgb(integrationUseCase.getThemeColor()))
             } catch (e: Exception) {
                 Log.e(TAG, "Issue getting/setting theme", e)
             }
@@ -142,5 +144,17 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun onFinish() {
         mainScope.cancel()
+    }
+
+    private fun parseColorWithRgb(colorString: String): Int {
+        val c: Pattern = Pattern.compile("rgb *\\( *([0-9]+), *([0-9]+), *([0-9]+) *\\)")
+        val m: Matcher = c.matcher(colorString)
+        return if (m.matches()) {
+            Color.rgb(
+                m.group(1).toInt(),
+                m.group(2).toInt(),
+                m.group(3).toInt()
+            )
+        } else Color.parseColor(colorString)
     }
 }

--- a/app/src/main/res/values-v29/styles.xml
+++ b/app/src/main/res/values-v29/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.HomeAssistant" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorButtonNormal">@color/colorPrimary</item>
+        <item name="android:forceDarkAllowed">true</item>
+        <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert</item>
+    </style>
+</resources>

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -44,7 +44,7 @@ object Config {
 
         object AndroidX {
 
-            const val webKit = "androidx.webkit:webkit:1.2.0"
+            const val webKit = "androidx.webkit:webkit:1.3.0-rc02"
             const val appcompat = "androidx.appcompat:appcompat:1.1.0"
             const val lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
             const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -39,11 +39,12 @@ object Config {
             const val dagger = "com.google.dagger:dagger:${daggerVersion}"
             const val daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
 
-            const val material = "com.google.android.material:material:1.1.0"
+            const val material = "com.google.android.material:material:1.2.0"
         }
 
         object AndroidX {
 
+            const val webKit = "androidx.webkit:webkit:1.2.0"
             const val appcompat = "androidx.appcompat:appcompat:1.1.0"
             const val lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
             const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"


### PR DESCRIPTION
Fixes #710 

Tested locally in the android emulator: https://drive.google.com/file/d/1hOGL1an0HHNRyKpiF0lBcVVCzHmvkpEC/view?usp=sharing

Also tested on my Pixel 4 XL against HA 0.113.x and 0.115dev

The manifest changes in the webview file seem to be from gradle? Not sure :)

As dark theme was recently added this only applies to applicable devices that are on API level 29

In case you are wondering why we need webkit RC version is due to `FORCE_DARK_STRATEGY` being added then, `FORCE_DARK_AUTO` does not work as intended.