### PR TITLE
Only register once for hardware sensors

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -14,6 +14,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
     companion object {
 
         private const val TAG = "LightSensor"
+        private var isListenerRegistered = false
         private val lightSensor = SensorManager.BasicSensor(
             "light_sensor",
             "sensor",
@@ -36,7 +37,6 @@ class LightSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
-    private var isListenerRegistered = false
 
     override fun requestSensorUpdate(
         context: Context
@@ -57,6 +57,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
                 this,
                 lightSensors,
                 SENSOR_DELAY_NORMAL)
+            Log.d(TAG, "Light sensor listener registered")
             isListenerRegistered = true
         }
     }
@@ -66,7 +67,6 @@ class LightSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        Log.d(TAG, "Light sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_LIGHT) {
                 onSensorUpdated(
@@ -79,6 +79,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Light sensor listener unregistered")
         isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -6,6 +6,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import android.util.Log
 import io.homeassistant.companion.android.R
 import kotlin.math.roundToInt
 
@@ -35,6 +36,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
+    private var isListenerRegistered = false
 
     override fun requestSensorUpdate(
         context: Context
@@ -50,11 +52,12 @@ class LightSensorManager : SensorManager, SensorEventListener {
         mySensorManager = latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val lightSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
-        if (lightSensors != null) {
+        if (lightSensors != null && !isListenerRegistered) {
             mySensorManager.registerListener(
                 this,
                 lightSensors,
                 SENSOR_DELAY_NORMAL)
+            isListenerRegistered = true
         }
     }
 
@@ -63,6 +66,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
+        Log.d(TAG, "Light sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_LIGHT) {
                 onSensorUpdated(
@@ -75,5 +79,6 @@ class LightSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -6,6 +6,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import android.util.Log
 import io.homeassistant.companion.android.R
 import java.math.RoundingMode
 
@@ -25,6 +26,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
+    private var isListenerRegistered = false
 
     override val name: Int
         get() = R.string.sensor_name_pressure
@@ -48,11 +50,12 @@ class PressureSensorManager : SensorManager, SensorEventListener {
         mySensorManager = latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val pressureSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
-        if (pressureSensors != null) {
+        if (pressureSensors != null && !isListenerRegistered) {
             mySensorManager.registerListener(
                 this,
                 pressureSensors,
                 SENSOR_DELAY_NORMAL)
+            isListenerRegistered = true
         }
     }
 
@@ -61,6 +64,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
+        Log.d(TAG, "Pressure sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_PRESSURE) {
                 onSensorUpdated(
@@ -73,5 +77,6 @@ class PressureSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -14,6 +14,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     companion object {
 
         private const val TAG = "PressureSensor"
+        private var isListenerRegistered = false
         private val pressureSensor = SensorManager.BasicSensor(
             "pressure_sensor",
             "sensor",
@@ -26,7 +27,6 @@ class PressureSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
-    private var isListenerRegistered = false
 
     override val name: Int
         get() = R.string.sensor_name_pressure
@@ -40,10 +40,10 @@ class PressureSensorManager : SensorManager, SensorEventListener {
 
     override fun requestSensorUpdate(context: Context) {
         latestContext = context
-        updatePressureSensor(context)
+        updatePressureSensor()
     }
 
-    private fun updatePressureSensor(context: Context) {
+    private fun updatePressureSensor() {
         if (!isEnabled(latestContext, pressureSensor.id))
             return
 
@@ -55,6 +55,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
                 this,
                 pressureSensors,
                 SENSOR_DELAY_NORMAL)
+            Log.d(TAG, "Pressure sensor listener registered")
             isListenerRegistered = true
         }
     }
@@ -64,7 +65,6 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        Log.d(TAG, "Pressure sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_PRESSURE) {
                 onSensorUpdated(
@@ -77,6 +77,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Pressure sensor listener unregistered")
         isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -14,6 +14,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     companion object {
 
         private const val TAG = "ProximitySensor"
+        private var isListenerRegistered = false
         private val proximitySensor = SensorManager.BasicSensor(
             "proximity_sensor",
             "sensor",
@@ -25,7 +26,6 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
     private var maxRange: Int = 0
-    private var isListenerRegistered = false
 
     override val name: Int
         get() = R.string.sensor_name_proximity
@@ -39,10 +39,10 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
 
     override fun requestSensorUpdate(context: Context) {
         latestContext = context
-        updateProximitySensor(context)
+        updateProximitySensor()
     }
 
-    private fun updateProximitySensor(context: Context) {
+    private fun updateProximitySensor() {
         if (!isEnabled(latestContext, proximitySensor.id))
             return
 
@@ -55,6 +55,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
                 proximitySensors,
                 SENSOR_DELAY_NORMAL
             )
+            Log.d(TAG, "Proximity sensor listener registered")
             isListenerRegistered = true
             maxRange = proximitySensors.maximumRange.roundToInt()
         }
@@ -65,7 +66,6 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        Log.d(TAG, "Proximity sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_PROXIMITY) {
                 val sensorValue = event.values[0].roundToInt()
@@ -86,6 +86,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Proximity sensor listener unregistered")
         isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -6,6 +6,7 @@ import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import android.util.Log
 import io.homeassistant.companion.android.R
 import kotlin.math.roundToInt
 
@@ -24,6 +25,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
     private var maxRange: Int = 0
+    private var isListenerRegistered = false
 
     override val name: Int
         get() = R.string.sensor_name_proximity
@@ -47,12 +49,13 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
         mySensorManager = latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
         val proximitySensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY)
-        if (proximitySensors != null) {
+        if (proximitySensors != null && !isListenerRegistered) {
             mySensorManager.registerListener(
                 this,
                 proximitySensors,
                 SENSOR_DELAY_NORMAL
             )
+            isListenerRegistered = true
             maxRange = proximitySensors.maximumRange.roundToInt()
         }
     }
@@ -62,6 +65,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
+        Log.d(TAG, "Proximity sensor change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_PROXIMITY) {
                 val sensorValue = event.values[0].roundToInt()
@@ -82,5 +86,6 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -8,6 +8,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
 import android.os.Build
+import android.util.Log
 import io.homeassistant.companion.android.R
 import kotlin.math.roundToInt
 
@@ -32,6 +33,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
+    private var isListenerRegistered = false
 
     override fun requiredPermissions(): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -59,12 +61,13 @@ class StepsSensorManager : SensorManager, SensorEventListener {
                 latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 
             val stepsSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
-            if (stepsSensors != null) {
+            if (stepsSensors != null && !isListenerRegistered) {
                 mySensorManager.registerListener(
                     this,
                     stepsSensors,
                     SENSOR_DELAY_NORMAL
                 )
+                isListenerRegistered = true
             }
         }
     }
@@ -74,6 +77,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
+        Log.d(TAG, "Step counter change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_STEP_COUNTER) {
                 onSensorUpdated(
@@ -86,5 +90,6 @@ class StepsSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        isListenerRegistered = false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -16,6 +16,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     companion object {
 
         private const val TAG = "StepsSensor"
+        private var isListenerRegistered = false
         private val stepsSensor = SensorManager.BasicSensor(
             "steps_sensor",
             "sensor",
@@ -33,7 +34,6 @@ class StepsSensorManager : SensorManager, SensorEventListener {
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
-    private var isListenerRegistered = false
 
     override fun requiredPermissions(): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -67,6 +67,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
                     stepsSensors,
                     SENSOR_DELAY_NORMAL
                 )
+                Log.d(TAG, "Steps sensor listener registered")
                 isListenerRegistered = true
             }
         }
@@ -77,7 +78,6 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        Log.d(TAG, "Step counter change detected")
         if (event != null) {
             if (event.sensor.type == Sensor.TYPE_STEP_COUNTER) {
                 onSensorUpdated(
@@ -90,6 +90,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
             }
         }
         mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Steps sensor listener unregistered")
         isListenerRegistered = false
     }
 }


### PR DESCRIPTION
A few fixes for the hardware sensors:
* Lets keep track of our listeners and only register once if we have not already registered.  If the app is killed by the user or the system these listeners are already removed, this is to prevent ourselves from registering again if we did not receive a `onSensorChanged` event.
* Adds some logging around when listeners are registered/unregistered. 
* Remove unused `context`