### PR TITLE
Add keyguard sensors

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/KeyguardSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/KeyguardSensorManager.kt
@@ -1,0 +1,133 @@
+package io.homeassistant.companion.android.sensors
+
+import android.app.KeyguardManager
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
+
+class KeyguardSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "KeyguardManager"
+
+        val deviceLocked = SensorManager.BasicSensor(
+            "device_locked",
+            "binary_sensor",
+            R.string.basic_sensor_name_device_locked,
+            R.string.sensor_description_device_locked
+        )
+        val deviceSecure = SensorManager.BasicSensor(
+            "device_secure",
+            "binary_sensor",
+            R.string.basic_sensor_name_device_secure,
+            R.string.sensor_description_device_secure
+        )
+        val keyguardLocked = SensorManager.BasicSensor(
+            "keyguard_locked",
+            "binary_sensor",
+            R.string.basic_sensor_name_keyguard_locked,
+            R.string.sensor_description_keyguard_locked
+        )
+        val keyguardSecure = SensorManager.BasicSensor(
+            "keyguard_secure",
+            "binary_sensor",
+            R.string.basic_sensor_name_keyguard_secure,
+            R.string.sensor_description_keyguard_secure
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_keyguard
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = when {
+            (Build.VERSION.SDK_INT >= 23) -> listOf(deviceLocked, deviceSecure, keyguardLocked, keyguardSecure)
+            (Build.VERSION.SDK_INT >= 22) -> listOf(deviceLocked, keyguardLocked, keyguardSecure)
+            else -> listOf(keyguardLocked, keyguardSecure)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        val km = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
+            updateDeviceLocked(context, km)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            updateDeviceSecure(context, km)
+
+        updateKeyguardLocked(context, km)
+        updateKeyguardSecure(context, km)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
+    private fun updateDeviceLocked(context: Context, km: KeyguardManager) {
+
+        if (!isEnabled(context, deviceLocked.id))
+            return
+
+        val isLocked = km.isDeviceLocked
+        val icon = if (isLocked) "mdi:cellphone-lock" else "mdi:cellphone"
+
+        onSensorUpdated(context,
+            deviceLocked,
+            isLocked,
+            icon,
+            mapOf()
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun updateDeviceSecure(context: Context, km: KeyguardManager) {
+
+        if (!isEnabled(context, deviceSecure.id))
+            return
+
+        val isSecure = km.isDeviceSecure
+        val icon = if (isSecure) "mdi:cellphone-key" else "mdi:cellphone"
+
+        onSensorUpdated(context,
+            deviceSecure,
+            isSecure,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateKeyguardLocked(context: Context, km: KeyguardManager) {
+
+        if (!isEnabled(context, keyguardLocked.id))
+            return
+
+        val isLocked = km.isKeyguardLocked
+        val icon = if (isLocked) "mdi:cellphone-lock" else "mdi:cellphone"
+
+        onSensorUpdated(context,
+            keyguardLocked,
+            isLocked,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateKeyguardSecure(context: Context, km: KeyguardManager) {
+
+        if (!isEnabled(context, keyguardSecure.id))
+            return
+
+        val isSecure = km.isKeyguardSecure
+        val icon = if (isSecure) "mdi:cellphone-key" else "mdi:cellphone"
+
+        onSensorUpdated(context,
+            keyguardSecure,
+            isSecure,
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -28,6 +28,7 @@ class SensorReceiver : BroadcastReceiver() {
             BluetoothSensorManager(),
             DNDSensorManager(),
             GeocodeSensorManager(),
+            KeyguardSensorManager(),
             LastRebootSensorManager(),
             LightSensorManager(),
             LocationSensorManager(),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,10 @@
   <string name="auth_error">Authentication Error</string>
   <string name="auth_error_message">The \'Username\' and \'Password\' fields must be completed</string>
   <string name="auth_request">Authentication Requested</string>
+  <string name="basic_sensor_name_device_locked">Device Locked</string>
+  <string name="basic_sensor_name_device_secure">Device Secure</string>
+  <string name="basic_sensor_name_keyguard_locked">Keyguard Locked</string>
+  <string name="basic_sensor_name_keyguard_secure">Keyguard Secure</string>
   <string name="basic_sensor_name_activity">Detected Activity</string>
   <string name="basic_sensor_name_alarm">Next Alarm</string>
   <string name="basic_sensor_name_battery_health">Battery Health</string>
@@ -179,6 +183,10 @@ for Home Assistant</string>
 like to connect to:</string>
   <string name="sensor">Sensor</string>
   <string name="sensor_description">Description</string>
+  <string name="sensor_description_device_locked">Whether the device is currently locked and requires a PIN, pattern or password to unlock.</string>
+  <string name="sensor_description_device_secure">Whether the device is secured with a PIN, pattern or password.</string>
+  <string name="sensor_description_keyguard_locked">Whether the keyguard is currently locked.</string>
+  <string name="sensor_description_keyguard_secure">Whether the keyguard is secured by a PIN, pattern or password or a SIM card is currently locked.</string>
   <string name="sensor_description_audio_mode">The state of the devices audio mode</string>
   <string name="sensor_description_audio_sensor">The state of the devices ringer mode</string>
   <string name="sensor_description_battery_health">The health of the battery</string>
@@ -232,6 +240,7 @@ like to connect to:</string>
   <string name="sensor_description_wifi_signal">The signal strength of the device to the WiFi network</string>
   <string name="sensor_description_wifi_state">Whether or not WiFi is enabled on the device</string>
   <string name="sensor_name_activity">Activity Sensors</string>
+  <string name="sensor_name_keyguard">Keyguard Sensors</string>
   <string name="sensor_name_alarm">Alarm Sensor</string>
   <string name="sensor_name_audio">Audio Sensors</string>
   <string name="sensor_name_audio_mode">Audio Mode</string>


### PR DESCRIPTION
Add sensors that represent the state from [Keyguard API](https://developer.android.com/reference/android/app/KeyguardManager)

* Device locked (requires API 22 or higher)
* Device secure (requires API 23 or higher)
* Keyguard locked
* Keyguard secure

Although they all sound the same they are actually a tiny bit different, and some update along with the screen on/off receivers.