### PR TITLE
Add Exoplayer view and interface

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,9 +164,9 @@ dependencies {
     testImplementation(Config.Dependency.Testing.mockk)
     testImplementation(Config.Dependency.Kotlin.coroutinesTest)
 
-    implementation("com.google.android.exoplayer:exoplayer-core:2.11.7")
-    implementation("com.google.android.exoplayer:exoplayer-hls:2.11.7")
-    implementation("com.google.android.exoplayer:exoplayer-ui:2.11.7")
+    implementation(Config.Dependency.Misc.exoCore)
+    implementation(Config.Dependency.Misc.exoHls)
+    implementation(Config.Dependency.Misc.exoUi)
 }
 
 // This plugin must stay at the bottom

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 buildscript {
     repositories {
         google()
+        jcenter()
         maven(url = Config.Repository.gradle)
     }
     dependencies {
@@ -162,6 +163,10 @@ dependencies {
     testImplementation(Config.Dependency.Testing.assertJ)
     testImplementation(Config.Dependency.Testing.mockk)
     testImplementation(Config.Dependency.Kotlin.coroutinesTest)
+
+    implementation("com.google.android.exoplayer:exoplayer-core:2.11.7")
+    implementation("com.google.android.exoplayer:exoplayer-hls:2.11.7")
+    implementation("com.google.android.exoplayer:exoplayer-ui:2.11.7")
 }
 
 // This plugin must stay at the bottom

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -569,14 +569,16 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         isInPictureInPictureMode: Boolean,
         newConfig: Configuration
     ) {
-        if (isInPictureInPictureMode) {
-            (decor.getChildAt(3) as FrameLayout).layoutParams.height =
-                FrameLayout.LayoutParams.MATCH_PARENT
-            decor.requestLayout()
-        } else {
-            if (decor.getChildAt(3) != null) {
-                (decor.getChildAt(3) as FrameLayout).layoutParams.height = videoHeight
+        if (exoPlayerView.visibility != View.VISIBLE) {
+            if (isInPictureInPictureMode) {
+                (decor.getChildAt(3) as FrameLayout).layoutParams.height =
+                    FrameLayout.LayoutParams.MATCH_PARENT
                 decor.requestLayout()
+            } else {
+                if (decor.getChildAt(3) != null) {
+                    (decor.getChildAt(3) as FrameLayout).layoutParams.height = videoHeight
+                    decor.requestLayout()
+                }
             }
         }
     }
@@ -587,7 +589,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         unlocked = false
         videoHeight = decor.height
         val bounds = Rect(0, 0, 1920, 1080)
-        if (isVideoFullScreen) {
+        if (isVideoFullScreen or isExoFullScreen) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 val mPictureInPictureParamsBuilder = PictureInPictureParams.Builder()
                 mPictureInPictureParamsBuilder.setAspectRatio(

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -42,8 +42,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import com.google.android.exoplayer2.DefaultLoadControl
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.source.hls.HlsMediaSource
@@ -425,7 +423,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             }
         }
     }
-    
+
     fun exoPlayHls(json: JSONObject) {
         val uri = Uri.parse(json.getString("payload"))
         val dataSourceFactory = DefaultHttpDataSourceFactory(

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -158,11 +158,13 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             override fun onClick(view: View) {
                 isExoFullScreen = !isExoFullScreen
                 exoResizeLayout()
-            } })
+            }
+        })
         exo_mute_icon.setOnClickListener(object : View.OnClickListener {
             override fun onClick(view: View) {
                 exoToggleMute()
-            } })
+            }
+        })
         if (!presenter.isLockEnabled())
             blurView.setBlurEnabled(false)
 
@@ -387,9 +389,9 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                     ),
                                     NFC_COMPLETE
                                 )
-                            "play_hls" -> exoPlayHls(json)
-                            "stop_hls" -> exoStopHls()
-                            "resize_hls" -> exoResizeHls(json)
+                            "exoplayer/play_hls" -> exoPlayHls(json)
+                            "exoplayer/stop" -> exoStopHls()
+                            "exoplayer/resize" -> exoResizeHls(json)
                         }
                     }
                 }
@@ -451,6 +453,18 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             exoPlayerView.setPlayer(exoPlayer)
             exoPlayerView.visibility = View.VISIBLE
         }
+        val script = "externalBus(" + "${
+            JSONObject(
+                mapOf(
+                    "id" to json.get("id"),
+                    "type" to "result",
+                    "success" to true,
+                    "result" to null
+                )
+            )
+        }" + ");"
+        Log.d(TAG, script)
+        webView.evaluateJavascript(script) { Log.d(TAG, "Callback $it") }
     }
 
     fun exoStopHls() {
@@ -478,10 +492,20 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         exoMute = !exoMute
         if (exoMute) {
             exoPlayer?.volume = 0f
-            exo_mute_icon.setImageDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.ic_baseline_volume_off_24))
+            exo_mute_icon.setImageDrawable(
+                ContextCompat.getDrawable(
+                    applicationContext,
+                    R.drawable.ic_baseline_volume_off_24
+                )
+            )
         } else {
             exoPlayer?.volume = 1f
-            exo_mute_icon.setImageDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.ic_baseline_volume_up_24))
+            exo_mute_icon.setImageDrawable(
+                ContextCompat.getDrawable(
+                    applicationContext,
+                    R.drawable.ic_baseline_volume_up_24
+                )
+            )
         }
     }
 
@@ -503,7 +527,12 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             exoPlayerView.layoutParams.width = FrameLayout.LayoutParams.MATCH_PARENT
             val screenWidth: Int = resources.displayMetrics.widthPixels
             val screenHeight: Int = resources.displayMetrics.heightPixels
-            exoLayoutParams.setMargins(exoLeft, exoTop, maxOf(screenWidth - exoRight, 0), maxOf(screenHeight - exoBottom, 0))
+            exoLayoutParams.setMargins(
+                exoLeft,
+                exoTop,
+                maxOf(screenWidth - exoRight, 0),
+                maxOf(screenHeight - exoBottom, 0)
+            )
             exo_fullscreen_icon.setImageDrawable(
                 ContextCompat.getDrawable(
                     applicationContext,

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -8,8 +8,10 @@ import android.content.pm.PackageManager
 import android.content.pm.ShortcutInfo
 import android.content.pm.ShortcutManager
 import android.content.res.Configuration
+import android.graphics.Color
 import android.graphics.Rect
 import android.graphics.drawable.Icon
+import android.net.Uri
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
@@ -38,7 +40,16 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+import com.google.android.exoplayer2.DefaultLoadControl
+import com.google.android.exoplayer2.SimpleExoPlayer
+import com.google.android.exoplayer2.source.hls.HlsMediaSource
+import com.google.android.exoplayer2.ui.PlayerView
+import com.google.android.exoplayer2.upstream.DefaultHttpDataSourceFactory
+import com.google.android.exoplayer2.util.Util
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.DaggerPresenterComponent
@@ -57,6 +68,7 @@ import io.homeassistant.companion.android.themes.ThemesManager
 import io.homeassistant.companion.android.util.isStarted
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.activity_webview.*
+import kotlinx.android.synthetic.main.exo_playback_control_view.*
 import org.json.JSONObject
 
 class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.webview.WebView {
@@ -89,6 +101,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private lateinit var decor: FrameLayout
     private lateinit var myCustomView: View
     private lateinit var authenticator: Authenticator
+    private lateinit var exoPlayerView: PlayerView
 
     private var isConnected = false
     private var isShowingError = false
@@ -98,6 +111,13 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private var firstAuthTime: Long = 0
     private var resourceURL: String = ""
     private var unlocked = false
+    private var exoPlayer: SimpleExoPlayer? = null
+    private var isExoFullScreen = false
+    private var exoTop: Int = 0 // These margins are from the DOM and scaled to screen
+    private var exoLeft: Int = 0
+    private var exoRight: Int = 0
+    private var exoBottom: Int = 0
+    private var exoMute: Boolean = true
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -127,6 +147,22 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             .setBlurRadius(5f)
             .setHasFixedTransformationMatrix(false)
 
+        exoPlayerView = findViewById(R.id.exoplayerView)
+        exoPlayerView.visibility = View.GONE
+        exoPlayerView.setBackgroundColor(Color.BLACK)
+        exoPlayerView.alpha = 1f
+        exoPlayerView.setShowBuffering(PlayerView.SHOW_BUFFERING_ALWAYS)
+        exoPlayerView.controllerHideOnTouch = true
+        exoPlayerView.controllerShowTimeoutMs = 2000
+        exo_fullscreen_icon.setOnClickListener(object : View.OnClickListener {
+            override fun onClick(view: View) {
+                isExoFullScreen = !isExoFullScreen
+                exoResizeLayout()
+            } })
+        exo_mute_icon.setOnClickListener(object : View.OnClickListener {
+            override fun onClick(view: View) {
+                exoToggleMute()
+            } })
         if (!presenter.isLockEnabled())
             blurView.setBlurEnabled(false)
 
@@ -326,7 +362,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                                 "result" to JSONObject(
                                                     mapOf(
                                                         "hasSettingsScreen" to true,
-                                                        "canWriteTag" to true
+                                                        "canWriteTag" to true,
+                                                        "hasExoPlayer" to true
                                                     )
                                                 )
                                             )
@@ -350,6 +387,53 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                     ),
                                     NFC_COMPLETE
                                 )
+                            "play_hls" -> {
+                                val uri = Uri.parse(json.getString("payload"))
+                                val dataSourceFactory = DefaultHttpDataSourceFactory(
+                                    Util.getUserAgent(
+                                        applicationContext,
+                                        getString(R.string.app_name)
+                                    )
+                                )
+                                val hlsMediaSource =
+                                    HlsMediaSource.Factory(dataSourceFactory).createMediaSource(uri)
+                                val loadControl = DefaultLoadControl.Builder().setBufferDurationsMs(
+                                    2500,
+                                    DefaultLoadControl.DEFAULT_MAX_BUFFER_MS,
+                                    2500,
+                                    2500
+                                ).createDefaultLoadControl()
+                                runOnUiThread {
+                                    exoPlayer =
+                                        SimpleExoPlayer.Builder(context).setLoadControl(loadControl)
+                                            .build()
+                                    exoPlayer?.prepare(hlsMediaSource)
+                                    exoPlayer?.playWhenReady = true
+                                    exoMute = !exoMute
+                                    exoToggleMute()
+                                    exoPlayerView.setPlayer(exoPlayer)
+                                    exoPlayerView.visibility = View.VISIBLE
+                                }
+                            }
+                            "stop_hls" -> {
+                                runOnUiThread {
+                                    exoPlayerView.visibility = View.GONE
+                                    exoPlayerView.setPlayer(null)
+                                    exoPlayer?.release()
+                                    exoPlayer = null
+                                }
+                            }
+                            "resize_hls" -> {
+                                val rect = json.getJSONObject("payload")
+                                val displayMetrics = context.resources.displayMetrics
+                                exoLeft = (rect.getInt("left") * displayMetrics.density).toInt()
+                                exoTop = (rect.getInt("top") * displayMetrics.density).toInt()
+                                exoRight = (rect.getInt("right") * displayMetrics.density).toInt()
+                                exoBottom = (rect.getInt("bottom") * displayMetrics.density).toInt()
+                                runOnUiThread {
+                                    exoResizeLayout()
+                                }
+                            }
                         }
                     }
                 }
@@ -382,6 +466,47 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                 Log.d(TAG, "NFC Write Complete $it")
             }
         }
+    }
+    
+    fun exoToggleMute() {
+        exoMute = !exoMute
+        if (exoMute) {
+            exoPlayer?.volume = 0f
+            exo_mute_icon.setImageDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.ic_baseline_volume_off_24))
+        } else {
+            exoPlayer?.volume = 1f
+            exo_mute_icon.setImageDrawable(ContextCompat.getDrawable(applicationContext, R.drawable.ic_baseline_volume_up_24))
+        }
+    }
+
+    fun exoResizeLayout() {
+        val exoLayoutParams = exoPlayerView.layoutParams as FrameLayout.LayoutParams
+        if (isExoFullScreen) {
+            exoLayoutParams.setMargins(0, 0, 0, 0)
+            exoPlayerView.layoutParams.height = FrameLayout.LayoutParams.MATCH_PARENT
+            exoPlayerView.layoutParams.width = FrameLayout.LayoutParams.MATCH_PARENT
+            exo_fullscreen_icon.setImageDrawable(
+                ContextCompat.getDrawable(
+                    applicationContext,
+                    R.drawable.ic_baseline_fullscreen_exit_24
+                )
+            )
+            hideSystemUI()
+        } else {
+            exoPlayerView.layoutParams.height = FrameLayout.LayoutParams.WRAP_CONTENT
+            exoPlayerView.layoutParams.width = FrameLayout.LayoutParams.MATCH_PARENT
+            val screenWidth: Int = resources.displayMetrics.widthPixels
+            val screenHeight: Int = resources.displayMetrics.heightPixels
+            exoLayoutParams.setMargins(exoLeft, exoTop, maxOf(screenWidth - exoRight, 0), maxOf(screenHeight - exoBottom, 0))
+            exo_fullscreen_icon.setImageDrawable(
+                ContextCompat.getDrawable(
+                    applicationContext,
+                    R.drawable.ic_baseline_fullscreen_24
+                )
+            )
+            showSystemUI()
+        }
+        exoPlayerView.requestLayout()
     }
 
     private fun authenticationResult(result: Int) {

--- a/app/src/main/res/drawable/ic_baseline_fullscreen_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_fullscreen_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M7,14L5,14v5h5v-2L7,17v-3zM5,10h2L7,7h3L10,5L5,5v5zM17,17h-3v2h5v-5h-2v3zM14,5v2h3v3h2L19,5h-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_fullscreen_exit_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_fullscreen_exit_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M5,16h3v3h2v-5L5,14v2zM8,8L5,8v2h5L10,5L8,5v3zM14,19h2v-3h3v-2h-5v5zM16,8L16,5h-2v5h5L19,8h-3z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_volume_off_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_volume_off_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v2.21l2.45,2.45c0.03,-0.2 0.05,-0.41 0.05,-0.63zM19,12c0,0.94 -0.2,1.82 -0.54,2.64l1.51,1.51C20.63,14.91 21,13.5 21,12c0,-4.28 -2.99,-7.86 -7,-8.77v2.06c2.89,0.86 5,3.54 5,6.71zM4.27,3L3,4.27 7.73,9L3,9v6h4l5,5v-6.73l4.25,4.25c-0.67,0.52 -1.42,0.93 -2.25,1.18v2.06c1.38,-0.31 2.63,-0.95 3.69,-1.81L19.73,21 21,19.73l-9,-9L4.27,3zM12,4L9.91,6.09 12,8.18L12,4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_baseline_volume_up_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_volume_up_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M3,9v6h4l5,5L12,4L7,9L3,9zM16.5,12c0,-1.77 -1.02,-3.29 -2.5,-4.03v8.05c1.48,-0.73 2.5,-2.25 2.5,-4.02zM14,3.23v2.06c2.89,0.86 5,3.54 5,6.71s-2.11,5.85 -5,6.71v2.06c4.01,-0.91 7,-4.49 7,-8.77s-2.99,-7.86 -7,-8.77z"/>
+</vector>

--- a/app/src/main/res/layout/activity_webview.xml
+++ b/app/src/main/res/layout/activity_webview.xml
@@ -1,4 +1,5 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -13,5 +14,16 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
     </eightbitlab.com.blurview.BlurView>
+
+    <FrameLayout
+        android:id="@+id/exoviewGroup"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+        <com.google.android.exoplayer2.ui.PlayerView
+            android:id="@+id/exoplayerView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+        </com.google.android.exoplayer2.ui.PlayerView>
+    </FrameLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="bottom"
+    android:layoutDirection="ltr"
+    android:background="#00000000"
+    android:orientation="vertical"
+    tools:targetApi="28">
+    <LinearLayout android:id="@+id/exo_play_pause_button"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:paddingTop="4dp"
+        android:orientation="horizontal">
+        <ImageButton android:id="@+id/exo_play" android:layout_height="24dp" android:layout_width="24dp"
+            style="@+style/ExoMediaButton.Play"/>
+        <ImageButton android:id="@+id/exo_pause" android:layout_height="24dp" android:layout_width="24dp"
+            style="@+style/ExoMediaButton.Pause"/>
+    </LinearLayout>
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="4dp"
+        android:gravity="bottom"
+        android:orientation="horizontal">
+        <TextView android:id="@+id/exo_position"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+        <View android:id="@+id/exo_progress_placeholder"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="26dp"/>
+        <TextView android:id="@+id/exo_duration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textStyle="bold"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:includeFontPadding="false"
+            android:textColor="#FFBEBEBE"/>
+        <ImageView
+            android:id="@+id/exo_mute_icon"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_baseline_volume_up_24"/>
+        <ImageView
+            android:id="@+id/exo_fullscreen_icon"
+            android:layout_width="26dp"
+            android:layout_height="26dp"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"
+            android:src="@drawable/ic_baseline_fullscreen_24"/>
+    </LinearLayout>
+</FrameLayout>

--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -15,9 +15,9 @@
         android:paddingTop="4dp"
         android:orientation="horizontal">
         <ImageButton android:id="@+id/exo_play" android:layout_height="24dp" android:layout_width="24dp"
-            style="@+style/ExoMediaButton.Play"/>
+            style="@style/ExoMediaButton.Play"/>
         <ImageButton android:id="@+id/exo_pause" android:layout_height="24dp" android:layout_width="24dp"
-            style="@+style/ExoMediaButton.Pause"/>
+            style="@style/ExoMediaButton.Pause"/>
     </LinearLayout>
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/exo_playback_control_view.xml
+++ b/app/src/main/res/layout/exo_playback_control_view.xml
@@ -47,6 +47,9 @@
             android:paddingRight="4dp"
             android:includeFontPadding="false"
             android:textColor="#FFBEBEBE"/>
+        <Space
+            android:layout_width="16dp"
+            android:layout_height="1dp"/>
         <ImageView
             android:id="@+id/exo_mute_icon"
             android:layout_width="26dp"
@@ -54,6 +57,9 @@
             android:adjustViewBounds="true"
             android:scaleType="fitCenter"
             android:src="@drawable/ic_baseline_volume_up_24"/>
+        <Space
+            android:layout_width="16dp"
+            android:layout_height="1dp"/>
         <ImageView
             android:id="@+id/exo_fullscreen_icon"
             android:layout_width="26dp"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -105,6 +105,9 @@ object Config {
             const val iconDialog = "com.maltaisn:icondialog:3.3.0"
             const val iconDialogMaterial = "com.maltaisn:iconpack-community-material:5.3.45"
             const val emoji = "com.vdurmont:emoji-java:5.1.1"
+            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.11.7"
+            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.11.7"
+            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.11.7"
         }
     }
 


### PR DESCRIPTION
See also https://github.com/home-assistant/frontend/pull/6606
H.265 videos are not supported through Chromium or Webview on Android. We can work around this for Android by using Exoplayer which supports H.265 if the codecs are available on the device. This PR defines an Exoplayer view for the Android client and uses the externalApp interface to help call it from the frontend.