### PR TITLE
Add migration fallback, improve crash handling

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -70,6 +70,7 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_9_10,
                     MIGRATION_10_11
                 )
+                .fallbackToDestructiveMigration()
                 .build()
         }
 
@@ -139,26 +140,37 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 val cursor = database.query("SELECT * FROM sensors")
                 val sensors = mutableListOf<ContentValues>()
-                if (cursor.count > 0) {
-                    while (cursor.moveToNext()) {
-                        sensors.add(ContentValues().also {
-                            it.put("id", cursor.getString(cursor.getColumnIndex("unique_id")))
-                            it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
-                            it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
-                            it.put("state", "")
-                            it.put("state_type", "")
-                            it.put("type", "")
-                            it.put("icon", "")
-                            it.put("name", "")
-                            it.put("device_class", "")
-                        })
+                var migrationSuccessful = false
+                if (cursor.moveToFirst()) {
+                    try {
+                        while (cursor.moveToNext()) {
+                            sensors.add(ContentValues().also {
+                                it.put("id", cursor.getString(cursor.getColumnIndex("unique_id")))
+                                it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
+                                it.put(
+                                    "registered",
+                                    cursor.getInt(cursor.getColumnIndex("registered"))
+                                )
+                                it.put("state", "")
+                                it.put("state_type", "")
+                                it.put("type", "")
+                                it.put("icon", "")
+                                it.put("name", "")
+                                it.put("device_class", "")
+                            })
+                        }
+                        migrationSuccessful = true
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to migrate, proceeding with recreating the table", e)
                     }
                 }
                 cursor.close()
                 database.execSQL("DROP TABLE IF EXISTS `sensors`")
                 database.execSQL("CREATE TABLE IF NOT EXISTS `sensors` (`id` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `registered` INTEGER NOT NULL, `state` TEXT NOT NULL, `state_type` TEXT NOT NULL, `type` TEXT NOT NULL, `icon` TEXT NOT NULL, `name` TEXT NOT NULL, `device_class` TEXT, `unit_of_measurement` TEXT, PRIMARY KEY(`id`))")
-                sensors.forEach {
-                    database.insert("sensors", OnConflictStrategy.REPLACE, it)
+                if (migrationSuccessful) {
+                    sensors.forEach {
+                        database.insert("sensors", OnConflictStrategy.REPLACE, it)
+                    }
                 }
 
                 database.execSQL("CREATE TABLE IF NOT EXISTS `sensor_attributes` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))")
@@ -178,26 +190,37 @@ abstract class AppDatabase : RoomDatabase() {
             override fun migrate(database: SupportSQLiteDatabase) {
                 val cursor = database.query("SELECT * FROM sensors")
                 val sensors = mutableListOf<ContentValues>()
-                if (cursor.count > 0) {
-                    while (cursor.moveToNext()) {
-                        sensors.add(ContentValues().also {
-                            it.put("id", cursor.getString(cursor.getColumnIndex("id")))
-                            it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
-                            it.put("registered", cursor.getInt(cursor.getColumnIndex("registered")))
-                            it.put("state", "")
-                            it.put("last_sent_state", "")
-                            it.put("state_type", "")
-                            it.put("type", "")
-                            it.put("icon", "")
-                            it.put("name", "")
-                        })
+                var migrationSuccessful = false
+                if (cursor.moveToFirst()) {
+                    try {
+                        while (cursor.moveToNext()) {
+                            sensors.add(ContentValues().also {
+                                it.put("id", cursor.getString(cursor.getColumnIndex("id")))
+                                it.put("enabled", cursor.getInt(cursor.getColumnIndex("enabled")))
+                                it.put(
+                                    "registered",
+                                    cursor.getInt(cursor.getColumnIndex("registered"))
+                                )
+                                it.put("state", "")
+                                it.put("last_sent_state", "")
+                                it.put("state_type", "")
+                                it.put("type", "")
+                                it.put("icon", "")
+                                it.put("name", "")
+                            })
+                        }
+                        migrationSuccessful = true
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to migrate, proceeding with recreating the table", e)
                     }
                 }
                 cursor.close()
                 database.execSQL("DROP TABLE IF EXISTS `sensors`")
                 database.execSQL("CREATE TABLE IF NOT EXISTS `sensors` (`id` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `registered` INTEGER NOT NULL, `state` TEXT NOT NULL, `last_sent_state` TEXT NOT NULL, `state_type` TEXT NOT NULL, `type` TEXT NOT NULL, `icon` TEXT NOT NULL, `name` TEXT NOT NULL, `device_class` TEXT, `unit_of_measurement` TEXT, PRIMARY KEY(`id`))")
-                sensors.forEach {
-                    database.insert("sensors", OnConflictStrategy.REPLACE, it)
+                if (migrationSuccessful) {
+                    sensors.forEach {
+                        database.insert("sensors", OnConflictStrategy.REPLACE, it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -1,14 +1,22 @@
 package io.homeassistant.companion.android.database
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.ContentValues
 import android.content.Context
+import android.os.Build
 import android.util.Log
+import android.widget.Toast
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import androidx.room.Database
 import androidx.room.OnConflictStrategy
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.authentication.AuthenticationDao
 import io.homeassistant.companion.android.database.sensor.Attribute
@@ -21,6 +29,7 @@ import io.homeassistant.companion.android.database.widget.StaticWidgetDao
 import io.homeassistant.companion.android.database.widget.StaticWidgetEntity
 import io.homeassistant.companion.android.database.widget.TemplateWidgetDao
 import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
+import kotlinx.coroutines.runBlocking
 
 @Database(
     entities = [
@@ -44,17 +53,23 @@ abstract class AppDatabase : RoomDatabase() {
     companion object {
         private const val DATABASE_NAME = "HomeAssistantDB"
         internal const val TAG = "AppDatabase"
+        const val channelId = "App Database"
+        const val NOTIFICATION_ID = 45
+        lateinit var appContext: Context
+        lateinit var integrationRepository: IntegrationRepository
 
         @Volatile
         private var instance: AppDatabase? = null
 
         fun getInstance(context: Context): AppDatabase {
+            appContext = context
             return instance ?: synchronized(this) {
                 instance ?: buildDatabase(context).also { instance = it }
             }
         }
 
         private fun buildDatabase(context: Context): AppDatabase {
+            appContext = context
             return Room
                 .databaseBuilder(context, AppDatabase::class.java, DATABASE_NAME)
                 .allowMainThreadQueries()
@@ -162,6 +177,24 @@ abstract class AppDatabase : RoomDatabase() {
                         migrationSuccessful = true
                     } catch (e: Exception) {
                         Log.e(TAG, "Unable to migrate, proceeding with recreating the table", e)
+                        createNotificationChannel()
+                        val notification = NotificationCompat.Builder(appContext, channelId)
+                            .setSmallIcon(R.drawable.ic_stat_ic_notification)
+                            .setContentTitle(appContext.getString(R.string.database_migration_failed))
+                            .setPriority(NotificationCompat.PRIORITY_HIGH)
+                            .build()
+                        with(NotificationManagerCompat.from(appContext)) {
+                            notify(NOTIFICATION_ID, notification)
+                        }
+                        runBlocking {
+                            try {
+                                integrationRepository.fireEvent("mobile_app.migration_failed", mapOf())
+                                Log.d(TAG, "Event sent to Home Assistant")
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Unable to send event to Home Assistant", e)
+                                Toast.makeText(appContext, R.string.database_event_failure, Toast.LENGTH_LONG).show()
+                            }
+                        }
                     }
                 }
                 cursor.close()
@@ -212,6 +245,24 @@ abstract class AppDatabase : RoomDatabase() {
                         migrationSuccessful = true
                     } catch (e: Exception) {
                         Log.e(TAG, "Unable to migrate, proceeding with recreating the table", e)
+                        createNotificationChannel()
+                        val notification = NotificationCompat.Builder(appContext, channelId)
+                            .setSmallIcon(R.drawable.ic_stat_ic_notification)
+                            .setContentTitle(appContext.getString(R.string.database_migration_failed))
+                            .setPriority(NotificationCompat.PRIORITY_HIGH)
+                            .build()
+                        with(NotificationManagerCompat.from(appContext)) {
+                            notify(NOTIFICATION_ID, notification)
+                        }
+                        runBlocking {
+                            try {
+                                integrationRepository.fireEvent("mobile_app.migration_failed", mapOf())
+                                Log.d(TAG, "Event sent to Home Assistant")
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Unable to send event to Home Assistant", e)
+                                Toast.makeText(appContext, R.string.database_event_failure, Toast.LENGTH_LONG).show()
+                            }
+                        }
                     }
                 }
                 cursor.close()
@@ -228,6 +279,21 @@ abstract class AppDatabase : RoomDatabase() {
         private val MIGRATION_10_11 = object : Migration(10, 11) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("CREATE TABLE IF NOT EXISTS `sensor_settings` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL DEFAULT 'string', PRIMARY KEY(`sensor_id`, `name`))")
+            }
+        }
+
+        private fun createNotificationChannel() {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val notificationManager = appContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+                var notificationChannel =
+                    notificationManager?.getNotificationChannel(channelId)
+                if (notificationChannel == null) {
+                    notificationChannel = NotificationChannel(
+                        channelId, TAG, NotificationManager.IMPORTANCE_HIGH
+                    )
+                    notificationManager?.createNotificationChannel(notificationChannel)
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,6 +69,8 @@
 to your home internet.</string>
   <string name="connected_to_home_assistant">Connected to Home Assistant</string>
   <string name="create_template">Create Template</string>
+  <string name="database_migration_failed">Database migration failed, all sensor data has been reset. Please re-enable your sensors.</string>
+  <string name="database_event_failure">Unable to send migration failure event to Home Assistant</string>
   <string name="developer_tools">Developer Tools</string>
   <string name="device_class">Device Class</string>
   <string name="device_name">Device Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -69,7 +69,7 @@
 to your home internet.</string>
   <string name="connected_to_home_assistant">Connected to Home Assistant</string>
   <string name="create_template">Create Template</string>
-  <string name="database_migration_failed">Database migration failed, all sensor data has been reset. Please re-enable your sensors.</string>
+  <string name="database_migration_failed">Database migration failed, all sensor and widget data has been reset. Please re-enable your sensors and recreate your widgets.</string>
   <string name="database_event_failure">Unable to send migration failure event to Home Assistant</string>
   <string name="developer_tools">Developer Tools</string>
   <string name="device_class">Device Class</string>


### PR DESCRIPTION
* Add a destructive migration fallback so the app never ends in a state where the database will crash due to a missing migration, I know it may never happen but good to have a fallback just in case
* Replace `cursor.count > 0` with `cursor.moveToFirst()` which is a boolean that will return `true` only IF the cursor can move to the first row
* Place entire migration in try and catch block to catch any errors in the migration
* Keep track if migration was successful in order to move the data after we recreate the table
* Perform clean migration in case of bad data
* Creates high priority notification informing user of the database recreation so they can redo sensors and widgets
* Fires an event to HA to help automate the situation better

Should fix the following sentry errors:

This error occurs when the table exists with more than 1 row but we can't access it, bad data that should be recreated

```
java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow.  Make sure the Cursor is initialized correctly before accessing data from it.
    at android.database.CursorWindow.nativeGetString(CursorWindow.java)
    at android.database.CursorWindow.getString(CursorWindow.java:438)
    at android.database.AbstractWindowedCursor.getString(AbstractWindowedCursor.java:51)
    at io.homeassistant.companion.android.database.AppDatabase$Companion$MIGRATION_9_10$1.migrate(AppDatabase.kt:184)
    at androidx.room.RoomOpenHelper.onUpgrade(RoomOpenHelper.java:99)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.onUpgrade(FrameworkSQLiteOpenHelper.java:177)
    at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:256)
    at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:163)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getWritableSupportDatabase(FrameworkSQLiteOpenHelper.java:145)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper.getWritableDatabase(FrameworkSQLiteOpenHelper.java:106)
    at androidx.room.RoomDatabase.inTransaction(RoomDatabase.java:476)
    at androidx.room.RoomDatabase.assertNotSuspendingTransaction(RoomDatabase.java:281)
    at io.homeassistant.companion.android.database.sensor.SensorDao_Impl.getFull(SensorDao_Impl.java:445)
    at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:120)
    at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:96)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

This error exists because somehow, someway we allowed a blob in our database? Bad data:

```
android.database.sqlite.SQLiteBlobTooBigException: Row too big to fit into CursorWindow requiredPos=0, totalRows=9
    at android.database.sqlite.SQLiteConnection.nativeExecuteForCursorWindow(SQLiteConnection.java)
    at android.database.sqlite.SQLiteConnection.executeForCursorWindow(SQLiteConnection.java:986)
    at android.database.sqlite.SQLiteSession.executeForCursorWindow(SQLiteSession.java:858)
    at android.database.sqlite.SQLiteQuery.fillWindow(SQLiteQuery.java:62)
    at android.database.sqlite.SQLiteCursor.fillWindow(SQLiteCursor.java:153)
    at android.database.sqlite.SQLiteCursor.getCount(SQLiteCursor.java:140)
    at io.homeassistant.companion.android.database.AppDatabase$Companion$MIGRATION_9_10$1.migrate(AppDatabase.kt:181)
    at androidx.room.RoomOpenHelper.onUpgrade(RoomOpenHelper.java:99)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.onUpgrade(FrameworkSQLiteOpenHelper.java:177)
    at android.database.sqlite.SQLiteOpenHelper.getDatabaseLocked(SQLiteOpenHelper.java:436)
    at android.database.sqlite.SQLiteOpenHelper.getWritableDatabase(SQLiteOpenHelper.java:332)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper$OpenHelper.getWritableSupportDatabase(FrameworkSQLiteOpenHelper.java:145)
    at androidx.sqlite.db.framework.FrameworkSQLiteOpenHelper.getWritableDatabase(FrameworkSQLiteOpenHelper.java:106)
    at androidx.room.RoomDatabase.inTransaction(RoomDatabase.java:476)
    at androidx.room.RoomDatabase.assertNotSuspendingTransaction(RoomDatabase.java:281)
    at io.homeassistant.companion.android.database.sensor.SensorDao_Impl.getFull(SensorDao_Impl.java:445)
    at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:120)
    at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:96)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

In both of these cases occur during migration 9 to 10 and it is safe to recreate it as the user cannot access the app.

We can consider this a breaking change but without it the app won't function until the user clears data so it should at least allow the app to continue to function.

In the future we can consider storing the data to a file so we can attempt to restore from that.