### PR TITLE
Bump some app dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -35,7 +35,7 @@ object Config {
         }
 
         object Google {
-            private const val daggerVersion = "2.27"
+            private const val daggerVersion = "2.28.3"
             const val dagger = "com.google.dagger:dagger:${daggerVersion}"
             const val daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
 
@@ -44,17 +44,17 @@ object Config {
 
         object AndroidX {
 
-            const val webKit = "androidx.webkit:webkit:1.3.0-rc02"
-            const val appcompat = "androidx.appcompat:appcompat:1.1.0"
+            const val webKit = "androidx.webkit:webkit:1.3.0"
+            const val appcompat = "androidx.appcompat:appcompat:1.2.0"
             const val lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
             const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"
-            const val constraintlayout = "androidx.constraintlayout:constraintlayout:1.1.3"
+            const val constraintlayout = "androidx.constraintlayout:constraintlayout:2.0.0"
             const val preference = "androidx.preference:preference-ktx:1.1.1"
 
             const val navigationFragment = "androidx.navigation:navigation-fragment-ktx:2.3.0"
             const val navigationUi = "androidx.navigation:navigation-ui-ktx:2.3.0"
 
-            const val workManager = "androidx.work:work-runtime-ktx:2.3.4"
+            const val workManager = "androidx.work:work-runtime-ktx:2.4.0"
             const val biometric = "androidx.biometric:biometric:1.0.1"
 
             private const val roomVersion = "2.2.5"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -45,7 +45,7 @@ object Config {
         object AndroidX {
 
             const val webKit = "androidx.webkit:webkit:1.3.0"
-            const val appcompat = "androidx.appcompat:appcompat:1.2.0"
+            const val appcompat = "androidx.appcompat:appcompat:1.1.0"
             const val lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
             const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"
             const val constraintlayout = "androidx.constraintlayout:constraintlayout:2.0.0"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -48,7 +48,7 @@ object Config {
             const val appcompat = "androidx.appcompat:appcompat:1.1.0"
             const val lifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0"
             const val recyclerview = "androidx.recyclerview:recyclerview:1.1.0"
-            const val constraintlayout = "androidx.constraintlayout:constraintlayout:2.0.0"
+            const val constraintlayout = "androidx.constraintlayout:constraintlayout:1.1.3"
             const val preference = "androidx.preference:preference-ktx:1.1.1"
 
             const val navigationFragment = "androidx.navigation:navigation-fragment-ktx:2.3.0"


### PR DESCRIPTION
Noticed some of our dependencies had updates recently so lets bump them.  For the mentioned breaking changes I did a global search and I did not see us using those APIs.  I tested this in the emulator and on my Pixel 4 XL and did not see any real issues.  Most of these are bug fixes which are good things :)

Note: Kotlin and Coroutines have updates but were not bumped since I am not sure if they should be done yet.

* Dagger release notes https://github.com/google/dagger/releases
* Webkit is no longer in RC https://developer.android.com/jetpack/androidx/releases/webkit?hl=en
* work manager update https://developer.android.com/jetpack/androidx/releases/work?hl=en