### PR TITLE
Add do not disturb sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android
 
 import android.app.Application
+import android.app.NotificationManager
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.IntentFilter
@@ -75,6 +76,14 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
                     addAction(AudioManager.ACTION_MICROPHONE_MUTE_CHANGED)
                     addAction(AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED)
                 }
+            )
+        }
+
+        // Add receiver for DND changes on devices that support it
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            registerReceiver(
+                sensorReceiver,
+                IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED)
             )
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -1,0 +1,62 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.provider.Settings.Global
+import android.util.Log
+import io.homeassistant.companion.android.domain.integration.SensorRegistration
+
+class DNDSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "DNDSensor"
+
+        private val dndSensor = SensorManager.BasicSensor(
+            "dnd_sensor",
+            "sensor",
+            "Do Not Disturb"
+        )
+        var dndState = "unavailable"
+    }
+
+    override val name: String
+        get() = "Do Not Disturb Sensor"
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(dndSensor)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun getSensorData(
+        context: Context,
+        sensorId: String
+    ): SensorRegistration<Any> {
+        return when (sensorId) {
+            dndSensor.id -> getDNDState(context)
+            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
+        }
+    }
+
+    private fun getDNDState(context: Context): SensorRegistration<Any> {
+
+        try {
+            dndState = when (Global.getInt(context.contentResolver, "zen_mode")) {
+                0 -> "off"
+                1 -> "priority_only"
+                2 -> "total_silence"
+                3 -> "alarms_only"
+                else -> "unknown"
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the devices DND mode", e)
+        }
+
+        val icon = "mdi:do-not-disturb"
+
+        return dndSensor.toSensorRegistration(
+            dndState,
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -12,7 +12,7 @@ class DNDSensorManager : SensorManager {
         private val dndSensor = SensorManager.BasicSensor(
             "dnd_sensor",
             "sensor",
-            "Do Not Disturb"
+            "Do Not Disturb Sensor"
         )
         var dndState = "unavailable"
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.sensors
 import android.content.Context
 import android.provider.Settings.Global
 import android.util.Log
-import io.homeassistant.companion.android.domain.integration.SensorRegistration
 
 class DNDSensorManager : SensorManager {
     companion object {
@@ -27,17 +26,14 @@ class DNDSensorManager : SensorManager {
         return emptyArray()
     }
 
-    override fun getSensorData(
-        context: Context,
-        sensorId: String
-    ): SensorRegistration<Any> {
-        return when (sensorId) {
-            dndSensor.id -> getDNDState(context)
-            else -> throw IllegalArgumentException("Unknown sensorId: $sensorId")
-        }
+    override fun requestSensorUpdate(context: Context) {
+        updateDNDState(context)
     }
 
-    private fun getDNDState(context: Context): SensorRegistration<Any> {
+    private fun updateDNDState(context: Context) {
+
+        if (!isEnabled(context, dndSensor.id))
+            return
 
         try {
             dndState = when (Global.getInt(context.contentResolver, "zen_mode")) {
@@ -53,7 +49,8 @@ class DNDSensorManager : SensorManager {
 
         val icon = "mdi:do-not-disturb"
 
-        return dndSensor.toSensorRegistration(
+        onSensorUpdated(context,
+            dndSensor,
             dndState,
             icon,
             mapOf()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -13,7 +13,6 @@ class DNDSensorManager : SensorManager {
             "sensor",
             "Do Not Disturb Sensor"
         )
-        var dndState = "unavailable"
     }
 
     override val name: String
@@ -35,6 +34,7 @@ class DNDSensorManager : SensorManager {
         if (!isEnabled(context, dndSensor.id))
             return
 
+        var dndState = "unavailable"
         try {
             dndState = when (Global.getInt(context.contentResolver, "zen_mode")) {
                 0 -> "off"
@@ -43,17 +43,16 @@ class DNDSensorManager : SensorManager {
                 3 -> "alarms_only"
                 else -> "unknown"
             }
+            val icon = "mdi:do-not-disturb"
+
+            onSensorUpdated(context,
+                dndSensor,
+                dndState,
+                icon,
+                mapOf()
+            )
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the devices DND mode", e)
         }
-
-        val icon = "mdi:do-not-disturb"
-
-        onSensorUpdated(context,
-            dndSensor,
-            dndState,
-            icon,
-            mapOf()
-        )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -24,6 +24,7 @@ class SensorReceiver : BroadcastReceiver() {
             AudioSensorManager(),
             BatterySensorManager(),
             BluetoothSensorManager(),
+            DNDSensorManager(),
             GeocodeSensorManager(),
             LastRebootSensorManager(),
             LightSensorManager(),


### PR DESCRIPTION
This PR adds a Do Not Disturb sensor that will update its state immediately upon a state change on Android 6.0+ devices. The initial state of the sensor will be `unavailable` for some devices that have never set their device into DND mode (I noticed my fire tablet on Android 5.0 experienced this behavior at first). When google first launched DND mode it was called interruptions and over time they had slowly made changes to its behavior.  This PR attempts to get the state from all supported Android versions, even the ones that don't support all the states like on Android 10.

State value are: `off`, `priority_only`, `total_silence`, `alarms_only` or `unknown` in addition to `unavailable` as mentioned up above.

On my pixel 4 xl the state is either `off` or `priority_only` I could not get it to be any of the other states.  On my Fire Tablet which is Android 5 I can see `off` `priority_only` and `total_silence` I suspect the other states are in different versions of Android.  We are just reading the value anyways and interpretting it from there.

https://stackoverflow.com/questions/31387137/android-detect-do-not-disturb-status

Fixes: #807 with the exception that we don't control the device yet

![image](https://user-images.githubusercontent.com/1634145/91221689-ddfbaa80-e6d2-11ea-84af-64c2ed8a5f20.png)
