### PR TITLE
Fix back stack of mobileAppIntegrationFragment

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -94,6 +94,7 @@ class OnboardingActivity : AppCompatActivity(), DiscoveryListener, ManualSetupLi
         supportFragmentManager
             .beginTransaction()
             .replace(R.id.content, mobileAppIntegrationFragment)
+            .addToBackStack(null)
             .commit()
     }
 


### PR DESCRIPTION
Back button of permission screen doesn't work. On back button press, the permission screen overlays the previous screen.