### PR TITLE
Show a toast failure when widgets fail to get or send data

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -11,6 +11,7 @@ import android.os.Looper
 import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
+import android.widget.Toast
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.graphics.drawable.toBitmap
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -217,6 +218,7 @@ class ButtonWidget : AppWidgetProvider() {
                     feedbackIcon = R.drawable.ic_check_black_24dp
                 } catch (e: Exception) {
                     Log.e(TAG, "Could not send service call.", e)
+                    Toast.makeText(context, R.string.widget_service_call_failure, Toast.LENGTH_LONG).show()
                 }
             }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.widget.RemoteViews
+import android.widget.Toast
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -121,6 +122,7 @@ class TemplateWidget : AppWidgetProvider() {
                     renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf())
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to render template: ${widget.template}", e)
+                    Toast.makeText(context, R.string.widget_template_error, Toast.LENGTH_LONG).show()
                 }
                 setTextViewText(
                     R.id.widgetTemplateText,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -371,6 +371,8 @@ like to connect to:</string>
   <string name="widget_static_image_description">Entity State</string>
   <string name="widget_text_hint_label">Label</string>
   <string name="widget_text_hint_service_data">Entity ID</string>
+  <string name="widget_service_call_failure">Unable to send service call</string>
+  <string name="widget_template_error">Unable to render the template</string>
   <string name="widget_text_hint_service_domain">Domain</string>
   <string name="widget_text_hint_service_service">Service</string>
   <string name="widget_text_size_default">30</string>


### PR DESCRIPTION
I figure we should give some type of response to the user when a widget fails upon an update so a toast seems best.  Like for example if the device does not have data or HA server is down. I can remove it from the button widget but I figure since we show a toast for all the others we might as well show a toast here too.

Also for entity state I have switched the call from `getEntities` to `getEntity` for the entity state widget.

This is only for when you tap to update a widget and that call fails for whatever reason.
