### PR TITLE
Split up external storage to its own sensor, part 1

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -15,8 +15,15 @@ class StorageSensorManager : SensorManager {
         private val storageSensor = SensorManager.BasicSensor(
             "storage_sensor",
             "sensor",
-            R.string.sensor_name_storage,
-            R.string.sensor_description_storage_sensor,
+            R.string.basic_sensor_name_internal_storage,
+            R.string.sensor_description_internal_storage,
+            unitOfMeasurement = "%"
+        )
+        private val externalStorage = SensorManager.BasicSensor(
+            "external_storage",
+            "sensor",
+            R.string.basic_sensor_name_external_storage,
+            R.string.sensor_description_external_storage,
             unitOfMeasurement = "%"
         )
         val path: File = Environment.getDataDirectory()
@@ -58,7 +65,7 @@ class StorageSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_storage
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(storageSensor)
+        get() = listOf(storageSensor, externalStorage)
 
     override fun requiredPermissions(): Array<String> {
         return emptyArray()
@@ -68,6 +75,7 @@ class StorageSensorManager : SensorManager {
         context: Context
     ) {
         updateStorageSensor(context)
+        updateExternalStorageSensor(context)
     }
 
     private fun updateStorageSensor(context: Context) {
@@ -101,6 +109,38 @@ class StorageSensorManager : SensorManager {
                 "Total internal storage" to totalInternalStorage,
                 "Free external storage" to freeExternalStorage,
                 "Total external storage" to totalExternalStorage
+            )
+        )
+    }
+
+    private fun updateExternalStorageSensor(context: Context) {
+        if (!isEnabled(context, externalStorage.id))
+            return
+
+        externalPath = externalMemoryAvailable(context)
+        var totalExternalStorage = "No SD Card"
+        var freeExternalStorage = "No SD Card"
+        var percentFreeExternal = 0
+
+        if (externalPath != null) {
+            val statSD = StatFs(externalPath.toString())
+            blockSizeSD = statSD.blockSizeLong
+            availableBlocksSD = statSD.availableBlocksLong
+            totalBlocksSD = statSD.blockCountLong
+            totalExternalStorage = getTotalExternalMemorySize()
+            freeExternalStorage = getAvailableExternalMemorySize()
+            percentFreeExternal = ((availableBlocksSD.toDouble() / totalBlocksSD.toDouble()) * 100).roundToInt()
+        }
+
+        val icon = "mdi:micro-sd"
+
+        onSensorUpdated(context,
+            externalStorage,
+            percentFreeExternal,
+            icon,
+            mapOf(
+                "free_external_storage" to freeExternalStorage,
+                "total_external_storage" to totalExternalStorage
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -107,8 +107,8 @@ class StorageSensorManager : SensorManager {
             mapOf(
                 "Free internal storage" to freeInternalStorage,
                 "Total internal storage" to totalInternalStorage,
-                "Free external storage" to freeExternalStorage,
-                "Total external storage" to totalExternalStorage
+                "Free external storage" to freeExternalStorage, // Remove after next release
+                "Total external storage" to totalExternalStorage // Remove after next release
             )
         )
     }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -144,7 +144,7 @@ instancia de Home Assistant</string>
   <string name="sensor_description_sim_1">Información sobre el proveedor de telefonía móvil actual en la ranura SIM 1</string>
   <string name="sensor_description_sim_2">Información sobre el proveedor de telefonía móvil actual en la ranura SIM 2</string>
   <string name="sensor_description_steps_sensor">El número total de pasos desde el último reinicio del dispositivo</string>
-  <string name="sensor_description_storage_sensor">Información sobre el espacio de almacenamiento total y disponible interno y externo</string>
+  <string name="sensor_description_internal_storage">Información sobre el espacio de almacenamiento total y disponible interno y externo</string>
   <string name="sensor_description_wifi_connection">Información sobre la red WiFi conectada actualmente</string>
   <string name="sensor_summary">Usa esto para controlar qué sensores están activados/desactivados.</string>
   <string name="sensor_title">Administrar sensores</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -147,7 +147,7 @@ Scansione della rete</string>
   <string name="sensor_description_sim_1">Informazioni sul provider di telefonia mobile corrente nello slot SIM 1</string>
   <string name="sensor_description_sim_2">Informazioni sul provider di telefonia mobile corrente nello slot SIM 2</string>
   <string name="sensor_description_steps_sensor">Il numero totale di passi dall\'ultimo riavvio del dispositivo</string>
-  <string name="sensor_description_storage_sensor">Informazioni sullo spazio di archiviazione totale e disponibile internamente ed esternamente</string>
+  <string name="sensor_description_internal_storage">Informazioni sullo spazio di archiviazione totale e disponibile internamente ed esternamente</string>
   <string name="sensor_description_wifi_connection">Informazioni sulla rete WiFi attualmente connessa</string>
   <string name="sensor_summary">Consente di gestire i sensori abilitati/disabilitati.</string>
   <string name="sensor_title">Gestione dei sensori</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -117,7 +117,7 @@
   <string name="security">Bezpieczeństwo</string>
   <string name="select_entity_to_display">Wybierz encję do wyświetlenia</string>
   <string name="select_instance">Wybierz instancję, z którą chcesz się połączyć:</string>
-  <string name="sensor_description_storage_sensor">Informacje o całkowitej i dostępnej przestrzeni dysku wewnętrznego i karty pamięci</string>
+  <string name="sensor_description_internal_storage">Informacje o całkowitej i dostępnej przestrzeni dysku wewnętrznego i karty pamięci</string>
   <string name="sensor_description_wifi_connection">Informacje o aktualnie podłączonej sieci WiFi</string>
   <string name="sensor_summary">Użyj tego, aby włączyć/wyłączyć sensory</string>
   <string name="sensor_title">Zarządzaj sensorami</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -144,7 +144,7 @@
   <string name="sensor_description_sim_1">Информация об операторе сотовой связи в слоте SIM 1</string>
   <string name="sensor_description_sim_2">Информация об операторе сотовой связи в слоте SIM 2</string>
   <string name="sensor_description_steps_sensor">Общее количество шагов с момента последней перезагрузки устройства</string>
-  <string name="sensor_description_storage_sensor">Информация о внутреннем и внешнем пространстве для хранения</string>
+  <string name="sensor_description_internal_storage">Информация о внутреннем и внешнем пространстве для хранения</string>
   <string name="sensor_description_wifi_connection">Информация о сети Wi-Fi, к которой подключено устройство</string>
   <string name="sensor_summary">Включение или отключение сенсоров мобильного приложения</string>
   <string name="sensor_title">Управление сенсорами</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -146,7 +146,7 @@ Home Assistant实例</string>
   <string name="sensor_description_sim_1">SIM插槽1中有关当前蜂窝电话提供商的信息</string>
   <string name="sensor_description_sim_2">SIM插槽2中有关当前蜂窝电话提供商的信息</string>
   <string name="sensor_description_steps_sensor">自上次重新启动设备以来的总步数</string>
-  <string name="sensor_description_storage_sensor">有关内部和外部总可用存储空间的信息</string>
+  <string name="sensor_description_internal_storage">有关内部和外部总可用存储空间的信息</string>
   <string name="sensor_description_wifi_connection">有关当前连接的WiFi网络的信息</string>
   <string name="sensor_summary">使用它来管理启用/禁用的传感器。</string>
   <string name="sensor_title">管理传感器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,8 @@ like to connect to:</string>
   <string name="sensor_description_doze">Whether or not the device is in Doze mode</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>
   <string name="sensor_name_power">Power Sensors</string>
+  <string name="basic_sensor_name_internal_storage">Internal Storage</string>
+  <string name="basic_sensor_name_external_storage">External Storage</string>
   <string name="basic_sensor_name_power_save">Power Save</string>
   <string name="basic_sensor_name_interactive">Interactive</string>
   <string name="basic_sensor_name_doze">Doze Mode</string>
@@ -189,14 +191,15 @@ like to connect to:</string>
   <string name="sensor_name_pressure">Pressure Sensor</string>
   <string name="sensor_name_proximity">Proximity Sensor</string>
   <string name="sensor_name_steps">Steps Sensor</string>
-  <string name="sensor_name_storage">Storage Sensor</string>
+  <string name="sensor_name_storage">Storage Sensors</string>
   <string name="sensor_description_phone_state">Whether or not the phone is ringing or in a call, no other caller information is stored</string>
   <string name="sensor_description_pressure_sensor">The current ambient air pressure reading</string>
   <string name="sensor_description_proximity_sensor">The current proximity reading, some devices only report near or far</string>
   <string name="sensor_description_sim_1">Information about the current cellular provider in SIM slot 1</string>
   <string name="sensor_description_sim_2">Information about the current cellular provider in SIM slot 2</string>
   <string name="sensor_description_steps_sensor">The total number of steps since the last reboot of the device</string>
-  <string name="sensor_description_storage_sensor">Information about the total and available storage space internally and externally</string>
+  <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
+  <string name="sensor_description_external_storage">Information about the total and available storage space externally</string>
   <string name="sensor_description_wifi_connection">Information about the currently connected WiFi network</string>
   <string name="sensor_summary">Use this to manage what sensors are enabled/disabled.</string>
   <string name="sensor_title">Manage Sensors</string>


### PR DESCRIPTION
Another part 1 split from #891 this time we are separating external storage from the storage sensor. The attributes for external storage will follow.  Unfortunately we can't just detect when a SD card is inserted to create the sensor so the behavior will remain the same with the exception that the default state is `0` if no SD card is detected.  So all devices will show both options and its up to the user to enable the external storage sensor.  Everything else remains the same here.