### PR TITLE
Locks and better lights in power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -59,6 +59,7 @@ class HaControlsProviderService : ControlsProviderService() {
         "cover" to CoverControl,
         "fan" to FanControl,
         "light" to LightControl,
+        "lock" to LockControl,
         "media_player" to null,
         "remote" to null,
         "scene" to SceneControl,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -9,8 +9,10 @@ import android.service.controls.DeviceTypes
 import android.service.controls.actions.BooleanAction
 import android.service.controls.actions.ControlAction
 import android.service.controls.actions.FloatAction
+import android.service.controls.templates.ControlButton
 import android.service.controls.templates.RangeTemplate
 import android.service.controls.templates.ToggleRangeTemplate
+import android.service.controls.templates.ToggleTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -40,22 +42,31 @@ class LightControl {
             control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(
                 R.string.state_on))
             control.setControlTemplate(
-                ToggleRangeTemplate(
-                    entity.entityId,
-                    entity.state != "off",
-                    "",
-                    RangeTemplate(
-                        entity.entityId,
-                        0f,
-                        100f,
-                        (entity.attributes["brightness"] as? Number)
-                            ?.toFloat()
-                            ?.div(255f)
-                            ?.times(100) ?: 0f,
-                        1f,
-                        "%.0f%%"
-                    )
-                )
+                    if ((entity.attributes["supported_features"] as Int) and 1 == 1)
+                        ToggleRangeTemplate(
+                                entity.entityId,
+                                entity.state != "off",
+                                "",
+                                RangeTemplate(
+                                        entity.entityId,
+                                        0f,
+                                        100f,
+                                        (entity.attributes["brightness"] as? Number)
+                                                ?.toFloat()
+                                                ?.div(255f)
+                                                ?.times(100) ?: 0f,
+                                        1f,
+                                        "%.0f%%"
+                                )
+                        )
+                    else
+                        ToggleTemplate(
+                                entity.entityId,
+                                ControlButton(
+                                        entity.state == "on",
+                                        "Description"
+                                )
+                        )
             )
             return control.build()
         }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -23,6 +23,8 @@ import kotlinx.coroutines.runBlocking
 @RequiresApi(Build.VERSION_CODES.R)
 class LightControl {
     companion object : HaControl {
+        const val SUPPORT_BRIGHTNESS = 1
+
         override fun createControl(
             context: Context,
             entity: Entity<Map<String, Any>>
@@ -42,7 +44,7 @@ class LightControl {
             control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(
                 R.string.state_on))
             control.setControlTemplate(
-                    if ((entity.attributes["supported_features"] as Int) and 1 == 1)
+                    if ((entity.attributes["supported_features"] as Int) and SUPPORT_BRIGHTNESS == SUPPORT_BRIGHTNESS)
                         ToggleRangeTemplate(
                                 entity.entityId,
                                 entity.state != "off",

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -1,0 +1,68 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.ToggleTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.runBlocking
+
+@RequiresApi(Build.VERSION_CODES.R)
+class LockControl {
+    companion object : HaControl {
+        override fun createControl(
+            context: Context,
+            entity: Entity<Map<String, Any>>
+        ): Control {
+            val control = Control.StatefulBuilder(
+                entity.entityId,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    WebViewActivity.newInstance(context.applicationContext).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    PendingIntent.FLAG_CANCEL_CURRENT
+                )
+            )
+            control.setTitle(entity.attributes["friendly_name"].toString())
+            control.setDeviceType(
+                DeviceTypes.TYPE_LOCK
+            )
+            control.setStatus(Control.STATUS_OK)
+            control.setStatusText(if (entity.state == "locked") context.getString(R.string.state_locked) else context.getString(R.string.state_unlocked))
+            control.setControlTemplate(
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
+                        entity.state == "locked",
+                        "Description"
+                    )
+                )
+            )
+            return control.build()
+        }
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return runBlocking {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if ((action as? BooleanAction)?.newState == true) "lock" else "unlock",
+                    hashMapOf("entity_id" to action.templateId)
+                )
+                return@runBlocking true
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -400,4 +400,6 @@ like to connect to:</string>
   <string name="state_closing">Closing</string>
   <string name="state_open">Open</string>
   <string name="state_opening">Opening</string>
+  <string name="state_locked">Locked</string>
+  <string name="state_unlocked">Unlocked</string>
 </resources>


### PR DESCRIPTION
- Add locks to power menu

- Only show range slider for lights when lights actually support brightness (via supported_features)

![photo_2020-10-24_16-32-54](https://user-images.githubusercontent.com/1506970/97084351-9a5fe700-1616-11eb-91d6-d8c327b1631a.jpg)
