### PR TITLE
Add pressure sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -1,0 +1,80 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Context.SENSOR_SERVICE
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+import java.math.RoundingMode
+
+class PressureSensorManager : SensorManager, SensorEventListener {
+    companion object {
+
+        private const val TAG = "PressureSensor"
+        private val pressureSensor = SensorManager.BasicSensor(
+            "pressure_sensor",
+            "sensor",
+            "Pressure Sensor",
+            "pressure",
+            "hPa"
+        )
+        private var pressureReading: String = "unavailable"
+        lateinit var mySensorManager: android.hardware.SensorManager
+    }
+
+    override val name: String
+        get() = "Pressure Sensors"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(pressureSensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            pressureSensor.id -> getPressureSensor(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getPressureSensor(context: Context): SensorRegistration<Any> {
+
+        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+
+        val pressureSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
+        if (pressureSensors != null) {
+            mySensorManager.registerListener(
+                this,
+                pressureSensors,
+                SENSOR_DELAY_NORMAL)
+        }
+
+        val icon = "mdi:gauge"
+
+        return pressureSensor.toSensorRegistration(
+            pressureReading,
+            icon,
+            mapOf()
+        )
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // Nothing happening here but we are required to call onAccuracyChanged for sensor events
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event != null) {
+            if (event.sensor.type == Sensor.TYPE_PRESSURE) {
+                pressureReading = event.values[0].toBigDecimal().setScale(1, RoundingMode.HALF_EVEN).toString()
+            }
+        }
+        mySensorManager.unregisterListener(this)
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -28,6 +28,7 @@ class SensorReceiver : BroadcastReceiver() {
             NetworkSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
+            PressureSensorManager(),
             StepsSensorManager(),
             StorageSensorManager()
         )


### PR DESCRIPTION
This PR adds a pressure sensor based on the devices local sensor. Its a raw reading and we only round to the first decimal point since my Pixel 4 XL had 4-5.  Devices that do not have a pressure sensor will show `unavailable`.  This sensor only updates with the sensor update interval.

![image](https://user-images.githubusercontent.com/1634145/90941060-e3e94700-e3c5-11ea-9a8d-e39463b0c6a5.png)
