### PR TITLE
Add audio sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -4,7 +4,9 @@ import android.app.Application
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.IntentFilter
+import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.telephony.TelephonyManager
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
@@ -50,9 +52,31 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
             }
         )
 
+        //Listen for bluetooth state changes
         registerReceiver(sensorReceiver,
             IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
         )
+
+        // Listen to changes to the audio input/output on the device
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter().apply {
+                addAction(AudioManager.ACTION_AUDIO_BECOMING_NOISY)
+                addAction(AudioManager.ACTION_HEADSET_PLUG)
+                addAction(AudioManager.RINGER_MODE_CHANGED_ACTION)
+            }
+        )
+
+        // Add extra audio receiver for devices that support it
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            registerReceiver(
+                sensorReceiver,
+                IntentFilter().apply {
+                    addAction(AudioManager.ACTION_MICROPHONE_MUTE_CHANGED)
+                    addAction(AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED)
+                }
+            )
+        }
     }
 
     override val appComponent: AppComponent

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -52,7 +52,7 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
             }
         )
 
-        //Listen for bluetooth state changes
+        // Listen for bluetooth state changes
         registerReceiver(sensorReceiver,
             IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -1,0 +1,103 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.media.AudioDeviceInfo
+import android.media.AudioManager
+import android.os.Build
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+
+class AudioSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "AudioSensor"
+
+        private val audioSensor = SensorManager.BasicSensor(
+            "audio_sensor",
+            "sensor",
+            "Audio Sensor"
+        )
+    }
+
+    override val name: String
+        get() = "Audio Sensor"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(audioSensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            audioSensor.id -> getAudioSensor(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getAudioSensor(context: Context): SensorRegistration<Any> {
+
+        val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val audioMode = when(audioManager.mode) {
+            AudioManager.MODE_NORMAL -> "normal"
+            AudioManager.MODE_RINGTONE -> "ringing"
+            AudioManager.MODE_IN_CALL -> "in_call"
+            AudioManager.MODE_IN_COMMUNICATION -> "in_communication"
+            else -> "unknown"
+        }
+
+        val ringerMode = when(audioManager.ringerMode) {
+            AudioManager.RINGER_MODE_NORMAL -> "normal"
+            AudioManager.RINGER_MODE_SILENT -> "silent"
+            AudioManager.RINGER_MODE_VIBRATE -> "vibrate"
+            else -> "unknown"
+        }
+
+        val isMicMuted = audioManager.isMicrophoneMute
+
+        val isMusicActive = audioManager.isMusicActive
+
+        val isSpeakerOn = audioManager.isSpeakerphoneOn
+        var isHeadphones = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_ALL)
+            for(deviceInfo in audioDevices) {
+                if (deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES || deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADSET || deviceInfo.type == AudioDeviceInfo.TYPE_USB_HEADSET)
+                    isHeadphones = true
+            }
+        } else {
+            // Use deprecated method as getDevices is API 23 and up only and we support API 21
+            isHeadphones = audioManager.isWiredHeadsetOn
+        }
+
+        val volumeLevelAlarm = audioManager.getStreamVolume(AudioManager.STREAM_ALARM)
+        val volumeLevelCall = audioManager.getStreamVolume(AudioManager.STREAM_VOICE_CALL)
+        val volumeLevelMusic = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
+        val volumeLevelRing = audioManager.getStreamVolume(AudioManager.STREAM_RING)
+
+        val icon = when(audioManager.ringerMode) {
+            AudioManager.RINGER_MODE_NORMAL -> "mdi:volume-high"
+            AudioManager.RINGER_MODE_SILENT -> "mdi:volume-off"
+            AudioManager.RINGER_MODE_VIBRATE -> "mdi:vibrate"
+            else -> "mdi:volume-low"
+        }
+
+        return audioSensor.toSensorRegistration(
+            ringerMode,
+            icon,
+            mapOf(
+                "audio_mode" to audioMode,
+                "is_headphones" to isHeadphones,
+                "is_mic_muted" to isMicMuted,
+                "is_music_active" to isMusicActive,
+                "is_speakerphone_on" to isSpeakerOn,
+                "volume_level_alarm" to volumeLevelAlarm,
+                "volume_level_call" to volumeLevelCall,
+                "volume_level_music" to volumeLevelMusic,
+                "volume_level_ring" to volumeLevelRing
+            )
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -62,7 +62,7 @@ class AudioSensorManager : SensorManager {
         val isSpeakerOn = audioManager.isSpeakerphoneOn
         var isHeadphones = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_ALL)
+            val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
             for (deviceInfo in audioDevices) {
                 if (deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES || deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADSET || deviceInfo.type == AudioDeviceInfo.TYPE_USB_HEADSET)
                     isHeadphones = true

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -40,7 +40,7 @@ class AudioSensorManager : SensorManager {
     private fun getAudioSensor(context: Context): SensorRegistration<Any> {
 
         val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        val audioMode = when(audioManager.mode) {
+        val audioMode = when (audioManager.mode) {
             AudioManager.MODE_NORMAL -> "normal"
             AudioManager.MODE_RINGTONE -> "ringing"
             AudioManager.MODE_IN_CALL -> "in_call"
@@ -48,7 +48,7 @@ class AudioSensorManager : SensorManager {
             else -> "unknown"
         }
 
-        val ringerMode = when(audioManager.ringerMode) {
+        val ringerMode = when (audioManager.ringerMode) {
             AudioManager.RINGER_MODE_NORMAL -> "normal"
             AudioManager.RINGER_MODE_SILENT -> "silent"
             AudioManager.RINGER_MODE_VIBRATE -> "vibrate"
@@ -63,7 +63,7 @@ class AudioSensorManager : SensorManager {
         var isHeadphones = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_ALL)
-            for(deviceInfo in audioDevices) {
+            for (deviceInfo in audioDevices) {
                 if (deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES || deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADSET || deviceInfo.type == AudioDeviceInfo.TYPE_USB_HEADSET)
                     isHeadphones = true
             }
@@ -77,7 +77,7 @@ class AudioSensorManager : SensorManager {
         val volumeLevelMusic = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
         val volumeLevelRing = audioManager.getStreamVolume(AudioManager.STREAM_RING)
 
-        val icon = when(audioManager.ringerMode) {
+        val icon = when (audioManager.ringerMode) {
             AudioManager.RINGER_MODE_NORMAL -> "mdi:volume-high"
             AudioManager.RINGER_MODE_SILENT -> "mdi:volume-off"
             AudioManager.RINGER_MODE_VIBRATE -> "mdi:vibrate"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -20,6 +20,7 @@ class SensorReceiver : BroadcastReceiver() {
     companion object {
         const val TAG = "SensorReceiver"
         val MANAGERS = listOf(
+            AudioSensorManager(),
             BatterySensorManager(),
             BluetoothSensorManager(),
             GeocodeSensorManager(),


### PR DESCRIPTION
Time for an audio sensor.

The state of the sensor will reflect the ringer mode of the device as we can listen to those changes immediately. Possible states are `normal`, `silent`, `vibrate` and `unknown`. The icon will reflect the state of the device.

Attributes:

- audio mode:  will show whether the device is `ringing`, `in_call` (identical to phone sensor), `in_communication` (using any other app for communication needs that uses audio/video), `normal` and `unknown`. In the next version of Android it will also be able to support whether a call is being screened.
- is headphones: boolean depending if headphones are plugged in, can be either USB headphones, headset or normal wired headphones, this will update immediately when connected/disconnected. Note: I did need to use a deprecated API in order to support API 21-22 here.
- is mic muted: boolean, will update immediately on devices that support it
- is music active: boolean, will update with normal sensor update interval
- is speakerphone on: boolean, will update immediately on devices that support it
- volume level for `alarm`, `call`, `music` and `ringer`

![image](https://user-images.githubusercontent.com/1634145/91004480-2e66f100-e589-11ea-99ea-0e157145274c.png)
