### PR TITLE
Add easier way to use of emoji in notifications

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,6 +117,7 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(Config.Dependency.Misc.blurView)
+    implementation(Config.Dependency.Misc.emoji)
 
     implementation(Config.Dependency.Kotlin.core)
     implementation(Config.Dependency.Kotlin.coroutines)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,9 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(Config.Dependency.Misc.blurView)
-    implementation(Config.Dependency.Misc.emoji)
+    implementation(Config.Dependency.Misc.emoji)  {
+        exclude(group = "org.json", module = "json")
+    }
 
     implementation(Config.Dependency.Kotlin.core)
     implementation(Config.Dependency.Kotlin.coroutines)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -117,7 +117,7 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(Config.Dependency.Misc.blurView)
-    implementation(Config.Dependency.Misc.emoji)  {
+    implementation(Config.Dependency.Misc.emoji) {
         exclude(group = "org.json", module = "json")
     }
 

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.vdurmont.emoji.EmojiParser
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.background.LocationBroadcastReceiver
 import io.homeassistant.companion.android.background.LocationBroadcastReceiverBase
@@ -274,7 +275,7 @@ class MessagingService : FirebaseMessagingService() {
             .setSmallIcon(R.drawable.ic_stat_ic_notification)
             .setStyle(
                 NotificationCompat.BigTextStyle()
-                    .setSummaryText(getSpannedTextFromHtml(group.substring(GROUP_PREFIX.length))
+                    .setSummaryText(prepareText(group.substring(GROUP_PREFIX.length))
                 )
             )
             .setGroup(group)
@@ -411,7 +412,7 @@ class MessagingService : FirebaseMessagingService() {
         data: Map<String, String>
     ) {
         data[SUBJECT]?.let {
-            builder.setContentText(getSpannedTextFromHtml(it))
+            builder.setContentText(prepareText(it))
         }
     }
 
@@ -420,19 +421,20 @@ class MessagingService : FirebaseMessagingService() {
         data: Map<String, String>
     ) {
         data[TITLE]?.let {
-            builder.setContentTitle(getSpannedTextFromHtml(it))
+            builder.setContentTitle(prepareText(it))
         }
         data[MESSAGE]?.let {
-            val text = getSpannedTextFromHtml(it)
+            val text = prepareText(it)
             builder.setContentText(text)
             builder.setStyle(NotificationCompat.BigTextStyle().bigText(text))
         }
     }
 
-    private fun getSpannedTextFromHtml(
+    private fun prepareText(
         text: String
     ): Spanned {
-        return HtmlCompat.fromHtml(text, HtmlCompat.FROM_HTML_MODE_LEGACY)
+        var emojiParsedText = EmojiParser.parseToUnicode(text)
+        return HtmlCompat.fromHtml(emojiParsedText, HtmlCompat.FROM_HTML_MODE_LEGACY)
     }
 
     private suspend fun handleLargeIcon(

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -103,6 +103,7 @@ object Config {
             const val threeTenAbp = "com.jakewharton.threetenabp:threetenabp:1.2.1"
             const val javaxInject = "javax.inject:javax.inject:1"
             const val blurView = "com.eightbitlab:blurview:1.6.3"
+            const val emoji = "com.vdurmont:emoji-java:5.1.1"
         }
     }
 


### PR DESCRIPTION
With this PR is easier to use emojis in notification. 
Just use the emoji shortcode and it will be parsed to the correct unicode code.
It is also possible to use fitzpatrick modifiers to change the skin tone of an emoji.

| Modifier | Type     |
| :------: | -------- |
|    🏻    | type_1_2 |
|    🏼    | type_3   |
|    🏽    | type_4   |
|    🏾    | type_5   |
|    🏿    | type_6   |

`:santa|type_6:`

Example:

```
message: "Now you can easy use emojis :santa|type_6::frog::sparkling_heart: in your notifications :sunglasses::rocket:"
title: "Easier use of Emojis :grinning::thumbsup:"
```

<img src="https://user-images.githubusercontent.com/12832850/90056711-9c84fb80-dcdf-11ea-9d05-65aac8cad573.png" width="50%">

More on the project site of the library which is used:
https://github.com/vdurmont/emoji-java

Here are a lists of emoji short codes:
https://emojipedia.org/