### PR TITLE
Fix sentry crash after target SDK change

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -8,6 +8,7 @@
         <meta-data android:name="io.sentry.auto-init" android:value="${sentryEnabled}" />
         <meta-data android:name="io.sentry.release" android:value="${sentryRelease}" />
         <meta-data android:name="io.sentry.session-tracking.enable" android:value="true" />
+        <meta-data android:name="io.sentry.ndk.enable" android:value="false" />
         <meta-data android:name="io.sentry.dsn" android:value="https://2d646f40f9574e0b9579e301a69bb030@o427061.ingest.sentry.io/5372876" />
 
         <receiver


### PR DESCRIPTION
After #1027 was merged I updated the production version where sentry is enabled.  The app immediately crashed and it turns out to be a known issue: https://github.com/getsentry/sentry-java/issues/904

Using the suggested workaround until Sentry fixes the issue: https://github.com/getsentry/sentry-java/issues/904#issuecomment-702033313

I can confirm this works on my physical device as I was able to reproduce the crash.