### PR TITLE
Breaking Change: Only send updates when a state change has been detected

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -30,7 +30,7 @@ import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
         StaticWidgetEntity::class,
         TemplateWidgetEntity::class
     ],
-    version = 8
+    version = 9
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun authenticationDao(): AuthenticationDao
@@ -63,7 +63,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_4_5,
                     MIGRATION_5_6,
                     MIGRATION_6_7,
-                    MIGRATION_7_8
+                    MIGRATION_7_8,
+                    MIGRATION_8_9
                 )
                 .build()
         }
@@ -160,6 +161,11 @@ abstract class AppDatabase : RoomDatabase() {
         private val MIGRATION_7_8 = object : Migration(7, 8) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE `sensor_attributes` ADD `value_type` TEXT NOT NULL DEFAULT 'string'")
+            }
+        }
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `sensors` ADD `state_changed` INTEGER NOT NULL DEFAULT ''")
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/Sensor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/Sensor.kt
@@ -13,6 +13,8 @@ data class Sensor(
     var enabled: Boolean,
     @ColumnInfo(name = "registered")
     var registered: Boolean,
+    @ColumnInfo(name = "state_changed")
+    var stateChanged: Boolean,
     @ColumnInfo(name = "state")
     var state: String,
     @ColumnInfo(name = "state_type")

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -251,6 +251,7 @@ class MobileAppIntegrationFragment : Fragment(), MobileAppIntegrationView {
                 uniqueId,
                 isChecked,
                 false,
+                true,
                 ""
             )
             sensorDao.add(sensor)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -155,7 +155,7 @@ class SensorDetailFragment(
             sensorEntity.enabled = isEnabled
             sensorDao.update(sensorEntity)
         } else {
-            sensorEntity = Sensor(basicSensor.id, isEnabled, false, "")
+            sensorEntity = Sensor(basicSensor.id, isEnabled, false, true, "")
             sensorDao.add(sensorEntity)
         }
         refreshSensorData()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Process.myPid
 import android.os.Process.myUid
+import android.util.Log
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Attribute
@@ -39,7 +40,7 @@ interface SensorManager {
 
         // If we haven't created the entity yet do so and default to enabled if required
         if (sensor == null) {
-            sensor = Sensor(sensorId, permission && enabledByDefault, false, "")
+            sensor = Sensor(sensorId, permission && enabledByDefault, false, true, "")
             sensorDao.add(sensor)
         }
 
@@ -67,6 +68,8 @@ interface SensorManager {
     ) {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val sensor = sensorDao.get(basicSensor.id) ?: return
+        Log.d("SensorManager", "Old sensor state ${sensor.state} compared to new state $state for ${sensor.name}")
+        sensor.stateChanged = (sensor.state != state.toString())
         sensor.id = basicSensor.id
         sensor.state = state.toString()
         sensor.stateType = when (state) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -124,7 +124,7 @@ class SensorReceiver : BroadcastReceiver() {
                         Log.e(TAG, "Issue registering sensor: ${reg.uniqueId}", e)
                     }
                 }
-                if (sensor?.enabled == true && fullSensor != null && sensor?.registered) {
+                if (sensor?.enabled == true && fullSensor != null && sensor?.registered && sensor?.stateChanged) {
                     enabledRegistrations.add(fullSensor.toSensorRegistration())
                 }
             }


### PR DESCRIPTION
This PR is another breaking change....sorry about this but we need to cut down on the amount of updates we are sending when there is no new data.  I will need to submit a follow up PR splitting up the non-static attributes so until that point some of the attributes will be slower to update.  If you feel I should add them here to avoid that being a breaking change I can do so but this already feels like a big change in itself so I opted to keep them separate.  So far Audio Sensor (all attributes), Battery State (all attributes but they all update anyways due to plug/unplug events with the exception of `battery_health`), Bluetooth (only for `is_bt_on` the rest update with the state), Storage Sensor (external attributes should become their own sensor however its tough to create on the fly if user removes the SD card so it may need to remain here) and Wifi Connection (all attributes) will be the ones that need to be split up immediately as we have broadcast receivers to update some of those attributes more quickly.

We will be keeping track of state changes in the database and only send updates when we have them.  If none of the sensors have a state change to report then nothing will get sent.  The default for this value is set to `true` the first time we register and update a sensor.

The only sensors that do not respect this change are the hardware sensors: Light, Pressure, Proximity and Step Counter.  These sensors need to be reconsidered on how they send updates since when we request for updates we actually don't see them when they are sent.  The `onSensorChanged` event can be triggered by any of these sensors at any point in time so the state change detection does not work there.  This is something I did not realize until I made this change and hence why I left the debug log so we can figure out what works best for those sensors. I think maybe triggering another update inside the event may fix that? But thats for another PR 😃 