### PR TITLE
Fix settings crash

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.text.InputType
+import android.util.Log
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.biometric.BiometricManager
@@ -147,20 +148,28 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
     override fun disableInternalConnection() {
         findPreference<EditTextPreference>("connection_internal")?.let {
             it.isEnabled = false
-            val unwrappedDrawable =
-                AppCompatResources.getDrawable(requireContext(), R.drawable.ic_computer)
-            unwrappedDrawable?.setTint(Color.DKGRAY)
-            it.icon = unwrappedDrawable
+            try {
+                val unwrappedDrawable =
+                    AppCompatResources.getDrawable(requireContext(), R.drawable.ic_computer)
+                unwrappedDrawable?.setTint(Color.DKGRAY)
+                it.icon = unwrappedDrawable
+            } catch (e: Exception) {
+                Log.d("SettingsFragment", "Unable to set the icon tint", e)
+            }
         }
     }
 
     override fun enableInternalConnection() {
         findPreference<EditTextPreference>("connection_internal")?.let {
             it.isEnabled = true
-            val unwrappedDrawable =
-                AppCompatResources.getDrawable(requireContext(), R.drawable.ic_computer)
-            unwrappedDrawable?.setTint(resources.getColor(R.color.colorAccent))
-            it.icon = unwrappedDrawable
+            try {
+                val unwrappedDrawable =
+                    AppCompatResources.getDrawable(requireContext(), R.drawable.ic_computer)
+                unwrappedDrawable?.setTint(resources.getColor(R.color.colorAccent))
+                it.icon = unwrappedDrawable
+            } catch (e: Exception) {
+                Log.d("SettingsFragment", "Unable to set the icon tint", e)
+            }
         }
     }
 


### PR DESCRIPTION
Noticed the following crash when I was changing the theme today on one of my devices. This was introduced in #895 sorry about that.

```
2020-09-09 15:18:13.074 19066-19066/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.homeassistant.companion.android, PID: 19066
    java.lang.IllegalStateException: Fragment SettingsFragment{e5a9a78} (56e2a415-3ef5-4b23-a3d7-f29ccd276b8b)} not attached to a context.
        at androidx.fragment.app.Fragment.requireContext(Fragment.java:805)
        at io.homeassistant.companion.android.settings.SettingsFragment.disableInternalConnection(SettingsFragment.kt:151)
        at io.homeassistant.companion.android.settings.SettingsPresenterImpl.handleInternalUrlStatus(SettingsPresenterImpl.kt:145)
        at io.homeassistant.companion.android.settings.SettingsPresenterImpl$onCreate$1.invokeSuspend(SettingsPresenterImpl.kt:135)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6188)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:911)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:801)
```