### PR TITLE
Catch the exception when we get null for attributes

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
@@ -128,7 +128,7 @@ class StaticWidget : AppWidgetProvider() {
         var fetchedAttributes: Map<*, *>
         var attributeValues: List<String?>
         try {
-            fetchedAttributes = entity?.attributes as Map<*, *>
+            fetchedAttributes = (entity?.attributes as? Map<*, *>)!!
             attributeValues = attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
             return entity.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "").plus(attributeValues.joinToString(attributeSeparator))
         } catch (e: Exception) {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
@@ -128,9 +128,9 @@ class StaticWidget : AppWidgetProvider() {
         var fetchedAttributes: Map<*, *>
         var attributeValues: List<String?>
         try {
-            fetchedAttributes = (entity?.attributes as? Map<*, *>)!!
+            fetchedAttributes = entity?.attributes as? Map<*, *> ?: mapOf<String, String>()
             attributeValues = attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
-            return entity.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "").plus(attributeValues.joinToString(attributeSeparator))
+            return entity?.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "").plus(attributeValues.joinToString(attributeSeparator))
         } catch (e: Exception) {
             Log.d(TAG, "Unable to fetch entity state and attributes", e)
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/StaticWidget.kt
@@ -125,9 +125,16 @@ class StaticWidget : AppWidgetProvider() {
 
         if (attributeIds == null) return entity?.state
 
-        val fetchedAttributes = entity?.attributes as Map<*, *>
-        val attributeValues = attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
-        return entity.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "").plus(attributeValues.joinToString(attributeSeparator))
+        var fetchedAttributes: Map<*, *>
+        var attributeValues: List<String?>
+        try {
+            fetchedAttributes = entity?.attributes as Map<*, *>
+            attributeValues = attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
+            return entity.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "").plus(attributeValues.joinToString(attributeSeparator))
+        } catch (e: Exception) {
+            Log.d(TAG, "Unable to fetch entity state and attributes", e)
+        }
+        return null
     }
 
     override fun onReceive(context: Context, intent: Intent) {


### PR DESCRIPTION
Fixes the following sentry error:

```
kotlin.TypeCastException: null cannot be cast to non-null type kotlin.collections.Map<*, *>
    at io.homeassistant.companion.android.widgets.StaticWidget.resolveTextToShow(StaticWidget.kt:128)
    at io.homeassistant.companion.android.widgets.StaticWidget$resolveTextToShow$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7697)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```