### PR TITLE
Fix state change detection if the sensor is already registered

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -68,8 +68,11 @@ interface SensorManager {
     ) {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val sensor = sensorDao.get(basicSensor.id) ?: return
-        Log.d("SensorManager", "Old sensor state ${sensor.state} compared to new state $state for ${sensor.name}")
-        sensor.stateChanged = sensor.stateChanged || (sensor.state != state.toString())
+        Log.d("SensorManager", "Old sensor state ${sensor.state} compared to new state $state for ${sensor.id} the state changed is ${(sensor.state != state.toString())}")
+        if (sensor.registered)
+            sensor.stateChanged = (sensor.state != state.toString())
+        else
+            sensor.stateChanged = sensor.stateChanged || (sensor.state != state.toString())
         sensor.id = basicSensor.id
         sensor.state = state.toString()
         sensor.stateType = when (state) {


### PR DESCRIPTION
Noticed an issue that once a sensor registered a state change it kept sending updates, it also impacted enabling a sensor for the first time.  With this change we only send one update when it detects a change and if we fail to update it then we will consider sending another.  Also made the logging statement more meaningful 