### PR TITLE
Update sensors bugfix

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -107,23 +107,24 @@ class SensorReceiver : BroadcastReceiver() {
             }
         }
 
-        var success = false
-        try {
-            if (enabledRegistrations.size > 0)
+        if (enabledRegistrations.isNotEmpty()) {
+            var success = false
+            try {
                 success = integrationUseCase.updateSensors(enabledRegistrations.toTypedArray())
-        } catch (e: Exception) {
-            Log.e(TAG, "Exception while updating sensors.", e)
-        }
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception while updating sensors.", e)
+            }
 
-        // We failed to update a sensor, we should re register next time
-        if (!success) {
-            enabledRegistrations.forEach {
-                val sensor = sensorDao.get(it.uniqueId)
-                if (sensor != null) {
-                    sensor.registered = false
-                    sensorDao.update(sensor)
+            // We failed to update a sensor, we should re register next time
+            if (!success) {
+                enabledRegistrations.forEach {
+                    val sensor = sensorDao.get(it.uniqueId)
+                    if (sensor != null) {
+                        sensor.registered = false
+                        sensorDao.update(sensor)
+                    }
                 }
             }
-        }
+        } else Log.d(TAG, "Nothing to update")
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -101,7 +101,7 @@ class SensorReceiver : BroadcastReceiver() {
                         Log.e(TAG, "Issue registering sensor: ${reg.uniqueId}", e)
                     }
                 }
-                if (fullSensor != null && sensor?.registered == true) {
+                if (sensor?.enabled == true && fullSensor != null && sensor?.registered) {
                     enabledRegistrations.add(fullSensor.toSensorRegistration())
                 }
             }
@@ -109,7 +109,8 @@ class SensorReceiver : BroadcastReceiver() {
 
         var success = false
         try {
-            success = integrationUseCase.updateSensors(enabledRegistrations.toTypedArray())
+            if (enabledRegistrations.size > 0)
+                success = integrationUseCase.updateSensors(enabledRegistrations.toTypedArray())
         } catch (e: Exception) {
             Log.e(TAG, "Exception while updating sensors.", e)
         }


### PR DESCRIPTION
Fixes: #878

PR fixes 2 issues with sensors update:
1. We are still updating disabled but previously registered sensors with outdated data from from db.
2. We are calling `update_sensor_states: []` even when we have nothing to update. Like in #878 when all sensors are disabled.