### PR TITLE
Rename notification dismissed to notification cleared for event type limit

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
@@ -45,13 +45,13 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
 
         runBlocking {
             try {
-                integrationRepository.fireEvent("mobile_app_notification_dismissed", hashData)
-                Log.d(TAG, "Notification dismiss event successful!")
+                integrationRepository.fireEvent("mobile_app_notification_cleared", hashData)
+                Log.d(TAG, "Notification cleared event successful!")
             } catch (e: Exception) {
                 Log.e(TAG, "Issue sending event to Home Assistant", e)
                 Toast.makeText(
                     context,
-                    R.string.notification_dismiss_failure,
+                    R.string.notification_clear_failure,
                     Toast.LENGTH_LONG
                 ).show()
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,7 +139,7 @@ Home Assistant instance</string>
   <string name="manual_setup">enter address manually</string>
   <string name="map">Map</string>
   <string name="need_help">Need Help?</string>
-  <string name="notification_dismiss_failure">Failed to send event on notification dismissed</string>
+  <string name="notification_clear_failure">Failed to send event on notification cleared</string>
   <string name="nfc_btn_create_duplicate">Create duplicate</string>
   <string name="rate_limit_title">Notification Rate Limit</string>
   <string name="rate_limit_summary">Rate limit data</string>


### PR DESCRIPTION
Fixes: #1040 

When I made #1012 I was unaware of the current limit set for the `event_type`  https://data.home-assistant.io/docs/events/#database-table 🙈  The default recorder did not complain about the size during testing which is why this got missed

Lets rename `mobile_app_notification_dismissed` (33 char) to `mobile_app_notification_cleared` (31 char) so its within the 32 character limit.