### PR TITLE
Fix missing message if notification is collapsed

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -423,7 +423,9 @@ class MessagingService : FirebaseMessagingService() {
             builder.setContentTitle(getSpannedTextFromHtml(it))
         }
         data[MESSAGE]?.let {
-            builder.setStyle(NotificationCompat.BigTextStyle().bigText(getSpannedTextFromHtml(it)))
+            val text = getSpannedTextFromHtml(it)
+            builder.setContentText(text)
+            builder.setStyle(NotificationCompat.BigTextStyle().bigText(text))
         }
     }
 


### PR DESCRIPTION
The message is missing in collapsed state of the notification. The message is only shown in expanded state of the notification.

For some devices (at least for oneplus), we need to set also the content text additionally to the big text to show the message also in collapsed notification state.
