### PR TITLE
Only check redirect uri if it starts with AUTH_CALLBACK

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationPresenterImpl.kt
@@ -36,7 +36,7 @@ class AuthenticationPresenterImpl @Inject constructor(
 
     override fun onRedirectUrl(redirectUrl: String): Boolean {
         val code = Uri.parse(redirectUrl).getQueryParameter("code")
-        return if (redirectUrl.contains(AUTH_CALLBACK) && !code.isNullOrBlank()) {
+        return if (redirectUrl.startsWith(AUTH_CALLBACK) && !code.isNullOrBlank()) {
             mainScope.launch {
                 try {
                     authenticationUseCase.registerAuthorizationCode(code)


### PR DESCRIPTION
We should only hijack the navigation to a url if it starts with our auth callback. It is legit to redirect if the auth callback is in the url.

This _should_ (but I have not tested it yet) fix the Android app going back to the server selection screen if it hits Home Assistant while it's still serving the landing page.