### PR TITLE
Support person profile image upload

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
-    
+
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
@@ -190,6 +192,16 @@
                 <data android:mimeType="text/*" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="io.homeassistant.companion.android.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_path"></meta-data>
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@ Home Assistant instance</string>
   <string name="label_attribute">Attribute:</string>
   <string name="label_dynamic_data">Data:</string>
   <string name="label_entity_id">Entity ID:</string>
+  <string name="profile_image">Select Profile Image</string>
   <string name="label_icon">Icon:</string>
   <string name="label_label">Label:</string>
   <string name="label_service">Service:</string>

--- a/app/src/main/res/xml/file_path.xml
+++ b/app/src/main/res/xml/file_path.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="my_images" path="Android/data/io.homeassistant.companion.android.debug/files/Pictures/UserProfileImage" />
+</paths>


### PR DESCRIPTION
Fixes: #959 

Upon navigating to Configuration > Persons and then selecting the image field we are now presented with 2 options: Camera or Files.

Selecting Camera will open up the default camera, once a user takes a picture and confirms it the image is then handed off to the frontend so the user can crop and save etc...

Selecting Files open up a file manager that will only display images, selecting an image will then hand it off to the frontend so the user can perform the rest of the actions.

If a user did not already grant camera permissions upon selecting the upload icon they will prompted to grant proper permissions.  I had also added reading/writing permissions as those are required for some versions of android.