### PR TITLE
Decouple location updates from other sensor updates.

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -21,8 +21,6 @@ import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.UpdateLocation
-import io.homeassistant.companion.android.database.AppDatabase
-import io.homeassistant.companion.android.database.sensor.Attribute
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -289,17 +287,6 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             Log.w(TAG, "Not getting single accurate location because of permissions.")
             return
         }
-        val now = System.currentTimeMillis()
-        val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
-        val fullSensor = sensorDao.getFull(backgroundLocation.id)
-        val latestAccurateLocation = fullSensor?.attributes?.firstOrNull { it.name == "lastAccurateLocationRequest" }?.value?.toLongOrNull() ?: 0L
-        // Only update accurate location at most once a minute
-        if (now < latestAccurateLocation + 60000) {
-            Log.d(TAG, "Not requesting accurate location, last accurate location was too recent")
-            return
-        }
-        sensorDao.add(Attribute(backgroundLocation.id, "lastAccurateLocationRequest", now.toString(), "string"))
-
         val maxRetries = 5
         val request = createLocationRequest()
         request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -29,7 +29,6 @@ class SensorReceiver : BroadcastReceiver() {
             GeocodeSensorManager(),
             LastRebootSensorManager(),
             LightSensorManager(),
-            LocationSensorManager(),
             NetworkSensorManager(),
             NextAlarmManager(),
             PhoneStateSensorManager(),
@@ -93,6 +92,11 @@ class SensorReceiver : BroadcastReceiver() {
 
         ioScope.launch {
             updateSensors(context, integrationUseCase)
+            if (intent.action == Intent.ACTION_BOOT_COMPLETED ||
+                intent.action == "android.intent.action.QUICKBOOT_POWERON" ||
+                intent.action == "com.htc.intent.action.QUICKBOOT_POWERON") {
+                updateLocationSensor(context)
+            }
             if (chargingActions.contains(intent.action)) {
                 // Add a 5 second delay to perform another update so charging state updates completely.
                 // This is necessary as the system needs a few seconds to verify the charger.
@@ -160,5 +164,15 @@ class SensorReceiver : BroadcastReceiver() {
                 }
             }
         } else Log.d(TAG, "Nothing to update")
+    }
+
+    suspend fun updateLocationSensor(
+        context: Context
+    ) {
+        try {
+            LocationSensorManager().requestSensorUpdate(context)
+        } catch (e: Exception) {
+            Log.e(TAG, "Issue requesting updates for ${context.getString(LocationSensorManager().name)}", e)
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorWorker.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorWorker.kt
@@ -72,6 +72,7 @@ class SensorWorker(
         setForeground(foregroundInfo)
 
         SensorReceiver().updateSensors(appContext, integrationUseCase)
+        SensorReceiver().updateLocationSensor(appContext)
         Result.success()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -21,7 +21,9 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
         override fun run() {
             SensorWorker.start(requireContext())
             val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
-            SensorReceiver.MANAGERS.forEach { managers ->
+            val managersList = SensorReceiver.MANAGERS.toMutableList()
+            managersList.add(LocationSensorManager())
+            managersList.forEach { managers ->
                 managers.availableSensors.forEach { basicSensor ->
                     findPreference<Preference>(basicSensor.id)?.let {
                         val sensorEntity = sensorDao.get(basicSensor.id)
@@ -56,7 +58,9 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
 
         setPreferencesFromResource(R.xml.sensors, rootKey)
 
-        SensorReceiver.MANAGERS.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
+        val managersList = SensorReceiver.MANAGERS.toMutableList()
+        managersList.add(LocationSensorManager())
+        managersList.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)
             prefCategory.title = getString(manager.name)
 


### PR DESCRIPTION
I guess this will not be merged too, because it goes against recent sensor unification changes, but may be will give you an idea.

So the whole story.

My parents recently started complaining about the battery drain. Previously the battery lived for 2-3 days, but some time ago it started discharging in just 1 day, causing inconvenience.

After investigation I've found that the cause is the recent Home Assistant app version.

I've installed my custom build on their phones and they are happy again. The battery drain is gone.

The most significant related changes in my custom build are:

1. a received intent doesn't trigger sensors update if the corresponding sensor is disabled (applied to all sensors, not only alarm and bluetooth)
2. sensors update doesn't trigger location sensor. Location sensor works independently and is only triggered by the periodic work and by passively received location updates that we are subscribed for (why do we ever need to explicitly request a location on each and every sensors update call if we are already subscribed for updates?).

The battery discharge curve has changed drastically after these modifications.

The most significant change is the second one. And this PR is how I did it.

The issue is that every time we receive an intent we are subscribed for, we are triggering all sensors update. This in turn triggers a location request. 1 minute limitation didn't help too much (but broke sensors detail screen with every 10 seconds update).

As I said earlier, why do we ever need to explicitly request a location on each and every sensors update call if we are already subscribed for updates?

I've decoupled location updates from another sensors update, and also removed 1 minute limitation as it is not needed any more.