### PR TITLE
Initial Support for Android 11 Power Menu Actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -120,6 +120,14 @@
             </intent-filter>
         </service>
 
+        <service android:name=".controls.HaControlsProviderService"
+            android:permission="android.permission.BIND_CONTROLS"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.controls.ControlsProviderService"/>
+            </intent-filter>
+        </service>
+
         <receiver
             android:name=".sensors.LocationSensorManager"
             android:enabled="true"

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ControlsComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ControlsComponent.kt
@@ -1,0 +1,10 @@
+package io.homeassistant.companion.android.controls
+
+import dagger.Component
+import io.homeassistant.companion.android.common.dagger.AppComponent
+
+@Component(dependencies = [AppComponent::class])
+interface ControlsComponent {
+
+    fun inject(service: HaControlsProviderService)
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -19,7 +19,7 @@ class DefaultSliderControl {
     companion object : HaControl {
         override fun createControl(
             context: Context,
-            entity: Entity<Map<*, *>>
+            entity: Entity<Map<String, Any>>
         ): Control {
             val control = Control.StatefulBuilder(
                 entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -20,7 +20,7 @@ class DefaultSwitchControl {
     companion object : HaControl {
         override fun createControl(
             context: Context,
-            entity: Entity<Map<*, *>>
+            entity: Entity<Map<String, Any>>
         ): Control {
             val control = Control.StatefulBuilder(
                 entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -1,0 +1,64 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.ToggleTemplate
+import androidx.annotation.RequiresApi
+import androidx.core.util.Consumer
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.runBlocking
+
+@RequiresApi(Build.VERSION_CODES.R)
+class DefaultSwitchControl {
+    companion object: HaControl {
+        override fun createControl(
+            context: Context,
+            entity: Entity<*>
+        ): Control {
+            val control = Control.StatefulBuilder(
+                entity.entityId,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    WebViewActivity.newInstance(context),
+                    PendingIntent.FLAG_CANCEL_CURRENT
+                )
+            )
+            control.setTitle(entity.entityId)
+            control.setDeviceType(DeviceTypes.TYPE_GENERIC_ON_OFF)
+            control.setStatus(Control.STATUS_OK)
+            control.setControlTemplate(
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
+                        entity.state == "on",
+                        "Description"
+                    )
+                )
+            )
+            return control.build()
+        }
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return runBlocking {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off",
+                    hashMapOf("entity_id" to action.templateId)
+                )
+                return@runBlocking true
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -21,7 +21,7 @@ class FanControl {
     companion object : HaControl {
         override fun createControl(
             context: Context,
-            entity: Entity<Map<*, *>>
+            entity: Entity<Map<String, Any>>
         ): Control {
             val speeds = entity.attributes["speed_list"].toString().split(", ")
 
@@ -62,9 +62,9 @@ class FanControl {
             return runBlocking {
                 // TODO: Get these from entity
                 val speeds = listOf("off", "low", "medium", "high")
-                val speed: String = if(action is BooleanAction){
-                    if(action.newState) speeds.last() else speeds.first()
-                } else if (action is FloatAction){
+                val speed: String = if (action is BooleanAction) {
+                    if (action.newState) speeds.last() else speeds.first()
+                } else if (action is FloatAction) {
                     speeds[action.newValue.toInt()]
                 } else {
                     ""

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -1,0 +1,84 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
+import android.service.controls.templates.RangeTemplate
+import android.service.controls.templates.ToggleRangeTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.runBlocking
+
+@RequiresApi(Build.VERSION_CODES.R)
+class FanControl {
+    companion object : HaControl {
+        override fun createControl(
+            context: Context,
+            entity: Entity<Map<*, *>>
+        ): Control {
+            val speeds = entity.attributes["speed_list"].toString().split(", ")
+
+            val control = Control.StatefulBuilder(
+                entity.entityId,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    WebViewActivity.newInstance(context),
+                    PendingIntent.FLAG_CANCEL_CURRENT
+                )
+            )
+            control.setTitle(entity.attributes["friendly_name"].toString())
+            control.setDeviceType(DeviceTypes.TYPE_FAN)
+            control.setStatus(Control.STATUS_OK)
+            control.setControlTemplate(
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    entity.state != "off",
+                    "",
+                    RangeTemplate(
+                        entity.entityId,
+                        0f,
+                        speeds.size.toFloat(),
+                        speeds.indexOf(entity.state).toFloat(),
+                        1f,
+                        ""
+                    )
+                )
+            )
+            return control.build()
+        }
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return runBlocking {
+                // TODO: Get these from entity
+                val speeds = listOf("off", "low", "medium", "high")
+                val speed: String = if(action is BooleanAction){
+                    if(action.newState) speeds.last() else speeds.first()
+                } else if (action is FloatAction){
+                    speeds[action.newValue.toInt()]
+                } else {
+                    ""
+                }
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "set_speed",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "speed" to speed
+                    )
+                )
+                return@runBlocking true
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -1,0 +1,14 @@
+package io.homeassistant.companion.android.controls
+
+import android.content.Context
+import android.service.controls.Control
+import android.service.controls.actions.ControlAction
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+
+interface HaControl {
+
+    fun createControl(context: Context, entity: Entity<*>): Control
+
+    fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -8,7 +8,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 
 interface HaControl {
 
-    fun createControl(context: Context, entity: Entity<Map<*, *>>): Control
+    fun createControl(context: Context, entity: Entity<Map<String, Any>>): Control
 
     fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -8,7 +8,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 
 interface HaControl {
 
-    fun createControl(context: Context, entity: Entity<*>): Control
+    fun createControl(context: Context, entity: Entity<Map<*, *>>): Control
 
     fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -1,0 +1,140 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.ControlsProviderService
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.ToggleTemplate
+import android.util.Log
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Flow
+import java.util.function.Consumer
+import javax.inject.Inject
+
+@RequiresApi(Build.VERSION_CODES.R)
+class HaControlsProviderService: ControlsProviderService() {
+
+    companion object {
+        private const val TAG = "HaConProService"
+    }
+
+    @Inject
+    lateinit var integrationRepository: IntegrationRepository
+
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
+
+    private var updateSubscriber: Flow.Subscriber<in Control>? = null
+
+    override fun onCreate() {
+        super.onCreate()
+
+        DaggerControlsComponent.builder()
+            .appComponent((application as GraphComponentAccessor).appComponent)
+            .build()
+            .inject(this)
+    }
+
+    override fun createPublisherForAllAvailable(): Flow.Publisher<Control> {
+        return Flow.Publisher { flow ->
+            ioScope.launch {
+                integrationRepository.getEntities()
+                    .filter { it.entityId.startsWith("input_boolean") }
+                    .map { createControl(it) }
+                    .forEach { flow.onNext(it) }
+                flow.onComplete()
+            }
+        }
+    }
+
+    override fun createPublisherFor(controlIds: MutableList<String>): Flow.Publisher<Control> {
+        Log.d(TAG, "publisherFor $controlIds")
+        return Flow.Publisher { subscriber ->
+            ioScope.launch {
+                integrationRepository.getEntities()
+                    .filter { it.entityId in controlIds }
+                    .map { createControl(it) }
+                    .forEach {
+                        subscriber.onSubscribe(object : Flow.Subscription {
+                            override fun request(n: Long) {
+                                Log.d(TAG, "request $n")
+                                updateSubscriber = subscriber
+                            }
+
+                            override fun cancel() {
+                                Log.d(TAG, "cancel")
+                                updateSubscriber = null
+                            }
+                        })
+                        subscriber.onNext(it)
+                    }
+            }
+        }
+    }
+
+    override fun performControlAction(
+        controlId: String,
+        action: ControlAction,
+        consumer: Consumer<Int>)
+    {
+        Log.d(TAG, "Control: $controlId, action: $action")
+        when {
+            controlId.startsWith("input_boolean") ->{
+                handleToggle(controlId, action as BooleanAction)
+            }
+            else -> {
+                Log.e(TAG, "Not handling $controlId action!")
+                consumer.accept(ControlAction.RESPONSE_OK)
+            }
+        }
+    }
+
+    private fun handleToggle(controlId: String, booleanAction: BooleanAction) {
+        runBlocking {
+            integrationRepository.callService(
+                "input_boolean",
+                if(booleanAction.newState) "turn_on" else "turn_off",
+                hashMapOf("entity_id" to controlId)
+            )
+            //TODO: Make this suck less
+            integrationRepository.getEntities().firstOrNull { it.entityId == controlId }?.let {
+                updateSubscriber?.onNext(createControl(it))
+            }
+        }
+    }
+
+    private fun createControl(entity: Entity<Any>): Control {
+        val control = Control.StatefulBuilder(
+            entity.entityId,
+            PendingIntent.getActivity(
+                applicationContext,
+                0,
+                WebViewActivity.newInstance(applicationContext),
+                PendingIntent.FLAG_CANCEL_CURRENT
+            )
+        )
+        control.setTitle(entity.entityId)
+        control.setDeviceType(DeviceTypes.TYPE_SWITCH)
+        control.setStatus(Control.STATUS_OK)
+        control.setControlTemplate(
+            ToggleTemplate(
+                entity.entityId,
+                ControlButton(
+                    entity.state == "on",
+                    "Description")
+            )
+        )
+        return control.build()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -60,7 +60,7 @@ class HaControlsProviderService : ControlsProviderService() {
                     .mapNotNull { it as? Entity<Map<*, *>> }
                     .mapNotNull {
                         val domain = it.entityId.split(".")[0]
-                        domainToHaControl[domain]?.createControl(applicationContext, it as Entity<Map<*, *>>)
+                        domainToHaControl[domain]?.createControl(applicationContext, it)
                     }
                     .forEach {
                         subscriber.onNext(it)

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -7,7 +7,10 @@ import android.service.controls.ControlsProviderService
 import android.service.controls.DeviceTypes
 import android.service.controls.actions.BooleanAction
 import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
 import android.service.controls.templates.ControlButton
+import android.service.controls.templates.RangeTemplate
+import android.service.controls.templates.ToggleRangeTemplate
 import android.service.controls.templates.ToggleTemplate
 import android.util.Log
 import androidx.annotation.RequiresApi
@@ -37,6 +40,18 @@ class HaControlsProviderService: ControlsProviderService() {
 
     private var updateSubscriber: Flow.Subscriber<in Control>? = null
 
+    private val domainToHaControl = mapOf<String, HaControl?>(
+        "camera" to null,
+        "climate" to null,
+        "fan" to null,
+        "light" to null,
+        "media_player" to null,
+        "remote" to null,
+        "input_boolean" to DefaultSwitchControl,
+        "switch" to DefaultSwitchControl,
+        "input_number" to null
+    )
+
     override fun onCreate() {
         super.onCreate()
 
@@ -47,13 +62,18 @@ class HaControlsProviderService: ControlsProviderService() {
     }
 
     override fun createPublisherForAllAvailable(): Flow.Publisher<Control> {
-        return Flow.Publisher { flow ->
+        return Flow.Publisher { subscriber ->
             ioScope.launch {
                 integrationRepository
                     .getEntities()
-                    .mapNotNull { createControl(it) }
-                    .forEach { flow.onNext(it) }
-                flow.onComplete()
+                    .mapNotNull {
+                        val domain = it.entityId.split(".")[0]
+                        domainToHaControl[domain]?.createControl(applicationContext, it)
+                    }
+                    .forEach {
+                        subscriber.onNext(it)
+                    }
+                subscriber.onComplete()
             }
         }
     }
@@ -64,7 +84,10 @@ class HaControlsProviderService: ControlsProviderService() {
             ioScope.launch {
                 integrationRepository.getEntities()
                     .filter { it.entityId in controlIds }
-                    .mapNotNull { createControl(it) }
+                    .mapNotNull {
+                        val domain = it.entityId.split(".")[0]
+                        domainToHaControl[domain]?.createControl(applicationContext, it)
+                    }
                     .forEach {
                         subscriber.onSubscribe(object : Flow.Subscription {
                             override fun request(n: Long) {
@@ -89,48 +112,45 @@ class HaControlsProviderService: ControlsProviderService() {
         consumer: Consumer<Int>)
     {
         Log.d(TAG, "Control: $controlId, action: $action")
-        when (action) {
-            is BooleanAction -> {
-                handleToggle(controlId, action)
-            }
-            else -> {
-                Log.e(TAG, "Not handling $controlId action!")
-                consumer.accept(ControlAction.RESPONSE_OK)
+        val domain = controlId.split(".")[0]
+        val haControl = domainToHaControl[domain]
+
+        var actionSuccess = false
+        if(haControl != null){
+            runBlocking {
+                actionSuccess = haControl.performAction(integrationRepository, action)
+
+                //TODO: Make this less awful, aka make single entity call
+                val entity = integrationRepository.getEntities().firstOrNull { it.entityId == controlId }
+                if(entity != null) {
+                    updateSubscriber?.onNext(haControl.createControl(applicationContext, entity))
+                }
             }
         }
-        runBlocking {
-            //TODO: Make this less awful, aka make single entity call
-            integrationRepository.getEntities().firstOrNull { it.entityId == controlId }?.let {
-                updateSubscriber?.onNext(createSwitchControl(it))
-            }
+        if (actionSuccess){
+            consumer.accept(ControlAction.RESPONSE_OK)
+        } else {
+            consumer.accept(ControlAction.RESPONSE_UNKNOWN)
         }
     }
 
-    private fun handleToggle(controlId: String, booleanAction: BooleanAction) {
+    private fun handleFloatAction(controlId: String, floatAction: FloatAction){
         runBlocking {
             integrationRepository.callService(
                 controlId.split(".")[0],
-                if(booleanAction.newState) "turn_on" else "turn_off",
-                hashMapOf("entity_id" to controlId)
+                "set_value",
+                hashMapOf(
+                    "entity_id" to controlId,
+                    "value" to floatAction.newValue
+                )
             )
         }
     }
 
-    private fun createControl(entity: Entity<Any>): Control? {
-        return when (entity.entityId.split(".")[0]) {
-            "camera",
-            "climate",
-            "fan",
-            "input_boolean",
-            "light",
-            "media_player",
-            "remote",
-            "switch" -> createSwitchControl(entity)
-            else -> null
-        }
-    }
-
-    private fun createSwitchControl(entity: Entity<Any>): Control {
+    private fun createSliderControl(
+        entity: Entity<Map<String, Any>>,
+        deviceType: Int
+    ): Control {
         val control = Control.StatefulBuilder(
             entity.entityId,
             PendingIntent.getActivity(
@@ -141,14 +161,21 @@ class HaControlsProviderService: ControlsProviderService() {
             )
         )
         control.setTitle(entity.entityId)
-        control.setDeviceType(DeviceTypes.TYPE_SWITCH)
+        control.setDeviceType(deviceType)
         control.setStatus(Control.STATUS_OK)
         control.setControlTemplate(
-            ToggleTemplate(
+            ToggleRangeTemplate(
                 entity.entityId,
-                ControlButton(
-                    entity.state == "on",
-                    "Description")
+                (entity.state.toFloatOrNull()?:0) == 0,
+                "Description?",
+                RangeTemplate(
+                    entity.entityId+"_range",
+                    (entity.attributes["min"] as? Number)?.toFloat() ?: 0f,
+                    (entity.attributes["max"] as? Number)?.toFloat() ?: 0f,
+                    entity.state.toFloatOrNull() ?: 0f,
+                    (entity.attributes["step"] as? Number)?.toFloat() ?: 0f,
+                    null
+                )
             )
         )
         return control.build()

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -35,7 +35,7 @@ class HaControlsProviderService : ControlsProviderService() {
         "camera" to null,
         "climate" to null,
         "fan" to null,
-        "light" to null,
+        "light" to LightControl,
         "media_player" to null,
         "remote" to null,
         "input_boolean" to DefaultSwitchControl,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -1,0 +1,90 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
+import android.service.controls.templates.RangeTemplate
+import android.service.controls.templates.ToggleRangeTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.runBlocking
+
+@RequiresApi(Build.VERSION_CODES.R)
+class LightControl {
+    companion object : HaControl {
+        override fun createControl(
+            context: Context,
+            entity: Entity<Map<*, *>>
+        ): Control {
+            val control = Control.StatefulBuilder(
+                entity.entityId,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    WebViewActivity.newInstance(context),
+                    PendingIntent.FLAG_CANCEL_CURRENT
+                )
+            )
+            control.setTitle(entity.attributes["friendly_name"].toString())
+            control.setDeviceType(DeviceTypes.TYPE_LIGHT)
+            control.setStatus(Control.STATUS_OK)
+            control.setControlTemplate(
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    entity.state != "off",
+                    "",
+                    RangeTemplate(
+                        entity.entityId,
+                        0f,
+                        255f,
+                        (entity.attributes["brightness"] as? Int)?.toFloat() ?: 0f,
+                        1f,
+                        ""
+                    )
+                )
+            )
+            return control.build()
+        }
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return runBlocking {
+                return@runBlocking when (action) {
+                    is BooleanAction -> {
+                        integrationRepository.callService(
+                            action.templateId.split(".")[0],
+                            if(action.newState) "turn_on" else "turn_off",
+                            hashMapOf(
+                                "entity_id" to action.templateId
+                            )
+                        )
+                        true
+                    }
+                    is FloatAction -> {
+                        integrationRepository.callService(
+                            action.templateId.split(".")[0],
+                            "turn_on",
+                            hashMapOf(
+                                "entity_id" to action.templateId,
+                                "brightness" to action.newValue.toInt()
+                            )
+                        )
+                        true
+                    }
+                    else -> {
+                        false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -21,7 +21,7 @@ class LightControl {
     companion object : HaControl {
         override fun createControl(
             context: Context,
-            entity: Entity<Map<*, *>>
+            entity: Entity<Map<String, Any>>
         ): Control {
             val control = Control.StatefulBuilder(
                 entity.entityId,
@@ -62,7 +62,7 @@ class LightControl {
                     is BooleanAction -> {
                         integrationRepository.callService(
                             action.templateId.split(".")[0],
-                            if(action.newState) "turn_on" else "turn_off",
+                            if (action.newState) "turn_on" else "turn_off",
                             hashMapOf(
                                 "entity_id" to action.templateId
                             )

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/TagReaderActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/TagReaderActivity.kt
@@ -43,7 +43,7 @@ class TagReaderActivity : AppCompatActivity() {
         mainScope.launch {
             if (NfcAdapter.ACTION_NDEF_DISCOVERED == intent.action) {
                 val rawMessages = intent.getParcelableArrayExtra(NfcAdapter.EXTRA_NDEF_MESSAGES)
-                val ndefMessage = rawMessages[0] as NdefMessage?
+                val ndefMessage = rawMessages?.get(0) as NdefMessage?
                 val url = ndefMessage?.records?.get(0)?.toUri().toString()
                 try {
                     handleTag(url)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -75,9 +75,9 @@ class PhoneStateSensorManager : SensorManager {
                     (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
 
                 currentPhoneState = when (telephonyManager.callState) {
-                    0 -> "idle"
-                    1 -> "ringing"
-                    2 -> "offhook"
+                    TelephonyManager.CALL_STATE_IDLE -> "idle"
+                    TelephonyManager.CALL_STATE_RINGING -> "ringing"
+                    TelephonyManager.CALL_STATE_OFFHOOK -> "offhook"
                     else -> "unknown"
                 }
             }
@@ -105,8 +105,9 @@ class PhoneStateSensorManager : SensorManager {
     fun updateCallNumber(context: Context, intent: Intent) {
         if (checkPermission(context, callNumber.id)) {
             if (intent.hasExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)) {
-                val number = intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)
-                updateCallNumberSensor(context, number)
+                intent.getStringExtra(TelephonyManager.EXTRA_INCOMING_NUMBER)?.let {
+                    updateCallNumberSensor(context, it)
+                }
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
@@ -62,11 +62,11 @@ class TrafficStatsManager : SensorManager {
     override fun hasSensor(context: Context): Boolean {
         val cm: ConnectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         val networkInfo = cm.allNetworks
-        var networkCapabilities: NetworkCapabilities
+        var networkCapabilities: NetworkCapabilities?
         for (item in networkInfo) {
             networkCapabilities = cm.getNetworkCapabilities(item)
             if (!hasCellular)
-                hasCellular = networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)
+                hasCellular = networkCapabilities?.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) ?: false
         }
         return true
     }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -16,9 +16,9 @@ object Config {
     }
 
     object Android {
-        const val compileSdk = 29
+        const val compileSdk = 30
         const val minSdk = 21
-        const val targetSdk = 29
+        const val targetSdk = 30
         const val ndk = "21.3.6528147"
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -35,6 +35,7 @@ interface IntegrationRepository {
     suspend fun getServices(): Array<Service>
 
     suspend fun getEntities(): Array<Entity<Any>>
+    suspend fun getEntity(entityId: String): Entity<Map<String, Any>>
 
     suspend fun callService(domain: String, service: String, serviceData: HashMap<String, Any>)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -395,6 +395,21 @@ class IntegrationRepositoryImpl @Inject constructor(
         }.toTypedArray()
     }
 
+    override suspend fun getEntity(entityId: String): Entity<Map<String, Any>> {
+        val response = integrationService.getState(
+            authenticationRepository.buildBearerToken(),
+            entityId
+        )
+        return Entity(
+            response.entityId,
+            response.state,
+            response.attributes,
+            response.lastChanged,
+            response.lastUpdated,
+            response.context
+        )
+    }
+
     override suspend fun registerSensor(sensorRegistration: SensorRegistration<Any>) {
         val registeredSensors = localStorage.getStringSet(PREF_SENSORS_REGISTERED)
         if (registeredSensors?.contains(sensorRegistration.uniqueId) == true) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
@@ -18,6 +18,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
+import retrofit2.http.Path
 import retrofit2.http.Url
 
 interface IntegrationService {
@@ -42,6 +43,12 @@ interface IntegrationService {
     suspend fun getStates(
         @Header("Authorization") auth: String
     ): Array<EntityResponse<Any>>
+
+    @GET("/api/states/{entityId}")
+    suspend fun getState(
+        @Header("Authorization") auth: String,
+        @Path("entityId") entityId: String
+    ): EntityResponse<Map<String, Any>>
 
     @POST
     suspend fun callWebhook(


### PR DESCRIPTION
![Screenshot_20201008-233019](https://user-images.githubusercontent.com/1051414/95540360-99944780-09be-11eb-90dc-3acc6a657eb1.png)

This is adding the foundation for power menu actions.  We currently support light, switch, input_boolean, and input_number domains.  More domains will be coming soon.