### PR TITLE
Add traffic stat sensors mobile and total data usage for transmitting and receving

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -37,7 +37,8 @@ class SensorReceiver : BroadcastReceiver() {
             PressureSensorManager(),
             ProximitySensorManager(),
             StepsSensorManager(),
-            StorageSensorManager()
+            StorageSensorManager(),
+            TrafficStatsManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
@@ -91,6 +91,7 @@ class TrafficStatsManager : SensorManager {
             mobileRx = TrafficStats.getMobileRxBytes().toFloat()
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the mobile rx bytes", e)
+            return
         }
 
         mobileRx /= GB
@@ -114,6 +115,7 @@ class TrafficStatsManager : SensorManager {
             mobileTx = TrafficStats.getMobileTxBytes().toFloat()
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the mobile tx bytes", e)
+            return
         }
 
         mobileTx /= GB
@@ -136,6 +138,7 @@ class TrafficStatsManager : SensorManager {
             totalRx = TrafficStats.getTotalRxBytes().toFloat().absoluteValue
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the total rx bytes", e)
+            return
         }
         totalRx /= GB
 
@@ -159,6 +162,7 @@ class TrafficStatsManager : SensorManager {
             totalTx = TrafficStats.getTotalTxBytes().toFloat().absoluteValue
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the total tx bytes", e)
+            return
         }
 
         totalTx /= GB

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
@@ -1,0 +1,173 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.net.TrafficStats
+import android.util.Log
+import io.homeassistant.companion.android.R
+import java.math.RoundingMode
+import kotlin.math.absoluteValue
+
+class TrafficStatsManager : SensorManager {
+    companion object {
+        private const val TAG = "TrafficStats"
+        private const val GB = 1000000000
+
+        val rxBytesMobile = SensorManager.BasicSensor(
+            "mobile_rx_gb",
+            "sensor",
+            R.string.basic_sensor_name_mobile_rx_gb,
+            R.string.sensor_description_mobile_rx_gb,
+            unitOfMeasurement = "GB"
+        )
+        val txBytesMobile = SensorManager.BasicSensor(
+            "mobile_tx_gb",
+            "sensor",
+            R.string.basic_sensor_name_mobile_tx_gb,
+            R.string.sensor_description_mobile_tx_gb,
+            unitOfMeasurement = "GB"
+        )
+        val rxBytesTotal = SensorManager.BasicSensor(
+            "total_rx_gb",
+            "sensor",
+            R.string.basic_sensor_name_total_rx_gb,
+            R.string.sensor_description_total_rx_gb,
+            unitOfMeasurement = "GB"
+        )
+        val txBytesTotal = SensorManager.BasicSensor(
+            "total_tx_gb",
+            "sensor",
+            R.string.basic_sensor_name_total_tx_gb,
+            R.string.sensor_description_total_tx_gb,
+            unitOfMeasurement = "GB"
+        )
+        private var hasCellular = false
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_traffic_stats
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = if (hasCellular) {
+            listOf(rxBytesMobile, txBytesMobile, rxBytesTotal, txBytesTotal)
+        } else listOf(rxBytesTotal, txBytesTotal)
+
+    override fun requiredPermissions(): Array<String> {
+        return emptyArray()
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val cm: ConnectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val networkInfo = cm.allNetworks
+        var networkCapabilities: NetworkCapabilities
+        for (item in networkInfo) {
+            networkCapabilities = cm.getNetworkCapabilities(item)
+            if (!hasCellular)
+                hasCellular = networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+        }
+        return true
+    }
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        updateMobileRxBytes(context)
+        updateMobileTxBytes(context)
+        updateTotalRxBytes(context)
+        updateTotalTxBytes(context)
+    }
+
+    private fun updateMobileRxBytes(context: Context) {
+
+        if (!isEnabled(context, rxBytesMobile.id))
+            return
+
+        var mobileRx = 0f
+        val icon = "mdi:radio-tower"
+
+        try {
+            mobileRx = TrafficStats.getMobileRxBytes().toFloat()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the mobile rx bytes", e)
+        }
+
+        mobileRx /= GB
+        onSensorUpdated(context,
+            rxBytesMobile,
+            mobileRx.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateMobileTxBytes(context: Context) {
+
+        if (!isEnabled(context, txBytesMobile.id))
+            return
+
+        var mobileTx = 0f
+        val icon = "mdi:radio-tower"
+
+        try {
+            mobileTx = TrafficStats.getMobileTxBytes().toFloat()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the mobile tx bytes", e)
+        }
+
+        mobileTx /= GB
+        onSensorUpdated(context,
+            txBytesMobile,
+            mobileTx.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf()
+        )
+    }
+    private fun updateTotalRxBytes(context: Context) {
+
+        if (!isEnabled(context, rxBytesTotal.id))
+            return
+
+        var totalRx = 0f
+        val icon = "mdi:radio-tower"
+
+        try {
+            totalRx = TrafficStats.getTotalRxBytes().toFloat().absoluteValue
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the total rx bytes", e)
+        }
+        totalRx /= GB
+
+        onSensorUpdated(context,
+            rxBytesTotal,
+            totalRx.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateTotalTxBytes(context: Context) {
+
+        if (!isEnabled(context, txBytesTotal.id))
+            return
+
+        var totalTx = 0f
+        val icon = "mdi:radio-tower"
+
+        try {
+            totalTx = TrafficStats.getTotalTxBytes().toFloat().absoluteValue
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting the total tx bytes", e)
+        }
+
+        totalTx /= GB
+
+        onSensorUpdated(context,
+            txBytesTotal,
+            totalTx.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
   <string name="auth_error">Authentication Error</string>
   <string name="auth_error_message">The \'Username\' and \'Password\' fields must be completed</string>
   <string name="auth_request">Authentication Requested</string>
+  <string name="basic_sensor_name_mobile_rx_gb">Mobile Rx GB</string>
+  <string name="basic_sensor_name_mobile_tx_gb">Mobile Tx GB</string>
+  <string name="basic_sensor_name_total_rx_gb">Total Rx GB</string>
+  <string name="basic_sensor_name_total_tx_gb">Total Tx GB</string>
   <string name="basic_sensor_name_activity">Detected Activity</string>
   <string name="basic_sensor_name_alarm">Next Alarm</string>
   <string name="basic_sensor_name_battery_health">Battery Health</string>
@@ -169,6 +173,10 @@ for Home Assistant</string>
 like to connect to:</string>
   <string name="sensor">Sensor</string>
   <string name="sensor_description">Description</string>
+  <string name="sensor_description_mobile_rx_gb">Total Rx GB on cellular data since last device reboot</string>
+  <string name="sensor_description_mobile_tx_gb">Total Tx GB on cellular data since last device reboot</string>
+  <string name="sensor_description_total_rx_gb">Total Rx GB since last device reboot</string>
+  <string name="sensor_description_total_tx_gb">Total Tx GB since last device reboot</string>
   <string name="sensor_description_audio_mode">The state of the devices audio mode</string>
   <string name="sensor_description_audio_sensor">The state of the devices ringer mode</string>
   <string name="sensor_description_battery_health">The health of the battery</string>
@@ -215,6 +223,7 @@ like to connect to:</string>
   <string name="sensor_description_wifi_link_speed">The current link speed of the device to the connected network</string>
   <string name="sensor_description_wifi_signal">The signal strength of the device to the WiFi network</string>
   <string name="sensor_description_wifi_state">Whether or not WiFi is enabled on the device</string>
+  <string name="sensor_name_traffic_stats">Traffic Stats Sensors</string>
   <string name="sensor_name_activity">Activity Sensors</string>
   <string name="sensor_name_alarm">Alarm Sensor</string>
   <string name="sensor_name_audio">Audio Sensors</string>


### PR DESCRIPTION
4 new sensors, all disabled by default. Fixes: #950 

* Mobile Rx GB
* Mobile Tx GB
* Total Rx GB
* Total Tx GB

The mobile sensors are only visible on devices that have cellular data, it is safe to assume that all devices will report total data as they are online. I opted not to check if the device has phone capabilities so we can include tablets that have cellular data.  This check is done in `hasSensor` which gets called before the available sensors so we are hiding them properly.  Tested this in the emulator, my pixel 4 xl and a Android 5.1 tablet.

Data is converted from bytes to GB as that is what the world measures in data usage.  Set to 3 decimal places so people don't see 0.00 like I did 😛 