### PR TITLE
Add Exoplayer view and interface

### DIFF
--- a/app/src/main/res/drawable/ic_baseline_fullscreen_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_fullscreen_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,14L5,14v5h5v-2L7,17v-3zM5,10h2L7,7h3L10,5L5,5v5zM17,17h-3v2h5v-5h-2v3zM14,5v2h3v3h2L19,5h-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_fullscreen_exit_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_fullscreen_exit_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M5,16h3v3h2v-5L5,14v2zM8,8L5,8v2h5L10,5L8,5v3zM14,19h2v-3h3v-2h-5v5zM16,8L16,5h-2v5h5L19,8h-3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_volume_off_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_volume_off_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v2.21l2.45,2.45c0.03,-0.2 0.05,-0.41 0.05,-0.63zM19,12c0,0.94 -0.2,1.82 -0.54,2.64l1.51,1.51C20.63,14.91 21,13.5 21,12c0,-4.28 -2.99,-7.86 -7,-8.77v2.06c2.89,0.86 5,3.54 5,6.71zM4.27,3L3,4.27 7.73,9L3,9v6h4l5,5v-6.73l4.25,4.25c-0.67,0.52 -1.42,0.93 -2.25,1.18v2.06c1.38,-0.31 2.63,-0.95 3.69,-1.81L19.73,21 21,19.73l-9,-9L4.27,3zM12,4L9.91,6.09 12,8.18L12,4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_volume_up_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_volume_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,9v6h4l5,5L12,4L7,9L3,9zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -13,5 +14,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
     </eightbitlab.com.blurview.BlurView>
+
+    <FrameLayout
+        android:id="@+id/exoviewGroup"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/exoplayerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+        </com.google.android.exoplayer2.ui.PlayerView>
+    </FrameLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="bottom"
+    android:layoutDirection="ltr"
+    android:background="#00000000"
+    android:orientation="vertical"
+    tools:targetApi="28">
+    <LinearLayout android:id="@+id/exo_play_pause_button"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:paddingTop="4dp"
+        android:orientation="horizontal">
+        <ImageButton android:id="@+id/exo_play" android:layout_height="24dp" android:layout_width="24dp"
+            style="@+style/ExoMediaButton.Play"/>
+        <ImageButton android:id="@+id/exo_pause" android:layout_height="24dp" android:layout_width="24dp"
+            style="@+style/ExoMediaButton.Pause"/>
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="4dp"
+        android:gravity="bottom"
+        android:orientation="horizontal">
+        <TextView android:id="@+id/exo_position"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+        <View android:id="@+id/exo_progress_placeholder"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="26dp"/>
+        <TextView android:id="@+id/exo_duration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+        <ImageView
+            android:id="@+id/exo_mute_icon"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_baseline_volume_up_24"/>
+        <ImageView
+            android:id="@+id/exo_fullscreen_icon"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_baseline_fullscreen_24"/>
+    </LinearLayout>
+</FrameLayout>


### PR DESCRIPTION
See also https://github.com/home-assistant/core/pull/38125 and https://github.com/home-assistant/frontend/pull/6591
H.265 videos are not supported through Chromium or Webview on Android. We can work around this for Android by using Exoplayer which supports H.265 if the codecs are available on the device. This PR defines an Exoplayer view for the Android client and provides a Javascript interface to help call it from the frontend.