### PR TITLE
Add themes selector

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceDataStore
 import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import io.homeassistant.companion.android.domain.integration.Panel
+import io.homeassistant.companion.android.domain.themes.ThemesUseCase
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
@@ -18,7 +19,8 @@ class SettingsPresenterImpl @Inject constructor(
     private val settingsView: SettingsView,
     private val urlUseCase: UrlUseCase,
     private val integrationUseCase: IntegrationUseCase,
-    private val authenticationUseCase: AuthenticationUseCase
+    private val authenticationUseCase: AuthenticationUseCase,
+    private val themesUseCase: ThemesUseCase
 ) : SettingsPresenter, PreferenceDataStore() {
 
     companion object {
@@ -54,6 +56,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "connection_external" -> (urlUseCase.getUrl(false) ?: "").toString()
                 "registration_name" -> integrationUseCase.getRegistration().deviceName
                 "session_timeout" -> integrationUseCase.getSessionTimeOut().toString()
+                "themes" -> themesUseCase.getCurrentTheme()
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }
         }
@@ -72,6 +75,7 @@ class SettingsPresenterImpl @Inject constructor(
                         Log.e(TAG, "Issue updating registration with new device name", e)
                     }
                 }
+                "themes" -> themesUseCase.saveTheme(value)
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/util/ThemeHandler.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/ThemeHandler.kt
@@ -1,0 +1,70 @@
+package io.homeassistant.companion.android.util
+
+import android.content.Context
+import android.content.res.Configuration
+import android.webkit.WebView
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
+
+object ThemeHandler {
+    fun setNightModeBaseOnTheme(theme: String?) {
+        when (theme) {
+            "dark" -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            }
+            "system" -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+            }
+            else -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            }
+        }
+    }
+    fun setTheme(context: Context, webView: WebView?, theme: String?) {
+        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY) &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+            setNightModeBaseOnTheme(theme)
+            webView?.let {
+                WebSettingsCompat.setForceDarkStrategy(
+                    webView.settings,
+                    WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
+                )
+                when (theme) {
+                    "newTheme" ->
+                    {
+                        // Just a template for custom themes
+                        // context.setTheme(android.R.style.newTheme);
+                    }
+                    "dark" -> {
+                        WebSettingsCompat.setForceDark(
+                            webView.settings,
+                            WebSettingsCompat.FORCE_DARK_ON
+                        )
+                    }
+                    "system" -> {
+                        val nightModeFlags =
+                            context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                        if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
+                            WebSettingsCompat.setForceDark(
+                                webView.settings,
+                                WebSettingsCompat.FORCE_DARK_ON
+                            )
+                        } else {
+                            WebSettingsCompat.setForceDark(
+                                webView.settings,
+                                WebSettingsCompat.FORCE_DARK_OFF
+                            )
+                        }
+                    }
+                    else -> {
+                        WebSettingsCompat.setForceDark(
+                            webView.settings,
+                            WebSettingsCompat.FORCE_DARK_OFF
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -39,8 +39,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.graphics.ColorUtils
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.DaggerPresenterComponent
@@ -54,6 +52,7 @@ import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.sensors.LocationBroadcastReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
 import io.homeassistant.companion.android.settings.SettingsActivity
+import io.homeassistant.companion.android.util.ThemeHandler
 import io.homeassistant.companion.android.util.isStarted
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.activity_webview.*
@@ -334,14 +333,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             }, "externalApp")
         }
 
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-            val nightModeFlags = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-            if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
-                WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_ON)
-            } else {
-                WebSettingsCompat.setForceDark(webView.settings, WebSettingsCompat.FORCE_DARK_OFF)
-            }
-        }
+        ThemeHandler.setTheme(applicationContext, webView, presenter.getCurrentTheme())
 
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)
@@ -473,9 +465,9 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         } else {
             flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR // Add light flag
         }
-        window.decorView.systemUiVisibility = flags
         window.statusBarColor = color
         window.navigationBarColor = color
+        window.decorView.systemUiVisibility = flags
     }
 
     override fun setExternalAuth(script: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -24,4 +24,7 @@ interface WebViewPresenter {
     fun getSessionExpireMillis(): Long
 
     fun onFinish()
+
+    fun isFollowSystemTheme(): Boolean
+    fun getCurrentTheme(): String?
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -7,6 +7,7 @@ import io.homeassistant.companion.android.domain.authentication.AuthenticationUs
 import io.homeassistant.companion.android.domain.authentication.SessionState
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import io.homeassistant.companion.android.domain.integration.Panel
+import io.homeassistant.companion.android.domain.themes.ThemesUseCase
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.util.UrlHandler
 import java.net.URL
@@ -24,7 +25,8 @@ class WebViewPresenterImpl @Inject constructor(
     private val view: WebView,
     private val urlUseCase: UrlUseCase,
     private val authenticationUseCase: AuthenticationUseCase,
-    private val integrationUseCase: IntegrationUseCase
+    private val integrationUseCase: IntegrationUseCase,
+    private val themesUseCase: ThemesUseCase
 ) : WebViewPresenter {
 
     companion object {
@@ -121,6 +123,18 @@ class WebViewPresenterImpl @Inject constructor(
         mainScope.launch {
             urlUseCase.saveUrl("", true)
             urlUseCase.saveUrl("", false)
+        }
+    }
+
+    override fun isFollowSystemTheme(): Boolean {
+        return runBlocking {
+            themesUseCase.getCurrentTheme() == "system"
+        }
+    }
+
+    override fun getCurrentTheme(): String? {
+        return runBlocking {
+            themesUseCase.getCurrentTheme()
         }
     }
 

--- a/app/src/main/res/drawable/ic_color_lens_24dp.xml
+++ b/app/src/main/res/drawable/ic_color_lens_24dp.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M12,3c-4.97,0 -9,4.03 -9,9s4.03,9 9,9c0.83,0 1.5,-0.67 1.5,-1.5 0,-0.39 -0.15,-0.74 -0.39,-1.01 -0.23,-0.26 -0.38,-0.61 -0.38,-0.99 0,-0.83 0.67,-1.5 1.5,-1.5L16,16c2.76,0 5,-2.24 5,-5 0,-4.42 -4.03,-8 -9,-8zM6.5,12c-0.83,0 -1.5,-0.67 -1.5,-1.5S5.67,9 6.5,9 8,9.67 8,10.5 7.33,12 6.5,12zM9.5,8C8.67,8 8,7.33 8,6.5S8.67,5 9.5,5s1.5,0.67 1.5,1.5S10.33,8 9.5,8zM14.5,8c-0.83,0 -1.5,-0.67 -1.5,-1.5S13.67,5 14.5,5s1.5,0.67 1.5,1.5S15.33,8 14.5,8zM17.5,12c-0.83,0 -1.5,-0.67 -1.5,-1.5S16.67,9 17.5,9s1.5,0.67 1.5,1.5 -0.67,1.5 -1.5,1.5z"/>
+</vector>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -109,4 +109,22 @@
   <string name="widget_text_hint_service_data">Entitäts-ID</string>
   <string name="widget_text_hint_service_domain">Domain</string>
   <string name="widget_text_hint_service_service">Dienst</string>
+  <string name="themes_title_settings">Theme</string>
+  <string name="themes_option_label_light">Hell</string>
+  <string name="themes_option_label_dark">Dunkel</string>
+  <string name="themes_option_label_system">System-Einstellungen verwenden</string>
+  <string name="themes_option_value_light">light</string>
+  <string name="themes_option_value_dark">dark</string>
+  <string name="themes_option_value_system">system</string>
+  <array name="pref_theme_option_labels">
+    <item>@string/themes_option_label_light</item>
+    <item>@string/themes_option_label_dark</item>
+    <item>@string/themes_option_label_system</item>
+  </array>
+
+  <array name="pref_theme_option_values">
+    <item>@string/themes_option_value_light</item>
+    <item>@string/themes_option_value_dark</item>
+    <item>@string/themes_option_value_system</item>
+  </array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,22 @@ like to connect to:</string>
   <string name="widget_text_hint_service_data">Entity ID</string>
   <string name="widget_text_hint_service_domain">Domain</string>
   <string name="widget_text_hint_service_service">Service</string>
+  <string name="themes_title_settings">Theme</string>
+  <string name="themes_option_label_light">Light</string>
+  <string name="themes_option_label_dark">Dark</string>
+  <string name="themes_option_label_system">Follow System Settings</string>
+  <string name="themes_option_value_light">light</string>
+  <string name="themes_option_value_dark">dark</string>
+  <string name="themes_option_value_system">system</string>
+  <array name="pref_theme_option_labels">
+    <item>@string/themes_option_label_light</item>
+    <item>@string/themes_option_label_dark</item>
+    <item>@string/themes_option_label_system</item>
+  </array>
+
+  <array name="pref_theme_option_values">
+    <item>@string/themes_option_value_light</item>
+    <item>@string/themes_option_value_dark</item>
+    <item>@string/themes_option_value_system</item>
+  </array>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -44,6 +44,9 @@
         <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>
         <item name="buttonBarNegativeButtonStyle">@style/Alert.Button.Negative</item>
         <item name="android:textColorPrimary">@color/colorDialogMessage</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="textColorAlertDialogListItem">@color/colorDialogMessage</item>
+        <item name="colorControlNormal">@color/colorDialogMessage</item>
     </style>
 
     <style name="Authentication_Dialog" parent="Theme.MaterialComponents.Light.Dialog">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -65,7 +65,13 @@
             android:icon="@drawable/ic_plus"
             android:title="@string/nfc_title_settings"
             android:summary="@string/nfc_summary" />
-
+        <ListPreference
+            android:key="themes"
+            android:defaultValue="@string/themes_option_value_light"
+            android:entries="@array/pref_theme_option_labels"
+            android:entryValues="@array/pref_theme_option_values"
+            android:icon="@drawable/ic_color_lens_24dp"
+            android:title="@string/themes_title_settings"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/app_version_info">

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/AppComponent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/AppComponent.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.dagger
 import dagger.Component
 import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import io.homeassistant.companion.android.domain.themes.ThemesUseCase
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.domain.widgets.WidgetUseCase
 
@@ -16,4 +17,6 @@ interface AppComponent {
     fun integrationUseCase(): IntegrationUseCase
 
     fun widgetUseCase(): WidgetUseCase
+
+    fun themesUseCase(): ThemesUseCase
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/DataComponent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/DataComponent.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.dagger
 import dagger.Component
 import io.homeassistant.companion.android.domain.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.domain.integration.IntegrationRepository
+import io.homeassistant.companion.android.domain.themes.ThemesRepository
 import io.homeassistant.companion.android.domain.url.UrlRepository
 import io.homeassistant.companion.android.domain.widgets.WidgetRepository
 
@@ -16,4 +17,6 @@ interface DataComponent {
     fun integrationRepository(): IntegrationRepository
 
     fun widgetRepository(): WidgetRepository
+
+    fun themesRepository(): ThemesRepository
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/DataModule.kt
@@ -10,11 +10,13 @@ import io.homeassistant.companion.android.data.authentication.AuthenticationRepo
 import io.homeassistant.companion.android.data.authentication.AuthenticationService
 import io.homeassistant.companion.android.data.integration.IntegrationRepositoryImpl
 import io.homeassistant.companion.android.data.integration.IntegrationService
+import io.homeassistant.companion.android.data.themes.ThemesRepositoryImpl
 import io.homeassistant.companion.android.data.url.UrlRepositoryImpl
 import io.homeassistant.companion.android.data.widgets.WidgetRepositoryImpl
 import io.homeassistant.companion.android.data.wifi.WifiHelper
 import io.homeassistant.companion.android.domain.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.domain.integration.IntegrationRepository
+import io.homeassistant.companion.android.domain.themes.ThemesRepository
 import io.homeassistant.companion.android.domain.url.UrlRepository
 import io.homeassistant.companion.android.domain.widgets.WidgetRepository
 import javax.inject.Named
@@ -25,6 +27,7 @@ class DataModule(
     private val sessionLocalStorage: LocalStorage,
     private val integrationLocalStorage: LocalStorage,
     private val widgetLocalStorage: LocalStorage,
+    private val themesLocalStorage: LocalStorage,
     private val wifiHelper: WifiHelper,
     private val deviceId: String
 ) {
@@ -57,6 +60,10 @@ class DataModule(
     fun provideWidgetLocalStorage() = widgetLocalStorage
 
     @Provides
+    @Named("themes")
+    fun provideThemesLocalStorage() = themesLocalStorage
+
+    @Provides
     @Named("manufacturer")
     fun provideDeviceManufacturer(): String = Build.MANUFACTURER
 
@@ -85,5 +92,8 @@ class DataModule(
 
         @Binds
         fun bindWidgetRepositoryImpl(repository: WidgetRepositoryImpl): WidgetRepository
+
+        @Binds
+        fun bindThemesRepositoryImpl(repository: ThemesRepositoryImpl): ThemesRepository
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/DomainComponent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/DomainComponent.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.dagger
 import dagger.Component
 import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCase
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
+import io.homeassistant.companion.android.domain.themes.ThemesUseCase
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.domain.widgets.WidgetUseCase
 
@@ -16,4 +17,6 @@ interface DomainComponent {
     fun integrationUseCase(): IntegrationUseCase
 
     fun widgetUseCase(): WidgetUseCase
+
+    fun themesUseCase(): ThemesUseCase
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/DomainModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/DomainModule.kt
@@ -6,6 +6,8 @@ import io.homeassistant.companion.android.domain.authentication.AuthenticationUs
 import io.homeassistant.companion.android.domain.authentication.AuthenticationUseCaseImpl
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCaseImpl
+import io.homeassistant.companion.android.domain.themes.ThemesUseCase
+import io.homeassistant.companion.android.domain.themes.ThemesUseCaseImpl
 import io.homeassistant.companion.android.domain.url.UrlUseCase
 import io.homeassistant.companion.android.domain.url.UrlUseCaseImpl
 import io.homeassistant.companion.android.domain.widgets.WidgetUseCase
@@ -25,4 +27,7 @@ interface DomainModule {
 
     @Binds
     fun bindWidgetUseCase(useCaseImpl: WidgetUseCaseImpl): WidgetUseCase
+
+    @Binds
+    fun bindThemesUseCase(useCaseImpl: ThemesUseCaseImpl): ThemesUseCase
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/dagger/Graph.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/dagger/Graph.kt
@@ -55,6 +55,12 @@ class Graph(
                             Context.MODE_PRIVATE
                         )
                     ),
+                    LocalStorageImpl(
+                        application.getSharedPreferences(
+                            "themes",
+                            Context.MODE_PRIVATE
+                        )
+                    ),
                     WifiHelperImpl(application.getSystemService(Context.WIFI_SERVICE) as WifiManager),
                     Settings.Secure.getString(application.contentResolver, Settings.Secure.ANDROID_ID)
                 )

--- a/data/src/main/java/io/homeassistant/companion/android/data/themes/ThemesRepositoryImpl.kt
+++ b/data/src/main/java/io/homeassistant/companion/android/data/themes/ThemesRepositoryImpl.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.data.themes
+
+import io.homeassistant.companion.android.data.LocalStorage
+import io.homeassistant.companion.android.domain.themes.ThemesRepository
+import javax.inject.Inject
+import javax.inject.Named
+
+class ThemesRepositoryImpl  @Inject constructor(
+    @Named("themes") private val localStorage: LocalStorage
+) : ThemesRepository {
+
+    companion object {
+        private const val PREF_THEME = "theme"
+    }
+
+    override suspend fun getCurrentTheme(): String? {
+        return localStorage.getString(PREF_THEME)
+    }
+
+    override suspend fun saveTheme(theme: String) {
+        localStorage.putString(PREF_THEME, theme)
+
+    }
+}

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesRepository.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesRepository.kt
@@ -1,0 +1,7 @@
+package io.homeassistant.companion.android.domain.themes
+
+interface ThemesRepository {
+    suspend fun getCurrentTheme(): String?
+
+    suspend fun saveTheme(theme: String)
+}

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesUseCase.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesUseCase.kt
@@ -1,0 +1,9 @@
+package io.homeassistant.companion.android.domain.themes
+
+interface ThemesUseCase {
+
+    suspend fun getCurrentTheme(): String?
+
+    suspend fun saveTheme(theme: String?)
+
+}

--- a/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesUseCaseImpl.kt
+++ b/domain/src/main/java/io/homeassistant/companion/android/domain/themes/ThemesUseCaseImpl.kt
@@ -1,0 +1,20 @@
+package io.homeassistant.companion.android.domain.themes
+
+
+import javax.inject.Inject
+
+class ThemesUseCaseImpl @Inject constructor(
+    private val themesRepository: ThemesRepository
+) : ThemesUseCase
+{
+    override suspend fun getCurrentTheme(): String? {
+        val theme = themesRepository.getCurrentTheme()
+        return if(theme.isNullOrEmpty()) "light"
+        else theme
+    }
+
+    override suspend fun saveTheme(theme: String?) {
+        theme?.let { themesRepository.saveTheme(it) }
+
+    }
+}


### PR DESCRIPTION
Fixes #773

This PR adds a theme selector to the preferences activity.

Now a user can use a light theme in HA and the dark mode of the system combined. He can easy set the theme of the app to "Light". 
<img src="https://user-images.githubusercontent.com/12832850/90344111-de32e080-e016-11ea-9336-f259a9af26b8.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/90344114-dffca400-e016-11ea-86c6-5c4df9c5f7a0.png" width="40%">