### PR TITLE
More skippable intents

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -10,7 +10,7 @@ class AudioSensorManager : SensorManager {
     companion object {
         private const val TAG = "AudioSensor"
 
-        private val audioSensor = SensorManager.BasicSensor(
+        val audioSensor = SensorManager.BasicSensor(
             "audio_sensor",
             "sensor",
             R.string.sensor_name_ringer_mode,
@@ -28,7 +28,7 @@ class AudioSensorManager : SensorManager {
             R.string.sensor_name_headphone,
             R.string.sensor_description_headphone
         )
-        private val micMuted = SensorManager.BasicSensor(
+        val micMuted = SensorManager.BasicSensor(
             "mic_muted",
             "binary_sensor",
             R.string.sensor_name_mic_muted,
@@ -40,7 +40,7 @@ class AudioSensorManager : SensorManager {
             R.string.sensor_name_music_active,
             R.string.sensor_description_music_active
         )
-        private val speakerphoneState = SensorManager.BasicSensor(
+        val speakerphoneState = SensorManager.BasicSensor(
             "speakerphone_state",
             "binary_sensor",
             R.string.sensor_name_speakerphone,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -9,7 +9,7 @@ class DNDSensorManager : SensorManager {
     companion object {
         private const val TAG = "DNDSensor"
 
-        private val dndSensor = SensorManager.BasicSensor(
+        val dndSensor = SensorManager.BasicSensor(
             "dnd_sensor",
             "sensor",
             R.string.sensor_name_dnd,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -12,19 +12,19 @@ class PowerSensorManager : SensorManager {
         private const val TAG = "PowerSensors"
         private const val packageName = "io.homeassistant.companion.android"
 
-        private val interactiveDevice = SensorManager.BasicSensor(
+        val interactiveDevice = SensorManager.BasicSensor(
             "is_interactive",
             "binary_sensor",
             R.string.basic_sensor_name_interactive,
             R.string.sensor_description_interactive
         )
-        private val doze = SensorManager.BasicSensor(
+        val doze = SensorManager.BasicSensor(
             "is_idle",
             "binary_sensor",
             R.string.basic_sensor_name_doze,
             R.string.sensor_description_doze
         )
-        private val powerSave = SensorManager.BasicSensor(
+        val powerSave = SensorManager.BasicSensor(
             "power_save",
             "binary_sensor",
             R.string.basic_sensor_name_power_save,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -78,8 +78,7 @@ class SensorReceiver : BroadcastReceiver() {
         NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED to DNDSensorManager.dndSensor.id,
         AudioManager.ACTION_MICROPHONE_MUTE_CHANGED to AudioSensorManager.micMuted.id,
         AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED to AudioSensorManager.speakerphoneState.id,
-        AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
-        TelephonyManager.ACTION_PHONE_STATE_CHANGED to PhoneStateSensorManager.phoneState.id
+        AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id
     )
 
     override fun onReceive(context: Context, intent: Intent) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -1,9 +1,13 @@
 package io.homeassistant.companion.android.sensors
 
+import android.annotation.SuppressLint
+import android.app.NotificationManager
 import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.media.AudioManager
+import android.os.PowerManager
 import android.telephony.TelephonyManager
 import android.util.Log
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
@@ -60,11 +64,22 @@ class SensorReceiver : BroadcastReceiver() {
         Intent.ACTION_POWER_DISCONNECTED
     )
 
+    // Suppress Lint because we only register for the receiver if the android version matches the intent
+    @SuppressLint("InlinedApi")
     private val skippableActions = mapOf(
         "android.app.action.NEXT_ALARM_CLOCK_CHANGED" to NextAlarmManager.nextAlarm.id,
         "android.bluetooth.device.action.ACL_CONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
         "android.bluetooth.device.action.ACL_DISCONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
-        BluetoothAdapter.ACTION_STATE_CHANGED to BluetoothSensorManager.bluetoothState.id
+        BluetoothAdapter.ACTION_STATE_CHANGED to BluetoothSensorManager.bluetoothState.id,
+        Intent.ACTION_SCREEN_OFF to PowerSensorManager.interactiveDevice.id,
+        Intent.ACTION_SCREEN_ON to PowerSensorManager.interactiveDevice.id,
+        PowerManager.ACTION_POWER_SAVE_MODE_CHANGED to PowerSensorManager.powerSave.id,
+        PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED to PowerSensorManager.doze.id,
+        NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED to DNDSensorManager.dndSensor.id,
+        AudioManager.ACTION_MICROPHONE_MUTE_CHANGED to AudioSensorManager.micMuted.id,
+        AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED to AudioSensorManager.speakerphoneState.id,
+        AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
+        TelephonyManager.ACTION_PHONE_STATE_CHANGED to PhoneStateSensorManager.phoneState.id
     )
 
     override fun onReceive(context: Context, intent: Intent) {


### PR DESCRIPTION
We had recently started to skip certain intents if the corresponding sensor was not enabled.  Lets add more to this list.  Pretty much any intent except for ones that are tied to more than one sensor are now skipped.  This should account for the majority of the events that are unwanted especially screen on/off.

Suppressing lint here is ok because we only register for receivers if the android version matches the intent.