### PR TITLE
Enhance PhoneStateSensorManager with carrier information sensors

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -2,6 +2,9 @@ package io.homeassistant.companion.android.sensors
 
 import android.Manifest
 import android.content.Context
+import android.os.Build
+import android.telephony.SubscriptionInfo
+import android.telephony.SubscriptionManager
 import android.telephony.TelephonyManager
 import io.homeassistant.companion.android.domain.integration.SensorRegistration
 
@@ -14,13 +17,25 @@ class PhoneStateSensorManager : SensorManager {
             "sensor",
             "Phone State"
         )
+
+        val sim_1 = SensorManager.BasicSensor(
+            "sim_1",
+            "sensor",
+            "SIM_1"
+        )
+
+        val sim_2 = SensorManager.BasicSensor(
+            "sim_2",
+            "sensor",
+            "SIM_2"
+        )
     }
 
     override val name: String
         get() = "Phone Sensors"
 
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(phoneState)
+        get() = listOf(phoneState, sim_1, sim_2)
 
     override fun requiredPermissions(): Array<String> {
         return arrayOf(Manifest.permission.READ_PHONE_STATE)
@@ -32,6 +47,8 @@ class PhoneStateSensorManager : SensorManager {
     ): SensorRegistration<Any> {
         return when (sensorId) {
             phoneState.id -> getPhoneStateSensor(context)
+            sim_1.id -> getSimSensor(context, 0)
+            sim_2.id -> getSimSensor(context, 1)
             else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
         }
     }
@@ -59,5 +76,45 @@ class PhoneStateSensorManager : SensorManager {
             phoneIcon,
             mapOf()
         )
+    }
+
+    private fun getSimSensor(context: Context, slotIndex: Int): SensorRegistration<Any> {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+            var displayName = "Unavailable"
+            val attrs = mutableMapOf<String, Any>()
+
+            if (checkPermission(context)) {
+                val subscriptionManager =
+                    (context.applicationContext.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE)) as SubscriptionManager
+                val info: SubscriptionInfo? = subscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(slotIndex)
+
+                if (info != null) {
+                    displayName = info.displayName.toString()
+                    attrs["carrier name"] = info.carrierName
+                    attrs["iso country code"] = info.countryIso
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        attrs["carrier id"] = info.carrierId
+                        attrs["mcc"] = info.mccString.toString()
+                        attrs["mnc"] = info.mncString.toString()
+                        attrs["is opportunistic"] = info.isOpportunistic
+                    if (info.dataRoaming == SubscriptionManager.DATA_ROAMING_ENABLE) attrs["data roaming"] = "enable"
+                        else attrs["data roaming"] = "disable"
+                    }
+                }
+            }
+
+            if (slotIndex == 1) {
+                return sim_2.toSensorRegistration(
+                    displayName,
+                    "mdi:sim",
+                    attrs
+                )
+            }
+            return sim_1.toSensorRegistration(
+                displayName,
+                "mdi:sim",
+                attrs
+            )
+        } else throw IllegalArgumentException("Sensor is not supported in current OS version. API 22 or above is required")
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -35,7 +35,9 @@ class PhoneStateSensorManager : SensorManager {
         get() = "Phone Sensors"
 
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(phoneState, sim_1, sim_2)
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
+            listOf(phoneState, sim_1, sim_2)
+        else listOf(phoneState)
 
     override fun requiredPermissions(): Array<String> {
         return arrayOf(Manifest.permission.READ_PHONE_STATE)


### PR DESCRIPTION
Fixes #768 

PR enhance current PhoneStateSensorManager with 2 new sensors SIM_1 and SIM_2. 
![Untitled](https://user-images.githubusercontent.com/3670941/90637996-642c7280-e235-11ea-8b77-cc3b6619a622.png)

Sensors require api level 22 or above. Moreover attributes {"carrier id", "mcc", "mnc", "is opportunistic", "data roaming"} require api 29+

I didn't add OnSubscriptionsChangedListener so sensors will be updated only on regular basis