### PR TITLE
Fix sorting of sensors on the manage sensor screen

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -120,12 +120,12 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
             }
         }
 
-        SensorReceiver.MANAGERS.sortedBy { it.name }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
+        SensorReceiver.MANAGERS.sortedBy { getString(it.name) }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)
             prefCategory.title = getString(manager.name)
 
             preferenceScreen.addPreference(prefCategory)
-            manager.availableSensors.sortedBy { it.name }.forEach { basicSensor ->
+            manager.availableSensors.sortedBy { getString(it.name) }.forEach { basicSensor ->
 
                 val pref = Preference(preferenceScreen.context)
                 pref.key = basicSensor.id


### PR DESCRIPTION
Noticed that the Sensor Managers and Basic Sensors were out of order as we were sorting by the ID instead of the actual string.