### PR TITLE
Only promote sensor worker to foreground service if there is at least 1 sensor enabled

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -41,4 +41,7 @@ interface SensorDao {
 
     @Query("UPDATE sensors SET last_sent_state = :state WHERE id = :sensorId")
     fun updateLastSendState(sensorId: String, state: String)
+
+    @Query("SELECT COUNT(id) FROM sensors WHERE enabled = 1")
+    fun getEnabledCount(): Int?
 }


### PR DESCRIPTION
Creates a query to send us a count of enabled sensors, only then do we promote and run sensor updates.  Maybe there is a better way to do this but this will at least prevent the service from being promoted to the foreground when a user disables all sensors.