### PR TITLE
Fix geocoded crash, report expected minimum accuracy for location

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -59,7 +59,7 @@ class GeocodeSensorManager : SensorManager {
                         .getFromLocation(location.latitude, location.longitude, 1)
                         .firstOrNull()
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to get geocoded location")
+                Log.e(TAG, "Failed to get geocoded location", e)
             }
             val attributes = address?.let {
                 mapOf(

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -54,7 +54,6 @@ class GeocodeSensorManager : SensorManager {
                     return@addOnSuccessListener
                 }
 
-
                 if (location.accuracy <= LocationSensorManager.MINIMUM_ACCURACY)
                     address = Geocoder(context)
                         .getFromLocation(location.latitude, location.longitude, 1)

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -7,6 +7,7 @@ import android.location.Geocoder
 import android.os.Build
 import android.util.Log
 import com.google.android.gms.location.LocationServices
+import java.lang.Exception
 
 class GeocodeSensorManager : SensorManager {
 
@@ -46,17 +47,21 @@ class GeocodeSensorManager : SensorManager {
             return
         val locApi = LocationServices.getFusedLocationProviderClient(context)
         locApi.lastLocation.addOnSuccessListener { location ->
-            if (location == null) {
-                Log.e(TAG, "Somehow location is null even though it was successful")
-                return@addOnSuccessListener
-            }
-
             var address: Address? = null
-            if (location.accuracy <= LocationSensorManager.MINIMUM_ACCURACY)
-                address = Geocoder(context)
-                    .getFromLocation(location.latitude, location.longitude, 1)
-                    .firstOrNull()
+            try {
+                if (location == null) {
+                    Log.e(TAG, "Somehow location is null even though it was successful")
+                    return@addOnSuccessListener
+                }
 
+
+                if (location.accuracy <= LocationSensorManager.MINIMUM_ACCURACY)
+                    address = Geocoder(context)
+                        .getFromLocation(location.latitude, location.longitude, 1)
+                        .firstOrNull()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to get geocoded location")
+            }
             val attributes = address?.let {
                 mapOf(
                     "Administrative Area" to it.adminArea,

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -191,10 +191,14 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                     "\nAccuracy: ${location.accuracy}" +
                     "\nBearing: ${location.bearing}"
         )
+        var accuracy = 0
+        if (location.accuracy.toInt() >= 0) {
+            accuracy = location.accuracy.toInt()
+        }
         val updateLocation = UpdateLocation(
             "",
             arrayOf(location.latitude, location.longitude),
-            location.accuracy.toInt(),
+            accuracy,
             location.speed.toInt(),
             location.altitude.toInt(),
             location.bearing.toInt(),


### PR DESCRIPTION
Fixes: #830 

Also fixes a edge case where sometimes we were sending an invalid `gps_accuracy` attribute which was less than 0.

Example error from HA: `Received invalid webhook payload: value must be at least 0 for dictionary value @ data['gps_accuracy']. Got -2147478` and `Received invalid webhook payload: value must be at least 0 for dictionary value @ data['gps_accuracy']. Got -2147471`

During these errors all updates do not come through so when we detect that accuracy >= 0 we will send the real value, otherwise we will send `0` which is the bare minimum that HA will accept