### PR TITLE
Split battery attributes, part 1

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -140,9 +140,9 @@ class BatterySensorManager : SensorManager {
             chargingStatus,
             getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
             mapOf(
-                "is_charging" to isCharging,
-                "charger_type" to chargerType,
-                "battery_health" to batteryHealth
+                "is_charging" to isCharging, // Remove after next release
+                "charger_type" to chargerType, // Remove after next release
+                "battery_health" to batteryHealth // Remove after next release
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -25,6 +25,25 @@ class BatterySensorManager : SensorManager {
             R.string.sensor_description_battery_state,
             "battery"
         )
+        private val isChargingState = SensorManager.BasicSensor(
+            "is_charging",
+            "binary_sensor",
+            R.string.basic_sensor_name_charging,
+            R.string.sensor_description_charging,
+            "plug"
+        )
+        private val chargerTypeState = SensorManager.BasicSensor(
+            "charger_type",
+            "sensor",
+            R.string.basic_sensor_name_charger_type,
+            R.string.sensor_description_charger_type
+        )
+        private val batteryHealthState = SensorManager.BasicSensor(
+            "battery_health",
+            "sensor",
+            R.string.basic_sensor_name_battery_health,
+            R.string.sensor_description_battery_health
+        )
     }
 
     override val enabledByDefault: Boolean
@@ -33,7 +52,7 @@ class BatterySensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_battery
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(batteryLevel, batteryState)
+        get() = listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState)
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
@@ -46,6 +65,9 @@ class BatterySensorManager : SensorManager {
         if (intent != null) {
             updateBatteryLevel(context, intent)
             updateBatteryState(context, intent)
+            updateIsCharging(context, intent)
+            updateChargerType(context, intent)
+            updateBatteryHealth(context, intent)
         }
     }
 
@@ -122,6 +144,59 @@ class BatterySensorManager : SensorManager {
                 "charger_type" to chargerType,
                 "battery_health" to batteryHealth
             )
+        )
+    }
+
+    private fun updateIsCharging(context: Context, intent: Intent) {
+        if (!isEnabled(context, isChargingState.id))
+            return
+
+        val isCharging = getIsCharging(intent)
+
+        val icon = if (isCharging) "mdi:power-plug" else "mdi:power-plug-off"
+        onSensorUpdated(
+            context,
+            isChargingState,
+            isCharging,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateChargerType(context: Context, intent: Intent) {
+        if (!isEnabled(context, chargerTypeState.id))
+            return
+
+        val percentage: Int = getBatteryPercentage(intent)
+        val isCharging = getIsCharging(intent)
+        val chargerType = getChargerType(intent)
+        val chargingStatus = getChargingStatus(intent)
+
+        onSensorUpdated(
+            context,
+            chargerTypeState,
+            chargerType,
+            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
+            mapOf()
+        )
+    }
+
+    private fun updateBatteryHealth(context: Context, intent: Intent) {
+        if (!isEnabled(context, batteryHealthState.id))
+            return
+
+        val percentage: Int = getBatteryPercentage(intent)
+        val isCharging = getIsCharging(intent)
+        val chargerType = getChargerType(intent)
+        val chargingStatus = getChargingStatus(intent)
+        val batteryHealth = getBatteryHealth(intent)
+
+        onSensorUpdated(
+            context,
+            batteryHealthState,
+            batteryHealth,
+            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
+            mapOf()
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,9 @@ like to connect to:</string>
   <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
   <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
+  <string name="sensor_description_charging">Whether or not the device is actively charging</string>
+  <string name="sensor_description_charger_type">The type of charger plugged into the phone currently</string>
+  <string name="sensor_description_battery_health">The health of the battery</string>
   <string name="sensor_name_power">Power Sensors</string>
   <string name="basic_sensor_name_power_save">Power Save</string>
   <string name="basic_sensor_name_interactive">Interactive</string>
@@ -174,6 +177,9 @@ like to connect to:</string>
   <string name="basic_sensor_name_phone">Phone State</string>
   <string name="basic_sensor_name_sim1">SIM 1</string>
   <string name="basic_sensor_name_sim2">SIM 2</string>
+  <string name="basic_sensor_name_charging">Is Charging</string>
+  <string name="basic_sensor_name_charger_type">Charger Type</string>
+  <string name="basic_sensor_name_battery_health">Battery Health</string>
   <string name="sensor_name_light">Light Sensor</string>
   <string name="sensor_name_activity">Activity Sensors</string>
   <string name="sensor_name_geolocation">Geolocation Sensors</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,7 +158,7 @@ like to connect to:</string>
   <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
   <string name="sensor_description_charging">Whether or not the device is actively charging</string>
-  <string name="sensor_description_charger_type">The type of charger plugged into the phone currently</string>
+  <string name="sensor_description_charger_type">The type of charger plugged into the device currently</string>
   <string name="sensor_description_battery_health">The health of the battery</string>
   <string name="sensor_name_power">Power Sensors</string>
   <string name="basic_sensor_name_power_save">Power Save</string>


### PR DESCRIPTION
Now that #891 has been merged its time to begin part 1 of splitting the attributes.  Starting off with the battery state sensor.

This is a non-breaking change as the attributes have not been removed from the Battery State sensor, that will happen in part 2 at a later point in time.

`is_charging` is now a binary sensor
`charger_type` is now a sensor
`battery_health` is now a sensor

As these are battery sensors they are all enabled by default so users should be able to switch easily over to the new sensors.  They may need to adjust their name/ID if there is a conflict in the entity registry.