### PR TITLE
Power Menu button enhancements

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -34,6 +34,14 @@ class ClimateControl {
             control.setTitle(entity.attributes["friendly_name"].toString())
             control.setDeviceType(DeviceTypes.TYPE_AC_HEATER)
             control.setStatus(Control.STATUS_OK)
+            control.setStatusText(
+                when (entity.state) {
+                    "off" -> "Off"
+                    "cool" -> "Cool"
+                    "heat" -> "Heat"
+                    else -> entity.state
+                }
+            )
             control.setControlTemplate(
                 RangeTemplate(
                     entity.entityId,
@@ -41,7 +49,7 @@ class ClimateControl {
                     100f,
                     (entity.attributes["temperature"] as? Number)?.toFloat() ?: 0f,
                     .5f,
-                    ""
+                    "%.0f"
                 )
 
             )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -36,9 +36,13 @@ class ClimateControl {
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {
-                    "off" -> "Off"
+                    "auto" -> "Auto"
                     "cool" -> "Cool"
+                    "dry" -> "Dry"
+                    "fan_only" -> "Fan Only"
                     "heat" -> "Heat"
+                    "heat_cool" -> "Heat Cool"
+                    "off" -> "Off"
                     else -> entity.state
                 }
             )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -31,8 +31,21 @@ class CoverControl {
             )
         )
         control.setTitle(entity.attributes["friendly_name"].toString())
-        control.setDeviceType(DeviceTypes.TYPE_GARAGE)
+        control.setDeviceType(
+            when (entity.attributes["device_class"]) {
+                "awning" -> DeviceTypes.TYPE_AWNING
+                "blind" -> DeviceTypes.TYPE_BLINDS
+                "curtain" -> DeviceTypes.TYPE_CURTAIN
+                "door" -> DeviceTypes.TYPE_DOOR
+                "garage" -> DeviceTypes.TYPE_GARAGE
+                "gate" -> DeviceTypes.TYPE_GATE
+                "shutter" -> DeviceTypes.TYPE_SHUTTER
+                "window" -> DeviceTypes.TYPE_WINDOW
+                else -> DeviceTypes.TYPE_GENERIC_OPEN_CLOSE
+            }
+        )
         control.setStatus(Control.STATUS_OK)
+        control.setStatusText(if (entity.state == "open") "Open" else "Closed")
         control.setControlTemplate(
             ToggleTemplate(
                 entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -45,7 +45,14 @@ class CoverControl {
             }
         )
         control.setStatus(Control.STATUS_OK)
-        control.setStatusText(if (entity.state == "open") "Open" else "Closed")
+        control.setStatusText(
+            when (entity.state) {
+                "closed" -> "Closed"
+                "closing" -> "Closing"
+                "open" -> "Open"
+                "opening" -> "Opening"
+                else -> entity.state
+            })
         control.setControlTemplate(
             ToggleTemplate(
                 entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -32,8 +32,14 @@ class DefaultSwitchControl {
                 )
             )
             control.setTitle(entity.attributes["friendly_name"].toString())
-            control.setDeviceType(DeviceTypes.TYPE_GENERIC_ON_OFF)
+            control.setDeviceType(
+                when (entity.entityId.split(".")[0]) {
+                    "switch" -> DeviceTypes.TYPE_SWITCH
+                    else -> DeviceTypes.TYPE_GENERIC_ON_OFF
+                }
+            )
             control.setStatus(Control.STATUS_OK)
+            control.setStatusText((if (entity.state == "off") "Off" else "On"))
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -39,7 +39,7 @@ class DefaultSwitchControl {
                 }
             )
             control.setStatus(Control.STATUS_OK)
-            control.setStatusText((if (entity.state == "off") "Off" else "On"))
+            control.setStatusText(if (entity.state == "off") "Off" else "On")
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -35,6 +35,7 @@ class LightControl {
             control.setTitle(entity.attributes["friendly_name"].toString())
             control.setDeviceType(DeviceTypes.TYPE_LIGHT)
             control.setStatus(Control.STATUS_OK)
+            control.setStatusText(if (entity.state == "off") "Off" else "On")
             control.setControlTemplate(
                 ToggleRangeTemplate(
                     entity.entityId,
@@ -44,9 +45,12 @@ class LightControl {
                         entity.entityId,
                         0f,
                         255f,
-                        (entity.attributes["brightness"] as? Number)?.toFloat() ?: 0f,
+                        (entity.attributes["brightness"] as? Number)
+                            ?.toFloat()
+                            ?.div(255f)
+                            ?.times(100) ?: 0f,
                         1f,
-                        ""
+                        "%.0f%%"
                     )
                 )
             )


### PR DESCRIPTION
Noticed that the sliders were missing the numbers and we just needed to set `formatString` as expected instead of leaving it blank.  The button now updates as you would expect for the tile.  I have also converted `brightness` to a percentage to match Google Assistant.  I noticed not all lights have `brightness_pct` attribute so I figured this was good enough.

Mapped a few device classes to device types so we get some nice icons for everything. 

Set the status text to match the state.

![image](https://user-images.githubusercontent.com/1634145/96214640-c00f3100-0f30-11eb-9e34-349a90a2453d.png)
