### PR TITLE
Fix configure widget theme colors

### DIFF
--- a/app/src/main/res/layout/fragment_mobile_app_integration.xml
+++ b/app/src/main/res/layout/fragment_mobile_app_integration.xml
@@ -58,7 +58,6 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/retry"
-            style="@style/Widget.HomeAssistant.Button.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="40dp"
@@ -106,7 +105,6 @@
 
             <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/location_perms"
-                style="@style/Widget.HomeAssistant.Button.Colored"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -56,7 +56,6 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_field_button"
-            style="@style/Widget.HomeAssistant.Button.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
@@ -108,7 +107,6 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_button"
-            style="@style/Widget.HomeAssistant.Button.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -98,7 +98,6 @@
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_button"
-            style="@style/Widget.HomeAssistant.Button.Colored"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="end"


### PR DESCRIPTION
Fixes: #729 

Dark mode - service call widget
![image](https://user-images.githubusercontent.com/1634145/89907402-7d804f80-dba1-11ea-904e-33a2b806a168.png)

Light mode - service call widget
![image](https://user-images.githubusercontent.com/1634145/89907433-8a04a800-dba1-11ea-9233-17a608137638.png)

Dark mode - entity static widget
![image](https://user-images.githubusercontent.com/1634145/89907457-90931f80-dba1-11ea-8951-b46eaed4e3f9.png)

Light mode - entity static widget
![image](https://user-images.githubusercontent.com/1634145/89907479-96890080-dba1-11ea-9836-7b4cebe2fbed.png)

Recommendation per: https://developer.android.com/guide/topics/ui/look-and-feel/darktheme#widgets_and_custom_notification_views