### PR TITLE
Hide NFC if the device reports it has no hardware

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.settings
 
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
@@ -96,7 +97,11 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
         }
 
         findPreference<Preference>("nfc_tags")?.let {
-            it.isVisible = presenter.nfcEnabled()
+            val pm: PackageManager = requireContext().packageManager
+            if (pm.hasSystemFeature(PackageManager.FEATURE_NFC))
+                it.isVisible = presenter.nfcEnabled()
+            else
+                it.isVisible = false
             it.onPreferenceClickListener = Preference.OnPreferenceClickListener {
                 startActivity(NfcSetupActivity.newInstance(requireActivity()))
                 true

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -350,6 +350,8 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                 }
                             }
                             "config/get" -> {
+                                val pm: PackageManager = context.packageManager
+                                val hasNfc = pm.hasSystemFeature(PackageManager.FEATURE_NFC)
                                 val script = "externalBus(" +
                                         "${JSONObject(
                                             mapOf(
@@ -359,7 +361,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                                                 "result" to JSONObject(
                                                     mapOf(
                                                         "hasSettingsScreen" to true,
-                                                        "canWriteTag" to true,
+                                                        "canWriteTag" to hasNfc,
                                                         "hasExoPlayer" to true
                                                     )
                                                 )


### PR DESCRIPTION
Was helping out a user in Discord who could not see the NFC option and it ended up being his HA version was not on 0.114 or higher.  While inspecting the code I noticed we do not check for NFC hardware when we look to make the option visible.  Now we will do a check with package manager and if successful we will continue with current logic looking at the HA version, if unavailable the option will be hidden.  Tested on my pixel 4 xl that has NFC support as well as 2 amazon tablets that do not have NFC, NFC remains hidden on tablets that don't have the hardware.