### PR TITLE
Incoming/Outgoing phone number tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
     

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.telephony.SubscriptionInfo
 import android.telephony.SubscriptionManager
@@ -17,6 +18,13 @@ class PhoneStateSensorManager : SensorManager {
             "sensor",
             R.string.basic_sensor_name_phone,
             R.string.sensor_description_phone_state
+        )
+
+        val callNumber = SensorManager.BasicSensor(
+            "call_number",
+            "sensor",
+            R.string.basic_sensor_name_call_number,
+            R.string.sensor_description_call_number
         )
 
         val sim_1 = SensorManager.BasicSensor(
@@ -41,45 +49,73 @@ class PhoneStateSensorManager : SensorManager {
 
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
-            listOf(phoneState, sim_1, sim_2)
-        else listOf(phoneState)
+            listOf(phoneState, callNumber, sim_1, sim_2)
+        else listOf(phoneState, callNumber)
 
     override fun requiredPermissions(sensorId: String): Array<String> {
-        return arrayOf(Manifest.permission.READ_PHONE_STATE)
+        return if (sensorId == callNumber.id) {
+            arrayOf(Manifest.permission.READ_PHONE_STATE, Manifest.permission.READ_CALL_LOG)
+        } else arrayOf(Manifest.permission.READ_PHONE_STATE)
     }
 
     override fun requestSensorUpdate(
         context: Context
     ) {
-        updatePhoneStateSensor(context)
+        checkPhoneState(context)
         updateSimSensor(context, 0)
         updateSimSensor(context, 1)
     }
 
-    private fun updatePhoneStateSensor(context: Context) {
-        if (!isEnabled(context, phoneState.id))
-            return
-        var currentPhoneState = "unavailable"
-        if (checkPermission(context, phoneState.id)) {
-            val telephonyManager =
-                (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+    private fun checkPhoneState(context: Context) {
+        if (isEnabled(context, phoneState.id) || isEnabled(context, callNumber.id)) {
+            var currentPhoneState = "unknown"
 
-            currentPhoneState = when (telephonyManager.callState) {
-                0 -> "idle"
-                1 -> "ringing"
-                2 -> "offhook"
-                else -> "unknown"
+            if (checkPermission(context, phoneState.id)) {
+                val telephonyManager =
+                    (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+
+                currentPhoneState = when (telephonyManager.callState) {
+                    0 -> "idle"
+                    1 -> "ringing"
+                    2 -> "offhook"
+                    else -> "unknown"
+                }
             }
-        }
+            if (isEnabled(context, phoneState.id))
+                updatePhoneStateSensor(context, currentPhoneState)
 
+            if (isEnabled(context, callNumber.id) && currentPhoneState in arrayOf("idle", "unknown"))
+                updateCallNumberSensor(context, "none")
+        }
+    }
+
+    private fun updatePhoneStateSensor(context: Context, state: String) {
         var phoneIcon = "mdi:phone"
-        if (currentPhoneState == "ringing" || currentPhoneState == "offhook")
+        if (state == "ringing" || state == "offhook")
             phoneIcon += "-in-talk"
 
         onSensorUpdated(context,
             phoneState,
-            currentPhoneState,
+            state,
             phoneIcon,
+            mapOf()
+        )
+    }
+
+    fun updateCallNumber(context: Context, intent: Intent) {
+        if (checkPermission(context, callNumber.id)) {
+            if (intent.hasExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)) {
+                val number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)
+                updateCallNumberSensor(context, number)
+            }
+        }
+    }
+
+    private fun updateCallNumberSensor(context: Context, number: String) {
+        onSensorUpdated(context,
+            callNumber,
+            number,
+            "mdi:numeric",
             mapOf()
         )
     }
@@ -110,7 +146,7 @@ class PhoneStateSensorManager : SensorManager {
                         attrs["mcc"] = info.mccString.toString()
                         attrs["mnc"] = info.mncString.toString()
                         attrs["is opportunistic"] = info.isOpportunistic
-                    if (info.dataRoaming == SubscriptionManager.DATA_ROAMING_ENABLE) attrs["data roaming"] = "enable"
+                        if (info.dataRoaming == SubscriptionManager.DATA_ROAMING_ENABLE) attrs["data roaming"] = "enable"
                         else attrs["data roaming"] = "disable"
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,7 @@
   <string name="basic_sensor_name_battery_state">Battery State</string>
   <string name="basic_sensor_name_bluetooth">Bluetooth Connection</string>
   <string name="basic_sensor_name_bluetooth_state">Bluetooth State</string>
+  <string name="basic_sensor_name_call_number">Call Number</string>
   <string name="basic_sensor_name_charger_type">Charger Type</string>
   <string name="basic_sensor_name_charging">Is Charging</string>
   <string name="basic_sensor_name_doze">Doze Mode</string>
@@ -185,6 +186,7 @@ like to connect to:</string>
   <string name="sensor_description_battery_state">The current charging state of the battery</string>
   <string name="sensor_description_bluetooth_connection">Information about currently connected bluetooth devices</string>
   <string name="sensor_description_bluetooth_state">Whether or not bluetooth is enabled on the device</string>
+  <string name="sensor_description_call_number">The cell number of the incoming or outgoing call</string>
   <string name="sensor_description_charger_type">The type of charger plugged into the device currently</string>
   <string name="sensor_description_charging">Whether or not the device is actively charging</string>
   <string name="sensor_description_detected_activity">The current activity type as computed by Googles Activity Recognition API</string>


### PR DESCRIPTION
Fixes: #892 

PR adds calling number track feature. It uses deprecated in api29 constant, but I don't find any other simple suitable solution. I hope google will add some before removed that. It tracks both incoming and outgoing calls.

There is small refactor of SensorReceiver class as well.