### PR TITLE
Only show sensors that are available for the device

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.content.Context
 import android.content.Context.SENSOR_SERVICE
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -36,6 +37,11 @@ class LightSensorManager : SensorManager, SensorEventListener {
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val packageManager: PackageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_LIGHT)
     }
 
     private lateinit var latestContext: Context

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.content.Context
 import android.content.Context.SENSOR_SERVICE
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -44,6 +45,11 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     override fun requestSensorUpdate(context: Context) {
         latestContext = context
         updatePressureSensor()
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val packageManager: PackageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_BAROMETER)
     }
 
     private fun updatePressureSensor() {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.content.Context
 import android.content.Context.SENSOR_SERVICE
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -38,6 +39,11 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val packageManager: PackageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_PROXIMITY)
     }
 
     override fun requestSensorUpdate(context: Context) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -54,6 +54,10 @@ interface SensorManager {
 
     fun requestSensorUpdate(context: Context)
 
+    fun hasSensor(context: Context): Boolean {
+        return true
+    }
+
     fun onSensorUpdated(
         context: Context,
         basicSensor: BasicSensor,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -56,35 +56,33 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
 
         setPreferencesFromResource(R.xml.sensors, rootKey)
 
-        SensorReceiver.MANAGERS.sortedBy { it.name }.forEach { manager ->
+        SensorReceiver.MANAGERS.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)
             prefCategory.title = getString(manager.name)
 
-            if (manager.hasSensor(requireContext())) {
-                preferenceScreen.addPreference(prefCategory)
-                manager.availableSensors.sortedBy { it.name }.forEach { basicSensor ->
+            preferenceScreen.addPreference(prefCategory)
+            manager.availableSensors.sortedBy { it.name }.forEach { basicSensor ->
 
-                    val pref = Preference(preferenceScreen.context)
-                    pref.key = basicSensor.id
-                    pref.title = getString(basicSensor.name)
+                val pref = Preference(preferenceScreen.context)
+                pref.key = basicSensor.id
+                pref.title = getString(basicSensor.name)
 
-                    pref.setOnPreferenceClickListener {
-                        parentFragmentManager
-                            .beginTransaction()
-                            .replace(
-                                R.id.content,
-                                SensorDetailFragment.newInstance(
-                                    manager,
-                                    basicSensor
-                                )
+                pref.setOnPreferenceClickListener {
+                    parentFragmentManager
+                        .beginTransaction()
+                        .replace(
+                            R.id.content,
+                            SensorDetailFragment.newInstance(
+                                manager,
+                                basicSensor
                             )
-                            .addToBackStack("Sensor Detail")
-                            .commit()
-                        return@setOnPreferenceClickListener true
-                    }
-
-                    prefCategory.addPreference(pref)
+                        )
+                        .addToBackStack("Sensor Detail")
+                        .commit()
+                    return@setOnPreferenceClickListener true
                 }
+
+                prefCategory.addPreference(pref)
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.sensors
 
-import android.content.pm.PackageManager
 import android.os.Bundle
 import android.os.Handler
 import androidx.preference.Preference
@@ -60,16 +59,8 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
         SensorReceiver.MANAGERS.sortedBy { it.name }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)
             prefCategory.title = getString(manager.name)
-            var hasSensor: Boolean
-            val packageManager: PackageManager? = context?.packageManager
-            hasSensor = when (manager.name) {
-                R.string.sensor_name_light -> packageManager!!.hasSystemFeature(PackageManager.FEATURE_SENSOR_LIGHT)
-                R.string.sensor_name_pressure -> packageManager!!.hasSystemFeature(PackageManager.FEATURE_SENSOR_BAROMETER)
-                R.string.sensor_name_proximity -> packageManager!!.hasSystemFeature(PackageManager.FEATURE_SENSOR_PROXIMITY)
-                R.string.sensor_name_steps -> packageManager!!.hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER)
-                else -> true
-            }
-            if (hasSensor) {
+
+            if (manager.hasSensor(requireContext())) {
                 preferenceScreen.addPreference(prefCategory)
                 manager.availableSensors.sortedBy { it.name }.forEach { basicSensor ->
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.sensors
 import android.Manifest
 import android.content.Context
 import android.content.Context.SENSOR_SERVICE
+import android.content.pm.PackageManager
 import android.hardware.Sensor
 import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
@@ -46,6 +47,11 @@ class StepsSensorManager : SensorManager, SensorEventListener {
         } else {
             arrayOf()
         }
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val packageManager: PackageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_STEP_COUNTER)
     }
 
     override fun requestSensorUpdate(


### PR DESCRIPTION
Now that sensors are disabled by default lets completely hide sensors that the device reports it does not have. One thing to note about this is that certain devices don't respect this API and still report they have a device when indeed they do not.  Our current null checks prevent that from being an issue anyways.

I was unable to add this check to the manager itself as we do not get context during this moment, I added this in the fragment to just completely hide it they are disabled anyways.  We can also use this for other sensors in the future that may exist in certain API levels too.  For now this change only impacts hardware sensors since not all devices have them.

Here we can see the emulator does not show the step sensor since it does not exist:
![image](https://user-images.githubusercontent.com/1634145/92161847-10e62280-ede6-11ea-9d75-63320fbed507.png)

Here is a Fire HD8 that only has a light sensor, the other 3 are notably not available:
![image](https://user-images.githubusercontent.com/1634145/92161944-32470e80-ede6-11ea-90e7-cf81d6e3fad3.png)

I do have one Fire HD7 that runs on lineage OS with google services, this device unfortunately reports it has the sensors and just returns a null value so we ignore those anyways.
