### PR TITLE
Add notification rate limit info to settings

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -133,7 +133,9 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
                 if (!rateLimits.isNullOrEmpty())
                     it.isVisible = true
-                it.summary = rateLimits
+                it.summary = "\nSuccessful: ${rateLimits?.get("successful")}       Errors: ${rateLimits?.get("errors")}" +
+                        "\n\nRemaining/Maximum: ${rateLimits?.get("remaining")}/${rateLimits?.get("maximum")}" +
+                        "\n\nResets at: ${rateLimits?.get("resetsAt")}"
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -130,13 +130,13 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
         if (BuildConfig.FLAVOR == "full") {
             findPreference<Preference>("notification_rate_limit")?.let {
-                val rateLimits = presenter.getNotificationRateLimits() as RateLimitResponse
+                val rateLimits = presenter.getNotificationRateLimits()
 
                 if (rateLimits != null)
                     it.isVisible = true
-                it.summary = "\nSuccessful: ${rateLimits.successful}       Errors: ${rateLimits.errors}" +
-                        "\n\nRemaining/Maximum: ${rateLimits.remaining}/${rateLimits.maximum}" +
-                        "\n\nResets at: ${rateLimits.resetsAt}"
+                it.summary = "\nSuccessful: ${rateLimits?.successful}       Errors: ${rateLimits?.errors}" +
+                        "\n\nRemaining/Maximum: ${rateLimits?.remaining}/${rateLimits?.maximum}" +
+                        "\n\nResets at: ${rateLimits?.resetsAt}"
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -22,6 +22,7 @@ import io.homeassistant.companion.android.PresenterModule
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.nfc.NfcSetupActivity
 import io.homeassistant.companion.android.sensors.SensorsSettingsFragment
 import io.homeassistant.companion.android.settings.ssid.SsidDialogFragment
@@ -129,13 +130,13 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
         if (BuildConfig.FLAVOR == "full") {
             findPreference<Preference>("notification_rate_limit")?.let {
-                val rateLimits = presenter.getNotificationRateLimits()
+                val rateLimits = presenter.getNotificationRateLimits() as RateLimitResponse
 
-                if (!rateLimits.isNullOrEmpty())
+                if (rateLimits != null)
                     it.isVisible = true
-                it.summary = "\nSuccessful: ${rateLimits?.get("successful")}       Errors: ${rateLimits?.get("errors")}" +
-                        "\n\nRemaining/Maximum: ${rateLimits?.get("remaining")}/${rateLimits?.get("maximum")}" +
-                        "\n\nResets at: ${rateLimits?.get("resetsAt")}"
+                it.summary = "\nSuccessful: ${rateLimits.successful}       Errors: ${rateLimits.errors}" +
+                        "\n\nRemaining/Maximum: ${rateLimits.remaining}/${rateLimits.maximum}" +
+                        "\n\nResets at: ${rateLimits.resetsAt}"
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -127,6 +127,16 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
             return@setOnPreferenceClickListener true
         }
 
+        if (BuildConfig.FLAVOR == "full") {
+            findPreference<Preference>("notification_rate_limit")?.let {
+                val rateLimits = presenter.getNotificationRateLimits()
+
+                if (!rateLimits.isNullOrEmpty())
+                    it.isVisible = true
+                it.summary = rateLimits
+            }
+        }
+
         findPreference<Preference>("changelog")?.let {
             val link = if (BuildConfig.VERSION_NAME.startsWith("LOCAL"))
                 "https://github.com/home-assistant/android/releases"

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -22,7 +22,6 @@ import io.homeassistant.companion.android.PresenterModule
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
-import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.nfc.NfcSetupActivity
 import io.homeassistant.companion.android.sensors.SensorsSettingsFragment
 import io.homeassistant.companion.android.settings.ssid.SsidDialogFragment

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.settings
 
 import androidx.preference.PreferenceDataStore
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 
 interface SettingsPresenter {
     fun getPreferenceDataStore(): PreferenceDataStore
@@ -9,7 +10,7 @@ interface SettingsPresenter {
     fun nfcEnabled(): Boolean
     fun isLockEnabled(): Boolean
     fun sessionTimeOut(): Int
-    fun getNotificationRateLimits(): Any
+    fun getNotificationRateLimits(): RateLimitResponse?
 
     fun setSessionExpireMillis(value: Long)
     fun getSessionExpireMillis(): Long

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -9,7 +9,7 @@ interface SettingsPresenter {
     fun nfcEnabled(): Boolean
     fun isLockEnabled(): Boolean
     fun sessionTimeOut(): Int
-    fun getNotificationRateLimits(): HashMap<String, *>?
+    fun getNotificationRateLimits(): Any
 
     fun setSessionExpireMillis(value: Long)
     fun getSessionExpireMillis(): Long

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -9,7 +9,7 @@ interface SettingsPresenter {
     fun nfcEnabled(): Boolean
     fun isLockEnabled(): Boolean
     fun sessionTimeOut(): Int
-    fun getNotificationRateLimits(): String
+    fun getNotificationRateLimits(): HashMap<String, *>?
 
     fun setSessionExpireMillis(value: Long)
     fun getSessionExpireMillis(): Long

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -9,6 +9,7 @@ interface SettingsPresenter {
     fun nfcEnabled(): Boolean
     fun isLockEnabled(): Boolean
     fun sessionTimeOut(): Int
+    fun getNotificationRateLimits(): String
 
     fun setSessionExpireMillis(value: Long)
     fun getSessionExpireMillis(): Long

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -189,7 +189,7 @@ class SettingsPresenterImpl @Inject constructor(
         }
     }
 
-    override fun getNotificationRateLimits(): String {
+    override fun getNotificationRateLimits(): HashMap<String, *>? {
         return runBlocking {
             integrationUseCase.getNotificationRateLimits()!!
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -189,9 +189,13 @@ class SettingsPresenterImpl @Inject constructor(
         }
     }
 
-    override fun getNotificationRateLimits(): HashMap<String, *>? {
+    override fun getNotificationRateLimits(): Any {
         return runBlocking {
-            integrationUseCase.getNotificationRateLimits()!!
+            try {
+                integrationUseCase.getNotificationRateLimits()!!
+            } catch (e: Exception) {
+                Log.d(TAG, "Unable to get rate limits")
+            }
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -25,7 +25,6 @@ class SettingsPresenterImpl @Inject constructor(
 
     companion object {
         private const val TAG = "SettingsPresenter"
-        private const val PREF_PUSH_TOKEN = "push_token"
     }
 
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -25,6 +25,7 @@ class SettingsPresenterImpl @Inject constructor(
 
     companion object {
         private const val TAG = "SettingsPresenter"
+        private const val PREF_PUSH_TOKEN = "push_token"
     }
 
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
@@ -186,6 +187,12 @@ class SettingsPresenterImpl @Inject constructor(
 
             return@runBlocking splitVersion.size > 2 &&
                     (Integer.parseInt(splitVersion[0]) > 0 || Integer.parseInt(splitVersion[1]) >= 114)
+        }
+    }
+
+    override fun getNotificationRateLimits(): String {
+        return runBlocking {
+            integrationUseCase.getNotificationRateLimits()!!
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -5,6 +5,7 @@ import androidx.preference.PreferenceDataStore
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.themes.ThemesManager
 import javax.inject.Inject
@@ -189,12 +190,13 @@ class SettingsPresenterImpl @Inject constructor(
         }
     }
 
-    override fun getNotificationRateLimits(): Any {
+    override fun getNotificationRateLimits(): RateLimitResponse? {
         return runBlocking {
             try {
-                integrationUseCase.getNotificationRateLimits()!!
+                integrationUseCase.getNotificationRateLimits()
             } catch (e: Exception) {
                 Log.d(TAG, "Unable to get rate limits")
+                return@runBlocking null
             }
         }
     }

--- a/app/src/main/res/drawable/ic_notifications.xml
+++ b/app/src/main/res/drawable/ic_notifications.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M18,17v-6c0,-3.07 -1.63,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.64,5.36 6,7.92 6,11v6H4v2h10h0.38H20v-2H18zM16,17H8v-6c0,-2.48 1.51,-4.5 4,-4.5s4,2.02 4,4.5V17z"/>
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4C10,21.1 10.9,22 12,22z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -137,6 +137,8 @@ Home Assistant instance</string>
   <string name="map">Map</string>
   <string name="need_help">Need Help?</string>
   <string name="nfc_btn_create_duplicate">Create duplicate</string>
+  <string name="rate_limit_title">Notification Rate Limit</string>
+  <string name="rate_limit_summary">Rate limit data</string>
   <string name="nfc_btn_fire_event">Fire event</string>
   <string name="nfc_btn_read_tag">Read NFC Tag</string>
   <string name="nfc_btn_share">Share</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -88,6 +88,11 @@
     <PreferenceCategory
         android:title="@string/app_version_info">
         <Preference
+            android:key="notification_rate_limit"
+            android:title="Notification Rate Limit"
+            app:isPreferenceVisible="false"
+            android:summary="No notifications"/>
+        <Preference
             android:key="changelog"
             android:icon="@drawable/ic_changelog"
             android:title="@string/changelog"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -91,6 +91,7 @@
             android:key="notification_rate_limit"
             android:title="@string/rate_limit_title"
             app:isPreferenceVisible="false"
+            app:enableCopying="true"
             android:icon="@drawable/ic_notifications"
             android:summary="@string/rate_limit_summary"/>
         <Preference

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -89,9 +89,10 @@
         android:title="@string/app_version_info">
         <Preference
             android:key="notification_rate_limit"
-            android:title="Notification Rate Limit"
+            android:title="@string/rate_limit_title"
             app:isPreferenceVisible="false"
-            android:summary="No notifications"/>
+            android:icon="@drawable/ic_notifications"
+            android:summary="@string/rate_limit_summary"/>
         <Preference
             android:key="changelog"
             android:icon="@drawable/ic_changelog"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -8,6 +8,7 @@ interface IntegrationRepository {
 
     suspend fun isRegistered(): Boolean
 
+    suspend fun getNotificationRateLimits(): String?
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String
 
     suspend fun updateLocation(updateLocation: UpdateLocation)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -10,7 +10,7 @@ interface IntegrationRepository {
 
     suspend fun isRegistered(): Boolean
 
-    suspend fun getNotificationRateLimits(): RateLimitResponse?
+    suspend fun getNotificationRateLimits(): RateLimitResponse
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String
 
     suspend fun updateLocation(updateLocation: UpdateLocation)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -8,7 +8,7 @@ interface IntegrationRepository {
 
     suspend fun isRegistered(): Boolean
 
-    suspend fun getNotificationRateLimits(): String?
+    suspend fun getNotificationRateLimits(): HashMap<String, *>?
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String
 
     suspend fun updateLocation(updateLocation: UpdateLocation)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.common.data.integration
 
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
+
 interface IntegrationRepository {
 
     suspend fun registerDevice(deviceRegistration: DeviceRegistration)
@@ -8,7 +10,7 @@ interface IntegrationRepository {
 
     suspend fun isRegistered(): Boolean
 
-    suspend fun getNotificationRateLimits(): HashMap<String, *>?
+    suspend fun getNotificationRateLimits(): RateLimitResponse?
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String
 
     suspend fun updateLocation(updateLocation: UpdateLocation)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -307,7 +307,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         return localStorage.getLong(PREF_SESSION_EXPIRE) ?: 0
     }
 
-    override suspend fun getNotificationRateLimits(): RateLimitResponse? {
+    override suspend fun getNotificationRateLimits(): RateLimitResponse {
         val pushToken = localStorage.getString(PREF_PUSH_TOKEN) ?: ""
         val requestBody = RateLimitRequest(pushToken)
         var checkRateLimits: RateLimitResponse? = null
@@ -317,7 +317,10 @@ class IntegrationRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Unable to get notification rate limits", e)
         }
-        return checkRateLimits
+        if (checkRateLimits!= null)
+            return checkRateLimits
+
+        throw IntegrationException()
     }
 
     override suspend fun getThemeColor(): String {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -16,6 +16,8 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.FireEventRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.GetConfigResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.IntegrationRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.SensorRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.ServiceCallRequest
@@ -305,17 +307,17 @@ class IntegrationRepositoryImpl @Inject constructor(
         return localStorage.getLong(PREF_SESSION_EXPIRE) ?: 0
     }
 
-    override suspend fun getNotificationRateLimits(): HashMap<String, *>? {
+    override suspend fun getNotificationRateLimits(): RateLimitResponse? {
         val pushToken = localStorage.getString(PREF_PUSH_TOKEN) ?: ""
-        val requestBody = mapOf("push_token" to pushToken)
-        var rateLimits: HashMap<String, *>? = null
+        val requestBody = RateLimitRequest(pushToken)
+        var checkRateLimits: RateLimitResponse? = null
 
         try {
-            rateLimits = integrationService.getRateLimit(RATE_LIMIT_URL, requestBody)["rateLimits"] as HashMap<String, *>?
+            checkRateLimits = integrationService.getRateLimit(RATE_LIMIT_URL, requestBody).rateLimits
         } catch (e: Exception) {
             Log.e(TAG, "Unable to get notification rate limits", e)
         }
-        return rateLimits
+        return checkRateLimits
     }
 
     override suspend fun getThemeColor(): String {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -316,7 +316,7 @@ class IntegrationRepositoryImpl @Inject constructor(
     override suspend fun getNotificationRateLimits(): String? {
         val pushToken = localStorage.getString(PREF_PUSH_TOKEN)
         val client = OkHttpClient()
-        var requestBody = pushToken?.let {
+        val requestBody = pushToken?.let {
             FormBody.Builder()
                 .add("push_token", it)
                 .build()
@@ -332,7 +332,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         if (request != null) {
             client.newCall(request).enqueue(object : Callback {
                 override fun onFailure(call: Call, e: IOException) {
-                    Log.e(TAG, "Unable to get notification rate limits")
+                    Log.e(TAG, "Unable to get notification rate limits", e)
                 }
 
                 override fun onResponse(call: Call, response: Response) {
@@ -340,9 +340,8 @@ class IntegrationRepositoryImpl @Inject constructor(
                     try {
                         val jsonObject = JSONObject(response.body!!.string())
                         rateLimits = jsonObject.getString("rateLimits")
-                        Log.d(TAG, "RATE LIMITS $rateLimits")
                     } catch (e: Exception) {
-                        Log.e(TAG, "Unable to parse the received data")
+                        Log.e(TAG, "Unable to parse the received data", e)
                     }
                 }
             })

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -317,7 +317,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Log.e(TAG, "Unable to get notification rate limits", e)
         }
-        if (checkRateLimits!= null)
+        if (checkRateLimits != null)
             return checkRateLimits
 
         throw IntegrationException()

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.data.integration.impl
 
+import android.util.Log
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
@@ -21,9 +22,18 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.Template
 import io.homeassistant.companion.android.common.data.integration.impl.entities.UpdateLocationRequest
 import io.homeassistant.companion.android.common.data.url.UrlRepository
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Named
+import kotlin.Exception
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.FormBody
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.json.JSONObject
 
 class IntegrationRepositoryImpl @Inject constructor(
     private val integrationService: IntegrationService,
@@ -52,6 +62,8 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_SESSION_TIMEOUT = "session_timeout"
         private const val PREF_SESSION_EXPIRE = "session_expire"
         private const val PREF_SENSORS_REGISTERED = "sensors_registered"
+        private const val TAG = "IntegrationRepository"
+        var rateLimits: String = ""
     }
 
     override suspend fun registerDevice(deviceRegistration: DeviceRegistration) {
@@ -299,6 +311,43 @@ class IntegrationRepositoryImpl @Inject constructor(
 
     override suspend fun getSessionExpireMillis(): Long {
         return localStorage.getLong(PREF_SESSION_EXPIRE) ?: 0
+    }
+
+    override suspend fun getNotificationRateLimits(): String? {
+        val pushToken = localStorage.getString(PREF_PUSH_TOKEN)
+        val client = OkHttpClient()
+        var requestBody = pushToken?.let {
+            FormBody.Builder()
+                .add("push_token", it)
+                .build()
+        }
+
+        val request = requestBody?.let {
+            Request.Builder()
+                .url("https://mobile-apps.home-assistant.io/api/checkRateLimits")
+                .post(it)
+                .build()
+        }
+
+        if (request != null) {
+            client.newCall(request).enqueue(object : Callback {
+                override fun onFailure(call: Call, e: IOException) {
+                    Log.e(TAG, "Unable to get notification rate limits")
+                }
+
+                override fun onResponse(call: Call, response: Response) {
+                    if (!response.isSuccessful) throw IOException("Unexpected response code $response")
+                    try {
+                        val jsonObject = JSONObject(response.body!!.string())
+                        rateLimits = jsonObject.getString("rateLimits")
+                        Log.d(TAG, "RATE LIMITS $rateLimits")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to parse the received data")
+                    }
+                }
+            })
+        }
+        return rateLimits
     }
 
     override suspend fun getThemeColor(): String {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
@@ -72,6 +72,12 @@ interface IntegrationService {
     ): Array<Panel>
 
     @POST
+    suspend fun getRateLimit(
+        @Url url: String,
+        @Body request: Map<String, String>
+    ): HashMap<String, *>
+
+    @POST
     suspend fun updateSensors(
         @Url url: HttpUrl,
         @Body request: IntegrationRequest

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
@@ -2,11 +2,13 @@ package io.homeassistant.companion.android.common.data.integration.impl
 
 import io.homeassistant.companion.android.common.data.integration.Panel
 import io.homeassistant.companion.android.common.data.integration.ZoneAttributes
+import io.homeassistant.companion.android.common.data.integration.impl.entities.CheckRateLimits
 import io.homeassistant.companion.android.common.data.integration.impl.entities.DiscoveryInfoResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.DomainResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.GetConfigResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.IntegrationRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceResponse
 import okhttp3.HttpUrl
@@ -74,8 +76,8 @@ interface IntegrationService {
     @POST
     suspend fun getRateLimit(
         @Url url: String,
-        @Body request: Map<String, String>
-    ): HashMap<String, *>
+        @Body request: RateLimitRequest
+    ): CheckRateLimits
 
     @POST
     suspend fun updateSensors(

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/CheckRateLimits.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/CheckRateLimits.kt
@@ -1,0 +1,9 @@
+package io.homeassistant.companion.android.common.data.integration.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class CheckRateLimits(
+    var target: String,
+    @JsonProperty("rateLimits")
+    var rateLimits: RateLimitResponse
+)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/RateLimitRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/RateLimitRequest.kt
@@ -1,0 +1,5 @@
+package io.homeassistant.companion.android.common.data.integration.impl.entities
+
+data class RateLimitRequest(
+    val push_token: String
+)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/RateLimitResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/RateLimitResponse.kt
@@ -1,0 +1,14 @@
+package io.homeassistant.companion.android.common.data.integration.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class RateLimitResponse(
+    var attempts: Int,
+    var successful: Int,
+    var errors: Int,
+    var total: Int,
+    var maximum: Int,
+    var remaining: Int,
+    @JsonProperty("resetsAt")
+    var resetsAt: String
+)


### PR DESCRIPTION
Fixes: #531 

This PR adds a preference that contains the notification rate limit data.  This preference is only visible if the user is on the `full` flavor and if the call was successful.  One thing to note for some reason the call does not return any data when we first visit settings, its only subsequent visits does the call save.

![image](https://user-images.githubusercontent.com/1634145/95357293-87aa8b80-087c-11eb-8da4-65896ad7bd29.png)

Docs: https://github.com/home-assistant/companion.home-assistant/pull/353