### PR TITLE
Allow all sensors to be enabled or disabled at once

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -5,10 +5,12 @@ import android.os.Handler
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreference
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
+import io.homeassistant.companion.android.database.sensor.Sensor
 import javax.inject.Inject
 
 class SensorsSettingsFragment : PreferenceFragmentCompat() {
@@ -20,28 +22,73 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
     private val refresh = object : Runnable {
         override fun run() {
             SensorWorker.start(requireContext())
+            totalDisabledSensors = 0
+            totalEnabledSensors = 0
             val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
-            SensorReceiver.MANAGERS.forEach { managers ->
-                managers.availableSensors.forEach { basicSensor ->
+            SensorReceiver.MANAGERS.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { managers ->
+                managers.availableSensors.sortedBy { it.name }.forEach { basicSensor ->
                     findPreference<Preference>(basicSensor.id)?.let {
                         val sensorEntity = sensorDao.get(basicSensor.id)
+                        val sensorSettings = sensorDao.getSettings(basicSensor.id)
+                        if (!sensorSettings.isNullOrEmpty()) {
+                            sensorSettings.forEach { setting ->
+                                if (!setting.name.isNullOrBlank())
+                                    if (getString(basicSensor.name) !in sensorsWithSettings) {
+                                        sensorsWithSettings += getString(basicSensor.name)
+                                        sensorsWithSettings.sort()
+                                    }
+                            }
+                        }
                         if (sensorEntity?.enabled == true) {
+                            totalEnabledSensors += 1
                             if (basicSensor.unitOfMeasurement.isNullOrBlank())
                                 it.summary = sensorEntity.state
                             else
                                 it.summary = sensorEntity.state + " " + basicSensor.unitOfMeasurement
                             // TODO: Add the icon from mdi:icon?
                         } else {
+                            totalDisabledSensors += 1
                             it.summary = "Disabled"
                         }
                     }
                 }
             }
+
+            findPreference<PreferenceCategory>("enable_disable_category")?.let {
+                it.summary = getString(R.string.manage_all_sensors_summary, (totalDisabledSensors + totalEnabledSensors))
+            }
+
+            findPreference<SwitchPreference>("enable_disable_sensors")?.let {
+                if (totalDisabledSensors == 0) {
+                    it.title = getString(R.string.disable_all_sensors, totalEnabledSensors)
+                    it.summary = ""
+                    it.isChecked = true
+                } else {
+                    if ((totalDisabledSensors + totalEnabledSensors) == totalDisabledSensors)
+                        it.title = getString(R.string.enable_all_sensors)
+                    else
+                        it.title = getString(R.string.enable_remaining_sensors, totalDisabledSensors)
+                    it.summary = getString(R.string.enable_all_sensors_summary)
+                    it.isChecked = false
+                }
+            }
+
+            findPreference<Preference>("sensors_with_settings")?.let {
+                it.summary = getString(
+                    R.string.sensors_with_settings,
+                    sensorsWithSettings.asList().toString().replace("[", "").replace("]", "")
+                )
+                it.isVisible = !sensorsWithSettings.isNullOrEmpty()
+            }
+
             handler.postDelayed(this, 10000)
         }
     }
 
     companion object {
+        private var totalEnabledSensors = 0
+        private var totalDisabledSensors = 0
+        private var sensorsWithSettings: Array<String> = arrayOf()
         fun newInstance(): SensorsSettingsFragment {
             return SensorsSettingsFragment()
         }
@@ -55,6 +102,37 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
             .inject(this)
 
         setPreferencesFromResource(R.xml.sensors, rootKey)
+
+        findPreference<SwitchPreference>("enable_disable_sensors")?.let {
+
+            var permArray: Array<String> = arrayOf()
+            it.setOnPreferenceChangeListener { _, newState ->
+                val enabledAll = newState as Boolean
+                val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
+
+                SensorReceiver.MANAGERS.forEach { managers ->
+                    managers.availableSensors.forEach { basicSensor ->
+                        var sensorEntity = sensorDao.get(basicSensor.id)
+
+                        if (!managers.checkPermission(requireContext(), basicSensor.id))
+                            permArray += managers.requiredPermissions(basicSensor.id).asList()
+
+                        if (sensorEntity != null) {
+                            sensorEntity.enabled = enabledAll
+                            sensorEntity.lastSentState = ""
+                            sensorDao.update(sensorEntity)
+                        } else {
+                            sensorEntity = Sensor(basicSensor.id, enabledAll, false, "")
+                            sensorDao.add(sensorEntity)
+                        }
+                    }
+                }
+                if (!permArray.isNullOrEmpty())
+                    requestPermissions(permArray, 0)
+                handler.postDelayed(refresh, 0)
+                return@setOnPreferenceChangeListener true
+            }
+        }
 
         SensorReceiver.MANAGERS.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,13 @@ to your home internet.</string>
   <string name="documentation">Documentation</string>
   <string name="enable_location_tracking">Enable Location Tracking</string>
   <string name="enable_location_tracking_description">Enabling this sensor will allow the Home Assistant application to track you location and report it back to your instance of Home Assistant. Ensure that you enable background access to location, otherwise we cannot enable location tracking.</string>
+  <string name="enable_all_sensors">Enable All Sensors</string>
+  <string name="enable_remaining_sensors">Enable %1$d Sensors</string>
+  <string name="enable_all_sensors_summary">All required permissions will be requested upon enabling</string>
+  <string name="manage_all_sensors">Manage All Sensors</string>
+  <string name="manage_all_sensors_summary">This device has %1$d available sensors to utilize.</string>
+  <string name="disable_all_sensors">Disable All %1$d Sensors</string>
+  <string name="sensors_with_settings">The following sensors offer custom settings: %1$s</string>
   <string name="enabled_summary">When enabled values will be sent to Home Assistant</string>
   <string name="enabled_title">Enabled</string>
   <string name="entity_attribute_checkbox">Append Attribute Value</string>

--- a/app/src/main/res/xml/sensors.xml
+++ b/app/src/main/res/xml/sensors.xml
@@ -6,10 +6,6 @@
     <androidx.preference.PreferenceCategory
         app:key="enable_disable_category"
         app:title="@string/manage_all_sensors">
-        <androidx.preference.Preference
-            app:key="sensors_with_settings"
-            app:isPreferenceVisible="false"
-            app:selectable="false" />
         <androidx.preference.SwitchPreference
             app:key="enable_disable_sensors"/>
     </androidx.preference.PreferenceCategory>

--- a/app/src/main/res/xml/sensors.xml
+++ b/app/src/main/res/xml/sensors.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.preference.PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.preference.PreferenceCategory
+        app:key="enable_disable_category"
+        app:title="@string/manage_all_sensors">
+        <androidx.preference.Preference
+            app:key="sensors_with_settings"
+            app:isPreferenceVisible="false"
+            app:selectable="false" />
+        <androidx.preference.SwitchPreference
+            app:key="enable_disable_sensors"/>
+    </androidx.preference.PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
* Adds a new preference category for managing all sensors
* Tells the user who many total available sensors they have on that device
* Add a toggle to enable or disable all sensors (will remain `off` if all sensors are not enabled)
* Upon enabling requests all required permissions (any that are not granted results in those sensors not being enabled)
* Once enabled a list of all sensors with custom settings are listed to help raise visibility

![image](https://user-images.githubusercontent.com/1634145/95025518-13cf6f80-063f-11eb-8e5c-8331d343f105.png)

![image](https://user-images.githubusercontent.com/1634145/95025519-19c55080-063f-11eb-8643-5e7dcfcb84ce.png)

![image](https://user-images.githubusercontent.com/1634145/95025521-2053c800-063f-11eb-854a-88846818d80a.png)
