### PR TITLE
Use a foreground service for the sensor worker to make updates more reliable

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorWorker.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorWorker.kt
@@ -1,14 +1,21 @@
 package io.homeassistant.companion.android.sensors
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.content.Context.NOTIFICATION_SERVICE
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.domain.integration.IntegrationUseCase
 import java.util.concurrent.TimeUnit
@@ -22,10 +29,15 @@ class SensorWorker(
 ) : CoroutineWorker(appContext, workerParams) {
     companion object {
         private const val TAG = "SensorWorker"
+        const val channelId = "Sensor Worker"
+        const val NOTIFICATION_ID = 42
+        var notificationText = ""
+
         fun start(context: Context) {
             val constraints = Constraints.Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED).build()
 
+            notificationText = context.getString(R.string.updating_sensors)
             val sensorWorker =
                 PeriodicWorkRequestBuilder<SensorWorker>(15, TimeUnit.MINUTES)
                     .setConstraints(constraints)
@@ -38,6 +50,8 @@ class SensorWorker(
     @Inject
     lateinit var integrationUseCase: IntegrationUseCase
 
+    private val notificationManager = appContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
     init {
         DaggerSensorComponent.builder()
             .appComponent((appContext.applicationContext as GraphComponentAccessor).appComponent)
@@ -47,7 +61,30 @@ class SensorWorker(
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
         Log.d(TAG, "Updating all Sensors.")
+        createNotificationChannel()
+        val notification = NotificationCompat.Builder(applicationContext, channelId)
+            .setSmallIcon(R.drawable.ic_stat_ic_notification)
+            .setContentTitle(notificationText)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+
+        val foregroundInfo = ForegroundInfo(NOTIFICATION_ID, notification)
+        setForeground(foregroundInfo)
+
         SensorReceiver().updateSensors(appContext, integrationUseCase)
         Result.success()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            var notificationChannel =
+                notificationManager?.getNotificationChannel(channelId)
+            if (notificationChannel == null) {
+                notificationChannel = NotificationChannel(
+                    channelId, TAG, NotificationManager.IMPORTANCE_LOW
+                )
+                notificationManager?.createNotificationChannel(notificationChannel)
+            }
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,6 +182,7 @@ like to connect to:</string>
   <string name="themes_title_settings">Theme</string>
   <string name="unable_to_register">Unable to Register Application</string>
   <string name="unique_id">Unique Id</string>
+  <string name="updating_sensors">Updating Sensors</string>
   <string name="url_invalid">Url Invalid</string>
   <string name="url_parse_error">Unable to parse your Home Assistant URL. It should look like https://example.com</string>
   <string name="username">Username</string>


### PR DESCRIPTION
WorkManager offers the ability to use a foreground service to make sure updates become more reliable.  I have been testing this out all day and I can see better updates compared to the play store beta and I do not see any additional battery drain!  This is a temporary notification that will appear in the status bar only during a sensor update. The priority is set to low as that is expected behavior.  This uses its own notification channel so users can make changes if they like.  This is very similar to recent changes done to the Google Phone app where we temporarily see the voice-mail syncing notification. 

The notification:
![image](https://user-images.githubusercontent.com/1634145/91765316-9d49d880-eb8d-11ea-9636-c52336ec57f8.png)


Production app:
![image](https://user-images.githubusercontent.com/1634145/91765261-830ffa80-eb8d-11ea-8d1d-3d3f19a7a44e.png)

With this change:
![image](https://user-images.githubusercontent.com/1634145/91765284-8c00cc00-eb8d-11ea-841d-12029c5730a4.png)

Should fix: #848 and hopefully #551 🤞 