### PR TITLE
Check if skip is not null before attempting to show the error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -161,7 +161,8 @@ class MobileAppIntegrationFragment : Fragment(), MobileAppIntegrationView {
 
     override fun showError(skippable: Boolean) {
         if (skippable) {
-            skip.visibility = View.VISIBLE
+            if (skip != null)
+                skip.visibility = View.VISIBLE
         }
         viewFlipper.displayedChild = ERROR_VIEW
     }


### PR DESCRIPTION
Fixes the following Sentry error: 

```
java.lang.IllegalStateException: skip must not be null
    at io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationFragment.showError(MobileAppIntegrationFragment.kt:164)
    at io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationPresenterBase$onRegistrationAttempt$1.invokeSuspend(MobileAppIntegrationPresenterBase.kt:40)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:55)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:224)
    at android.app.ActivityThread.main(ActivityThread.java:7562)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```