### PR TITLE
Battery and next alarm sensor improvements

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -21,9 +21,11 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
         // This will cause the sensor to be updated every time the OS broadcasts that a cable was plugged/unplugged.
         // This should be nearly instantaneous allowing automations to fire immediately when a phone is plugged
-        // in or unplugged.
+        // in or unplugged. Updates will also be triggered when the system reports low battery and when it recovers.
         registerReceiver(
             ChargingBroadcastReceiver(appComponent.integrationUseCase()), IntentFilter().apply {
+                addAction(Intent.ACTION_BATTERY_LOW)
+                addAction(Intent.ACTION_BATTERY_OKAY)
                 addAction(Intent.ACTION_POWER_CONNECTED)
                 addAction(Intent.ACTION_POWER_DISCONNECTED)
             }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -99,11 +99,15 @@ class BatterySensorManager : SensorManager {
 
         val percentage: Int = getBatteryPercentage(level, scale)
 
+        val isCharging = getIsCharging(intent)
+        val chargerType = getChargerType(intent)
+        val chargingStatus = getChargingStatus(intent)
+
         return Sensor(
             "battery_level",
             percentage,
             "sensor",
-            getBatteryIcon(percentage),
+            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
             mapOf()
         )
     }
@@ -118,23 +122,10 @@ class BatterySensorManager : SensorManager {
             return null
         }
 
-        val isCharging: Boolean = status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                status == BatteryManager.BATTERY_STATUS_FULL
-
-        val chargerType: String = when (intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)) {
-            BatteryManager.BATTERY_PLUGGED_AC -> "ac"
-            BatteryManager.BATTERY_PLUGGED_USB -> "usb"
-            BatteryManager.BATTERY_PLUGGED_WIRELESS -> "wireless"
-            else -> "unknown"
-        }
-
-        val chargingStatus: String = when (status) {
-            BatteryManager.BATTERY_STATUS_FULL -> "full"
-            BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
-            BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
-            BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
-            else -> "unknown"
-        }
+        val isCharging = getIsCharging(intent)
+        val chargerType = getChargerType(intent)
+        val chargingStatus = getChargingStatus(intent)
+        val batteryHealth = getBatteryHealth(intent)
 
         val percentage: Int = getBatteryPercentage(level, scale)
 
@@ -145,8 +136,47 @@ class BatterySensorManager : SensorManager {
             getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
             mapOf(
                 "is_charging" to isCharging,
-                "charger_type" to chargerType
+                "charger_type" to chargerType,
+                "battery_health" to batteryHealth
             )
         )
+    }
+
+    private fun getIsCharging(intent: Intent): Boolean {
+        val status: Int = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
+
+        return status == BatteryManager.BATTERY_STATUS_CHARGING ||
+            status == BatteryManager.BATTERY_STATUS_FULL
+    }
+
+    private fun getChargerType(intent: Intent): String {
+        return when (intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)) {
+            BatteryManager.BATTERY_PLUGGED_AC -> "ac"
+            BatteryManager.BATTERY_PLUGGED_USB -> "usb"
+            BatteryManager.BATTERY_PLUGGED_WIRELESS -> "wireless"
+            else -> "unknown"
+        }
+    }
+
+    private fun getChargingStatus(intent: Intent): String {
+        return when (intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)) {
+            BatteryManager.BATTERY_STATUS_FULL -> "full"
+            BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
+            BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
+            else -> "unknown"
+        }
+    }
+
+    private fun getBatteryHealth(intent: Intent): String {
+        return when (intent.getIntExtra(BatteryManager.EXTRA_HEALTH, -1)) {
+            BatteryManager.BATTERY_HEALTH_COLD -> "cold"
+            BatteryManager.BATTERY_HEALTH_DEAD -> "dead"
+            BatteryManager.BATTERY_HEALTH_GOOD -> "good"
+            BatteryManager.BATTERY_HEALTH_OVERHEAT -> "overheated"
+            BatteryManager.BATTERY_HEALTH_OVER_VOLTAGE -> "over_voltage"
+            BatteryManager.BATTERY_HEALTH_UNSPECIFIED_FAILURE -> "failed"
+            else -> "unknown"
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ChargingBroadcastReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ChargingBroadcastReceiver.kt
@@ -5,9 +5,9 @@ import android.content.Context
 import android.content.Intent
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 class ChargingBroadcastReceiver(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ChargingBroadcastReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ChargingBroadcastReceiver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -17,6 +18,10 @@ class ChargingBroadcastReceiver(
     override fun onReceive(context: Context, intent: Intent?) {
         updateJob?.cancel()
         updateJob = ioScope.launch {
+            AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
+            // Add a 5 second delay to perform another update so charging state updates completely.
+            // This is necessary as the system needs a few seconds to verify the charger.
+            delay(5000L)
             AllSensorsUpdaterImpl(integrationUseCase, context).updateSensors()
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -48,6 +48,7 @@ class NextAlarmManager : SensorManager {
         var triggerTime = 0L
         var local = ""
         var utc = "unavailable"
+        var pendingIntent = ""
 
         try {
             val alarmManager: AlarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
@@ -56,6 +57,7 @@ class NextAlarmManager : SensorManager {
 
             if (alarmClockInfo != null) {
                 triggerTime = alarmClockInfo.triggerTime
+                pendingIntent = alarmClockInfo.showIntent.creatorPackage.toString()
 
                 val cal: Calendar = GregorianCalendar()
                 cal.timeInMillis = triggerTime
@@ -79,7 +81,8 @@ class NextAlarmManager : SensorManager {
             icon,
             mapOf(
                 "Local Time" to local,
-                "Time in Milliseconds" to triggerTime
+                "Time in Milliseconds" to triggerTime,
+                "Package" to pendingIntent
             )
         )
     }


### PR DESCRIPTION
Battery level sensor:
- Fix battery level icon so it matches battery state. This will align with the iOS app and fixes #536 

Battery state sensor:

- Add attribute for battery health
- Add intents for battery low and okay. Battery low triggers when the system alerts the user the battery is low. Okay triggers when it recovers from being low
- Add a second update when we receive a battery intent to update the charging state faster. As mentioned in #525 by @yoxjames without the battery changed intent the charging state won't fully update until the next sensor update.  This is because the device is verifying the charging status.  When we switch to battery intent the system sees several state updates which are a bit unnecessary.  Waiting 5 seconds to update the state again ensures we not only detect the plug event instantly but also makes sure the state is as expected.

Next alarm sensor
- Add attribute for the package name that scheduled the alarm. Partially fixes: #737 