### PR TITLE
Add deadband setting for last reboot sensor

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@ like to connect to:</string>
   <string name="sensor_description_headphone">Whether or not headphones are plugged into the device</string>
   <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
   <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
-  <string name="sensor_description_last_reboot">The date and time of the devices last reboot. The setting below will allow you to adjust the offset in milliseconds, if you still find the value to jump incorrectly. The default value is 60000 (1 minute).</string>
+  <string name="sensor_description_last_reboot">The date and time of the devices last reboot. The setting below will allow you to adjust the deadband in milliseconds, if you still find the value to jump incorrectly. The default value is 60000 (1 minute).</string>
   <string name="sensor_description_light_sensor">The current level of illuminance</string>
   <string name="sensor_description_location_background">Update your location behind the scenes, periodically.</string>
   <string name="sensor_description_location_zone">Import existing Home Assistant zones as geofences for zone based tracking.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,7 +186,7 @@ like to connect to:</string>
   <string name="sensor_description_headphone">Whether or not headphones are plugged into the device</string>
   <string name="sensor_description_interactive">Whether or not the device is in an interactive state</string>
   <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
-  <string name="sensor_description_last_reboot">The date and time of the devices last reboot</string>
+  <string name="sensor_description_last_reboot">The date and time of the devices last reboot. The setting below will allow you to adjust the offset in milliseconds, if you still find the value to jump incorrectly. The default value is 60000 (1 minute).</string>
   <string name="sensor_description_light_sensor">The current level of illuminance</string>
   <string name="sensor_description_location_background">Update your location behind the scenes, periodically.</string>
   <string name="sensor_description_location_zone">Import existing Home Assistant zones as geofences for zone based tracking.</string>


### PR DESCRIPTION
Fixes: #910 

As we noticed that there may be a difference between cell phone and cell tower time lets add an `offset` for the last reboot sensor. The default value is set to `60000` or 1 minute, we can adjust it but I think this should fix the issue for most users.  Making it a setting in case they want to make the value larger or smaller.  The description has been updated to explain the setting and I have also moved some static strings to be constant values.