### PR TITLE
Add storage sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -14,7 +14,8 @@ class BluetoothSensorManager : SensorManager {
         private val bluetoothConnection = SensorManager.BasicSensor(
             "bluetooth_connection",
             "sensor",
-            "Bluetooth Connection"
+            "Bluetooth Connection",
+            unitOfMeasurement = "connection(s)"
         )
     }
 
@@ -72,7 +73,9 @@ class BluetoothSensorManager : SensorManager {
                     if (isConnected(BluetoothDevice)) {
                         connectedNotPairedAddress = BluetoothDevice.address
                         connectedNotPairedDevices.add(connectedNotPairedAddress)
-                        totalConnectedDevices += 1
+                        if (connectedNotPairedAddress != connectedAddress) {
+                            totalConnectedDevices += 1
+                        }
                     }
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -85,10 +85,12 @@ class SensorReceiver : BroadcastReceiver() {
                     try {
                         integrationUseCase.registerSensor(sensorData)
                         sensor.registered = true
-                        enabledRegistrations.add(sensorData)
                     } catch (e: Exception) {
                         Log.e(TAG, "Issue registering sensor: ${sensorData.uniqueId}", e)
                     }
+                }
+                if (sensorData != null) {
+                    enabledRegistrations.add(sensorData)
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -25,7 +25,8 @@ class SensorReceiver : BroadcastReceiver() {
             NetworkSensorManager(),
             GeocodeSensorManager(),
             NextAlarmManager(),
-            PhoneStateSensorManager()
+            PhoneStateSensorManager(),
+            StorageSensorManager()
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -11,6 +11,12 @@ class StorageSensorManager : SensorManager {
     companion object {
 
         private const val TAG = "StorageSensor"
+        private val storageSensor = SensorManager.BasicSensor(
+            "storage_sensor",
+            "sensor",
+            "Storage Sensor",
+            unitOfMeasurement = "%"
+        )
         val path: File = Environment.getDataDirectory()
         private val stat = StatFs(path.path)
         var availableBlocks = stat.availableBlocksLong
@@ -31,13 +37,21 @@ class StorageSensorManager : SensorManager {
 
     override val name: String
         get() = "Storage Sensors"
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(StorageSensorManager.storageSensor)
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
     }
 
-    override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
-        return listOf(getStorageSensor(context))
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            StorageSensorManager.storageSensor.id -> getStorageSensor(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
     }
 
     private fun getStorageSensor(context: Context): SensorRegistration<Any> {
@@ -61,19 +75,15 @@ class StorageSensorManager : SensorManager {
 
         val icon = "mdi:harddisk"
 
-        return SensorRegistration(
-            "storage_sensor",
+        return storageSensor.toSensorRegistration(
             percentageFreeInternalStorage,
-            "sensor",
             icon,
             mapOf(
                 "Free internal storage" to freeInternalStorage,
                 "Total internal storage" to totalInternalStorage,
                 "Free external storage" to freeExternalStorage,
                 "Total external storage" to totalExternalStorage
-            ),
-            "Storage Sensor",
-            unitOfMeasurement = "%"
+            )
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -20,7 +20,7 @@ class StorageSensorManager : SensorManager {
         var availableBlocksSD = 0L
         var totalBlocksSD = 0L
 
-        private fun externalMemoryAvailable() : Boolean {
+        private fun externalMemoryAvailable(): Boolean {
             return if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED) {
                 Environment.isExternalStorageRemovable()
             } else {
@@ -77,7 +77,7 @@ class StorageSensorManager : SensorManager {
         )
     }
 
-    private fun formatSize(size: Long) : String {
+    private fun formatSize(size: Long): String {
         var suffix = ""
 
         var sizeLong = size
@@ -89,7 +89,7 @@ class StorageSensorManager : SensorManager {
                 sizeLong /= 1024
                 if (size >= 1024) {
                     suffix = "GB"
-                    sizeLong /=1024
+                    sizeLong /= 1024
                 }
             }
         }
@@ -106,7 +106,7 @@ class StorageSensorManager : SensorManager {
         return resultBuffer.toString()
     }
 
-    private fun getTotalInternalMemorySize() : String {
+    private fun getTotalInternalMemorySize(): String {
         return formatSize(totalBlocks * blockSize)
     }
 
@@ -125,5 +125,4 @@ class StorageSensorManager : SensorManager {
     private fun getTotalExternalMemorySize(): String {
         return formatSize(totalBlocksSD * blockSizeSD)
     }
-
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -1,0 +1,129 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.os.Environment
+import android.os.StatFs
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import java.io.File
+import kotlin.math.roundToInt
+
+class StorageSensorManager : SensorManager {
+    companion object {
+
+        private const val TAG = "StorageSensor"
+        val path: File = Environment.getDataDirectory()
+        private val stat = StatFs(path.path)
+        var availableBlocks = stat.availableBlocksLong
+        var blockSize = stat.blockSizeLong
+        var totalBlocks = stat.blockCountLong
+        var blockSizeSD = 0L
+        var availableBlocksSD = 0L
+        var totalBlocksSD = 0L
+
+        private fun externalMemoryAvailable() : Boolean {
+            return if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED) {
+                Environment.isExternalStorageRemovable()
+            } else {
+                false
+            }
+        }
+    }
+
+    override val name: String
+        get() = "Storage Sensors"
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
+        return listOf(getStorageSensor(context))
+    }
+
+    private fun getStorageSensor(context: Context): SensorRegistration<Any> {
+
+        var totalInternalStorage = getTotalInternalMemorySize()
+        var freeInternalStorage = getAvailableInternalMemorySize()
+        val percentageFreeInternalStorage = getPercentageInternal()
+        val hasExternalStorage = externalMemoryAvailable()
+        var totalExternalStorage = "No SD Card"
+        var freeExternalStorage = "No SD Card"
+
+        if (hasExternalStorage) {
+            val pathSD = context.getExternalFilesDir(null)
+            val statSD = StatFs(pathSD?.path)
+            blockSizeSD = statSD.blockSizeLong
+            availableBlocksSD = statSD.availableBlocksLong
+            totalBlocksSD = statSD.blockCountLong
+            totalExternalStorage = getTotalExternalMemorySize()
+            freeExternalStorage = getAvailableExternalMemorySize()
+        }
+
+        val icon = "mdi:harddisk"
+
+        return SensorRegistration(
+            "storage_sensor",
+            percentageFreeInternalStorage,
+            "sensor",
+            icon,
+            mapOf(
+                "Free internal storage" to freeInternalStorage,
+                "Total internal storage" to totalInternalStorage,
+                "Free external storage" to freeExternalStorage,
+                "Total external storage" to totalExternalStorage
+            ),
+            "Storage Sensor",
+            unitOfMeasurement = "%"
+        )
+    }
+
+    private fun formatSize(size: Long) : String {
+        var suffix = ""
+
+        var sizeLong = size
+        if (size >= 1024) {
+            suffix = "KB"
+            sizeLong /= 1024
+            if (size >= 1024) {
+                suffix = "MB"
+                sizeLong /= 1024
+                if (size >= 1024) {
+                    suffix = "GB"
+                    sizeLong /=1024
+                }
+            }
+        }
+
+        val resultBuffer = StringBuilder(sizeLong.toString())
+
+        var commaOffset = resultBuffer.length - 3
+        while (commaOffset > 0) {
+            resultBuffer.insert(commaOffset, ',')
+            commaOffset -= 3
+        }
+
+        if (suffix != null) resultBuffer.append(suffix)
+        return resultBuffer.toString()
+    }
+
+    private fun getTotalInternalMemorySize() : String {
+        return formatSize(totalBlocks * blockSize)
+    }
+
+    private fun getAvailableInternalMemorySize(): String {
+        return formatSize(availableBlocks * blockSize)
+    }
+
+    private fun getPercentageInternal(): Int {
+        return ((availableBlocks.toDouble() / totalBlocks.toDouble()) * 100).roundToInt()
+    }
+
+    private fun getAvailableExternalMemorySize(): String {
+        return formatSize(availableBlocksSD * blockSizeSD)
+    }
+
+    private fun getTotalExternalMemorySize(): String {
+        return formatSize(totalBlocksSD * blockSizeSD)
+    }
+
+}


### PR DESCRIPTION
Adds a storage sensor, the state will be the percentage of free space so we align with the iOS app.

Attributes will be as follows:

- Free internal storage in GB
- Total internal storage in GB
- Free external storage in GB
- Total external storage in GB

External storage will reflect `No SD Card` if the device does not have a SD card.

This sensor will only update during the sensor update interval.

![image](https://user-images.githubusercontent.com/1634145/90189999-0a2e3780-dd73-11ea-8297-d22e581b35eb.png)


Also a fix for the bluetooth sensor to avoid adding duplicate devices to the total count of connected devices, and a proper `unit_of_measurement`. See: https://github.com/home-assistant/android/pull/743#issuecomment-673578475

This also fixes an issue introduced in #752 where sensors were only updating when first registered.