### PR TITLE
Fix listing all apps after target SDK change

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,8 @@
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>


### PR DESCRIPTION
Fixes: #1042 

A new permission is now required when you want to query all apps: https://developer.android.com/training/basics/intents/package-visibility#all-apps

https://developer.android.com/reference/kotlin/android/Manifest.permission#query_all_packages

According to Google we also need watch out for an upcoming Google Play Policy update:

```
In an upcoming policy update, look for Google Play to provide guidelines for apps that need the QUERY_ALL_PACKAGES permission.
```

I think we should be ok but something to be mindful of.