### PR TITLE
Speed up sensor details screen

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -38,7 +38,7 @@ class SensorDetailFragment(
     private val refresh = object : Runnable {
         override fun run() {
             refreshSensorData()
-            handler.postDelayed(this, 10000)
+            handler.postDelayed(this, 5000)
         }
     }
 
@@ -73,6 +73,8 @@ class SensorDetailFragment(
 
                 updateSensorEntity(isEnabled)
 
+                if (isEnabled)
+                    sensorManager.requestSensorUpdate(requireContext())
                 return@setOnPreferenceChangeListener true
             }
         }
@@ -167,6 +169,7 @@ class SensorDetailFragment(
                             val isEnabled = newState as Boolean
 
                             sensorDao.add(Setting(basicSensor.id, setting.name, isEnabled.toString(), "toggle"))
+                            sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
                         if (!it.contains(pref))
@@ -198,6 +201,7 @@ class SensorDetailFragment(
                                     setting.valueType
                                 )
                             )
+                            sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
                     if (!it.contains(pref))
@@ -228,6 +232,7 @@ class SensorDetailFragment(
                                     "list-apps"
                                 )
                             )
+                            sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
                         if (pref.values != null)


### PR DESCRIPTION
* On sensor details screen refresh data every 5 seconds instead of 10 to make it update faster for settings
* After user changes any setting we force the sensor to do an update immediately in `onPreferenceChangeListener` so the next refresh pulls correct data as sometimes we have to wait for the second update for the change to really take place.

These should make the page feel like it updates a lot faster than what it does today since at times there can be a 10-20 second delay depending on when you change a setting and when the last update ran.
