### PR TITLE
Fix settings getting overriden by default value, show summary provider if we have it as a result

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -195,6 +195,8 @@ class SensorDetailFragment(
                                     setting.valueType
                                 )
                             )
+                        else
+                            pref.text = setting.value
                     if (!it.contains(pref))
                         it.addPreference(pref)
                     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -155,7 +155,7 @@ class SensorDetailFragment(
         findPreference<PreferenceCategory>("sensor_settings")?.let {
             if (sensorData.enabled && !sensorSettings.isNullOrEmpty()) {
                 sensorSettings.forEach { setting ->
-                    val key = "setting_${setting.name}"
+                    val key = "setting_${basicSensor.id}_${setting.name}"
                     if (setting.valueType == "toggle") {
                         val pref = findPreference(key) ?: SwitchPreference(requireContext())
                         pref.key = key
@@ -175,8 +175,10 @@ class SensorDetailFragment(
                         pref.key = key
                         pref.title = setting.name
                         pref.dialogTitle = setting.name
-                        pref.text = setting.value
-                        pref.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
+                        if (pref.text != null)
+                            pref.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
+                        else
+                            pref.summary = setting.value
                         pref.isIconSpaceReserved = false
 
                         pref.setOnBindEditTextListener { fieldType ->


### PR DESCRIPTION
I noticed a few issues while testing out the location settings

* If more than 1 sensor used the same setting name we were using the same preference, so now we set the `key` to include the `basicSensor.id`
* Settings were flipping back to default upon the next update (caused by `pref.text = setting.value` which is now only set if `pref.text == null`)
* Summary provider was showing `Not Set` when it was null (as a result of above changes) so if we are null then we default to showing the database value

I wonder if we should consider decreasing the refresh time here to make things look faster?