### PR TITLE
Fix some stale icons

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -128,17 +128,23 @@ class BatterySensorManager : SensorManager {
         if (!isEnabled(context, batteryState.id))
             return
 
-        val percentage: Int = getBatteryPercentage(intent)
         val isCharging = getIsCharging(intent)
         val chargerType = getChargerType(intent)
         val chargingStatus = getChargingStatus(intent)
         val batteryHealth = getBatteryHealth(intent)
 
+        val icon = when (chargingStatus) {
+            "charging" -> "mdi:battery-plus"
+            "discharging" -> "mdi:battery-minus"
+            "full" -> "mdi:battery-charging"
+            "not_charging" -> "mdi:battery"
+            else -> "mdi:battery-unknown"
+        }
         onSensorUpdated(
             context,
             batteryState,
             chargingStatus,
-            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
+            icon,
             mapOf(
                 "is_charging" to isCharging, // Remove after next release
                 "charger_type" to chargerType, // Remove after next release
@@ -167,16 +173,19 @@ class BatterySensorManager : SensorManager {
         if (!isEnabled(context, chargerTypeState.id))
             return
 
-        val percentage: Int = getBatteryPercentage(intent)
-        val isCharging = getIsCharging(intent)
         val chargerType = getChargerType(intent)
-        val chargingStatus = getChargingStatus(intent)
 
+        val icon = when (chargerType) {
+            "ac" -> "mdi:power-plug"
+            "usb" -> "mdi:usb-port"
+            "wireless" -> "battery-charging-wireless"
+            else -> "mdi:battery-unknown"
+        }
         onSensorUpdated(
             context,
             chargerTypeState,
             chargerType,
-            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
+            icon,
             mapOf()
         )
     }
@@ -185,17 +194,17 @@ class BatterySensorManager : SensorManager {
         if (!isEnabled(context, batteryHealthState.id))
             return
 
-        val percentage: Int = getBatteryPercentage(intent)
-        val isCharging = getIsCharging(intent)
-        val chargerType = getChargerType(intent)
-        val chargingStatus = getChargingStatus(intent)
         val batteryHealth = getBatteryHealth(intent)
 
+        val icon = when (batteryHealth) {
+            "good" -> "mdi:battery-heart-variant"
+            else -> "mdi:battery-alert"
+        }
         onSensorUpdated(
             context,
             batteryHealthState,
             batteryHealth,
-            getBatteryIcon(percentage, isCharging, chargerType, chargingStatus),
+            icon,
             mapOf()
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -139,16 +139,7 @@ class NetworkSensorManager : SensorManager {
             }?.level ?: -1
         }
 
-        var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
-        }
-
-        val icon = "mdi:wifi-strength-" + when (signalStrength) {
-            -1 -> "off"
-            0 -> "outline"
-            else -> signalStrength
-        }
+        val icon = if (ssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"
 
         val attributes = conInfo?.let {
             mapOf(
@@ -176,30 +167,15 @@ class NetworkSensorManager : SensorManager {
             return
 
         var conInfo: WifiInfo? = null
-        var lastScanStrength = -1
 
         if (checkPermission(context)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
-
-            lastScanStrength = wifiManager.scanResults.firstOrNull {
-                it.BSSID == conInfo.bssid
-            }?.level ?: -1
-        }
-
-        var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
-        }
-
-        val icon = "mdi:wifi-strength-" + when (signalStrength) {
-            -1 -> "off"
-            0 -> "outline"
-            else -> signalStrength
         }
 
         val bssid = if (conInfo!!.bssid == null) "<not connected>" else conInfo.bssid
+        val icon = if (bssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"
         onSensorUpdated(
             context,
             bssidState,
@@ -215,7 +191,6 @@ class NetworkSensorManager : SensorManager {
 
         var conInfo: WifiInfo? = null
         var deviceIp = "Unknown"
-        var lastScanStrength = -1
 
         if (checkPermission(context)) {
             val wifiManager =
@@ -227,22 +202,9 @@ class NetworkSensorManager : SensorManager {
             } else {
                 getIpAddress(conInfo.ipAddress)
             }
-
-            lastScanStrength = wifiManager.scanResults.firstOrNull {
-                it.BSSID == conInfo.bssid
-            }?.level ?: -1
         }
 
-        var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
-        }
-
-        val icon = "mdi:wifi-strength-" + when (signalStrength) {
-            -1 -> "off"
-            0 -> "outline"
-            else -> signalStrength
-        }
+        val icon = "mdi:ip"
 
         onSensorUpdated(
             context,
@@ -326,7 +288,6 @@ class NetworkSensorManager : SensorManager {
 
         var conInfo: WifiInfo? = null
         var frequency = 0
-        var lastScanStrength = -1
 
         if (checkPermission(context)) {
             val wifiManager =
@@ -338,22 +299,9 @@ class NetworkSensorManager : SensorManager {
             } else {
                 conInfo.frequency
             }
-
-            lastScanStrength = wifiManager.scanResults.firstOrNull {
-                it.BSSID == conInfo.bssid
-            }?.level ?: -1
         }
 
-        var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
-        }
-
-        val icon = "mdi:wifi-strength-" + when (signalStrength) {
-            -1 -> "off"
-            0 -> "outline"
-            else -> signalStrength
-        }
+        val icon = "mdi:wifi"
 
         onSensorUpdated(
             context,


### PR DESCRIPTION
After #891 and splitting up some sensors I noticed we were leaving some stale icons because we no longer update them when the state has no changes. Lets now update the icons according to the state change.