### PR TITLE
Breaking Change: Switch call number permission for android 11 changes and google play policy

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.READ_CALL_LOG" />
+    <uses-permission android:name="android.permission.READ_PHONE_NUMBERS" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="com.google.android.gms.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -7,6 +7,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
+import android.os.Build
 import android.os.PowerManager
 import android.telephony.TelephonyManager
 import android.util.Log
@@ -98,8 +99,9 @@ class SensorReceiver : BroadcastReceiver() {
         }
 
         if (intent.action.equals(TelephonyManager.ACTION_PHONE_STATE_CHANGED) &&
-            isSensorEnabled(context, PhoneStateSensorManager.callNumber.id)) {
-            PhoneStateSensorManager().updateCallNumber(context, intent)
+            isSensorEnabled(context, PhoneStateSensorManager.callNumber.id) &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            PhoneStateSensorManager().updateCallNumber(context)
         }
 
         ioScope.launch {


### PR DESCRIPTION
We had a rejection notice from Google so I _think_ this is what they are asking for.

There is a google play policy about the usage of `READ_CALL_LOG` and that our app has to meet certain criteria to support it as a primary function.  This permission is only used for the `call_number` sensor and the old permission supports the minimum API that we support.

https://support.google.com/googleplay/android-developer/answer/9047303#intended
https://support.google.com/googleplay/android-developer/answer/9888170/

Unfortunately in Android 11 to get the phone number has changed too so we need to use a completely different method and permission.  The permission only works in API 26 and above so this will be a breaking change to some users.

https://developer.android.com/about/versions/11/privacy/permissions#phone-numbers

Unless I am misunderstanding something this is what we need to do? Tested this on my Pixel 4 XL and the phone number still gets pulled in.

As we have to consider users in an unsupported API may have this sensor previously enabled I have opted to just hide the sensor from the manage sensor screen and it will skip updates completely so we don't hit any errors.  The good news is that this sensor is not in production yet so the impacted users will not be as much.
