### PR TITLE
Allow customizing keystore path with KEYSTORE_PATH environment variable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,7 @@ android {
 
     signingConfigs {
         create("release") {
-            storeFile = file("release_keystore.keystore")
+            storeFile = file(System.getenv("KEYSTORE_PATH") ?: "release_keystore.keystore")
             storePassword = System.getenv("KEYSTORE_PASSWORD") ?: ""
             keyAlias = System.getenv("KEYSTORE_ALIAS") ?: ""
             keyPassword = System.getenv("KEYSTORE_ALIAS_PASSWORD") ?: ""


### PR DESCRIPTION
This PR allows to customize the path to the keystore used to sign release packages with a `KEYSTORE_PATH` environment variable.

I used to have a symlink from `app/release_keystore.keystore` to my local keystore file, but every once in a while, I commit that symlink into git...

Another option would be to add `app/release_keystore.keystore` to `.gitignore` but adding an environment variable fits well with the other aleady available variables (`KEYSTORE_PASSWORD`, `KEYSTORE_ALIAS` and `KEYSTORE_ALIAS_PASSWORD`).
