### PR TITLE
Change exoplayer/play_hls payload type

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -416,7 +416,9 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     }
 
     fun exoPlayHls(json: JSONObject) {
-        val uri = Uri.parse(json.getString("payload"))
+        val payload = json.getJSONObject("payload")
+        val uri = Uri.parse(payload.getString("payload"))
+        exoMute = payload.optBoolean("muted")
         val dataSourceFactory = DefaultHttpDataSourceFactory(
             Util.getUserAgent(
                 applicationContext,

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -417,7 +417,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
 
     fun exoPlayHls(json: JSONObject) {
         val payload = json.getJSONObject("payload")
-        val uri = Uri.parse(payload.getString("payload"))
+        val uri = Uri.parse(payload.getString("url"))
         exoMute = payload.optBoolean("muted")
         val dataSourceFactory = DefaultHttpDataSourceFactory(
             Util.getUserAgent(


### PR DESCRIPTION
The frontend may need to send additional options to the exoplayer/play_hls interface such as whether to be muted or not: https://github.com/home-assistant/frontend/issues/6857 . With that in mind it is probably better to use a JSONObject instead of a String for the payload.