### PR TITLE
Discard duplicate locations coming within seconds of each other

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -59,6 +59,9 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
         private var isBackgroundLocationSetup = false
         private var isZoneLocationSetup = false
+
+        private var lastLocationSend = 0L
+        private var lastUpdateLocation = ""
     }
 
     @Inject
@@ -223,33 +226,20 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             if (Build.VERSION.SDK_INT >= 26) location.verticalAccuracyMeters.toInt() else 0
         )
 
-        val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
-        val fullSensor = sensorDao.getFull(backgroundLocation.id)
-        val locationEntity = fullSensor?.sensor
-        val lastLocationSend = fullSensor?.attributes?.firstOrNull { it.name == "lastLocationSent" }?.value?.toLongOrNull() ?: 0L
         val now = System.currentTimeMillis()
 
-        if (locationEntity?.state == updateLocation.gps.contentToString()) {
-            if (now >= lastLocationSend + 900000) {
-                Log.d(TAG, "Sending location since it's been more than 15 minutes")
-            } else {
-                Log.d(TAG, "Same location as last update, not sending to HA")
+        if (lastUpdateLocation == updateLocation.gps.contentToString()) {
+            if (now < lastLocationSend + 9000) {
+                Log.d(TAG, "Duplicate location received, not sending to HA")
                 return
             }
         }
+        lastLocationSend = now
+        lastUpdateLocation = updateLocation.gps.contentToString()
 
         ioScope.launch {
             try {
                 integrationUseCase.updateLocation(updateLocation)
-                onSensorUpdated(
-                    latestContext,
-                    backgroundLocation,
-                    updateLocation.gps.contentToString(),
-                    "",
-                    mapOf(
-                        "lastLocationSent" to now.toString()
-                    )
-                )
             } catch (e: Exception) {
                 Log.e(TAG, "Could not update location.", e)
             }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -229,7 +229,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         val now = System.currentTimeMillis()
 
         if (lastUpdateLocation == updateLocation.gps.contentToString()) {
-            if (now < lastLocationSend + 9000) {
+            if (now < lastLocationSend + 900000) {
                 Log.d(TAG, "Duplicate location received, not sending to HA")
                 return
             }


### PR DESCRIPTION
Fixes #872.

Discard duplicate locations coming within seconds of each other.

Do not discard subsequent regular updates (this is how I want it to work, if you prefer to discard same locations within 15 minutes interval, you are free to change the code).

The reason why algorithm introduced in #863 didn't work, is the race condition. Database was not yet updated at the moment when a duplicate was received. So it discarded regular updates coming some minutes after, but didn't discard real duplicates.

Look at the log, duplicate update coming just 2 ms after the first update gets discarded now.

Subsequent regular updates which we are subscribed for are not discarded because the time-frame for discarding is set to some seconds.

```
09-06 16:52:13.078 22794 22841 D SensorWorker: Updating all Sensors.
09-06 16:54:25.714 22794 22794 D LocBroadcastReceiver: Received location update.
09-06 16:54:25.714 22794 22794 D LocBroadcastReceiver: Last Location:
09-06 16:54:25.714 22794 22794 D LocBroadcastReceiver: Coords:(55.6373473, 37.3570945)
09-06 16:54:25.714 22794 22794 D LocBroadcastReceiver: Accuracy: 12.474
09-06 16:54:25.714 22794 22794 D LocBroadcastReceiver: Bearing: 0.0
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Got single accurate location update: Location[fused 55,637347,37,357095 hAcc=12 et=+4d16h44m31s788ms alt=201.8000030517578 vAcc=2 sAcc=??? bAcc=??? {Bundle[mParcelledData.dataSize=52]}]
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Location accurate enough, all done with high accuracy.
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Last Location:
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Coords:(55.6373473, 37.3570945)
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Accuracy: 12.474
09-06 16:54:25.716 22794 22794 D LocBroadcastReceiver: Bearing: 0.0
09-06 16:54:25.717 22794 22794 D LocBroadcastReceiver: Duplicate location received, not sending to HA
```