### PR TITLE
Do not trigger sensors update on alarm and bluetooth events if the corresponding sensor is disabled

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -11,7 +11,7 @@ import java.lang.reflect.Method
 class BluetoothSensorManager : SensorManager {
     companion object {
         private const val TAG = "BluetoothSM"
-        private val bluetoothConnection = SensorManager.BasicSensor(
+        val bluetoothConnection = SensorManager.BasicSensor(
             "bluetooth_connection",
             "sensor",
             R.string.basic_sensor_name_bluetooth,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -14,7 +14,7 @@ class NextAlarmManager : SensorManager {
     companion object {
         private const val TAG = "NextAlarm"
 
-        private val nextAlarm = SensorManager.BasicSensor(
+        val nextAlarm = SensorManager.BasicSensor(
             "next_alarm",
             "sensor",
             R.string.basic_sensor_name_alarm,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.sensors
 
+import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -60,6 +61,27 @@ class SensorReceiver : BroadcastReceiver() {
             .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
             .build()
             .inject(this)
+
+        when (intent.action) {
+            "android.app.action.NEXT_ALARM_CLOCK_CHANGED" -> {
+                val sensorDao = AppDatabase.getInstance(context).sensorDao()
+                val sensor = sensorDao.get(NextAlarmManager.nextAlarm.id)
+                if (sensor?.enabled != true) {
+                    Log.d(TAG, "Alarm Sensor disabled, skipping sensors update")
+                    return
+                }
+            }
+            "android.bluetooth.device.action.ACL_CONNECTED",
+                "android.bluetooth.device.action.ACL_DISCONNECTED",
+                BluetoothAdapter.ACTION_STATE_CHANGED -> {
+                val sensorDao = AppDatabase.getInstance(context).sensorDao()
+                val sensor = sensorDao.get(BluetoothSensorManager.bluetoothConnection.id)
+                if (sensor?.enabled != true) {
+                    Log.d(TAG, "Bluetooth Sensor disabled, skipping sensors update")
+                    return
+                }
+            }
+        }
 
         ioScope.launch {
             updateSensors(context, integrationUseCase)


### PR DESCRIPTION
Do not trigger sensors update on alarm and bluetooth events if the corresponding sensor is disabled

Partially fixes #869. I wanted to implement some kind of filter, but this is discussable. So here is the easiest solution to get rid of spam just by disabling the corresponding sensor ;-0
