### PR TITLE
Split up bluetooth state into its own sensor, part 1

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -98,7 +98,7 @@ class BluetoothSensorManager : SensorManager {
             mapOf(
                 "connected_paired_devices" to connectedPairedDevices,
                 "connected_not_paired_devices" to connectedNotPairedDevices,
-                "is_bt_on" to isBtOn,  // Remove after next release
+                "is_bt_on" to isBtOn, // Remove after next release
                 "paired_devices" to bondedString
             )
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -18,6 +18,12 @@ class BluetoothSensorManager : SensorManager {
             R.string.sensor_description_bluetooth_connection,
             unitOfMeasurement = "connection(s)"
         )
+        val bluetoothState = SensorManager.BasicSensor(
+            "bluetooth_state",
+            "binary_sensor",
+            R.string.basic_sensor_name_bluetooth_state,
+            R.string.sensor_description_blueooth_state
+        )
     }
 
     override val enabledByDefault: Boolean
@@ -25,7 +31,7 @@ class BluetoothSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_bluetooth
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(bluetoothConnection)
+        get() = listOf(bluetoothConnection, bluetoothState)
 
     override fun requiredPermissions(): Array<String> {
         return arrayOf(Manifest.permission.BLUETOOTH)
@@ -35,6 +41,7 @@ class BluetoothSensorManager : SensorManager {
         context: Context
     ) {
         updateBluetoothConnectionSensor(context)
+        updateBluetoothState(context)
     }
 
     private fun updateBluetoothConnectionSensor(context: Context) {
@@ -94,6 +101,33 @@ class BluetoothSensorManager : SensorManager {
                 "is_bt_on" to isBtOn,
                 "paired_devices" to bondedString
             )
+        )
+    }
+
+    private fun updateBluetoothState(context: Context) {
+        if (!isEnabled(context, bluetoothState.id))
+            return
+
+        var isBtOn = false
+
+        if (checkPermission(context)) {
+
+            val bluetoothManager =
+                (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+
+            if (bluetoothManager.adapter != null) {
+                val adapter = bluetoothManager.adapter
+                isBtOn = adapter.isEnabled
+            }
+        }
+        val icon = if (isBtOn) "mdi:bluetooth" else "mdi:bluetooth-off"
+
+        onSensorUpdated(
+            context,
+            bluetoothState,
+            isBtOn,
+            icon,
+            mapOf()
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -22,7 +22,7 @@ class BluetoothSensorManager : SensorManager {
             "bluetooth_state",
             "binary_sensor",
             R.string.basic_sensor_name_bluetooth_state,
-            R.string.sensor_description_blueooth_state
+            R.string.sensor_description_bluetooth_state
         )
     }
 
@@ -98,7 +98,7 @@ class BluetoothSensorManager : SensorManager {
             mapOf(
                 "connected_paired_devices" to connectedPairedDevices,
                 "connected_not_paired_devices" to connectedNotPairedDevices,
-                "is_bt_on" to isBtOn,
+                "is_bt_on" to isBtOn,  // Remove after next release
                 "paired_devices" to bondedString
             )
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -73,12 +73,19 @@ class SensorReceiver : BroadcastReceiver() {
                 }
             }
             "android.bluetooth.device.action.ACL_CONNECTED",
-                "android.bluetooth.device.action.ACL_DISCONNECTED",
-                BluetoothAdapter.ACTION_STATE_CHANGED -> {
+                "android.bluetooth.device.action.ACL_DISCONNECTED" -> {
                 val sensorDao = AppDatabase.getInstance(context).sensorDao()
-                val sensor = sensorDao.get(BluetoothSensorManager.bluetoothConnection.id)
-                if (sensor?.enabled != true) {
-                    Log.d(TAG, "Bluetooth Sensor disabled, skipping sensors update")
+                val sensorBtConn = sensorDao.get(BluetoothSensorManager.bluetoothConnection.id)
+                if (sensorBtConn?.enabled != true) {
+                    Log.d(TAG, "Bluetooth Connection Sensor disabled, skipping sensors update")
+                    return
+                }
+            }
+            BluetoothAdapter.ACTION_STATE_CHANGED -> {
+                val sensorDao = AppDatabase.getInstance(context).sensorDao()
+                val sensorBtState = sensorDao.get(BluetoothSensorManager.bluetoothState.id)
+                if (sensorBtState?.enabled != true) {
+                    Log.d(TAG, "Bluetooth State Sensor disabled, skipping sensors update")
                     return
                 }
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,6 +157,7 @@ like to connect to:</string>
   <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
   <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
+  <string name="sensor_description_blueooth_state">Whether or not bluetooth is enabled on the device</string>
   <string name="sensor_name_power">Power Sensors</string>
   <string name="basic_sensor_name_power_save">Power Save</string>
   <string name="basic_sensor_name_interactive">Interactive</string>
@@ -174,6 +175,7 @@ like to connect to:</string>
   <string name="basic_sensor_name_phone">Phone State</string>
   <string name="basic_sensor_name_sim1">SIM 1</string>
   <string name="basic_sensor_name_sim2">SIM 2</string>
+  <string name="basic_sensor_name_bluetooth_state">Bluetooth State</string>
   <string name="sensor_name_light">Light Sensor</string>
   <string name="sensor_name_activity">Activity Sensors</string>
   <string name="sensor_name_geolocation">Geolocation Sensors</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -157,7 +157,7 @@ like to connect to:</string>
   <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
   <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
-  <string name="sensor_description_blueooth_state">Whether or not bluetooth is enabled on the device</string>
+  <string name="sensor_description_bluetooth_state">Whether or not bluetooth is enabled on the device</string>
   <string name="sensor_name_power">Power Sensors</string>
   <string name="basic_sensor_name_power_save">Power Save</string>
   <string name="basic_sensor_name_interactive">Interactive</string>


### PR DESCRIPTION
Following on from #891 we are splitting up one attribute from the bluetooth sensor.  Part 1 just creating the sensor and leaving the attribute where it is.

`is_bt_on` is now a binary sensor

This is the only attribute that updates outside of the state updates for the existing bluetooth connection sensor.  The other attributes only update when the state of bluetooth connection changes. Paired devices is a list of devices the user has paired to the android system, like wise those devices will only show up under connected paired devices.  Some devices may or may not pair with the system while also pairing with their stand alone app.  These devices are also caught and reported however they are either connected or not connected so they also update with the state regardless of where they are paired. The state always reflects the total count of connected devices.

I have also adjusted the receiver logic to account for this change.  Previously `ACTION_STATE_CHANGED` was added only for this attribute to update faster.  The attribute will still update with this change only a few seconds slower as bluetooth is waiting for the device to connect.  I made this split in case a user decides they only want one sensor and not both.