### PR TITLE
Add setting for next alarm allow list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.os.Handler
 import android.text.InputType
 import androidx.preference.EditTextPreference
+import androidx.preference.MultiSelectListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
@@ -199,6 +200,37 @@ class SensorDetailFragment(
                             pref.text = setting.value
                     if (!it.contains(pref))
                         it.addPreference(pref)
+                    } else if (setting.valueType == "list-apps") {
+                        val packageManager: PackageManager? = context?.packageManager
+                        val packages = packageManager?.getInstalledApplications(PackageManager.GET_META_DATA)
+                        val packageName: MutableList<String> = ArrayList()
+                        if (packages != null) {
+                            for (packageItem in packages) {
+                                packageName.add(packageItem.packageName)
+                            }
+                            packageName.sort()
+                        }
+                        val pref = findPreference(key) ?: MultiSelectListPreference(requireContext())
+                        pref.key = key
+                        pref.title = setting.name
+                        pref.entries = packageName.toTypedArray()
+                        pref.entryValues = packageName.toTypedArray()
+                        pref.dialogTitle = setting.name
+                        pref.isIconSpaceReserved = false
+                        if (pref.values != null) {
+                            pref.summary = pref.values.toString()
+                            sensorDao.add(
+                                Setting(
+                                    basicSensor.id,
+                                    setting.name,
+                                    pref.values.toString().replace("[", "").replace("]", ""),
+                                    "list-apps"
+                                )
+                            )
+                        } else
+                            pref.summary = setting.value
+                        if (!it.contains(pref))
+                            it.addPreference(pref)
                     }
                 }
                 it.isVisible = true

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -178,8 +178,10 @@ class SensorDetailFragment(
                         pref.dialogTitle = setting.name
                         if (pref.text != null)
                             pref.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
-                        else
+                        else {
                             pref.summary = setting.value
+                            pref.text = setting.value
+                        }
                         pref.isIconSpaceReserved = false
 
                         pref.setOnBindEditTextListener { fieldType ->
@@ -187,17 +189,17 @@ class SensorDetailFragment(
                                 fieldType.inputType = InputType.TYPE_CLASS_NUMBER
                         }
 
-                        if (pref.text != null)
+                        pref.setOnPreferenceChangeListener { _, newValue ->
                             sensorDao.add(
                                 Setting(
                                     basicSensor.id,
                                     setting.name,
-                                    pref.text,
+                                    newValue as String,
                                     setting.valueType
                                 )
                             )
-                        else
-                            pref.text = setting.value
+                            return@setOnPreferenceChangeListener true
+                        }
                     if (!it.contains(pref))
                         it.addPreference(pref)
                     } else if (setting.valueType == "list-apps") {
@@ -217,17 +219,20 @@ class SensorDetailFragment(
                         pref.entryValues = packageName.toTypedArray()
                         pref.dialogTitle = setting.name
                         pref.isIconSpaceReserved = false
-                        if (pref.values != null) {
-                            pref.summary = pref.values.toString()
+                        pref.setOnPreferenceChangeListener { _, newValue ->
                             sensorDao.add(
                                 Setting(
                                     basicSensor.id,
                                     setting.name,
-                                    pref.values.toString().replace("[", "").replace("]", ""),
+                                    newValue.toString().replace("[", "").replace("]", ""),
                                     "list-apps"
                                 )
                             )
-                        } else
+                            return@setOnPreferenceChangeListener true
+                        }
+                        if (pref.values != null)
+                            pref.summary = pref.values.toString()
+                        else
                             pref.summary = setting.value
                         if (!it.contains(pref))
                             it.addPreference(pref)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,7 +202,7 @@ like to connect to:</string>
   <string name="sensor_description_location_zone">Import existing Home Assistant zones as geofences for zone based tracking.  The Minimum Accuracy setting will allow you to decide how accurate the device location (in meters) has to be in order to send to Home Assistant.</string>
   <string name="sensor_description_mic_muted">Whether or not the microphone is muted on the device</string>
   <string name="sensor_description_music_active">Whether or not music is actively playing on the device</string>
-  <string name="sensor_description_next_alarm">The date and time of the next scheduled alarm, any app or manufacturer can override the default behavior. The package attribute will tell you which app set the next scheduled alarm.</string>
+  <string name="sensor_description_next_alarm">The date and time of the next scheduled alarm, any app or manufacturer can override the default behavior. The package attribute will tell you which app set the next scheduled alarm. The setting below will create an Allow List so you can specify what packages you want the alarm event from. This will ignore alarm events for packages not selected and the state will not update until the next scheduled alarm matches one of the selected packages.</string>
   <string name="sensor_description_none">No description</string>
   <string name="sensor_description_phone_state">Whether or not the phone is ringing or in a call, no other caller information is stored</string>
   <string name="sensor_description_power_save">Whether or not the device is in Power Save mode</string>


### PR DESCRIPTION
Fixes: #748 

This implements `valueType: "list-apps"` which creates a MultiSelectListPreference that will list all installed packages on the users device.  Given that many alarm packages are also installed as a system app we cannot ignore them.  This list is then saved to the DB stripping away unnecessary characters to make the iteration easier with a `String.split` we also save the `value` as a String so this made the most sense to me.

I went with an Allow List because users know what app they set their alarm in, there are far too many apps out there (now and in the future) that can make use of the API so an Allow List makes the most sense.

Also given that we have a `package` attribute for users to identify the incorrect state I am listing the package itself instead of a friendly name so its easier for users to identify what to block since we already provide that data to them.

![image](https://user-images.githubusercontent.com/1634145/93811399-ef1dd580-fc04-11ea-899f-1ad742615604.png)

![image](https://user-images.githubusercontent.com/1634145/93811403-f1802f80-fc04-11ea-8d14-ff5462c70b50.png)
