### PR TITLE
Fix wireless charging icon, replace unknown with none if no charger detected

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -178,8 +178,8 @@ class BatterySensorManager : SensorManager {
         val icon = when (chargerType) {
             "ac" -> "mdi:power-plug"
             "usb" -> "mdi:usb-port"
-            "wireless" -> "battery-charging-wireless"
-            else -> "mdi:battery-unknown"
+            "wireless" -> "mdi:battery-charging-wireless"
+            else -> "mdi:battery"
         }
         onSensorUpdated(
             context,
@@ -221,7 +221,7 @@ class BatterySensorManager : SensorManager {
             BatteryManager.BATTERY_PLUGGED_AC -> "ac"
             BatteryManager.BATTERY_PLUGGED_USB -> "usb"
             BatteryManager.BATTERY_PLUGGED_WIRELESS -> "wireless"
-            else -> "unknown"
+            else -> "none"
         }
     }
 


### PR DESCRIPTION
Noticed an error in my logs after #927 so fixing the broken icon/state change.

Also the states for charger type do not include `unknown` so I am replacing this with `none` this may be a breaking change for some users.

Fixes: #930 