### PR TITLE
Use latest context in pressure and proximity sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -35,15 +35,15 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun requestSensorUpdate(context: Context) {
+        latestContext = context
         updatePressureSensor(context)
     }
 
     private fun updatePressureSensor(context: Context) {
-        if (!isEnabled(context, pressureSensor.id))
+        if (!isEnabled(latestContext, pressureSensor.id))
             return
 
-        latestContext = context
-        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+        mySensorManager = latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val pressureSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
         if (pressureSensors != null) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -39,10 +39,10 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateProximitySensor(context: Context) {
-        if (!isEnabled(context, proximitySensor.id))
+        if (!isEnabled(latestContext, proximitySensor.id))
             return
 
-        mySensorManager = context.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
+        mySensorManager = latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val proximitySensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY)
         if (proximitySensors != null) {


### PR DESCRIPTION
Was testing out the new sensor updates interval on the settings screen and noticed 2 sensors that were not updating unless the others had updates.  Added `latestContext` in the same places and it updated as I expected :) I basically copied what we did in the light sensor for these other hardware sensors.