### PR TITLE
Allow overriding PUSH_URL and RATE_LIMIT_URL in local.properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,14 @@ If you get stuck while setting up your own environment, you can ask questions in
 
 ### Push Notifications
 
-If you want to work on push notifications or use a development build with push notifications, please go the server side code [HERE](https://github.com/home-assistant/mobile-apps-fcm-push) and deploy it to your firebase project. Once you have your androidV1 URL to the deployed service, add it to your `local.properties` file, e.g.:
-
+If you want to work on push notifications or use a development build with push notifications, please go the server side code [HERE](https://github.com/home-assistant/mobile-apps-fcm-push) and deploy it to your firebase project. Once you have your androidV1 URL to the deployed service, set it in to your `${GRADLE_USER_HOME}/gradle.properties` file, e.g.:
 ```properties
-push_url=https://mydomain.cloudfunctions.net/androidV1
+homeAssistantAndroidPushUrl=https://mydomain.cloudfunctions.net/androidV1
 ```
 
 You can also define the rate limit function URL, e.g.:
 ```properties
-rate_limit_url=https://mydomain.cloudfunctions.net/checkRateLimits
+homeAssistantAndroidRateLimitUrl=https://mydomain.cloudfunctions.net/checkRateLimits
 ```
 
 ## App Flavors

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ If you get stuck while setting up your own environment, you can ask questions in
 
 ### Push Notifications
 
-If you want to work on push notifications or use a development build with push notifications please go the server side code [HERE](https://github.com/home-assistant/mobile-apps-fcm-push) and deploy it to your firebase project.  Once you have your androidV1 URL to the deployed service, exchange that for your local builds [PUSH_URL](https://github.com/home-assistant/android/blob/master/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt#L43).
+If you want to work on push notifications or use a development build with push notifications, please go the server side code [HERE](https://github.com/home-assistant/mobile-apps-fcm-push) and deploy it to your firebase project. Once you have your androidV1 URL to the deployed service, add it to your `local.properties` file, e.g.:
+
+```properties
+push_url=https://mydomain.cloudfunctions.net/androidV1
+```
+
+You can also define the rate limit function URL, e.g.:
+```properties
+rate_limit_url=https://mydomain.cloudfunctions.net/checkRateLimits
+```
 
 ## App Flavors
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,36 +1,19 @@
-import java.io.FileInputStream
-import java.io.InputStreamReader
-import java.util.Properties
-
 plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
 }
 
-fun gradleLocalProperties(projectRootDir: File): java.util.Properties {
-    val properties = Properties()
-    val localProperties = File(projectRootDir, "local.properties")
-    if (localProperties.isFile) {
-        InputStreamReader(FileInputStream(localProperties), Charsets.UTF_8).use { reader ->
-            properties.load(reader)
-        }
-    }
-    return properties
-}
-
-val pushUrl: String = gradleLocalProperties(rootDir).getProperty("push_url")
-    ?: "https://mobile-apps.home-assistant.io/api/sendPush/android/v1"
-val rateLimitUrl: String = gradleLocalProperties(rootDir).getProperty("rate_limit_url")
-    ?: "https://mobile-apps.home-assistant.io/api/checkRateLimits"
+val homeAssistantAndroidPushUrl: String by project
+val homeAssistantAndroidRateLimitUrl: String by project
 
 android {
     compileSdkVersion(Config.Android.compileSdk)
 
     defaultConfig {
         minSdkVersion(Config.Android.minSdk)
-        buildConfigField("String", "PUSH_URL", "\"$pushUrl\"")
-        buildConfigField("String", "RATE_LIMIT_URL", "\"$rateLimitUrl\"")
+        buildConfigField("String", "PUSH_URL", "\"$homeAssistantAndroidPushUrl\"")
+        buildConfigField("String", "RATE_LIMIT_URL", "\"$homeAssistantAndroidRateLimitUrl\"")
     }
 }
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,14 +1,36 @@
+import java.io.FileInputStream
+import java.io.InputStreamReader
+import java.util.Properties
+
 plugins {
     id("com.android.library")
     id("kotlin-android")
     id("kotlin-kapt")
 }
 
+fun gradleLocalProperties(projectRootDir: File): java.util.Properties {
+    val properties = Properties()
+    val localProperties = File(projectRootDir, "local.properties")
+    if (localProperties.isFile) {
+        InputStreamReader(FileInputStream(localProperties), Charsets.UTF_8).use { reader ->
+            properties.load(reader)
+        }
+    }
+    return properties
+}
+
+val pushUrl: String = gradleLocalProperties(rootDir).getProperty("push_url")
+    ?: "https://mobile-apps.home-assistant.io/api/sendPush/android/v1"
+val rateLimitUrl: String = gradleLocalProperties(rootDir).getProperty("rate_limit_url")
+    ?: "https://mobile-apps.home-assistant.io/api/checkRateLimits"
+
 android {
     compileSdkVersion(Config.Android.compileSdk)
 
     defaultConfig {
         minSdkVersion(Config.Android.minSdk)
+        buildConfigField("String", "PUSH_URL", "\"$pushUrl\"")
+        buildConfigField("String", "RATE_LIMIT_URL", "\"$rateLimitUrl\"")
     }
 }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.common.data.integration.impl
 
 import android.util.Log
+import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
@@ -44,7 +45,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val APP_ID = "io.homeassistant.companion.android"
         private const val APP_NAME = "Home Assistant"
         private const val OS_NAME = "Android"
-        private const val PUSH_URL = "https://mobile-apps.home-assistant.io/api/sendPush/android/v1"
+        private const val PUSH_URL = BuildConfig.PUSH_URL
 
         private const val PREF_APP_VERSION = "app_version"
         private const val PREF_DEVICE_NAME = "device_name"
@@ -57,7 +58,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_SESSION_EXPIRE = "session_expire"
         private const val PREF_SENSORS_REGISTERED = "sensors_registered"
         private const val TAG = "IntegrationRepository"
-        private const val RATE_LIMIT_URL = "https://mobile-apps.home-assistant.io/api/checkRateLimits"
+        private const val RATE_LIMIT_URL = BuildConfig.RATE_LIMIT_URL
     }
 
     override suspend fun registerDevice(deviceRegistration: DeviceRegistration) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,8 @@ org.gradle.jvmargs=-Xmx1536m
 kotlin.code.style=official
 
 android.useAndroidX = true
+
+# The default API URL used by the Home Assistant Android application.
+# Override these in your ${GRADLE_USER_HOME}/gradle.properties file if needed.
+homeAssistantAndroidPushUrl=https://mobile-apps.home-assistant.io/api/sendPush/android/v1
+homeAssistantAndroidRateLimitUrl=https://mobile-apps.home-assistant.io/api/checkRateLimits


### PR DESCRIPTION
This PR takes on @JBassett's [suggestion](https://github.com/home-assistant/android/pull/1010#pullrequestreview-502453327) to extract PUSH_URL in a properties file.

The same is done for RATE_LIMIT_URL.