### PR TITLE
Attempt to fix SD card path in storage sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.sensors
 import android.content.Context
 import android.os.Environment
 import android.os.StatFs
+import android.util.Log
 import io.homeassistant.companion.android.domain.integration.SensorRegistration
 import java.io.File
 import kotlin.math.roundToInt
@@ -25,20 +26,36 @@ class StorageSensorManager : SensorManager {
         var blockSizeSD = 0L
         var availableBlocksSD = 0L
         var totalBlocksSD = 0L
+        private var externalPath: File? = null
 
-        private fun externalMemoryAvailable(): Boolean {
-            return if (Environment.getExternalStorageState() == Environment.MEDIA_MOUNTED) {
-                Environment.isExternalStorageRemovable()
-            } else {
-                false
+        private fun externalMemoryAvailable(context: Context): File? {
+            val pathsSD = context.getExternalFilesDirs(null)
+            var removable: Boolean
+            Log.d(TAG, "PATHS SD ${pathsSD.size}")
+            for (item in pathsSD) {
+                if (item != null) {
+                    Log.d(
+                        TAG,
+                        "PATH $item is mounted ${Environment.getExternalStorageState(item) == Environment.MEDIA_MOUNTED} and removable is ${Environment.isExternalStorageRemovable(
+                            item
+                        )}"
+                    )
+                    if (Environment.getExternalStorageState(item) == Environment.MEDIA_MOUNTED) {
+                        removable = Environment.isExternalStorageRemovable(item)
+                        if (removable) {
+                            externalPath = item
+                        }
+                    }
+                }
             }
+            return externalPath
         }
     }
 
     override val name: String
         get() = "Storage Sensors"
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(StorageSensorManager.storageSensor)
+        get() = listOf(storageSensor)
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
@@ -49,7 +66,7 @@ class StorageSensorManager : SensorManager {
         sensorId: String
     ): SensorRegistration<Any> {
         return when (sensorId) {
-            StorageSensorManager.storageSensor.id -> getStorageSensor(context)
+            storageSensor.id -> getStorageSensor(context)
             else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
         }
     }
@@ -59,12 +76,12 @@ class StorageSensorManager : SensorManager {
         var totalInternalStorage = getTotalInternalMemorySize()
         var freeInternalStorage = getAvailableInternalMemorySize()
         val percentageFreeInternalStorage = getPercentageInternal()
-        val hasExternalStorage = externalMemoryAvailable()
+        externalPath = externalMemoryAvailable(context)
         var totalExternalStorage = "No SD Card"
         var freeExternalStorage = "No SD Card"
 
-        if (hasExternalStorage) {
-            val pathSD = context.getExternalFilesDir(null)
+        if (externalPath != null) {
+            val pathSD = context.getExternalFilesDir(externalPath.toString())
             val statSD = StatFs(pathSD?.path)
             blockSizeSD = statSD.blockSizeLong
             availableBlocksSD = statSD.availableBlocksLong

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -81,8 +81,7 @@ class StorageSensorManager : SensorManager {
         var freeExternalStorage = "No SD Card"
 
         if (externalPath != null) {
-            val pathSD = context.getExternalFilesDir(externalPath.toString())
-            val statSD = StatFs(pathSD?.path)
+            val statSD = StatFs(externalPath.toString())
             blockSizeSD = statSD.blockSizeLong
             availableBlocksSD = statSD.availableBlocksLong
             totalBlocksSD = statSD.blockCountLong


### PR DESCRIPTION
We were previously just using the default SD card path, unfortunately not all manufacturers use this path and override it.  To get around this we first grab all of the paths we can get, then we iterate through each one and check if its mounted and removable.  Only then will we send the data over on the SD card.

There is one caveat that if the user has a USB flash drive plugged in and a SD card then the reading may not be correct as the order in the array is never the same when it comes to external paths.  I think most users will only have a SD card inserted, I don't foresee having a flash drive plugged in while the phone is in the pocket.

I left some debug statements as well in case we don't capture all cases here so we can at least find a better solution.  Maybe dynamically add attributes for additional external storage devices?  I am not sure how we can differentiate between what is a USB drive and what is a SD card.

Fixes: #763 (hopefully)