### PR TITLE
Add proximity sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -1,0 +1,87 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Context.SENSOR_SERVICE
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import kotlin.math.roundToInt
+
+class ProximitySensorManager : SensorManager, SensorEventListener {
+    companion object {
+
+        private const val TAG = "ProximitySensor"
+        private val proximitySensor = SensorManager.BasicSensor(
+            "proximity_sensor",
+            "sensor",
+            "Proximity Sensor"
+        )
+        private var proximityReading: String = "unavailable"
+        lateinit var mySensorManager: android.hardware.SensorManager
+    }
+
+    override val name: String
+        get() = "Proximity Sensors"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(proximitySensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            proximitySensor.id -> getProximitySensor(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getProximitySensor(context: Context): SensorRegistration<Any> {
+
+        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+
+        val proximitySensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY)
+        if (proximitySensors != null) {
+            mySensorManager.registerListener(
+                this,
+                proximitySensors,
+                SENSOR_DELAY_NORMAL)
+
+            // Some devices only report 2 values, one of which is the max range so lets account for those devices
+            if (proximitySensors.maximumRange.roundToInt() == 5) {
+                proximityReading = if (proximityReading == "5") {
+                    "far"
+                } else {
+                    "near"
+                }
+            }
+        }
+
+        val icon = "mdi:leak"
+
+        return proximitySensor.toSensorRegistration(
+            proximityReading,
+            icon,
+            mapOf()
+        )
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // Nothing happening here but we are required to call onAccuracyChanged for sensor events
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event != null) {
+            if (event.sensor.type == Sensor.TYPE_PROXIMITY) {
+                proximityReading = event.values[0].roundToInt().toString()
+            }
+        }
+        mySensorManager.unregisterListener(this)
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -28,6 +28,7 @@ class SensorReceiver : BroadcastReceiver() {
             NetworkSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
+            ProximitySensorManager(),
             StepsSensorManager(),
             StorageSensorManager()
         )


### PR DESCRIPTION
This PR adds a proximity sensor which will update during the sensor update interval. Based on the [docs](https://developer.android.com/guide/topics/sensors/sensors_position#sensors-pos-prox) not all devices report the actual distance in a real value. 

```
Note: Some proximity sensors return binary values that represent "near" or "far." In this case, the sensor usually reports its maximum range value in the far state and a lesser value in the near state. Typically, the far value is a value > 5 cm, but this can vary from sensor to sensor. You can determine a sensor's maximum range by using the getMaximumRange() method.
```

 Some devices, like my Pixel 4 XL only report 2 values either `5` or `0` for `far` or `near` respectively. We account for this difference and the state will be `far` or `near` only on those devices.  For devices whose `maximumRange` is not 5 we will continue to show the raw data.

I am not certain how this will work on other devices but on devices that do not have a proximity sensor the state remains as `unavailable`.  We may need to get some feedback from users on this as there very well can be differences between manufacturers.  For my test I basically put my hand over the sensor to get a `near` reading and taking away my hand would generate a `far` reading.  To my understanding some device manufacturers use a combination of this binary reading along with the light sensor value to really judge if something is close by or not.

![image](https://user-images.githubusercontent.com/1634145/90939167-cc0ec480-e3bf-11ea-860a-84ff61f91cbb.png)
