### PR TITLE
Enable Stale Bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,66 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - under investigation
+  - Help wanted
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  There hasn't been any activity on this issue recently. Due to the high number
+  of incoming GitHub notifications, we have to clean some of the old issues,
+  as many of them have already been resolved with the latest updates.
+
+  Please make sure to update to the latest Home Assistant version and check
+  if that solves the issue. Let us know if that works for you by adding a
+  comment 👍
+
+  This issue now has been marked as stale and will be closed if no further
+  activity occurs. Thank you for your contributions.
+
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+# closeComment: >
+#   Your comment here.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Handle pull requests a little bit faster and with an adjusted comment.
+pulls:
+  daysUntilStale: 30
+  exemptProjects: false
+  markComment: >
+    There hasn't been any activity on this pull request recently. This pull
+    request has been automatically marked as stale because of that and will
+    be closed if no further activity occurs within 7 days.
+
+    Thank you for your contributions.


### PR DESCRIPTION
We have been sitting at around a 100 issues for a while now.  While going through several of the older ones I released that they had been fixed.  By enabling stale bot we will be able to more easily see what is still affecting people.

Config stolen from core.