### PR TITLE
Battery Icon when 100% and not charging

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -205,8 +205,7 @@ class BatterySensorManager : SensorManager {
     private fun getIsCharging(intent: Intent): Boolean {
         val status: Int = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
 
-        return status == BatteryManager.BATTERY_STATUS_CHARGING ||
-                status == BatteryManager.BATTERY_STATUS_FULL
+        return status == BatteryManager.BATTERY_STATUS_CHARGING
     }
 
     private fun getChargerType(intent: Intent): String {


### PR DESCRIPTION
* fix `IsCharging` state determination

I assume this at least should fix one-time battery status determination, not sure about changing statuses after plugging/unplugging. Sorry, I couldn't find any sandbox/test environment where I could reproduce this bug and test its fix. So, this PR is more of a hypothesis.