### PR TITLE
Fix theme selector

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -140,9 +140,6 @@
   <string name="themes_option_label_dark">Dunkel</string>
   <string name="themes_option_label_light">Hell</string>
   <string name="themes_option_label_system">System-Einstellungen verwenden</string>
-  <string name="themes_option_value_dark">dunkel</string>
-  <string name="themes_option_value_light">hell</string>
-  <string name="themes_option_value_system">System</string>
   <string name="themes_title_settings">Theme</string>
   <string name="unable_to_register">Die Applikation konnte nicht registriert werden</string>
   <string name="unique_id">Eindeutige ID</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string-array name="pref_theme_option_labels">
-    <item>@string/themes_option_label_light</item>
-    <item>@string/themes_option_label_dark</item>
-    <item>@string/themes_option_label_system</item>
-  </string-array>
-  <string-array name="pref_theme_option_values">
-    <item>@string/themes_option_value_light</item>
-    <item>@string/themes_option_value_dark</item>
-    <item>@string/themes_option_value_system</item>
-  </string-array>
   <string name="add_service_data_field">Aggiungi Campo</string>
   <string name="add_widget">Aggiungi Widget</string>
   <string name="app_name">Home Assistant</string>
@@ -178,9 +168,6 @@ Scansione della rete</string>
   <string name="themes_option_label_dark">Scuro</string>
   <string name="themes_option_label_light">Chiaro</string>
   <string name="themes_option_label_system">Segui le impostazioni di sistema</string>
-  <string name="themes_option_value_dark">scuro</string>
-  <string name="themes_option_value_light">chiaro</string>
-  <string name="themes_option_value_system">sistema</string>
   <string name="themes_title_settings">Tema</string>
   <string name="unable_to_register">Impossibile registrare l\'applicazione</string>
   <string name="unique_id">ID univoco</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -142,9 +142,6 @@
   <string name="themes_option_label_dark">어둡게</string>
   <string name="themes_option_label_light">밝게</string>
   <string name="themes_option_label_system">시스템 설정 따르기</string>
-  <string name="themes_option_value_dark">어둡게</string>
-  <string name="themes_option_value_light">밝게</string>
-  <string name="themes_option_value_system">시스템</string>
   <string name="themes_title_settings">테마</string>
   <string name="unable_to_register">응용 프로그램을 등록할 수 없습니다</string>
   <string name="unique_id">고유 ID</string>

--- a/app/src/main/res/values-nb-rNO/strings.xml
+++ b/app/src/main/res/values-nb-rNO/strings.xml
@@ -143,8 +143,6 @@ for Home Assistant</string>
   <string name="themes_option_label_dark">Mørk</string>
   <string name="themes_option_label_light">Lys</string>
   <string name="themes_option_label_system">Følg systeminnstillinger</string>
-  <string name="themes_option_value_dark">mørk</string>
-  <string name="themes_option_value_light">lys</string>
   <string name="themes_title_settings">Tema</string>
   <string name="unable_to_register">Kunne ikke registrere applikasjonen</string>
   <string name="unique_id">Unik ID</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -140,9 +140,6 @@
   <string name="themes_option_label_dark">Donker</string>
   <string name="themes_option_label_light">Licht</string>
   <string name="themes_option_label_system">Systeeminstellingen volgen</string>
-  <string name="themes_option_value_dark">donker</string>
-  <string name="themes_option_value_light">licht</string>
-  <string name="themes_option_value_system">systeem</string>
   <string name="themes_title_settings">Thema</string>
   <string name="unable_to_register">Niet mogelijk om de applicatie te registeren.</string>
   <string name="unique_id">Unieke ID</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -138,9 +138,6 @@
   <string name="themes_option_label_dark">Ciemny</string>
   <string name="themes_option_label_light">Jasny</string>
   <string name="themes_option_label_system">Podążaj za ustawieniami systemu</string>
-  <string name="themes_option_value_dark">ciemny</string>
-  <string name="themes_option_value_light">jasny</string>
-  <string name="themes_option_value_system">systemowy</string>
   <string name="themes_title_settings">Motyw</string>
   <string name="unable_to_register">Nie można zarejestrować aplikacji</string>
   <string name="unique_id">Unikalny identyfikator</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -165,9 +165,6 @@
   <string name="themes_option_label_dark">Тёмная</string>
   <string name="themes_option_label_light">Светлая</string>
   <string name="themes_option_label_system">По умолчанию</string>
-  <string name="themes_option_value_dark">тёмная</string>
-  <string name="themes_option_value_light">светлая</string>
-  <string name="themes_option_value_system">по умолчанию</string>
   <string name="themes_title_settings">Тема</string>
   <string name="unable_to_register">Не удалось зарегистрировать приложение</string>
   <string name="unique_id">Уникальный ID</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -144,9 +144,6 @@ sa chcete pripojiť:</string>
   <string name="themes_option_label_dark">Tmavá</string>
   <string name="themes_option_label_light">Svetlá</string>
   <string name="themes_option_label_system">Podľa nastavenia systému</string>
-  <string name="themes_option_value_dark">tmavá</string>
-  <string name="themes_option_value_light">svetlá</string>
-  <string name="themes_option_value_system">systém</string>
   <string name="themes_title_settings">Téma</string>
   <string name="unable_to_register">Nepodarilo sa registrovať aplikáciu</string>
   <string name="unique_id">Unikátne ID</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string-array name="pref_theme_option_labels">
-    <item>@string/themes_option_label_light</item>
-    <item>@string/themes_option_label_dark</item>
-    <item>@string/themes_option_label_system</item>
-  </string-array>
-  <string-array name="pref_theme_option_values">
-    <item>@string/themes_option_value_light</item>
-    <item>@string/themes_option_value_dark</item>
-    <item>@string/themes_option_value_system</item>
-  </string-array>
   <string name="add_service_data_field">添加字段</string>
   <string name="add_widget">添加小部件</string>
   <string name="app_name">Home Assistant</string>
@@ -177,9 +167,6 @@ Home Assistant实例</string>
   <string name="themes_option_label_dark">深色</string>
   <string name="themes_option_label_light">亮色</string>
   <string name="themes_option_label_system">跟随系统设置</string>
-  <string name="themes_option_value_dark">深色</string>
-  <string name="themes_option_value_light">亮色</string>
-  <string name="themes_option_value_system">系统</string>
   <string name="themes_title_settings">主题</string>
   <string name="unable_to_register">无法注册应用程序</string>
   <string name="unique_id">唯一 ID</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -84,9 +84,6 @@
   <string name="themes_option_label_dark">暗黑</string>
   <string name="themes_option_label_light">亮色</string>
   <string name="themes_option_label_system">跟隨系統模式</string>
-  <string name="themes_option_value_dark">暗黑</string>
-  <string name="themes_option_value_light">亮色</string>
-  <string name="themes_option_value_system">系統</string>
   <string name="themes_title_settings">主題</string>
   <string name="url_invalid">網址無效</string>
   <string name="url_parse_error">無法解析您的 Home Assistan URL，它看起來應該像https://example.com</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,7 +5,8 @@
     <item>@string/themes_option_label_dark</item>
     <item>@string/themes_option_label_system</item>
   </string-array>
-  <string-array name="pref_theme_option_values">
+  <!-- Do not localize entryvalues -->
+  <string-array name="pref_theme_option_values" translatable="false">
     <item>@string/themes_option_value_light</item>
     <item>@string/themes_option_value_dark</item>
     <item>@string/themes_option_value_system</item>
@@ -209,9 +210,12 @@ like to connect to:</string>
   <string name="themes_option_label_dark">Dark</string>
   <string name="themes_option_label_light">Light</string>
   <string name="themes_option_label_system">Follow System Settings</string>
-  <string name="themes_option_value_dark">dark</string>
-  <string name="themes_option_value_light">light</string>
-  <string name="themes_option_value_system">system</string>
+  <!-- Do not localize entryvalues -->
+  <string name="themes_option_value_dark" translatable="false">dark</string>
+  <!-- Do not localize entryvalues -->
+  <string name="themes_option_value_light" translatable="false">light</string>
+  <!-- Do not localize entryvalues -->
+  <string name="themes_option_value_system" translatable="false">system</string>
   <string name="themes_title_settings">Theme</string>
   <string name="unable_to_register">Unable to Register Application</string>
   <string name="unique_id">Unique Id</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
-  <string-array name="pref_theme_option_labels">
+  <!-- Do not localize -->
+  <string-array name="pref_theme_option_labels" translatable="false">
     <item>@string/themes_option_label_light</item>
     <item>@string/themes_option_label_dark</item>
     <item>@string/themes_option_label_system</item>
   </string-array>
-  <!-- Do not localize entryvalues -->
+  <!-- Do not localize -->
   <string-array name="pref_theme_option_values" translatable="false">
     <item>@string/themes_option_value_light</item>
     <item>@string/themes_option_value_dark</item>
@@ -210,11 +211,11 @@ like to connect to:</string>
   <string name="themes_option_label_dark">Dark</string>
   <string name="themes_option_label_light">Light</string>
   <string name="themes_option_label_system">Follow System Settings</string>
-  <!-- Do not localize entryvalues -->
+  <!-- Do not localize -->
   <string name="themes_option_value_dark" translatable="false">dark</string>
-  <!-- Do not localize entryvalues -->
+  <!-- Do not localize -->
   <string name="themes_option_value_light" translatable="false">light</string>
-  <!-- Do not localize entryvalues -->
+  <!-- Do not localize -->
   <string name="themes_option_value_system" translatable="false">system</string>
   <string name="themes_title_settings">Theme</string>
   <string name="unable_to_register">Unable to Register Application</string>


### PR DESCRIPTION
Right now the theme selector is broken for some languages,
because the internal options values were translated by mistake.
Marked them as untranslatable.

Hopefully lokalise.com does use the "untranslatable" attribute 