### PR TITLE
Update wifi sensor on state changes

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -3,10 +3,12 @@ package io.homeassistant.companion.android
 import android.app.Application
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.wifi.WifiManager
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.sensors.ChargingBroadcastReceiver
+import io.homeassistant.companion.android.sensors.WifiStateReceiver
 
 open class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
@@ -26,6 +28,10 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
                 addAction(Intent.ACTION_POWER_DISCONNECTED)
             }
         )
+
+        // This will trigger an update any time the wifi state has changed
+        registerReceiver(WifiStateReceiver(),  IntentFilter( WifiManager.NETWORK_STATE_CHANGED_ACTION))
+
     }
 
     override val appComponent: AppComponent

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -30,8 +30,7 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
         )
 
         // This will trigger an update any time the wifi state has changed
-        registerReceiver(WifiStateReceiver(),  IntentFilter( WifiManager.NETWORK_STATE_CHANGED_ACTION))
-
+        registerReceiver(WifiStateReceiver(), IntentFilter(WifiManager.NETWORK_STATE_CHANGED_ACTION))
     }
 
     override val appComponent: AppComponent

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -46,6 +46,8 @@ class NetworkSensorManager : SensorManager {
             (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
         val conInfo = wifiManager.connectionInfo
 
+        val wifiEnabled = wifiManager.isWifiEnabled
+
         val ssid = if (conInfo.networkId == -1) {
             "<not connected>"
         } else {
@@ -77,6 +79,7 @@ class NetworkSensorManager : SensorManager {
                 "ip_address" to getIpAddress(conInfo.ipAddress),
                 "link_speed" to conInfo.linkSpeed,
                 "is_hidden" to conInfo.hiddenSSID,
+                "is_wifi_on" to wifiEnabled,
                 "frequency" to conInfo.frequency,
                 "signal_level" to lastScanStrength
             )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
@@ -10,4 +10,6 @@ interface SensorComponent {
     fun inject(worker: SensorWorker)
 
     fun inject(receiver: NextAlarmReceiver)
+
+    fun inject(receiver: WifiStateReceiver)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/WifiStateReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/WifiStateReceiver.kt
@@ -1,0 +1,44 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.wifi.WifiManager
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+
+class WifiStateReceiver() : BroadcastReceiver() {
+
+    @Inject
+    lateinit var integrationUseCase: IntegrationUseCase
+    private val ioScope = CoroutineScope(Dispatchers.IO)
+    var updateJob: Job? = null
+    override fun onReceive(context: Context, intent: Intent) {
+
+        val wifiState = intent.getIntExtra(
+            WifiManager.EXTRA_WIFI_STATE,
+            WifiManager.WIFI_STATE_UNKNOWN
+        )
+
+        if (wifiState < 0) {
+            return
+        }
+
+        DaggerSensorComponent
+            .builder()
+            .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
+            .build()
+            .inject(this)
+
+        updateJob?.cancel()
+        updateJob = ioScope.launch {
+            AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/WifiStateReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/WifiStateReceiver.kt
@@ -6,12 +6,11 @@ import android.content.Intent
 import android.net.wifi.WifiManager
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import javax.inject.Inject
-
 
 class WifiStateReceiver() : BroadcastReceiver() {
 


### PR DESCRIPTION
Use a broadcast receiver to update the wifi sensor whenever the state has changed. This includes enabling/disabling and network changes.

Adds `is_wifi_on` attribute to the sensor

Fixes: #429 