### PR TITLE
Make template widgets editable

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
@@ -20,4 +20,7 @@ interface TemplateWidgetDao {
 
     @Query("DELETE FROM template_widgets WHERE id = :id")
     fun delete(id: Int)
+
+    @Query("SELECT * FROM template_widgets")
+    fun getAll(): Array<TemplateWidgetEntity>?
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -372,6 +372,7 @@ like to connect to:</string>
   <string name="no_widgets">No Widgets Found</string>
   <string name="no_widgets_summary">You have not added any widgets, please add one from the home screen to populate this list.</string>
   <string name="list_entity_state_widgets">List of Entity State Widgets</string>
+  <string name="list_template_widgets">List of Template Widgets</string>
   <string name="widgets">Widgets</string>
   <string name="manage_widgets">Manage Widgets</string>
   <string name="manage_widgets_summary">Edit your widgets, adding/deleting can only be done from the home screen</string>

--- a/app/src/main/res/xml/manage_widgets.xml
+++ b/app/src/main/res/xml/manage_widgets.xml
@@ -15,4 +15,9 @@
         android:title="@string/list_entity_state_widgets"
         app:iconSpaceReserved="false"
         app:isPreferenceVisible="false" />
+    <PreferenceCategory
+        android:key="list_template_widgets"
+        android:title="@string/list_template_widgets"
+        app:iconSpaceReserved="false"
+        app:isPreferenceVisible="false" />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
As we don't have labels for template widgets I opted to show the first 100 characters for the title.  Should be enough to show users which template it is.

![image](https://user-images.githubusercontent.com/1634145/97055259-4d5b1280-153b-11eb-90d8-400a72ffde0d.png)

![image](https://user-images.githubusercontent.com/1634145/97055178-2270be80-153b-11eb-8885-3b9009369c09.png)
