### PR TITLE
Fix top button back stack of settings activity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -11,7 +11,6 @@ import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.settings.ssid.SsidDialogFragment
 import io.homeassistant.companion.android.settings.ssid.SsidPreference
-import io.homeassistant.companion.android.webview.WebViewActivity
 
 class SettingsActivity : AppCompatActivity(),
     PreferenceFragmentCompat.OnPreferenceDisplayDialogCallback {


### PR DESCRIPTION
Right now the top button back stack of the settings screen is frustrating. If you open sensors screen and then go back, the web view screen is called again instead of the previous settings screen. Just the same for: sensors -> a random sensor. If you leave the specific sensor screen, the web view screen is called.
It should instead go back to the previous screen.

Edit: This behavior does only occur if the back button on top is used.

This PR fixes this behavior. 