### PR TITLE
Add power sensors: Interactive, Doze, Power Save

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -8,6 +8,7 @@ import android.content.IntentFilter
 import android.media.AudioManager
 import android.net.wifi.WifiManager
 import android.os.Build
+import android.os.PowerManager
 import android.telephony.TelephonyManager
 import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
@@ -38,6 +39,24 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
                 addAction(Intent.ACTION_POWER_DISCONNECTED)
             }
         )
+
+        // This will cause interactive and power save to update upon a state change
+        registerReceiver(
+            sensorReceiver, IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_OFF)
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+            }
+        )
+
+        // Update doze mode immediately on supported devices
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            registerReceiver(
+                sensorReceiver, IntentFilter().apply {
+                    addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED)
+                }
+            )
+        }
 
         // This will trigger an update any time the wifi state has changed
         registerReceiver(

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
@@ -17,13 +17,15 @@ data class SensorWithAttributes(
         val attributes = attributes.map { it.name to it.value }.toMap()
         val state = when (sensor.stateType) {
             "" -> ""
+            "boolean" -> sensor.state.toBoolean()
+            "float" -> sensor.state.toFloat()
+            "int" -> sensor.state.toInt()
             "string" -> sensor.state
-            "number" -> sensor.state.toFloat()
             else -> throw IllegalArgumentException("State is of unknown type: ${sensor.stateType}")
         }
         return SensorRegistration(
             sensor.id,
-            sensor.state,
+            state,
             sensor.type,
             sensor.icon,
             attributes,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -1,0 +1,115 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Context.POWER_SERVICE
+import android.os.Build
+import android.os.PowerManager
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
+
+class PowerSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "PowerSensors"
+        private const val packageName = "io.homeassistant.companion.android"
+
+        private val interactiveDevice = SensorManager.BasicSensor(
+            "is_interactive",
+            "sensor",
+            R.string.basic_sensor_name_interactive,
+            R.string.sensor_description_interactive
+        )
+        private val doze = SensorManager.BasicSensor(
+            "is_idle",
+            "sensor",
+            R.string.basic_sensor_name_doze,
+            R.string.sensor_description_doze
+        )
+        private val powerSave = SensorManager.BasicSensor(
+            "power_save",
+            "sensor",
+            R.string.basic_sensor_name_power_save,
+            R.string.sensor_description_power_save
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_power
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            listOf(interactiveDevice, doze, powerSave)
+        } else {
+            listOf(interactiveDevice, powerSave)
+        }
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        val powerManager = context.getSystemService(POWER_SERVICE) as PowerManager
+        updateInteractive(context, powerManager)
+        updatePowerSave(context, powerManager)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            updateDoze(context, powerManager)
+        }
+    }
+
+    private fun updateInteractive(context: Context, powerManager: PowerManager) {
+
+        if (!isEnabled(context, interactiveDevice.id))
+            return
+
+        val interactiveState = powerManager.isInteractive
+        val icon = if (interactiveState) "mdi:cellphone" else "mdi:cellphone-off"
+
+        onSensorUpdated(
+            context,
+            interactiveDevice,
+            interactiveState.toString(),
+            icon,
+            mapOf()
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun updateDoze(context: Context, powerManager: PowerManager) {
+
+        if (!isEnabled(context, doze.id))
+            return
+
+        val dozeState = powerManager.isDeviceIdleMode
+        val icon = if (dozeState) "mdi:sleep" else "mdi:sleep-off"
+
+        onSensorUpdated(
+            context,
+            doze,
+            dozeState.toString(),
+            icon,
+            mapOf(
+                "ignoring_battery_optizimations" to powerManager.isIgnoringBatteryOptimizations(packageName)
+            )
+        )
+    }
+
+    private fun updatePowerSave(context: Context, powerManager: PowerManager) {
+
+        if (!isEnabled(context, powerSave.id))
+            return
+
+        val powerSaveState = powerManager.isPowerSaveMode
+        val icon = "mdi:battery-plus"
+
+        onSensorUpdated(
+            context,
+            powerSave,
+            powerSaveState.toString(),
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -14,19 +14,19 @@ class PowerSensorManager : SensorManager {
 
         private val interactiveDevice = SensorManager.BasicSensor(
             "is_interactive",
-            "sensor",
+            "binary_sensor",
             R.string.basic_sensor_name_interactive,
             R.string.sensor_description_interactive
         )
         private val doze = SensorManager.BasicSensor(
             "is_idle",
-            "sensor",
+            "binary_sensor",
             R.string.basic_sensor_name_doze,
             R.string.sensor_description_doze
         )
         private val powerSave = SensorManager.BasicSensor(
             "power_save",
-            "sensor",
+            "binary_sensor",
             R.string.basic_sensor_name_power_save,
             R.string.sensor_description_power_save
         )
@@ -70,7 +70,7 @@ class PowerSensorManager : SensorManager {
         onSensorUpdated(
             context,
             interactiveDevice,
-            interactiveState.toString(),
+            interactiveState,
             icon,
             mapOf()
         )
@@ -88,7 +88,7 @@ class PowerSensorManager : SensorManager {
         onSensorUpdated(
             context,
             doze,
-            dozeState.toString(),
+            dozeState,
             icon,
             mapOf(
                 "ignoring_battery_optizimations" to powerManager.isIgnoringBatteryOptimizations(packageName)
@@ -107,7 +107,7 @@ class PowerSensorManager : SensorManager {
         onSensorUpdated(
             context,
             powerSave,
-            powerSaveState.toString(),
+            powerSaveState,
             icon,
             mapOf()
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -71,8 +71,10 @@ interface SensorManager {
         sensor.id = basicSensor.id
         sensor.state = state.toString()
         sensor.stateType = when (state) {
+            is Boolean -> "boolean"
+            is Int -> "int"
+            is Number -> "float"
             is String -> "string"
-            is Number -> "number"
             else -> throw IllegalArgumentException("Unknown Sensor State Type")
         }
         sensor.type = basicSensor.type

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -32,6 +32,7 @@ class SensorReceiver : BroadcastReceiver() {
             NetworkSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
+            PowerSensorManager(),
             PressureSensorManager(),
             ProximitySensorManager(),
             StepsSensorManager(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -152,6 +152,13 @@ like to connect to:</string>
   <string name="sensor_description_location_zone">Import existing Home Assistant zones as geofences for zone based tracking.</string>
   <string name="sensor_description_next_alarm">The date and time of the next scheduled alarm, any app or manufacturer can override the default behavior. The package attribute will tell you which app set the next scheduled alarm.</string>
   <string name="sensor_description_none">No description</string>
+  <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
+  <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
+  <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
+  <string name="sensor_name_power">Power Sensors</string>
+  <string name="basic_sensor_name_power_save">Power Save</string>
+  <string name="basic_sensor_name_interactive">Interactive</string>
+  <string name="basic_sensor_name_doze">Doze Mode</string>
   <string name="basic_sensor_name_activity">Detected Activity</string>
   <string name="basic_sensor_name_geolocation">Geocoded Location</string>
   <string name="basic_sensor_name_location_background">Background Location</string>


### PR DESCRIPTION
3 new binary sensors, all disabled by default:

* Interactive  - Reflects the interactive state of the device, most typically when the screen turns on and off.  I have also added a broadcast receiver so the state updates immediately. We should look into adding this for the widgets, having them update when the screen turns on would add to the experience 👍 

* Doze mode!! Only available on Android 6.0+, will update immediately upon a state change.  One attribute of the sensor is `ignoring_battery_optimizations` for our application. Tested the state change using: https://developer.android.com/training/monitoring-device-state/doze-standby#testing_doze

![image](https://user-images.githubusercontent.com/1634145/92310350-53346e80-ef62-11ea-9188-703bde78a4fa.png)

* Power Save mode - Updates immediately when the device enters and exits power saving mode.