### PR TITLE
Add last reboot sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
@@ -1,0 +1,76 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.os.SystemClock
+import android.util.Log
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+class LastRebootSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "LastReboot"
+
+        private val lastRebootSensor = SensorManager.BasicSensor(
+            "last_reboot",
+            "sensor",
+            "Last Reboot",
+            "timestamp"
+        )
+    }
+
+    override val name: String
+        get() = "Last Reboot Sensor"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(lastRebootSensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            lastRebootSensor.id -> getLastReboot()
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getLastReboot(): SensorRegistration<Any> {
+
+        var timeInMillis = 0L
+        var local = ""
+        var utc = "unavailable"
+
+        try {
+            timeInMillis = System.currentTimeMillis() - SystemClock.elapsedRealtime()
+            val cal: Calendar = GregorianCalendar()
+            cal.timeInMillis = timeInMillis
+            local = cal.time.toString()
+
+            val dateFormat = "yyyy-MM-dd'T'HH:mm:ss'Z'"
+            val sdf = SimpleDateFormat(dateFormat)
+            sdf.timeZone = TimeZone.getTimeZone("UTC")
+            utc = sdf.format(Date(timeInMillis))
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the last reboot timestamp", e)
+        }
+
+        val icon = "mdi:restart"
+
+        return lastRebootSensor.toSensorRegistration(
+            utc,
+            icon,
+            mapOf(
+                "Local Time" to local,
+                "Time in Milliseconds" to timeInMillis
+            )
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -22,9 +22,10 @@ class SensorReceiver : BroadcastReceiver() {
         val MANAGERS = listOf(
             BatterySensorManager(),
             BluetoothSensorManager(),
-            NetworkSensorManager(),
             GeocodeSensorManager(),
+            LastRebootSensorManager(),
             LightSensorManager(),
+            NetworkSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
             StepsSensorManager(),


### PR DESCRIPTION
This PR adds a last reboot sensor that is a timestamp of the time the device last booted up.  It was mentioned in #792 that steps are reset only during the last reboot so I thought this might be helpful.  To match the Next Alarm sensor attributes for local time and time in milliseconds are also provided.

![image](https://user-images.githubusercontent.com/1634145/90713621-99978700-e25a-11ea-8bfe-68022156a809.png)
