### PR TITLE
Split permissions per sensor enity

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -108,7 +108,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(activity)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(
                 Manifest.permission.ACTIVITY_RECOGNITION

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -33,7 +33,7 @@ class GeocodeSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(geocodedLocation)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(
                 Manifest.permission.ACCESS_FINE_LOCATION,
@@ -51,7 +51,7 @@ class GeocodeSensorManager : SensorManager {
     }
 
     private fun updateGeocodedLocation(context: Context) {
-        if (!isEnabled(context, geocodedLocation.id) || !checkPermission(context))
+        if (!isEnabled(context, geocodedLocation.id) || !checkPermission(context, geocodedLocation.id))
             return
         val locApi = LocationServices.getFusedLocationProviderClient(context)
         locApi.lastLocation.addOnSuccessListener { location ->

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -107,7 +107,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     }
 
     private fun setupLocationTracking() {
-        if (!checkPermission(latestContext)) {
+        if (!checkPermission(latestContext, backgroundLocation.id)) {
             Log.w(TAG, "Not starting location reporting because of permissions.")
             return
         }
@@ -149,7 +149,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     }
 
     private fun requestLocationUpdates() {
-        if (!checkPermission(latestContext)) {
+        if (!checkPermission(latestContext, backgroundLocation.id)) {
             Log.w(TAG, "Not registering for location updates because of permissions.")
             return
         }
@@ -165,7 +165,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     }
 
     private suspend fun requestZoneUpdates() {
-        if (!checkPermission(latestContext)) {
+        if (!checkPermission(latestContext, zoneLocation.id)) {
             Log.w(TAG, "Not registering for zone based updates because of permissions.")
             return
         }
@@ -308,7 +308,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     }
 
     private fun requestSingleAccurateLocation() {
-        if (!checkPermission(latestContext)) {
+        if (!checkPermission(latestContext, singleAccurateLocation.id)) {
             Log.w(TAG, "Not getting single accurate location because of permissions.")
             return
         }
@@ -402,7 +402,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(singleAccurateLocation, backgroundLocation, zoneLocation)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(
                 Manifest.permission.ACCESS_FINE_LOCATION,

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -66,12 +66,13 @@ class MobileAppIntegrationFragment : Fragment(), MobileAppIntegrationView {
             findViewById<TextInputEditText>(R.id.deviceName).setText(Build.MODEL)
 
             findViewById<SwitchMaterial>(R.id.locationTracking)?.let {
-                it.isChecked = LocationSensorManager().checkPermission(context)
+                val sensorId = LocationSensorManager.backgroundLocation.id
+                it.isChecked = LocationSensorManager().checkPermission(context, sensorId)
                 it.setOnCheckedChangeListener { _, isChecked ->
                     setLocationTracking(isChecked)
-                    if (isChecked && !LocationSensorManager().checkPermission(requireContext())) {
+                    if (isChecked && !LocationSensorManager().checkPermission(requireContext(), sensorId)) {
                         this@MobileAppIntegrationFragment.requestPermissions(
-                            LocationSensorManager().requiredPermissions(),
+                            LocationSensorManager().requiredPermissions(sensorId),
                             LOCATION_REQUEST_CODE
                         )
                     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -81,7 +81,7 @@ class AudioSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(audioSensor, audioState, headphoneState, micMuted, speakerphoneState, musicActive, volAlarm, volCall, volMusic, volRing)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -54,7 +54,7 @@ class BatterySensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -33,7 +33,7 @@ class BluetoothSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(bluetoothConnection, bluetoothState)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf(Manifest.permission.BLUETOOTH)
     }
 
@@ -56,7 +56,7 @@ class BluetoothSensorManager : SensorManager {
         var bondedString = ""
         var isBtOn = false
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, bluetoothConnection.id)) {
 
             val bluetoothManager =
                 (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
@@ -110,7 +110,7 @@ class BluetoothSensorManager : SensorManager {
 
         var isBtOn = false
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, bluetoothState.id)) {
 
             val bluetoothManager =
                 (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -25,7 +25,7 @@ class DNDSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(dndSensor)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
@@ -37,7 +37,7 @@ class LastRebootSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(lastRebootSensor)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -35,7 +35,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(lightSensor)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -91,14 +91,20 @@ class NetworkSensorManager : SensorManager {
             publicIp
         )
 
-    override fun requiredPermissions(): Array<String> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            arrayOf(
-                Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_BACKGROUND_LOCATION
-            )
-        } else {
-            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return when {
+            sensorId == publicIp.id -> {
+                arrayOf()
+            }
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                )
+            }
+            else -> {
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
         }
     }
 
@@ -124,7 +130,7 @@ class NetworkSensorManager : SensorManager {
         var lastScanStrength = -1
         var wifiEnabled = false
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiConnection.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
@@ -171,7 +177,7 @@ class NetworkSensorManager : SensorManager {
 
         var conInfo: WifiInfo? = null
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, bssidState.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
@@ -215,7 +221,7 @@ class NetworkSensorManager : SensorManager {
         var conInfo: WifiInfo? = null
         var deviceIp = "Unknown"
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiIp.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
@@ -246,7 +252,7 @@ class NetworkSensorManager : SensorManager {
         var linkSpeed = 0
         var lastScanStrength = -1
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiLinkSpeed.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
@@ -288,7 +294,7 @@ class NetworkSensorManager : SensorManager {
 
         var wifiEnabled = false
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiState.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
 
@@ -312,7 +318,7 @@ class NetworkSensorManager : SensorManager {
         var conInfo: WifiInfo? = null
         var frequency = 0
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiFrequency.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo
@@ -342,7 +348,7 @@ class NetworkSensorManager : SensorManager {
         var conInfo: WifiInfo? = null
         var lastScanStrength = -1
 
-        if (checkPermission(context)) {
+        if (checkPermission(context, wifiSignalStrength.id)) {
             val wifiManager =
                 (context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
             conInfo = wifiManager.connectionInfo

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -34,7 +34,7 @@ class NextAlarmManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(nextAlarm)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -44,7 +44,7 @@ class PhoneStateSensorManager : SensorManager {
             listOf(phoneState, sim_1, sim_2)
         else listOf(phoneState)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf(Manifest.permission.READ_PHONE_STATE)
     }
 
@@ -60,7 +60,7 @@ class PhoneStateSensorManager : SensorManager {
         if (!isEnabled(context, phoneState.id))
             return
         var currentPhoneState = "unavailable"
-        if (checkPermission(context)) {
+        if (checkPermission(context, phoneState.id)) {
             val telephonyManager =
                 (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
 
@@ -96,7 +96,7 @@ class PhoneStateSensorManager : SensorManager {
             var displayName = "Unavailable"
             val attrs = mutableMapOf<String, Any>()
 
-            if (checkPermission(context)) {
+            if (checkPermission(context, basicSimSensor.id)) {
                 val subscriptionManager =
                     (context.applicationContext.getSystemService(Context.TELEPHONY_SUBSCRIPTION_SERVICE)) as SubscriptionManager
                 val info: SubscriptionInfo? = subscriptionManager.getActiveSubscriptionInfoForSimSlotIndex(slotIndex)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -44,7 +44,7 @@ class PowerSensorManager : SensorManager {
             listOf(interactiveDevice, powerSave)
         }
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -38,7 +38,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(pressureSensor)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -37,7 +37,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(proximitySensor)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -54,7 +54,7 @@ class SensorDetailFragment(
 
         findPreference<SwitchPreference>("enabled")?.let {
             val dao = sensorDao.get(basicSensor.id)
-            val perm = sensorManager.checkPermission(requireContext())
+            val perm = sensorManager.checkPermission(requireContext(), basicSensor.id)
             if (dao == null && sensorManager.enabledByDefault) {
                 it.isChecked = perm
             }
@@ -66,8 +66,8 @@ class SensorDetailFragment(
             it.setOnPreferenceChangeListener { _, newState ->
                 val isEnabled = newState as Boolean
 
-                if (isEnabled && !sensorManager.checkPermission(requireContext())) {
-                    requestPermissions(sensorManager.requiredPermissions(), 0)
+                if (isEnabled && !sensorManager.checkPermission(requireContext(), basicSensor.id)) {
+                    requestPermissions(sensorManager.requiredPermissions(basicSensor.id), 0)
                     return@setOnPreferenceChangeListener false
                 }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -24,10 +24,10 @@ interface SensorManager {
         val unitOfMeasurement: String? = null
     )
 
-    fun requiredPermissions(): Array<String>
+    fun requiredPermissions(sensorId: String): Array<String>
 
-    fun checkPermission(context: Context): Boolean {
-        return requiredPermissions().all {
+    fun checkPermission(context: Context, sensorId: String): Boolean {
+        return requiredPermissions(sensorId).all {
             context.checkPermission(it, myPid(), myUid()) == PackageManager.PERMISSION_GRANTED
         }
     }
@@ -35,7 +35,7 @@ interface SensorManager {
     fun isEnabled(context: Context, sensorId: String): Boolean {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         var sensor = sensorDao.get(sensorId)
-        val permission = checkPermission(context)
+        val permission = checkPermission(context, sensorId)
 
         // If we haven't created the entity yet do so and default to enabled if required
         if (sensor == null) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -39,7 +39,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(
                 Manifest.permission.ACTIVITY_RECOGNITION
@@ -65,7 +65,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
         if (!isEnabled(latestContext, stepsSensor.id))
             return
 
-        if (checkPermission(latestContext)) {
+        if (checkPermission(latestContext, stepsSensor.id)) {
             mySensorManager =
                 latestContext.getSystemService(SENSOR_SERVICE) as android.hardware.SensorManager
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -67,7 +67,7 @@ class StorageSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf(storageSensor, externalStorage)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
@@ -55,7 +55,7 @@ class TrafficStatsManager : SensorManager {
             listOf(rxBytesMobile, txBytesMobile, rxBytesTotal, txBytesTotal)
         } else listOf(rxBytesTotal, txBytesTotal)
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(senorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -19,7 +19,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf()
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         // Noop
         return emptyArray()
     }

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -23,7 +23,7 @@ class GeocodeSensorManager : SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf()
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -51,7 +51,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     override val availableSensors: List<SensorManager.BasicSensor>
         get() = listOf()
 
-    override fun requiredPermissions(): Array<String> {
+    override fun requiredPermissions(sensorId: String): Array<String> {
         // Noop
         return emptyArray()
     }


### PR DESCRIPTION
PR adds feature to define requirred permission for single sensor rather than whole sensor manager.
It is required for new call numbers sensor. Also publicIp sensor does not require any permission.