### PR TITLE
Register only once for location updates

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -56,6 +56,9 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             R.string.sensor_description_location_zone
         )
         internal const val TAG = "LocBroadcastReceiver"
+
+        private var isBackgroundLocationSetup = false
+        private var isZoneLocationSetup = false
     }
 
     @Inject
@@ -64,9 +67,6 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     lateinit var latestContext: Context
-
-    private var isBackgroundLocationSetup = false
-    private var isZoneLocationSetup = false
 
     override fun onReceive(context: Context, intent: Intent) {
         latestContext = context


### PR DESCRIPTION
PR #863 had an attempt to ensure that we only register once for location updates.

However the variables were placed in the wrong place and the code didn't work. Actually we were re-registering every time because the variable was not static and every time defaulted to false. The PR fixed this.