### PR TITLE
Allow TTS notifications to use the alarm stream

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -12,6 +12,8 @@ import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.text.Spanned
@@ -209,7 +211,13 @@ class MessagingService : FirebaseMessagingService() {
                 textToSpeech?.speak(tts, TextToSpeech.QUEUE_ADD, null, "")
                 Log.d(TAG, "speaking notification")
             } else {
-                Toast.makeText(applicationContext, getString(R.string.tts_error, tts), Toast.LENGTH_LONG).show()
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(
+                        applicationContext,
+                        getString(R.string.tts_error, tts),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
             }
         }
     }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -116,7 +116,7 @@ class MessagingService : FirebaseMessagingService() {
                 }
                 it[MESSAGE] == TTS -> {
                     Log.d(TAG, "Sending notification title to TTS")
-                    speakNotification(it[TITLE])
+                    speakNotification(it)
                 }
                 it[MESSAGE] in DEVICE_COMMANDS -> {
                     Log.d(TAG, "Processing device command")
@@ -175,9 +175,9 @@ class MessagingService : FirebaseMessagingService() {
         }
     }
 
-    private fun speakNotification(title: String?) {
+    private fun speakNotification(data: Map<String, String>) {
         var textToSpeech: TextToSpeech? = null
-        var tts = title
+        var tts = data[TITLE]
         if (tts.isNullOrEmpty())
             tts = getString(R.string.tts_no_title)
         textToSpeech = TextToSpeech(applicationContext
@@ -199,6 +199,13 @@ class MessagingService : FirebaseMessagingService() {
                     }
                 }
                 textToSpeech?.setOnUtteranceProgressListener(listener)
+                if (data["channel"] == "alarm_stream") {
+                    val audioAttributes = AudioAttributes.Builder()
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                        .setUsage(AudioAttributes.USAGE_ALARM)
+                        .build()
+                    textToSpeech?.setAudioAttributes(audioAttributes)
+                }
                 textToSpeech?.speak(tts, TextToSpeech.QUEUE_ADD, null, "")
                 Log.d(TAG, "speaking notification")
             } else {


### PR DESCRIPTION
Was doing some more testing around TTS notifications.  Came to find out that by default they use the `MUSIC_STREAM` which means that they will ignore the devices ringer mode but not the volume level.  By using the `ALARM_STREAM` we use a separate volume level so it can bypass if media volume is off.

Example:

```
message: TTS
title: I am speaking
data:
  channel: alarm_stream
```

`channel: alarm_stream` is only used to override the default stream.