### PR TITLE
Remove device_class from battery state sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -22,8 +22,7 @@ class BatterySensorManager : SensorManager {
             "battery_state",
             "sensor",
             R.string.basic_sensor_name_battery_state,
-            R.string.sensor_description_battery_state,
-            "battery"
+            R.string.sensor_description_battery_state
         )
         private val isChargingState = SensorManager.BasicSensor(
             "is_charging",


### PR DESCRIPTION
According to [the docs](https://www.home-assistant.io/integrations/sensor/) device class battery is something that represents `Percentage of battery that is left.`

This doesn't match the battery_state sensor. Therefore, this PR removes it