### PR TITLE
Only do the migration if we have rows to migrate

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -139,18 +139,20 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 val cursor = database.query("SELECT * FROM sensors")
                 val sensors = mutableListOf<ContentValues>()
-                while (cursor.moveToNext()) {
-                    sensors.add(ContentValues().also {
-                        it.put("id", cursor.getString(cursor.getColumnIndex("unique_id")))
-                        it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
-                        it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
-                        it.put("state", "")
-                        it.put("state_type", "")
-                        it.put("type", "")
-                        it.put("icon", "")
-                        it.put("name", "")
-                        it.put("device_class", "")
-                    })
+                if (cursor.count > 0) {
+                    while (cursor.moveToNext()) {
+                        sensors.add(ContentValues().also {
+                            it.put("id", cursor.getString(cursor.getColumnIndex("unique_id")))
+                            it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
+                            it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
+                            it.put("state", "")
+                            it.put("state_type", "")
+                            it.put("type", "")
+                            it.put("icon", "")
+                            it.put("name", "")
+                            it.put("device_class", "")
+                        })
+                    }
                 }
                 cursor.close()
                 database.execSQL("DROP TABLE IF EXISTS `sensors`")
@@ -176,18 +178,20 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 val cursor = database.query("SELECT * FROM sensors")
                 val sensors = mutableListOf<ContentValues>()
-                while (cursor.moveToNext()) {
-                    sensors.add(ContentValues().also {
-                        it.put("id", cursor.getString(cursor.getColumnIndex("id")))
-                        it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
-                        it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
-                        it.put("state", "")
-                        it.put("last_sent_state", "")
-                        it.put("state_type", "")
-                        it.put("type", "")
-                        it.put("icon", "")
-                        it.put("name", "")
-                    })
+                if (cursor.count > 0) {
+                    while (cursor.moveToNext()) {
+                        sensors.add(ContentValues().also {
+                            it.put("id", cursor.getString(cursor.getColumnIndex("id")))
+                            it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
+                            it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
+                            it.put("state", "")
+                            it.put("last_sent_state", "")
+                            it.put("state_type", "")
+                            it.put("type", "")
+                            it.put("icon", "")
+                            it.put("name", "")
+                        })
+                    }
                 }
                 cursor.close()
                 database.execSQL("DROP TABLE IF EXISTS `sensors`")


### PR DESCRIPTION
This should fix the following sentry error, we do the same check for the widget migration:

```
java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
    at android.database.CursorWindow.nativeGetString(CursorWindow.java)
    at android.database.CursorWindow.getString(CursorWindow.java:469)
    at android.database.AbstractWindowedCursor.getString(AbstractWindowedCursor.java:53)
    at io.homeassistant.companion.android.database.AppDatabase$Companion$MIGRATION_9_10$1.migrate(AppDatabase.kt:178)
    at androidx.room.RoomOpenHelper.onUpgrade(RoomOpenHelper.java:99)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.onUpgrade(FrameworkSQLiteOpenHelper.java:177)
    at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:417)
    at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:317)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getWritableSupportDatabase(FrameworkSQLiteOpenHelper.java:145)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper.getWritableDatabase(FrameworkSQLiteOpenHelper.java:106)
    at androidx.room.RoomDatabase.inTransaction(RoomDatabase.java:476)
    at androidx.room.RoomDatabase.assertNotSuspendingTransaction(RoomDatabase.java:281)
    at io.homeassistant.companion.android.database.sensor.SensorDao_Impl.getFull(SensorDao_Impl.java:365)
    at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:119)
    at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:95)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```