### PR TITLE
Initial commit of next alarm sensor

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AllSensorsUpdaterImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AllSensorsUpdaterImpl.kt
@@ -13,7 +13,8 @@ class AllSensorsUpdaterImpl(
     override suspend fun getManagers(): List<SensorManager> {
         val sensorManagers = mutableListOf(
             BatterySensorManager(),
-            NetworkSensorManager()
+            NetworkSensorManager(),
+            NextAlarmManager()
         )
 
         if (integrationUseCase.isBackgroundTrackingEnabled() && PermissionManager.checkLocationPermission(appContext)) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -88,6 +88,13 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name=".sensors.NextAlarmReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />
+            </intent-filter>
+        </receiver>
+
         <activity android:name=".launch.LaunchActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -15,9 +15,6 @@ class NextAlarmManager : SensorManager {
     companion object {
 
         private const val TAG = "NextAlarm"
-        var triggerTime = 0L
-        var local = ""
-        var utc = ""
     }
 
     override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
@@ -48,6 +45,10 @@ class NextAlarmManager : SensorManager {
 
     private fun getNextAlarm(context: Context): Sensor<Any>? {
 
+        var triggerTime = 0L
+        var local = ""
+        var utc = "unavailable"
+
         try {
             val alarmManager: AlarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
 
@@ -64,12 +65,9 @@ class NextAlarmManager : SensorManager {
                 val sdf = SimpleDateFormat(dateFormat)
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
-            } else {
-                utc = "unavailable"
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)
-            return null
         }
 
         val icon = "mdi:alarm"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -67,9 +67,8 @@ class NextAlarmManager : SensorManager {
             } else {
                 utc = "unavailable"
             }
-
         } catch (e: Exception) {
-            Log.e(TAG,"Error getting the next alarm info", e)
+            Log.e(TAG, "Error getting the next alarm info", e)
             return null
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -1,0 +1,89 @@
+package io.homeassistant.companion.android.sensors
+
+import android.app.AlarmManager
+import android.content.Context
+import android.util.Log
+import io.homeassistant.companion.android.domain.integration.Sensor
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+class NextAlarmManager : SensorManager {
+    companion object {
+
+        private const val TAG = "NextAlarm"
+        var triggerTime = 0L
+        var local = ""
+        var utc = ""
+    }
+
+    override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
+        val sensorRegistrations = mutableListOf<SensorRegistration<Any>>()
+
+        getNextAlarm(context)?.let {
+            sensorRegistrations.add(
+                SensorRegistration(
+                    it,
+                    "Next Alarm",
+                    "timestamp"
+                )
+            )
+        }
+
+        return sensorRegistrations
+    }
+
+    override fun getSensors(context: Context): List<Sensor<Any>> {
+        val sensors = mutableListOf<Sensor<Any>>()
+
+        getNextAlarm(context)?.let {
+            sensors.add(it)
+        }
+
+        return sensors
+    }
+
+    private fun getNextAlarm(context: Context): Sensor<Any>? {
+
+        try {
+            val alarmManager: AlarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+
+            val alarmClockInfo = alarmManager.nextAlarmClock
+
+            if (alarmClockInfo != null) {
+                triggerTime = alarmClockInfo.triggerTime
+
+                val cal: Calendar = GregorianCalendar()
+                cal.timeInMillis = triggerTime
+                local = cal.time.toString()
+
+                val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+                val sdf = SimpleDateFormat(dateFormat)
+                sdf.timeZone = TimeZone.getTimeZone("UTC")
+                utc = sdf.format(Date(triggerTime))
+            } else {
+                utc = "unavailable"
+            }
+
+        } catch (e: Exception) {
+            Log.e(TAG,"Error getting the next alarm info", e)
+            return null
+        }
+
+        val icon = "mdi:alarm"
+
+        return Sensor(
+            "next_alarm",
+            utc,
+            "sensor",
+            icon,
+            mapOf(
+                "Local Time" to local,
+                "Time in Milliseconds" to triggerTime
+            )
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
@@ -20,10 +20,11 @@ class NextAlarmReceiver() : BroadcastReceiver() {
     var updateJob: Job? = null
     override fun onReceive(context: Context, intent: Intent) {
         val isBootIntent = Intent.ACTION_BOOT_COMPLETED.equals(intent.action, ignoreCase = true)
-        val isNextAlarmIntent = AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED.equals(intent.action, ignoreCase = true)
-            if (!isBootIntent && !isNextAlarmIntent) {
-                return
-            }
+        val isNextAlarmIntent =
+            AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED.equals(intent.action, ignoreCase = true)
+        if (!isBootIntent && !isNextAlarmIntent) {
+            return
+        }
 
         DaggerSensorComponent
             .builder()
@@ -31,9 +32,9 @@ class NextAlarmReceiver() : BroadcastReceiver() {
             .build()
             .inject(this)
 
-            updateJob?.cancel()
-            updateJob = ioScope.launch {
-                AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
-            }
+        updateJob?.cancel()
+        updateJob = ioScope.launch {
+            AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
         }
+    }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
@@ -1,16 +1,16 @@
 package io.homeassistant.companion.android.sensors
 
-import android.app.AlarmManager;
+import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 class NextAlarmReceiver() : BroadcastReceiver() {
 
@@ -22,7 +22,7 @@ class NextAlarmReceiver() : BroadcastReceiver() {
         val isBootIntent = Intent.ACTION_BOOT_COMPLETED.equals(intent.action, ignoreCase = true)
         val isNextAlarmIntent = AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED.equals(intent.action, ignoreCase = true)
             if (!isBootIntent && !isNextAlarmIntent) {
-                return;
+                return
             }
 
         DaggerSensorComponent
@@ -35,5 +35,5 @@ class NextAlarmReceiver() : BroadcastReceiver() {
             updateJob = ioScope.launch {
                 AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
             }
-     }
+        }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmReceiver.kt
@@ -1,0 +1,39 @@
+package io.homeassistant.companion.android.sensors
+
+import android.app.AlarmManager;
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class NextAlarmReceiver() : BroadcastReceiver() {
+
+    @Inject
+    lateinit var integrationUseCase: IntegrationUseCase
+    private val ioScope = CoroutineScope(Dispatchers.IO)
+    var updateJob: Job? = null
+    override fun onReceive(context: Context, intent: Intent) {
+        val isBootIntent = Intent.ACTION_BOOT_COMPLETED.equals(intent.action, ignoreCase = true)
+        val isNextAlarmIntent = AlarmManager.ACTION_NEXT_ALARM_CLOCK_CHANGED.equals(intent.action, ignoreCase = true)
+            if (!isBootIntent && !isNextAlarmIntent) {
+                return;
+            }
+
+        DaggerSensorComponent
+            .builder()
+            .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
+            .build()
+            .inject(this)
+
+            updateJob?.cancel()
+            updateJob = ioScope.launch {
+                AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
+            }
+     }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
@@ -8,4 +8,6 @@ import io.homeassistant.companion.android.common.dagger.AppComponent
 interface SensorComponent {
 
     fun inject(worker: SensorWorker)
+
+    fun inject(receiver: NextAlarmReceiver)
 }

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/AllSensorsUpdaterImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/AllSensorsUpdaterImpl.kt
@@ -11,7 +11,8 @@ class AllSensorsUpdaterImpl(
     override suspend fun getManagers(): List<SensorManager> {
         val sensorManagers = mutableListOf(
             BatterySensorManager(),
-            NetworkSensorManager()
+            NetworkSensorManager(),
+            NextAlarmManager()
         )
 
         return sensorManagers


### PR DESCRIPTION
This PR adds a next alarm sensor that utilizes androids [`AlarmManager`](https://developer.android.com/reference/android/app/AlarmManager) and fixes #56

The state is provided in UTC date format so the front end can translate it properly with device class `timestamp`

There are also attributes for local time and time in milliseconds.

The sensor will update anytime the alarm is updated.  The state will become `unavailable` when there is no next alarm.

![image](https://user-images.githubusercontent.com/1634145/89797463-d25b9180-dadf-11ea-9ba8-f1273458212c.png)

![image](https://user-images.githubusercontent.com/1634145/89797473-d5568200-dadf-11ea-8d31-edc91cace6a4.png)
