### PR TITLE
Add steps counter sensor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -27,6 +27,7 @@ class SensorReceiver : BroadcastReceiver() {
             LightSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
+            StepsSensorManager(),
             StorageSensorManager()
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -1,0 +1,79 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Context.SENSOR_SERVICE
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import kotlin.math.roundToInt
+
+class StepsSensorManager : SensorManager, SensorEventListener {
+    companion object {
+
+        private const val TAG = "StepsSensor"
+        private val stepsSensor = SensorManager.BasicSensor(
+            "steps_sensor",
+            "sensor",
+            "Steps Sensor",
+            unitOfMeasurement = "steps"
+        )
+        private var stepsReading: String = "unavailable"
+        lateinit var mySensorManager: android.hardware.SensorManager
+    }
+
+    override val name: String
+        get() = "Steps Sensors"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(stepsSensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            stepsSensor.id -> getStepsSensor(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getStepsSensor(context: Context): SensorRegistration<Any> {
+
+        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+
+        val stepsSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
+        if (stepsSensors != null) {
+            mySensorManager.registerListener(
+                this,
+                stepsSensors,
+                SENSOR_DELAY_NORMAL)
+        }
+
+        val icon = "mdi:brightness-5"
+
+        return stepsSensor.toSensorRegistration(
+            stepsReading,
+            icon,
+            mapOf()
+        )
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // Nothing happening here but we are required to call onAccuracyChanged for sensor events
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event != null) {
+            if (event.sensor.type == Sensor.TYPE_STEP_COUNTER) {
+                stepsReading = event.values[0].roundToInt().toString()
+            }
+        }
+        mySensorManager.unregisterListener(this)
+    }
+}


### PR DESCRIPTION
This PR adds a steps counter based on the devices hardware.  There is one caveat in that android only resets the steps total when the device is restarted, for now we are providing the raw data.  This sensor also requires explicit permissions for Activity Recognition (just like #784 ) and is disabled until permissions are granted.  Once the sensor is enabled we will ask for permissions on devices that require it.  There is no receiver for this sensor so it will only update when other sensors are triggered or during the sensor update interval.

![image](https://user-images.githubusercontent.com/1634145/90697995-8a054780-e234-11ea-97c4-81936c9884ff.png)

![image](https://user-images.githubusercontent.com/1634145/90698007-9093bf00-e234-11ea-8893-9d89c9b8ed21.png)
