### PR TITLE
Allow control of DND via notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
     <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>


### PR DESCRIPTION
Fixes: #436 

This PR introduces a new device command `message: command_dnd` which takes a mandatory parameter set by the user as the `title`.  The only accepted titles are that which is of the DND sensor state: `off` `alarms_only` `priority_only` `total_silence` anything else that is provided results in the notification posting as normal. As DND control is only supported in Android 6+ if a command is sent to an unsupported device that device will also receive the notification as normal.

This type of command requires a special permission which we can only launch an activity.  This activity is launched when the user sends the first command if the permission has not already been granted.  Upon the next command received everything will process as usual.

Examples:
```
message: command_dnd
title: priority_only
```

```
message: command_dnd
title: off
```

There is also some organization done here for future PR's that may introduce new commands so everything can be neatly organized and added.

Docs: Pending (Looking into creating a notification command page for better organization, and also may need to adjust based on review comments)
FCM: Pending (will wait to submit a PR once we finalize this one)