### PR TITLE
Disable network manager by default

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -73,7 +73,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     override val enabledByDefault: Boolean
-        get() = true
+        get() = false
     override val name: Int
         get() = R.string.sensor_name_network
     override val availableSensors: List<SensorManager.BasicSensor>


### PR DESCRIPTION
This manager should've been set to disable by default when I did the sensor split but I did not notice it until the public IP was enabled after the update.  Now things will behave as expected where only wifi connection becomes enabled if the user grants location permissions during onboarding.