### PR TITLE
Write application record to NFC tags.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -10,13 +10,15 @@ import android.nfc.NfcAdapter
 import android.nfc.Tag
 import android.nfc.tech.Ndef
 import android.nfc.tech.NdefFormatable
+import io.homeassistant.companion.android.BuildConfig
 import java.io.IOException
 
 object NFCUtil {
     @Throws(Exception::class)
     fun createNFCMessage(url: String, intent: Intent?): Boolean {
         val nfcRecord = NdefRecord.createUri(url)
-        val nfcMessage = NdefMessage(arrayOf(nfcRecord))
+        val applicationRecord = NdefRecord.createApplicationRecord(BuildConfig.APPLICATION_ID)
+        val nfcMessage = NdefMessage(arrayOf(nfcRecord, applicationRecord))
         intent?.let {
             val tag = it.getParcelableExtra<Tag>(NfcAdapter.EXTRA_TAG)
             return writeMessageToTag(nfcMessage, tag)


### PR DESCRIPTION
Relates to #876

This fixes an issue where on certain devices a dialog was showing up when scanning the NFC tags.

After this change, scanned NFC tags go directly into the home assistant android companion app.

I also tested on an iOS device to ensure the written NFC tag is correctly read.