### PR TITLE
Fix statusbar not readable when using a light theme (#433)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
@@ -6,7 +6,7 @@ interface WebView {
 
     fun loadUrl(url: String)
 
-    fun setStatusBarColor(color: Int)
+    fun setStatusBarAndNavigationBarColor(color: Int)
 
     fun setExternalAuth(script: String)
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -458,15 +458,16 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         waitForConnection()
     }
 
-    override fun setStatusBarColor(color: Int) {
+    override fun setStatusBarAndNavigationBarColor(color: Int) {
         var flags = window.decorView.systemUiVisibility
         flags = if (ColorUtils.calculateLuminance(color) < 0.5) { // If color is dark...
-            flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv() // Remove LIGHT_STATUS_BAR flag
+            flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv() and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv() // Remove light flag
         } else {
-            flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR // Add LIGHT_STATUS_BAR flag
+            flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR // Add light flag
         }
         window.decorView.systemUiVisibility = flags
         window.statusBarColor = color
+        window.navigationBarColor = color
     }
 
     override fun setExternalAuth(script: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -36,6 +36,7 @@ import android.widget.ImageView
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.graphics.ColorUtils
 import androidx.room.Room
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig
@@ -458,6 +459,13 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     }
 
     override fun setStatusBarColor(color: Int) {
+        var flags = window.decorView.systemUiVisibility
+        flags = if (ColorUtils.calculateLuminance(color) < 0.5) { // If color is dark...
+            flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv() // Remove LIGHT_STATUS_BAR flag
+        } else {
+            flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR // Add LIGHT_STATUS_BAR flag
+        }
+        window.decorView.systemUiVisibility = flags
         window.statusBarColor = color
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -61,7 +61,7 @@ class WebViewPresenterImpl @Inject constructor(
             }
 
             try {
-                view.setStatusBarColor(parseColorWithRgb(integrationUseCase.getThemeColor()))
+                view.setStatusBarAndNavigationBarColor(parseColorWithRgb(integrationUseCase.getThemeColor()))
             } catch (e: Exception) {
                 Log.e(TAG, "Issue getting/setting theme", e)
             }


### PR DESCRIPTION
Fixes #433 
Fixes #524

Light theme:
<img src="https://user-images.githubusercontent.com/12832850/89721151-5f1c2780-d9da-11ea-8304-4d310eae245f.png" width="40%">

Dark theme:
<img src="https://user-images.githubusercontent.com/12832850/89721161-70fdca80-d9da-11ea-8ff0-f4a490086124.png" width="40%">