### PR TITLE
Send an event when a notification is dismissed

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -142,7 +142,6 @@ class MessagingService : FirebaseMessagingService() {
         val notificationManagerCompat = NotificationManagerCompat.from(this)
 
         val tag = data["tag"]
-        val message = data[MESSAGE]
         val messageId = tag?.hashCode() ?: System.currentTimeMillis().toInt()
 
         var group = data["group"]
@@ -189,7 +188,7 @@ class MessagingService : FirebaseMessagingService() {
 
         handleActions(notificationBuilder, tag, messageId, data)
 
-        handleDeleteIntent(notificationBuilder, message, messageId, group, groupId)
+        handleDeleteIntent(notificationBuilder, data, messageId, group, groupId)
 
         handleContentIntent(notificationBuilder, messageId, group, groupId, data)
 
@@ -235,14 +234,16 @@ class MessagingService : FirebaseMessagingService() {
 
     private fun handleDeleteIntent(
         builder: NotificationCompat.Builder,
-        message: String?,
+        data: Map<String, String>,
         messageId: Int,
         group: String?,
         groupId: Int
+
     ) {
 
+        val dataString = convertMap2String(data)
         val deleteIntent = Intent(this, NotificationDeleteReceiver::class.java).apply {
-            putExtra(NotificationDeleteReceiver.EXTRA_MESSAGE, message)
+            putExtra(NotificationDeleteReceiver.EXTRA_DATA, dataString)
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP, group)
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP_ID, groupId)
         }
@@ -639,5 +640,14 @@ class MessagingService : FirebaseMessagingService() {
                 Log.e(TAG, "Issue updating token", e)
             }
         }
+    }
+
+    private fun convertMap2String(map: Map<String, String>): String {
+        val mapAsString = StringBuilder("")
+        for (key in map.keys) {
+            mapAsString.append(key + "=" + map[key] + ", ")
+        }
+        mapAsString.delete(mapAsString.length - 2, mapAsString.length).append("")
+        return mapAsString.toString()
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -241,9 +241,8 @@ class MessagingService : FirebaseMessagingService() {
 
     ) {
 
-        val dataString = convertMap2String(data)
         val deleteIntent = Intent(this, NotificationDeleteReceiver::class.java).apply {
-            putExtra(NotificationDeleteReceiver.EXTRA_DATA, dataString)
+            putExtra(NotificationDeleteReceiver.EXTRA_DATA, HashMap(data))
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP, group)
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP_ID, groupId)
         }
@@ -640,14 +639,5 @@ class MessagingService : FirebaseMessagingService() {
                 Log.e(TAG, "Issue updating token", e)
             }
         }
-    }
-
-    private fun convertMap2String(map: Map<String, String>): String {
-        val mapAsString = StringBuilder("")
-        for (key in map.keys) {
-            mapAsString.append(key + "=" + map[key] + ", ")
-        }
-        mapAsString.delete(mapAsString.length - 2, mapAsString.length).append("")
-        return mapAsString.toString()
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -142,6 +142,7 @@ class MessagingService : FirebaseMessagingService() {
         val notificationManagerCompat = NotificationManagerCompat.from(this)
 
         val tag = data["tag"]
+        val message = data[MESSAGE]
         val messageId = tag?.hashCode() ?: System.currentTimeMillis().toInt()
 
         var group = data["group"]
@@ -188,7 +189,7 @@ class MessagingService : FirebaseMessagingService() {
 
         handleActions(notificationBuilder, tag, messageId, data)
 
-        handleDeleteIntent(notificationBuilder, messageId, group, groupId)
+        handleDeleteIntent(notificationBuilder, message, messageId, group, groupId)
 
         handleContentIntent(notificationBuilder, messageId, group, groupId, data)
 
@@ -234,12 +235,14 @@ class MessagingService : FirebaseMessagingService() {
 
     private fun handleDeleteIntent(
         builder: NotificationCompat.Builder,
+        message: String?,
         messageId: Int,
         group: String?,
         groupId: Int
     ) {
 
         val deleteIntent = Intent(this, NotificationDeleteReceiver::class.java).apply {
+            putExtra(NotificationDeleteReceiver.EXTRA_MESSAGE, message)
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP, group)
             putExtra(NotificationDeleteReceiver.EXTRA_NOTIFICATION_GROUP_ID, groupId)
         }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
@@ -31,7 +31,8 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
             .build()
             .inject(this)
 
-        val dataList = intent.getStringExtra(EXTRA_DATA)
+        @SuppressWarnings("unchecked")
+        val hashData = intent.getSerializableExtra(EXTRA_DATA) as HashMap<String, *>
         val group = intent.getStringExtra(EXTRA_NOTIFICATION_GROUP)
         val groupId = intent.getIntExtra(EXTRA_NOTIFICATION_GROUP_ID, -1)
 
@@ -42,11 +43,9 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
         // Then only the empty group is left and needs to be cancelled
         notificationManagerCompat.cancelGroupIfNeeded(group, groupId)
 
-        val data = convertString2Map(dataList)
-
         runBlocking {
             try {
-                integrationRepository.fireEvent("mobile_app_notification_dismissed", data)
+                integrationRepository.fireEvent("mobile_app_notification_dismissed", hashData)
                 Log.d(TAG, "Notification dismiss event successful!")
             } catch (e: Exception) {
                 Log.e(TAG, "Issue sending event to Home Assistant", e)
@@ -56,13 +55,6 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
                     Toast.LENGTH_LONG
                 ).show()
             }
-        }
-    }
-
-    private fun convertString2Map(mapAsString: String): Map<String, String> {
-        return mapAsString.split(", ").associate {
-            val (left, right) = it.split("=")
-            left to right
         }
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.runBlocking
 
 class NotificationDeleteReceiver : BroadcastReceiver() {
     companion object {
-        const val EXTRA_MESSAGE = "EXTRA_MESSAGE"
+        const val EXTRA_DATA = "EXTRA_DATA"
         const val EXTRA_NOTIFICATION_GROUP = "EXTRA_NOTIFICATION_GROUP"
         const val EXTRA_NOTIFICATION_GROUP_ID = "EXTRA_NOTIFICATION_GROUP_ID"
         const val TAG = "NotifDeleteReceiver"
@@ -31,7 +31,7 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
             .build()
             .inject(this)
 
-        val message = intent.getStringExtra(EXTRA_MESSAGE)
+        val dataList = intent.getStringExtra(EXTRA_DATA)
         val group = intent.getStringExtra(EXTRA_NOTIFICATION_GROUP)
         val groupId = intent.getIntExtra(EXTRA_NOTIFICATION_GROUP_ID, -1)
 
@@ -42,9 +42,7 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
         // Then only the empty group is left and needs to be cancelled
         notificationManagerCompat.cancelGroupIfNeeded(group, groupId)
 
-        val data = mutableMapOf(
-            "message" to message
-        )
+        val data = convertString2Map(dataList)
 
         runBlocking {
             try {
@@ -58,6 +56,13 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
                     Toast.LENGTH_LONG
                 ).show()
             }
+        }
+    }
+
+    private fun convertString2Map(mapAsString: String): Map<String, String> {
+        return mapAsString.split(", ").associate {
+            val (left, right) = it.split("=")
+            left to right
         }
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
@@ -3,17 +3,35 @@ package io.homeassistant.companion.android.notifications
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.util.Log
+import android.widget.Toast
 import androidx.core.app.NotificationManagerCompat
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.util.cancelGroupIfNeeded
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 class NotificationDeleteReceiver : BroadcastReceiver() {
     companion object {
+        const val EXTRA_MESSAGE = "EXTRA_MESSAGE"
         const val EXTRA_NOTIFICATION_GROUP = "EXTRA_NOTIFICATION_GROUP"
         const val EXTRA_NOTIFICATION_GROUP_ID = "EXTRA_NOTIFICATION_GROUP_ID"
+        const val TAG = "NotifDeleteReceiver"
     }
+
+    @Inject
+    lateinit var integrationRepository: IntegrationRepository
 
     override fun onReceive(context: Context, intent: Intent) {
 
+        DaggerServiceComponent.builder()
+            .appComponent((context.applicationContext as GraphComponentAccessor).appComponent)
+            .build()
+            .inject(this)
+
+        val message = intent.getStringExtra(EXTRA_MESSAGE)
         val group = intent.getStringExtra(EXTRA_NOTIFICATION_GROUP)
         val groupId = intent.getIntExtra(EXTRA_NOTIFICATION_GROUP_ID, -1)
 
@@ -23,5 +41,23 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
         // This maybe the case if timeoutAfter has deleted the notification
         // Then only the empty group is left and needs to be cancelled
         notificationManagerCompat.cancelGroupIfNeeded(group, groupId)
+
+        val data = mutableMapOf(
+            "message" to message
+        )
+
+        runBlocking {
+            try {
+                integrationRepository.fireEvent("mobile_app_notification_dismissed", data)
+                Log.d(TAG, "Notification dismiss event successful!")
+            } catch (e: Exception) {
+                Log.e(TAG, "Issue sending event to Home Assistant", e)
+                Toast.makeText(
+                    context,
+                    R.string.notification_dismiss_failure,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/ServiceComponent.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/ServiceComponent.kt
@@ -9,4 +9,6 @@ interface ServiceComponent {
     fun inject(service: MessagingService)
 
     fun inject(receiver: NotificationActionReceiver)
+
+    fun inject(receiver: NotificationDeleteReceiver)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@ Home Assistant instance</string>
   <string name="manual_setup">enter address manually</string>
   <string name="map">Map</string>
   <string name="need_help">Need Help?</string>
+  <string name="notification_dismiss_failure">Failed to send event on notification dismissed</string>
   <string name="nfc_btn_create_duplicate">Create duplicate</string>
   <string name="nfc_btn_fire_event">Fire event</string>
   <string name="nfc_btn_read_tag">Read NFC Tag</string>


### PR DESCRIPTION
Fixes: #418 

When a notification is dismissed we will send `mobile_app_notification_dismissed` event along with the `message` as part of the event data.

Example data:

```
{
    "event_type": "mobile_app_notification_dismissed",
    "data": {
        "message": "test",
        "device_id": "DEVICE_ID"
    },
    "origin": "REMOTE",
    "time_fired": "2020-10-06T05:36:12.864583+00:00",
    "context": {
        "id": "ID",
        "parent_id": null,
        "user_id": "USER_ID"
    }
}
```

Docs: https://github.com/home-assistant/companion.home-assistant/pull/352