### PR TITLE
Add file chooser to webview

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -99,7 +99,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private lateinit var authenticator: Authenticator
     private lateinit var exoPlayerView: PlayerView
 
-    private var mFilePathCallback: ValueCallback<Array<Uri?>?>? = null
+    private var mFilePathCallback: ValueCallback<Array<Uri>>? = null
     private var isConnected = false
     private var isShowingError = false
     private var alertDialog: AlertDialog? = null
@@ -300,17 +300,14 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                 }
 
                 override fun onShowFileChooser(
-                    view: WebView?,
-                    uploadMsg: ValueCallback<Array<Uri?>?>,
-                    fileChooserParams: FileChooserParams?
+                    view: WebView,
+                    uploadMsg: ValueCallback<Array<Uri>>,
+                    fileChooserParams: FileChooserParams
                 ): Boolean {
-                    val i = Intent(Intent.ACTION_GET_CONTENT)
-                    i.addCategory(Intent.CATEGORY_OPENABLE)
-                    i.type = "*/*"
                     mFilePathCallback = uploadMsg
-
-                    val chooserIntent = Intent.createChooser(i, resources.getString(R.string.select_file))
-                    startActivityForResult(chooserIntent, FILE_CHOOSER_RESULT_CODE)
+                    val i = fileChooserParams.createIntent()
+                    i.type = "*/*"
+                    startActivityForResult(i, FILE_CHOOSER_RESULT_CODE)
                     return true
                 }
 
@@ -445,11 +442,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                 Log.d(TAG, "NFC Write Complete $it")
             }
         } else if (requestCode == FILE_CHOOSER_RESULT_CODE) {
-            val results: Uri? = data?.data
-            if (results != null)
-                mFilePathCallback!!.onReceiveValue(arrayOf(results))
-            else
-                mFilePathCallback?.onReceiveValue(arrayOf())
+            mFilePathCallback?.onReceiveValue(WebChromeClient.FileChooserParams.parseResult(resultCode, data))
             mFilePathCallback = null
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -24,6 +24,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.JsResult
 import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
+import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -74,6 +75,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
         private const val CAMERA_REQUEST_CODE = 8675309
         private const val AUDIO_REQUEST_CODE = 42
         private const val NFC_COMPLETE = 1
+        private const val FILE_CHOOSER_RESULT_CODE = 15
 
         fun newInstance(context: Context, path: String? = null): Intent {
             return Intent(context, WebViewActivity::class.java).apply {
@@ -97,6 +99,7 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
     private lateinit var authenticator: Authenticator
     private lateinit var exoPlayerView: PlayerView
 
+    private var mFilePathCallback: ValueCallback<Array<Uri?>?>? = null
     private var isConnected = false
     private var isShowingError = false
     private var alertDialog: AlertDialog? = null
@@ -296,6 +299,21 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
                     }
                 }
 
+                override fun onShowFileChooser(
+                    view: WebView?,
+                    uploadMsg: ValueCallback<Array<Uri?>?>,
+                    fileChooserParams: FileChooserParams?
+                ): Boolean {
+                    val i = Intent(Intent.ACTION_GET_CONTENT)
+                    i.addCategory(Intent.CATEGORY_OPENABLE)
+                    i.type = "*/*"
+                    mFilePathCallback = uploadMsg
+
+                    val chooserIntent = Intent.createChooser(i, resources.getString(R.string.select_file))
+                    startActivityForResult(chooserIntent, FILE_CHOOSER_RESULT_CODE)
+                    return true
+                }
+
                 override fun onShowCustomView(view: View, callback: CustomViewCallback) {
                     myCustomView = view
                     decor.addView(
@@ -426,6 +444,13 @@ class WebViewActivity : AppCompatActivity(), io.homeassistant.companion.android.
             webView.evaluateJavascript("externalBus(${JSONObject(message)})") {
                 Log.d(TAG, "NFC Write Complete $it")
             }
+        } else if (requestCode == FILE_CHOOSER_RESULT_CODE) {
+            val results: Uri? = data?.data
+            if (results != null)
+                mFilePathCallback!!.onReceiveValue(arrayOf(results))
+            else
+                mFilePathCallback?.onReceiveValue(arrayOf())
+            mFilePathCallback = null
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,6 @@
   <string name="calendar">Calendar</string>
   <string name="cancel">Cancel</string>
   <string name="changelog">Change Log</string>
-  <string name="select_file">Select a file</string>
   <string name="checking_with_home_assistant">Checking with Home Assistant</string>
   <string name="config">Configuration</string>
   <string name="configure_service_call">Configure Service Call</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,6 +61,7 @@
   <string name="calendar">Calendar</string>
   <string name="cancel">Cancel</string>
   <string name="changelog">Change Log</string>
+  <string name="select_file">Select a file</string>
   <string name="checking_with_home_assistant">Checking with Home Assistant</string>
   <string name="config">Configuration</string>
   <string name="configure_service_call">Configure Service Call</string>


### PR DESCRIPTION
This PR adds basic support to show the file chooser prompt when the webview calls for it (i.e. person image upload).

In this PR we are not restricting the file type nor do we show the camera, this is for basic file upload support.  Person image upload already looks for images and will reject any invalid selected file.

We will need to think about a better way to do things like #974 while still allowing the user to upload any file.  This consideration is important in case any add-on or future feature calls for more than just images.  Maybe we should consider looking at the URL to determine what type of file chooser to show?