### PR TITLE
Add Bluetooth sensor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="io.homeassistant.companion.android">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
@@ -94,6 +95,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />
+            </intent-filter>
+        </receiver>
+
+        <receiver android:name=".sensors.BluetoothReceiver">
+            <intent-filter>
+                <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
+                <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android
 
 import android.app.Application
+import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.wifi.WifiManager
@@ -8,6 +9,7 @@ import android.telephony.TelephonyManager
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.sensors.BluetoothReceiver
 import io.homeassistant.companion.android.sensors.ChargingBroadcastReceiver
 import io.homeassistant.companion.android.sensors.PhoneStateReceiver
 import io.homeassistant.companion.android.sensors.WifiStateReceiver
@@ -42,6 +44,8 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
                 addAction(TelephonyManager.ACTION_PHONE_STATE_CHANGED)
             }
         )
+
+        registerReceiver(BluetoothReceiver(), IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
     }
 
     override val appComponent: AppComponent

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothReceiver.kt
@@ -1,0 +1,32 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class BluetoothReceiver() : BroadcastReceiver() {
+
+    @Inject
+    lateinit var integrationUseCase: IntegrationUseCase
+    private val ioScope = CoroutineScope(Dispatchers.IO)
+    private var updateJob: Job? = null
+    override fun onReceive(context: Context, intent: Intent?) {
+        DaggerSensorComponent
+            .builder()
+            .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
+            .build()
+            .inject(this)
+
+        updateJob?.cancel()
+        updateJob = ioScope.launch {
+            SensorReceiver().updateSensors(context, integrationUseCase)
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothReceiver.kt
@@ -5,11 +5,11 @@ import android.content.Context
 import android.content.Intent
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import javax.inject.Inject
 
 class BluetoothReceiver() : BroadcastReceiver() {
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -19,9 +19,9 @@ class BluetoothSensorManager : SensorManager {
     override fun requiredPermissions(): Array<String> {
         return PermissionManager.getBluetoohPermissionArray()
     }
+
     override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
         return listOf(getBluetoothConnectionSensor(context))
-
     }
 
     private fun getBluetoothConnectionSensor(context: Context): SensorRegistration<Any> {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -8,7 +8,6 @@ import io.homeassistant.companion.android.domain.integration.SensorRegistration
 import io.homeassistant.companion.android.util.PermissionManager
 import java.lang.reflect.Method
 
-
 class BluetoothSensorManager : SensorManager {
     companion object {
         private const val TAG = "BluetoothSM"
@@ -51,7 +50,6 @@ class BluetoothSensorManager : SensorManager {
                 var bondedDevices = adapter.bondedDevices
                 bondedString = bondedDevices.toString()
                 for (BluetoothDevice in bondedDevices) {
-
                     if (isConnected(BluetoothDevice)) {
                         connectedAddress = BluetoothDevice.address
                         connectedPairedDevices.add(connectedAddress)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -44,8 +44,6 @@ class BluetoothSensorManager : SensorManager {
             var adapter = bluetoothManager.adapter
             isBtOn = adapter.isEnabled
 
-
-
             if (isBtOn) {
                 var bondedDevices = adapter.bondedDevices
                 bondedString = bondedDevices.toString()
@@ -64,7 +62,6 @@ class BluetoothSensorManager : SensorManager {
                     }
                 }
             }
-
         }
         return SensorRegistration(
             "bluetooth_connection",

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -1,0 +1,94 @@
+package io.homeassistant.companion.android.sensors
+
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile.GATT
+import android.content.Context
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import io.homeassistant.companion.android.util.PermissionManager
+import java.lang.reflect.Method
+
+
+class BluetoothSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "BluetoothSM"
+    }
+    override val name: String
+        get() = "Bluetooth Sensors"
+
+    override fun requiredPermissions(): Array<String> {
+        return PermissionManager.getBluetoohPermissionArray()
+    }
+    override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
+        return listOf(getBluetoothConnectionSensor(context))
+
+    }
+
+    private fun getBluetoothConnectionSensor(context: Context): SensorRegistration<Any> {
+
+        var connectedNotPairedAddress = ""
+        var totalConnectedDevices = 0
+        val icon = "mdi:bluetooth"
+        var connectedPairedDevices: MutableList<String> = ArrayList()
+        var connectedNotPairedDevices: MutableList<String> = ArrayList()
+        var bondedString = ""
+        var isBtOn = false
+
+        if (PermissionManager.checkBluetoothPermission(context)) {
+
+            val bluetoothManager =
+                (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+
+            val btConnectedDevices = bluetoothManager.getConnectedDevices(GATT)
+            var connectedAddress = ""
+
+            var adapter = bluetoothManager.adapter
+            isBtOn = adapter.isEnabled
+
+
+
+            if (isBtOn) {
+                var bondedDevices = adapter.bondedDevices
+                bondedString = bondedDevices.toString()
+                for (BluetoothDevice in bondedDevices) {
+
+                    if (isConnected(BluetoothDevice)) {
+                        connectedAddress = BluetoothDevice.address
+                        connectedPairedDevices.add(connectedAddress)
+                        totalConnectedDevices += 1
+                    }
+                }
+                for (BluetoothDevice in btConnectedDevices) {
+                    if (isConnected(BluetoothDevice)) {
+                        connectedNotPairedAddress = BluetoothDevice.address
+                        connectedNotPairedDevices.add(connectedNotPairedAddress)
+                        totalConnectedDevices += 1
+                    }
+                }
+            }
+
+        }
+        return SensorRegistration(
+            "bluetooth_connection",
+            totalConnectedDevices,
+            "sensor",
+            icon,
+            mapOf(
+                "connected_paired_devices" to connectedPairedDevices,
+                "connected_not_paired_devices" to connectedNotPairedDevices,
+                "is_bt_on" to isBtOn,
+                "paired_devices" to bondedString
+                ),
+            "Bluetooth Connection"
+            )
+        }
+    }
+
+    private fun isConnected(device: BluetoothDevice): Boolean {
+        return try {
+            val m: Method = device.javaClass.getMethod("isConnected")
+            m.invoke(device) as Boolean
+        } catch (e: Exception) {
+            throw IllegalStateException(e)
+        }
+    }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorComponent.kt
@@ -17,6 +17,8 @@ interface SensorComponent {
 
     fun inject(sensorDetailFragment: SensorDetailFragment)
 
+    fun inject(receiver: BluetoothReceiver)
+
     fun inject(receiver: NextAlarmReceiver)
 
     fun inject(receiver: WifiStateReceiver)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -22,6 +22,7 @@ class SensorReceiver : BroadcastReceiver() {
         const val TAG = "SensorReceiver"
         val MANAGERS = listOf(
             BatterySensorManager(),
+            BluetoothSensorManager(),
             NetworkSensorManager(),
             GeocodeSensorManager(),
             NextAlarmManager(),

--- a/app/src/main/java/io/homeassistant/companion/android/util/PermissionManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/PermissionManager.kt
@@ -41,6 +41,15 @@ class PermissionManager {
             return true
         }
 
+        fun checkBluetoothPermission(context: Context): Boolean {
+            for (permission in getBluetoohPermissionArray()) {
+                if (!hasPermission(context, permission)) {
+                    return false
+                }
+            }
+            return true
+        }
+
         /**
          * Returns an Array with required location permissions.
          * ACCESS_FINE_LOCATION and, if API level >= 29, ACCESS_BACKGROUND_LOCATION.
@@ -51,6 +60,10 @@ class PermissionManager {
             } else {
                 arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
             }
+        }
+
+        fun getBluetoohPermissionArray(): Array<String> {
+            return arrayOf(Manifest.permission.BLUETOOTH)
         }
 
         fun validateLocationPermissions(


### PR DESCRIPTION
Fixes: #452 

- The state of the sensor will be the total number of connected devices including both paired and not paired devices
- Attributes will be `connected paired devices` `connected not paired devices` `paired devices` all provided in a list with the devices mac address. `is bt on` will reflect the state of the bluetooth adapter.
- The sensor will update when bluetooth state changes as well as connection changes are broadcasted.

Connected but not paired devices will include devices like a Mi Band or any other device that pairs with their own app instead of the system itself.  Bluetooth headsets are always paired with the system and so we can see whether they are paired as well as if they are connected.  Bluetooth names are not always given for a device so I have not included them.  There are other bluetooth things we can pull in like device battery (only supported on android 10) however we should think about how we want to expose them to the user.  For now lets just show what is connected and/or paired. 