### PR TITLE
Fix changelog link by removing full and minimal reference

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -130,7 +130,7 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
         findPreference<Preference>("changelog")?.let {
             val link = if (BuildConfig.VERSION_NAME.startsWith("LOCAL"))
                 "https://github.com/home-assistant/android/releases"
-            else "https://github.com/home-assistant/android/releases/tag/${BuildConfig.VERSION_NAME}"
+            else "https://github.com/home-assistant/android/releases/tag/${BuildConfig.VERSION_NAME.replace("-full", "").replace("-minimal", "")}"
             it.summary = link
             val intent = Intent()
             intent.action = "android.intent.action.VIEW"


### PR DESCRIPTION
Noticed that the version name included the flavor so just stripping that out so users dont get hit with a 404.