### PR TITLE
Fix statusbar color if theme used rgb color instead of hex color

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -16,6 +16,9 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 class WebViewPresenterImpl @Inject constructor(
     private val view: WebView,

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -10,13 +10,12 @@ import io.homeassistant.companion.android.domain.integration.Panel
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.util.UrlHandler
 import java.net.URL
+import java.util.regex.Matcher
+import java.util.regex.Pattern
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 class WebViewPresenterImpl @Inject constructor(
     private val view: WebView,
@@ -59,7 +58,7 @@ class WebViewPresenterImpl @Inject constructor(
             }
 
             try {
-                view.setStatusBarColor(Color.parseColor(integrationUseCase.getThemeColor()))
+                view.setStatusBarColor(parseColorWithRgb(integrationUseCase.getThemeColor()))
             } catch (e: Exception) {
                 Log.e(TAG, "Issue getting/setting theme", e)
             }
@@ -142,5 +141,17 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun onFinish() {
         mainScope.cancel()
+    }
+
+    private fun parseColorWithRgb(colorString: String): Int {
+        val c: Pattern = Pattern.compile("rgb *\\( *([0-9]+), *([0-9]+), *([0-9]+) *\\)")
+        val m: Matcher = c.matcher(colorString)
+        return if (m.matches()) {
+            Color.rgb(
+                m.group(1).toInt(),
+                m.group(2).toInt(),
+                m.group(3).toInt()
+            )
+        } else Color.parseColor(colorString)
     }
 }


### PR DESCRIPTION
If a theme is using rgb instead of hex for color, the status wont be colored.

**Example:**
Does work:

```
Google` Dark Theme:
  # Header:
  app-header-background-color: #171717
```
Does not work, because color is defined as rgb
```
Google` Dark Theme:
  # Header:
  app-header-background-color: rgb(23, 23, 23)
```

**Solution:** 
Try to parse rgb color first. If not possible, parse hex color