### PR TITLE
Start sensor worker when the app is updated

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,6 +44,7 @@
         <receiver android:name=".sensors.SensorReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.PACKAGE_REPLACED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />


### PR DESCRIPTION
Noticed an edge case where the sensor worker does not run if the app was updated and never restarted.  This PR adds a receiver for when the app is updated to start the sensor worker just like we do when the device has been booted and unlocked.