### PR TITLE
Fix alert dialog background for light and dark modes

### DIFF
--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -1,0 +1,22 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.DayNight.Dialog.Alert">
+        <item name="android:textColor">@color/colorDialogTitle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Alert.Button.Negative</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Alert.Button.Neutral</item>
+        <item name="android:textColorPrimary">@color/colorDialogMessage</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="textColorAlertDialogListItem">@color/colorDialogMessage</item>
+        <item name="colorControlNormal">@color/colorDialogMessage</item>
+    </style>
+
+    <style name="Authentication_Dialog" parent="Theme.MaterialComponents.DayNight.Dialog">
+        <item name="android:textColor">@color/colorDialogTitle</item>
+        <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>
+        <item name="buttonBarNegativeButtonStyle">@style/Alert.Button.Negative</item>
+        <item name="buttonBarNeutralButtonStyle">@style/Alert.Button.Neutral</item>
+        <item name="windowMinWidthMajor">300dp</item>
+        <item name="windowMinWidthMinor">0dp</item>
+        <item name="android:textColorPrimary">@color/colorDialogMessage</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,5 +1,4 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-
     <style name="Theme.HomeAssistant" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
@@ -39,7 +38,6 @@
     </style>
 
     <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.Light.Dialog.Alert">
-        <item name="android:background">@color/colorDialogBackground</item>
         <item name="android:textColor">@color/colorDialogTitle</item>
         <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>
         <item name="buttonBarNegativeButtonStyle">@style/Alert.Button.Negative</item>
@@ -51,7 +49,6 @@
     </style>
 
     <style name="Authentication_Dialog" parent="Theme.MaterialComponents.Light.Dialog">
-        <item name="android:background">@color/colorDialogBackground</item>
         <item name="android:textColor">@color/colorDialogTitle</item>
         <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>
         <item name="buttonBarNegativeButtonStyle">@style/Alert.Button.Negative</item>
@@ -59,7 +56,6 @@
         <item name="windowMinWidthMajor">300dp</item>
         <item name="windowMinWidthMinor">0dp</item>
         <item name="android:textColorPrimary">@color/colorDialogMessage</item>
-
     </style>
 
     <style name="Alert.Button.Neutral" parent="Widget.MaterialComponents.Button.TextButton">


### PR DESCRIPTION
Without this change, floating popups like copy/paste actions that show when long clicking on text are masked, e.g. in the application configuration:

Light mode | Dark mode
------------ | -------------
<img src="https://user-images.githubusercontent.com/318490/95920023-f3c24d80-0dae-11eb-8470-bb61754b9f13.png" width="50%"> | <img src="https://user-images.githubusercontent.com/318490/95920066-09377780-0daf-11eb-80e1-6782d1233173.png" width="50%">

With this change, text can be selected and copy/pasted properly:

Light mode | Dark mode
------------ | -------------
<img src="https://user-images.githubusercontent.com/318490/95919899-b78eed00-0dae-11eb-8229-3d22ffe7afe1.png" width="50%"> | <img src="https://user-images.githubusercontent.com/318490/95919974-d7beac00-0dae-11eb-90ca-03b288632b79.png" width="50%">

FWIW, I debugged this using [Android Studio's Layout Inspector](https://developer.android.com/studio/debug/layout-inspector) to understand what was masking the content of the dialog.

As noted [here](https://stackoverflow.com/questions/18346920/change-the-background-color-of-a-pop-up-dialog#comment92796502_37422953), [changing `android:background`](https://github.com/home-assistant/android/pull/1043/files#diff-1e051f2b0330608e92eba8edc616403ec7bdaa76e29ce0cfb794700686715925L42) will change the background color of every view.

Another option that may be investigated to customize all floating components (dialogs, popups, cards, etc.) would be to use [`colorBackgroundFloating`](https://developer.android.com/reference/android/R.attr.html#colorBackgroundFloating) as described [here](https://stackoverflow.com/a/55685622/316805) but that requires API level 23.