### PR TITLE
Fix light sensor crash on older devices that don't have one

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -48,7 +48,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
 
         mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
-        val lightSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT) as Sensor
+        val lightSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
         if (lightSensors != null) {
             mySensorManager.registerListener(
                 this,


### PR DESCRIPTION
Older android devices that did not have a light sensor was crashing, this now fixes the below crash

```
08-14 22:15:22.224 5657-5704/? E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-2
    Process: io.homeassistant.companion.android, PID: 5657
    kotlin.TypeCastException: null cannot be cast to non-null type android.hardware.Sensor
        at io.homeassistant.companion.android.sensors.LightSensorManager.getLightSensor(LightSensorManager.kt:51)
        at io.homeassistant.companion.android.sensors.LightSensorManager.getSensorData(LightSensorManager.kt:42)
        at io.homeassistant.companion.android.sensors.SensorManager$DefaultImpls.getEnabledSensorData(SensorManager.kt:71)
        at io.homeassistant.companion.android.sensors.LightSensorManager.getEnabledSensorData(LightSensorManager.kt:12)
        at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:81)
        at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:56)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)

```

I noticed this on my fire tablet that's on android 5, will make sure to include it during testing next time :)