### PR TITLE
Allow notifications to do TTS

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -9,6 +9,7 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.media.RingtoneManager
 import android.os.Build
+import android.speech.tts.TextToSpeech
 import android.text.Spanned
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -100,6 +101,10 @@ class MessagingService : FirebaseMessagingService() {
                     Log.d(TAG, "Removing Notification channel ${it["tag"]}")
                     removeNotificationChannel(it["channel"]!!)
                 }
+                it[TITLE]?.startsWith("TTS")!! -> {
+                    Log.d(TAG, "Sending notification to TTS")
+                    speakNotification(it[MESSAGE])
+                }
                 else -> mainScope.launch {
                     Log.d(TAG, "Creating notification with following data: $it")
                     sendNotification(it)
@@ -134,6 +139,13 @@ class MessagingService : FirebaseMessagingService() {
         }
     }
 
+    private fun speakNotification(message: String?) {
+        val textToSpeech = TextToSpeech(null, null)
+        textToSpeech.language = Locale.ENGLISH
+        textToSpeech.speak(message, TextToSpeech.QUEUE_FLUSH, null, "")
+        textToSpeech.stop()
+        textToSpeech.shutdown()
+    }
     /**
      * Create and show a simple notification containing the received FCM message.
      *

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -10,6 +10,7 @@ import android.graphics.Color
 import android.media.RingtoneManager
 import android.os.Build
 import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
 import android.text.Spanned
 import android.util.Log
 import android.widget.Toast
@@ -149,15 +150,24 @@ class MessagingService : FirebaseMessagingService() {
         textToSpeech = TextToSpeech(applicationContext
         ) {
             if (it == TextToSpeech.SUCCESS) {
+                val listener = object : UtteranceProgressListener() {
+                    override fun onStart(p0: String?) {
+                        // No op
+                    }
+
+                    override fun onDone(p0: String?) {
+                        textToSpeech?.stop()
+                        textToSpeech?.shutdown()
+                    }
+
+                    override fun onError(p0: String?) {
+                        textToSpeech?.stop()
+                        textToSpeech?.shutdown()
+                    }
+                }
+                textToSpeech?.setOnUtteranceProgressListener(listener)
                 textToSpeech?.speak(tts, TextToSpeech.QUEUE_ADD, null, "")
                 Log.d(TAG, "speaking notification")
-
-                // We need to use some sort of delay to properly shut down the TTS engine
-                // We will be in the background and we don't call onDestroy here
-                // Without this delay nothing will be said and its probably not a good idea to keep it open
-                Thread.sleep(10000)
-                textToSpeech?.stop()
-                textToSpeech?.shutdown()
             } else {
                 Toast.makeText(applicationContext, getString(R.string.tts_error, tts), Toast.LENGTH_LONG).show()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@ to your home internet.</string>
   <string name="enable_location_tracking_description">Enabling this sensor will allow the Home Assistant application to track you location and report it back to your instance of Home Assistant. Ensure that you enable background access to location, otherwise we cannot enable location tracking.</string>
   <string name="enabled_summary">When enabled values will be sent to Home Assistant</string>
   <string name="enabled_title">Enabled</string>
+  <string name="tts_error">Unable to process notification "%1$s" as text to speech.</string>
+  <string name="tts_no_title">Please set a title for text to speech to process</string>
   <string name="entity_attribute_checkbox">Append Attribute Value</string>
   <string name="error_auth_revoked">It appears that your authorization was revoked, please reconnect to Home Assistant.</string>
   <string name="error_connection_failed">Unable to connect to Home Assistant.</string>


### PR DESCRIPTION
This PR will speak a notification instead of posting it to the device.  For the first release we are not setting the locale so it will default to what the device has as a default.  As we already have commands that use the `message` we are going to use that here and the `title` is where the actual spoken text will reside.  In case of a blank title we have a default, in case of an error we will send a toast.

Example automation:
```
message: TTS
title: I am speaking
```

Fixes: #912 

Docs: https://github.com/home-assistant/companion.home-assistant/pull/351