### PR TITLE
Add automations and scripts to power menu controls

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -53,6 +53,7 @@ class HaControlsProviderService : ControlsProviderService() {
     private var updateSubscriber: Flow.Subscriber<in Control>? = null
 
     private val domainToHaControl = mapOf(
+        "automation" to DefaultSwitchControl,
         "camera" to null,
         "climate" to ClimateControl,
         "cover" to CoverControl,
@@ -61,6 +62,7 @@ class HaControlsProviderService : ControlsProviderService() {
         "media_player" to null,
         "remote" to null,
         "scene" to SceneControl,
+        "script" to SceneControl,
         "switch" to DefaultSwitchControl,
         "input_boolean" to DefaultSwitchControl,
         "input_number" to DefaultSliderControl


### PR DESCRIPTION
With this it's possible to start scripts via the new power menu controls and enable/disable automations.

I'm using the SceneControl for scripts because it's exactly what i need, but it might be an idea to rename that class to something like "RoutineControl"