### PR TITLE
Attempt to request accurate location quicker.

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -340,9 +340,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         sensorDao.add(Attribute(singleAccurateLocation.id, "lastAccurateLocationRequest", now.toString(), "string"))
 
         val maxRetries = 5
-        val request = createLocationRequest()
-        request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
-        request.numUpdates = maxRetries
+        val request = createLocationRequest().apply {
+            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+            numUpdates = maxRetries
+            interval = 10000
+            fastestInterval = 5000
+        }
         LocationServices.getFusedLocationProviderClient(latestContext)
             .requestLocationUpdates(
                 request,


### PR DESCRIPTION
After re-reading [the documentation](https://developer.android.com/training/location/change-location-settings.html) around the fused location provider I saw this note:

> The priority of PRIORITY_HIGH_ACCURACY, combined with the ACCESS_FINE_LOCATION permission setting that you've defined in the app manifest, and a fast update interval of 5000 milliseconds (5 seconds), causes the fused location provider to return location updates that are accurate to within a few feet. This approach is appropriate for mapping apps that display the location in real time.

This is an attempt to request the updates quicker in an effort to get more accurate results.  This _should_ cause GPS to attempt a lock.