### PR TITLE
Fix state change when we fail to send data to HA

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -69,7 +69,7 @@ interface SensorManager {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val sensor = sensorDao.get(basicSensor.id) ?: return
         Log.d("SensorManager", "Old sensor state ${sensor.state} compared to new state $state for ${sensor.name}")
-        sensor.stateChanged = (sensor.state != state.toString())
+        sensor.stateChanged = sensor.stateChanged || (sensor.state != state.toString())
         sensor.id = basicSensor.id
         sensor.state = state.toString()
         sensor.stateType = when (state) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -144,6 +144,7 @@ class SensorReceiver : BroadcastReceiver() {
                     val sensor = sensorDao.get(it.uniqueId)
                     if (sensor != null) {
                         sensor.registered = false
+                        sensor.stateChanged = false
                         sensorDao.update(sensor)
                     }
                 }


### PR DESCRIPTION
Found an issue with #891  with the help of @JBassett since sometimes the call to HA would fail however we still recorded the state change at that moment so we never sent the update back on the next attempt.  Now if we fail we set to `false` and then check it against the detection.