### PR TITLE
Add light sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -1,15 +1,15 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.content.Context.SENSOR_SERVICE
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
-import androidx.appcompat.app.AppCompatActivity
 import io.homeassistant.companion.android.domain.integration.SensorRegistration
 import kotlin.math.roundToInt
 
-class LightSensorManager : SensorManager, SensorEventListener, AppCompatActivity() {
+class LightSensorManager : SensorManager, SensorEventListener {
     companion object {
 
         private const val TAG = "LightSensor"
@@ -75,10 +75,6 @@ class LightSensorManager : SensorManager, SensorEventListener, AppCompatActivity
                 lightReading = event.values[0].roundToInt().toString()
             }
         }
-    }
-
-    override fun onPause() {
-        super.onPause()
         mySensorManager.unregisterListener(this)
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -1,0 +1,84 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Context.SENSOR_SERVICE
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import android.util.Log
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import kotlin.math.roundToInt
+
+class LightSensorManager : SensorManager, SensorEventListener {
+    companion object {
+
+        private const val TAG = "LightSensor"
+        private var lightReading: String = 0f.roundToInt().toString()
+        lateinit var mySensorManager: android.hardware.SensorManager
+    }
+
+    override val name: String
+        get() = "Light Sensors"
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorRegistrations(context: Context): List<SensorRegistration<Any>> {
+        return listOf(getLightSensor(context))
+    }
+
+    private fun getLightSensor(context: Context): SensorRegistration<Any> {
+
+        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+
+        val lightSensor = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT) as Sensor
+        if(lightSensor != null){
+            mySensorManager.registerListener(
+                this,
+                lightSensor,
+                SENSOR_DELAY_NORMAL);
+
+        } else {
+            Log.e(TAG, "Light sensor not found for the device, sending unavailable")
+            lightReading = "unavailable"
+        }
+
+
+
+        val icon = "mdi:brightness-5"
+
+        return SensorRegistration(
+            "light_sensor",
+            lightReading,
+            "sensor",
+            icon,
+            mapOf(),
+            "Light Sensor",
+            "illuminance",
+            "lx"
+        )
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // TODO Auto-generated method stub
+
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event != null) {
+            if(event.sensor.type == Sensor.TYPE_LIGHT){
+                lightReading = event.values[0].roundToInt().toString()
+            }
+        }
+    }
+
+    fun onPause() {
+
+        mySensorManager.unregisterListener(this)
+
+       // super.onPause()
+    }
+
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -49,11 +49,11 @@ class LightSensorManager : SensorManager, SensorEventListener, AppCompatActivity
         mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val lightSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT) as Sensor
-        if(lightSensors != null){
+        if (lightSensors != null) {
             mySensorManager.registerListener(
                 this,
                 lightSensors,
-                SENSOR_DELAY_NORMAL);
+                SENSOR_DELAY_NORMAL)
         }
 
         val icon = "mdi:brightness-5"
@@ -71,7 +71,7 @@ class LightSensorManager : SensorManager, SensorEventListener, AppCompatActivity
 
     override fun onSensorChanged(event: SensorEvent?) {
         if (event != null) {
-            if(event.sensor.type == Sensor.TYPE_LIGHT){
+            if (event.sensor.type == Sensor.TYPE_LIGHT) {
                 lightReading = event.values[0].roundToInt().toString()
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -24,6 +24,7 @@ class SensorReceiver : BroadcastReceiver() {
             BluetoothSensorManager(),
             NetworkSensorManager(),
             GeocodeSensorManager(),
+            LightSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
             StorageSensorManager()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -46,7 +46,7 @@ class SensorReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
 
         DaggerSensorComponent.builder()
-            .appComponent((context as GraphComponentAccessor).appComponent)
+            .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
             .build()
             .inject(this)
 


### PR DESCRIPTION
This PR adds a light sensor whose state will represent the current `lx` the device sees. If this sensor is enabled on a device that does not offer a light sensor the state will remain `unavailable`.

The light sensor will only update with the normal sensor update interval or when any other sensor that updates on a state change.

I did notice one odd issue in that on first launch the sensor may first show `unavailable` before updating to the actual value or we just need to restart the app.  This is a one time thing that I have noticed and once a real value gets reported those are what remain.  I suspect this is because these sensors require event listeners and we need to wait for them to be ready or we are reporting the value too early. This behavior is unlike what we see with the battery state sensor when we plug in the device.

![image](https://user-images.githubusercontent.com/1634145/90281629-c3e3e180-de21-11ea-8730-85048c083a9f.png)

There is also a fix for #751 