### PR TITLE
Ensure that we default to expected values to meet requirements for android power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -37,9 +37,13 @@ class DefaultSliderControl {
                 RangeTemplate(
                     entity.entityId,
                     (entity.attributes["min"] as? Number)?.toFloat() ?: 0f,
-                    (entity.attributes["max"] as? Number)?.toFloat() ?: 0f,
+                    (entity.attributes["max"] as? Number)?.toFloat() ?: 1f,
                     entity.state.toFloatOrNull() ?: 0f,
-                    (entity.attributes["step"] as? Number)?.toFloat() ?: 0f,
+                    (
+                            if ((entity.attributes["step"] as? Number)?.toFloat()!! <= 0)
+                                1
+                            else
+                                entity.attributes["step"] as? Number)?.toFloat() ?: 1f,
                     null
                 )
             )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -39,11 +39,7 @@ class DefaultSliderControl {
                     (entity.attributes["min"] as? Number)?.toFloat() ?: 0f,
                     (entity.attributes["max"] as? Number)?.toFloat() ?: 1f,
                     entity.state.toFloatOrNull() ?: 0f,
-                    (
-                            if ((entity.attributes["step"] as? Number)?.toFloat()!! <= 0)
-                                1
-                            else
-                                entity.attributes["step"] as? Number)?.toFloat() ?: 1f,
+                    (entity.attributes["step"] as? Number)?.toFloat() ?: 1f,
                     null
                 )
             )


### PR DESCRIPTION
Should fix the following sentry error:

```
java.lang.IllegalArgumentException: stepValue=0,000000 <= 0
    at android.service.controls.templates.RangeTemplate.validate(RangeTemplate.java:184)
    at android.service.controls.templates.RangeTemplate.<init>(RangeTemplate.java:83)
    at io.homeassistant.companion.android.controls.DefaultSliderControl$Companion.createControl(DefaultSliderControl.kt:37)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherForAllAvailable$1$1.invokeSuspend(HaControlsProviderService.kt:85)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

According to the `input_number` code we don't need to adjust much as they already take care of most requirements:

https://developer.android.com/reference/android/service/controls/templates/RangeTemplate#RangeTemplate(java.lang.String,%20float,%20float,%20float,%20float,%20java.lang.CharSequence)

https://github.com/home-assistant/core/blob/dev/homeassistant/components/input_number/__init__.py#L53

https://github.com/home-assistant/core/blob/dev/homeassistant/components/input_number/__init__.py#L68