### PR TITLE
Change order of package for apps that don't provide it

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -67,8 +67,7 @@ class NextAlarmManager : SensorManager {
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
 
-                pendingIntent = alarmClockInfo.showIntent?.creatorPackage?: "Unknown"
-
+                pendingIntent = alarmClockInfo.showIntent?.creatorPackage ?: "Unknown"
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -57,7 +57,6 @@ class NextAlarmManager : SensorManager {
 
             if (alarmClockInfo != null) {
                 triggerTime = alarmClockInfo.triggerTime
-                pendingIntent = alarmClockInfo.showIntent.creatorPackage.toString()
 
                 val cal: Calendar = GregorianCalendar()
                 cal.timeInMillis = triggerTime
@@ -67,6 +66,8 @@ class NextAlarmManager : SensorManager {
                 val sdf = SimpleDateFormat(dateFormat)
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
+
+                pendingIntent = alarmClockInfo.showIntent.creatorPackage.toString()
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -67,7 +67,8 @@ class NextAlarmManager : SensorManager {
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
 
-                pendingIntent = alarmClockInfo.showIntent.creatorPackage.toString()
+                pendingIntent = alarmClockInfo.showIntent?.creatorPackage?: "Unknown"
+
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)


### PR DESCRIPTION
Fixes: #774 

Turns out not all apps provide the `package` in the AlarmClockInfo intent and thus fails the call.  Lets move `package` to the end of the logic so the state and other attributes populate accordingly.