### PR TITLE
Add support for TLS client certificates

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/KeyChainLookup.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/KeyChainLookup.kt
@@ -1,0 +1,33 @@
+package io.homeassistant.companion.android.webview
+
+import android.content.Context
+import android.os.AsyncTask
+import android.security.KeyChain
+import android.security.KeyChainException
+import android.webkit.ClientCertRequest
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+
+internal class KeyChainLookup(context: Context, handler: ClientCertRequest, alias: String) :
+    AsyncTask<Void?, Void?, Void?>() {
+    private val mContext: Context = context.applicationContext
+    private val mHandler: ClientCertRequest = handler
+    private val mAlias: String = alias
+
+    override fun doInBackground(vararg params: Void?): Void? {
+        val privateKey: PrivateKey?
+        val certificateChain: Array<X509Certificate>?
+        try {
+            privateKey = KeyChain.getPrivateKey(mContext, mAlias)
+            certificateChain = KeyChain.getCertificateChain(mContext, mAlias)
+        } catch (e: InterruptedException) {
+            mHandler.ignore()
+            return null
+        } catch (e: KeyChainException) {
+            mHandler.ignore()
+            return null
+        }
+        mHandler.proceed(privateKey, certificateChain)
+        return null
+    }
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
@@ -6,8 +6,12 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.url.UrlRepository
+import java.security.KeyStore
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509TrustManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -19,38 +23,64 @@ class HomeAssistantRetrofit @Inject constructor(urlRepository: UrlRepository) {
         private const val LOCAL_HOST = "http://localhost/"
     }
 
-    val retrofit: Retrofit = Retrofit
-        .Builder()
-        .addConverterFactory(
-            JacksonConverterFactory.create(
-                ObjectMapper()
-                    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                    .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
-                    .registerKotlinModule()
+    val retrofit: Retrofit
+
+    init {
+        val trustManagerFactory =
+            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        trustManagerFactory.init(null as KeyStore?)
+        val trustManagers = trustManagerFactory.trustManagers
+        if (trustManagers.size != 1 || trustManagers[0] !is X509TrustManager) {
+            throw IllegalStateException(
+                "Unexpected default trust managers:" + trustManagers!!.contentToString()
             )
-        )
-        .client(
-            OkHttpClient.Builder().apply {
-                if (BuildConfig.DEBUG) {
-                    addInterceptor(HttpLoggingInterceptor().apply {
-                        level = HttpLoggingInterceptor.Level.BODY
-                    })
-                }
-            }.addInterceptor {
-                    return@addInterceptor if (it.request().url.toString().contains(LOCAL_HOST)) {
-                        val newRequest = runBlocking {
-                            it.request().newBuilder()
-                                .url(it.request().url.toString().replace(LOCAL_HOST, urlRepository.getUrl().toString()))
-                                .build()
+        }
+        val trustManager = trustManagers[0]
+
+        val sslContext = SSLContext.getInstance("TLS")
+        sslContext.init(null, arrayOf(trustManager), null)
+        val sslSocketFactory = sslContext.socketFactory
+
+        retrofit = Retrofit
+            .Builder()
+            .addConverterFactory(
+                JacksonConverterFactory.create(
+                    ObjectMapper()
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                        .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
+                        .registerKotlinModule()
+                )
+            )
+            .client(
+                OkHttpClient.Builder()
+                    .sslSocketFactory(sslSocketFactory, trustManager as X509TrustManager)
+                    .apply {
+                        if (BuildConfig.DEBUG) {
+                            addInterceptor(HttpLoggingInterceptor().apply {
+                                level = HttpLoggingInterceptor.Level.BODY
+                            })
                         }
-                        it.proceed(newRequest)
-                    } else {
-                        it.proceed(it.request())
+                    }.addInterceptor {
+                        return@addInterceptor if (it.request().url.toString()
+                                .contains(LOCAL_HOST)
+                        ) {
+                            val newRequest = runBlocking {
+                                it.request().newBuilder()
+                                    .url(
+                                        it.request().url.toString()
+                                            .replace(LOCAL_HOST, urlRepository.getUrl().toString())
+                                    )
+                                    .build()
+                            }
+                            it.proceed(newRequest)
+                        } else {
+                            it.proceed(it.request())
+                        }
                     }
-                }
-                .readTimeout(30L, TimeUnit.SECONDS)
-                .build()
-        )
-        .baseUrl(LOCAL_HOST)
-        .build()
+                    .readTimeout(30L, TimeUnit.SECONDS)
+                    .build()
+            )
+            .baseUrl(LOCAL_HOST)
+            .build()
+    }
 }


### PR DESCRIPTION
This PR adds support for selecting a TLS Client Certificate on app launch when requested by the server (e.g. with Apache HTTPd proxy):

![image](https://user-images.githubusercontent.com/318490/91959483-f5f1b080-ed08-11ea-9d28-c829b97bd571.png)


Resolves #27 