### PR TITLE
Allow sensors to be disabled by default until user enables them

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -100,6 +100,8 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
         return "on_foot"
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_activity
 

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -22,6 +22,8 @@ class GeocodeSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_geolocation
     override val availableSensors: List<SensorManager.BasicSensor>

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -364,6 +364,9 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             )
     }
 
+    override val enabledByDefault: Boolean
+        get() = true
+
     override val name: Int
         get() = R.string.sensor_name_location
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -18,6 +18,9 @@ class AudioSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
+
     override val name: Int
         get() = R.string.sensor_name_audio
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -27,6 +27,9 @@ class BatterySensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = true
+
     override val name: Int
         get() = R.string.sensor_name_battery
     override val availableSensors: List<SensorManager.BasicSensor>

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -20,6 +20,8 @@ class BluetoothSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_bluetooth
     override val availableSensors: List<SensorManager.BasicSensor>

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -17,6 +17,8 @@ class DNDSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_dnd
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
@@ -23,6 +23,8 @@ class LastRebootSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_last_reboot
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -23,6 +23,9 @@ class LightSensorManager : SensorManager, SensorEventListener {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
+
     override val name: Int
         get() = R.string.sensor_name_light
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -18,6 +18,8 @@ class NetworkSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = true
     override val name: Int
         get() = R.string.sensor_name_network
     override val availableSensors: List<SensorManager.BasicSensor>

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -23,6 +23,8 @@ class NextAlarmManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_alarm
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -34,6 +34,8 @@ class PhoneStateSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_phone
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -26,6 +26,9 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
 
+    override val enabledByDefault: Boolean
+        get() = false
+
     override val name: Int
         get() = R.string.sensor_name_pressure
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -25,6 +25,9 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     private lateinit var mySensorManager: android.hardware.SensorManager
     private var maxRange: Int = 0
 
+    override val enabledByDefault: Boolean
+        get() = false
+
     override val name: Int
         get() = R.string.sensor_name_proximity
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -155,7 +155,7 @@ class SensorDetailFragment(
             sensorEntity.enabled = isEnabled
             sensorDao.update(sensorEntity)
         } else {
-            sensorEntity = Sensor(basicSensor.id, false, false, "")
+            sensorEntity = Sensor(basicSensor.id, isEnabled, false, "")
             sensorDao.add(sensorEntity)
         }
         refreshSensorData()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -12,6 +12,7 @@ import androidx.preference.contains
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.database.AppDatabase
+import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorDao
 
 class SensorDetailFragment(
@@ -51,9 +52,10 @@ class SensorDetailFragment(
         findPreference<SwitchPreference>("enabled")?.let {
             val dao = sensorDao.get(basicSensor.id)
             val perm = sensorManager.checkPermission(requireContext())
-            if (dao == null) {
+            if (dao == null && sensorManager.enabledByDefault) {
                 it.isChecked = perm
-            } else {
+            }
+            if (dao != null) {
                 it.isChecked = dao.enabled && perm
             }
             updateSensorEntity(it.isChecked)
@@ -148,10 +150,13 @@ class SensorDetailFragment(
     private fun updateSensorEntity(
         isEnabled: Boolean
     ) {
-        val sensorEntity = sensorDao.get(basicSensor.id)
+        var sensorEntity = sensorDao.get(basicSensor.id)
         if (sensorEntity != null) {
             sensorEntity.enabled = isEnabled
             sensorDao.update(sensorEntity)
+        } else {
+            sensorEntity = Sensor(basicSensor.id, false, false, "")
+            sensorDao.add(sensorEntity)
         }
         refreshSensorData()
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -13,6 +13,7 @@ interface SensorManager {
 
     val name: Int
     val availableSensors: List<BasicSensor>
+    val enabledByDefault: Boolean
 
     data class BasicSensor(
         val id: String,
@@ -36,19 +37,20 @@ interface SensorManager {
         var sensor = sensorDao.get(sensorId)
         val permission = checkPermission(context)
 
-        // If we haven't created the entity yet do so and default to enabled
-        if (sensor == null) {
+        // If we haven't created the entity yet do so and default to enabled if required
+        if (sensor == null && enabledByDefault) {
             sensor = Sensor(sensorId, permission, false, "")
             sensorDao.add(sensor)
         }
 
         // If we don't have permission but we are still enabled then we aren't really enabled.
-        if (sensor.enabled && !permission) {
-            sensor.enabled = false
-            sensorDao.update(sensor)
+        if (sensor != null) {
+            if (sensor.enabled && !permission) {
+                sensor.enabled = false
+                sensorDao.update(sensor)
+            }
         }
-
-        return sensor.enabled
+        return sensor!!.enabled
     }
 
     fun requestSensorUpdate(context: Context)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -38,19 +38,18 @@ interface SensorManager {
         val permission = checkPermission(context)
 
         // If we haven't created the entity yet do so and default to enabled if required
-        if (sensor == null && enabledByDefault) {
-            sensor = Sensor(sensorId, permission, false, "")
+        if (sensor == null) {
+            sensor = Sensor(sensorId, permission && enabledByDefault, false, "")
             sensorDao.add(sensor)
         }
 
         // If we don't have permission but we are still enabled then we aren't really enabled.
-        if (sensor != null) {
             if (sensor.enabled && !permission) {
                 sensor.enabled = false
                 sensorDao.update(sensor)
             }
-        }
-        return sensor!!.enabled
+
+        return sensor.enabled
     }
 
     fun requestSensorUpdate(context: Context)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -83,7 +83,7 @@ class SensorReceiver : BroadcastReceiver() {
             try {
                 manager.requestSensorUpdate(context)
             } catch (e: Exception) {
-                Log.e(TAG, "Issue requesting updates for ${manager.name}", e)
+                Log.e(TAG, "Issue requesting updates for ${context.getString(manager.name)}", e)
             }
             manager.availableSensors.forEach { basicSensor ->
                 val fullSensor = sensorDao.getFull(basicSensor.id)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -24,6 +24,9 @@ class StepsSensorManager : SensorManager, SensorEventListener {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
+
     override val name: Int
         get() = R.string.sensor_name_steps
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -53,6 +53,8 @@ class StorageSensorManager : SensorManager {
         }
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_storage
     override val availableSensors: List<SensorManager.BasicSensor>

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -11,6 +11,8 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
         // Noop
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_activity
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -15,6 +15,8 @@ class GeocodeSensorManager : SensorManager {
         )
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_geolocation
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -36,6 +36,8 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         // Noop
     }
 
+    override val enabledByDefault: Boolean
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_location
     override val availableSensors: List<SensorManager.BasicSensor>


### PR DESCRIPTION
Fixes: #867 & #856 

Now that we have a lot of sensors lets just allow sensible defaults so we don't overload new users. This really impacts onboarding more than current users.  For now battery sensors will be defaulted to true, location and network sensors will default to true only if given permission during onboarding.  Geocoded location will be false by default to allow it to be a opt-in sensor instead of opt-out (I know this goes against what #853 just did but we did have a specific request for Geocoded to be opt-in instead of opt-out #582 )

Are we ok with the defaults for new users?

One issue I saw which is purely cosmetic is that after enabling one sensor another sensor will briefly show the toggle enabled even though it is not enabled. Going back to the same screen will show the correct state so maybe a caching issue?