### PR TITLE
Allow sensors to have custom settings

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.sensor.Attribute
 import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorDao
+import io.homeassistant.companion.android.database.sensor.Setting
 import io.homeassistant.companion.android.database.widget.ButtonWidgetDao
 import io.homeassistant.companion.android.database.widget.ButtonWidgetEntity
 import io.homeassistant.companion.android.database.widget.StaticWidgetDao
@@ -26,11 +27,12 @@ import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
         Attribute::class,
         Authentication::class,
         Sensor::class,
+        Setting::class,
         ButtonWidgetEntity::class,
         StaticWidgetEntity::class,
         TemplateWidgetEntity::class
     ],
-    version = 10
+    version = 11
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun authenticationDao(): AuthenticationDao
@@ -65,7 +67,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_6_7,
                     MIGRATION_7_8,
                     MIGRATION_8_9,
-                    MIGRATION_9_10
+                    MIGRATION_9_10,
+                    MIGRATION_10_11
                 )
                 .build()
         }
@@ -192,6 +195,12 @@ abstract class AppDatabase : RoomDatabase() {
                 sensors.forEach {
                     database.insert("sensors", OnConflictStrategy.REPLACE, it)
                 }
+            }
+        }
+
+        private val MIGRATION_10_11 = object : Migration(10, 11) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `sensor_settings` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL DEFAULT 'string', PRIMARY KEY(`sensor_id`, `name`))")
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -17,11 +17,18 @@ interface SensorDao {
     @Query("SELECT * FROM Sensors WHERE id = :id")
     fun getFull(id: String): SensorWithAttributes?
 
+    @Transaction
+    @Query("SELECT * FROM Sensors WHERE id = :id")
+    fun getSettings(id: String): SensorWithSettings?
+
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun add(sensor: Sensor)
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun add(attribute: Attribute)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    fun add(setting: Setting)
 
     @Update
     fun update(sensor: Sensor)

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -18,8 +18,8 @@ interface SensorDao {
     fun getFull(id: String): SensorWithAttributes?
 
     @Transaction
-    @Query("SELECT * FROM Sensors WHERE id = :id")
-    fun getSettings(id: String): SensorWithSettings?
+    @Query("SELECT * FROM sensor_settings WHERE sensor_id = :id")
+    fun getSettings(id: String): List<Setting>
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     fun add(sensor: Sensor)
@@ -29,6 +29,9 @@ interface SensorDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun add(setting: Setting)
+
+    @Query("DELETE FROM sensor_settings WHERE sensor_id = :sensorId AND name = :settingName")
+    fun removeSetting(sensorId: String, settingName: String)
 
     @Update
     fun update(sensor: Sensor)

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithSettings.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithSettings.kt
@@ -1,0 +1,14 @@
+package io.homeassistant.companion.android.database.sensor
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class SensorWithSettings(
+    @Embedded
+    val sensor: Sensor,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "sensor_id"
+    )
+    val settings: List<Setting>
+)

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/Setting.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/Setting.kt
@@ -1,0 +1,16 @@
+package io.homeassistant.companion.android.database.sensor
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+
+@Entity(tableName = "sensor_settings", primaryKeys = ["sensor_id", "name"])
+data class Setting(
+    @ColumnInfo(name = "sensor_id")
+    val sensorId: String,
+    @ColumnInfo(name = "name")
+    val name: String,
+    @ColumnInfo(name = "value")
+    var value: String,
+    @ColumnInfo(name = "value_type")
+    var valueType: String
+)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -181,11 +181,18 @@ class NetworkSensorManager : SensorManager {
         val settingName = "replace_$bssid"
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val fullSensor = sensorDao.getSettings(bssidState.id)
+        val getNextBSSID = fullSensor?.settings?.firstOrNull { it.name == "get_next_bssid" }?.value ?: "false"
         val currentSetting = fullSensor?.settings?.firstOrNull { it.name == settingName }?.value ?: ""
-        if (currentSetting != "") {
-            bssid = currentSetting
+        if (getNextBSSID == "true") {
+            if (currentSetting == "") {
+                sensorDao.add(Setting(bssidState.id, "get_next_bssid", "false", "toggle"))
+                sensorDao.add(Setting(bssidState.id, settingName, "", "string"))
+            }
         } else {
-            sensorDao.add(Setting(bssidState.id, settingName, "", "string"))
+            if (currentSetting != "")
+                bssid = currentSetting
+
+            sensorDao.add(Setting(bssidState.id, "get_next_bssid", "false", "toggle"))
         }
 
         val icon = if (bssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -72,6 +72,7 @@ class NetworkSensorManager : SensorManager {
             R.string.basic_sensor_name_public_ip,
             R.string.sensor_description_public_ip
         )
+        private const val GET_CURRENT_BSSID = "get_current_bssid"
     }
 
     override val enabledByDefault: Boolean
@@ -180,12 +181,12 @@ class NetworkSensorManager : SensorManager {
 
         val settingName = "replace_$bssid"
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
-        val fullSensor = sensorDao.getSettings(bssidState.id)
-        val getCurrentBSSID = fullSensor?.firstOrNull { it.name == "get_current_bssid" }?.value ?: "false"
-        val currentSetting = fullSensor?.firstOrNull { it.name == settingName }?.value ?: ""
+        val sensorSettings = sensorDao.getSettings(bssidState.id)
+        val getCurrentBSSID = sensorSettings?.firstOrNull { it.name == GET_CURRENT_BSSID }?.value ?: "false"
+        val currentSetting = sensorSettings?.firstOrNull { it.name == settingName }?.value ?: ""
         if (getCurrentBSSID == "true") {
             if (currentSetting == "") {
-                sensorDao.add(Setting(bssidState.id, "get_current_bssid", "false", "toggle"))
+                sensorDao.add(Setting(bssidState.id, GET_CURRENT_BSSID, "false", "toggle"))
                 sensorDao.add(Setting(bssidState.id, settingName, bssid, "string"))
             }
         } else {
@@ -194,7 +195,7 @@ class NetworkSensorManager : SensorManager {
             else
                 sensorDao.removeSetting(bssidState.id, settingName)
 
-            sensorDao.add(Setting(bssidState.id, "get_current_bssid", "false", "toggle"))
+            sensorDao.add(Setting(bssidState.id, GET_CURRENT_BSSID, "false", "toggle"))
         }
 
         val icon = if (bssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -181,18 +181,20 @@ class NetworkSensorManager : SensorManager {
         val settingName = "replace_$bssid"
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val fullSensor = sensorDao.getSettings(bssidState.id)
-        val getNextBSSID = fullSensor?.settings?.firstOrNull { it.name == "get_next_bssid" }?.value ?: "false"
-        val currentSetting = fullSensor?.settings?.firstOrNull { it.name == settingName }?.value ?: ""
-        if (getNextBSSID == "true") {
+        val getCurrentBSSID = fullSensor?.firstOrNull { it.name == "get_current_bssid" }?.value ?: "false"
+        val currentSetting = fullSensor?.firstOrNull { it.name == settingName }?.value ?: ""
+        if (getCurrentBSSID == "true") {
             if (currentSetting == "") {
-                sensorDao.add(Setting(bssidState.id, "get_next_bssid", "false", "toggle"))
-                sensorDao.add(Setting(bssidState.id, settingName, "", "string"))
+                sensorDao.add(Setting(bssidState.id, "get_current_bssid", "false", "toggle"))
+                sensorDao.add(Setting(bssidState.id, settingName, bssid, "string"))
             }
         } else {
             if (currentSetting != "")
                 bssid = currentSetting
+            else
+                sensorDao.removeSetting(bssidState.id, settingName)
 
-            sensorDao.add(Setting(bssidState.id, "get_next_bssid", "false", "toggle"))
+            sensorDao.add(Setting(bssidState.id, "get_current_bssid", "false", "toggle"))
         }
 
         val icon = if (bssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -175,7 +175,7 @@ class SensorDetailFragment(
                         if (!it.contains(pref))
                             it.addPreference(pref)
                     }
-                    if (setting.valueType == "string") {
+                    if (setting.valueType == "string" || setting.valueType == "number") {
                         val pref = findPreference(key) ?: EditTextPreference(requireContext())
                         pref.key = key
                         pref.title = setting.name
@@ -186,7 +186,7 @@ class SensorDetailFragment(
                         pref.isIconSpaceReserved = false
 
                         pref.setOnBindEditTextListener { fieldType ->
-                            if (setting.valueType == "int" || setting.valueType == "float")
+                            if (setting.valueType == "number")
                                 fieldType.inputType = InputType.TYPE_CLASS_NUMBER
                         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -100,7 +100,6 @@ class SensorDetailFragment(
             return
         val sensorData = fullData.sensor
         val attributes = fullData.attributes
-        val settings = sensorSettings?.settings
 
         findPreference<Preference>("unique_id")?.let {
             it.isCopyingEnabled = true
@@ -154,8 +153,8 @@ class SensorDetailFragment(
         }
 
         findPreference<PreferenceCategory>("sensor_settings")?.let {
-            if (sensorData.enabled && !settings.isNullOrEmpty()) {
-                settings.forEach { setting ->
+            if (sensorData.enabled && !sensorSettings.isNullOrEmpty()) {
+                sensorSettings.forEach { setting ->
                     val key = "setting_${setting.name}"
                     if (setting.valueType == "toggle") {
                         val pref = findPreference(key) ?: SwitchPreference(requireContext())
@@ -168,14 +167,14 @@ class SensorDetailFragment(
 
                             if (isEnabled) {
                                 sensorDao.add(Setting(basicSensor.id, setting.name, "true", "toggle"))
-                                return@setOnPreferenceChangeListener true
+                            } else {
+                                sensorDao.add(Setting(basicSensor.id, setting.name, "false", "toggle"))
                             }
-                            return@setOnPreferenceChangeListener false
+                            return@setOnPreferenceChangeListener true
                         }
                         if (!it.contains(pref))
                             it.addPreference(pref)
-                    }
-                    if (setting.valueType == "string" || setting.valueType == "number") {
+                    } else if (setting.valueType == "string" || setting.valueType == "number") {
                         val pref = findPreference(key) ?: EditTextPreference(requireContext())
                         pref.key = key
                         pref.title = setting.name

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -165,11 +165,7 @@ class SensorDetailFragment(
                         pref.setOnPreferenceChangeListener { _, newState ->
                             val isEnabled = newState as Boolean
 
-                            if (isEnabled) {
-                                sensorDao.add(Setting(basicSensor.id, setting.name, "true", "toggle"))
-                            } else {
-                                sensorDao.add(Setting(basicSensor.id, setting.name, "false", "toggle"))
-                            }
+                            sensorDao.add(Setting(basicSensor.id, setting.name, isEnabled.toString(), "toggle"))
                             return@setOnPreferenceChangeListener true
                         }
                         if (!it.contains(pref))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@ like to connect to:</string>
   <string name="sensor_description_volume_call">Volume level for calls on the device</string>
   <string name="sensor_description_volume_music">Volume level for music on the device</string>
   <string name="sensor_description_volume_ring">Volume level for the ringer on the device</string>
-  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point</string>
+  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point. The settings will allow you to replace the selected mac address with any name you want.</string>
   <string name="sensor_description_wifi_connection">The name of the network the device is currently connected to</string>
   <string name="sensor_description_wifi_frequency">The frequency band of the connected network</string>
   <string name="sensor_description_wifi_ip">The current IP address of the device on the network</string>
@@ -242,6 +242,7 @@ like to connect to:</string>
   <string name="sensor_name_volume_call">Volume Level Call</string>
   <string name="sensor_name_volume_music">Volume Level Music</string>
   <string name="sensor_name_volume_ring">Volume Level Ringer</string>
+  <string name="sensor_settings">Sensor Settings</string>
   <string name="sensor_summary">Use this to manage what sensors are enabled/disabled.</string>
   <string name="sensor_title">Manage Sensors</string>
   <string name="sensors">Sensors</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@ like to connect to:</string>
   <string name="sensor_description_volume_call">Volume level for calls on the device</string>
   <string name="sensor_description_volume_music">Volume level for music on the device</string>
   <string name="sensor_description_volume_ring">Volume level for the ringer on the device</string>
-  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point. The settings will allow you to replace the selected mac address with any name you want.</string>
+  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point. Enabling the "get_next_bssid" toggle will create a new setting allowing you to rename the state sent back to Home Assistant for the chosen mac address. The toggle will default to off after the next BSSID is stored, so you will need to enable it once for each BSSID you wish to rename.</string>
   <string name="sensor_description_wifi_connection">The name of the network the device is currently connected to</string>
   <string name="sensor_description_wifi_frequency">The frequency band of the connected network</string>
   <string name="sensor_description_wifi_ip">The current IP address of the device on the network</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@ like to connect to:</string>
   <string name="sensor_description_volume_call">Volume level for calls on the device</string>
   <string name="sensor_description_volume_music">Volume level for music on the device</string>
   <string name="sensor_description_volume_ring">Volume level for the ringer on the device</string>
-  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point. Enabling the "get_next_bssid" toggle will create a new setting allowing you to rename the state sent back to Home Assistant for the chosen mac address. The toggle will default to off after the next BSSID is stored, so you will need to enable it once for each BSSID you wish to rename.</string>
+  <string name="sensor_description_wifi_bssid">The mac address of the currently connected WiFi access point. Enabling the "get_current_bssid" toggle will create a new setting allowing you to rename the state sent back to Home Assistant for the chosen mac address. The toggle will default to off after the current BSSID is stored, so you will need to enable it once for each BSSID you wish to rename. You can also clear out the value to remove the setting in the next update.</string>
   <string name="sensor_description_wifi_connection">The name of the network the device is currently connected to</string>
   <string name="sensor_description_wifi_frequency">The frequency band of the connected network</string>
   <string name="sensor_description_wifi_ip">The current IP address of the device on the network</string>

--- a/app/src/main/res/xml/sensor_detail.xml
+++ b/app/src/main/res/xml/sensor_detail.xml
@@ -36,4 +36,9 @@
         app:key="attributes"
         app:title="@string/attributes"
         app:iconSpaceReserved="false"/>
+
+    <androidx.preference.PreferenceCategory
+        app:key="sensor_settings"
+        app:title="@string/sensor_settings"
+        app:iconSpaceReserved="false"/>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
This PR allows any sensor to have a custom setting to fit its need.  A table identical to attributes is created and most of the logic around the sensor detail fragment is the same too with the exception that we use a `EditTextPreference` to get the value for the manager to handle.  I chose to keep it separate from attributes since these are really more app specific but I think we can allow the managers to provide them as an attribute if we see the need.

With this PR each sensor manager is responsible for: 

* Updating its `BasicSensor.description` to describe each setting
* Creating the setting in the table and in proper order
* Handling null or unwanted values
* Setting `valueType: "number"` or `valueType: "string"` to handle a dynamic keyboard change
* Setting `valueType: "toggle"` if they require a toggle to enable a setting
* Setting a sensible default if required.

For this PR I have chosen `wifi_bssid` to have a custom setting. The user must first enable the toggle `get_next_bssid` then and only then will we create a new field to rename the current BSSID. The user will need to enable the toggle again if they want to rename another BSSID, the toggle will turn itself off after creating one field.  In my house I have 2 AP's so I have chosen to send `Den` or `Bedroom` depending on the connected mac address. This will negate the need to use a template sensor and without the need to use secret values to mask it.

Things to be worked in a future PR would be to allow a user to hide a setting and possibly reset them.  Later on we can use `valueType` to also dictate if instead of a `EditTextPreference` or `SwitchPreference` to use something like Mult-select List or Checkbox etc...  I think for now we should stick to some small basics for an MVP. In the current state it should allow a wide variety of things to be done including #890 

![image](https://user-images.githubusercontent.com/1634145/93162664-1424bc80-f6ca-11ea-932b-f65798c178b0.png)

![image](https://user-images.githubusercontent.com/1634145/93371628-82bb6480-f807-11ea-8a5a-61a3dcb58249.png)

![image](https://user-images.githubusercontent.com/1634145/93162679-1dae2480-f6ca-11ea-9756-1cebbf05d821.png)
