### PR TITLE
Allow deleting widgets from the manage widget screen in case the widget was lost

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
@@ -46,6 +46,15 @@ class ManageWidgetsSettingsFragment : PreferenceFragmentCompat() {
             findPreference<Preference>("no_widgets")?.let {
                 it.isVisible = true
             }
+            findPreference<PreferenceCategory>("list_entity_state_widgets")?.let {
+                it.isVisible = false
+            }
+            findPreference<PreferenceCategory>("list_template_widgets")?.let {
+                it.isVisible = false
+            }
+            findPreference<PreferenceCategory>("list_button_widgets")?.let {
+                it.isVisible = false
+            }
         } else {
 
             val prefCategoryStatic = findPreference<PreferenceCategory>("list_entity_state_widgets")

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
@@ -55,7 +55,14 @@ class ManageWidgetsSettingsFragment : PreferenceFragmentCompat() {
             findPreference<PreferenceCategory>("list_button_widgets")?.let {
                 it.isVisible = false
             }
+            findPreference<PreferenceCategory>("list_media_player_widgets")?.let {
+                it.isVisible = false
+            }
         } else {
+
+            findPreference<Preference>("no_widgets")?.let {
+                it.isVisible = false
+            }
 
             val prefCategoryStatic = findPreference<PreferenceCategory>("list_entity_state_widgets")
             if (!staticWidgetList.isNullOrEmpty()) {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -70,7 +70,6 @@ class ButtonWidgetConfigureActivity : AppCompatActivity(), IconDialog.Callback {
 
     private var onDeleteWidget = View.OnClickListener {
         val context = this@ButtonWidgetConfigureActivity
-
         deleteConfirmation(context)
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.widgets.button
 
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
@@ -9,6 +10,7 @@ import android.text.Editable
 import android.text.TextWatcher
 import android.util.Log
 import android.view.View
+import android.view.View.VISIBLE
 import android.view.ViewGroup
 import android.widget.AutoCompleteTextView
 import android.widget.EditText
@@ -65,6 +67,12 @@ class ButtonWidgetConfigureActivity : AppCompatActivity(), IconDialog.Callback {
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+
+    private var onDeleteWidget = View.OnClickListener {
+        val context = this@ButtonWidgetConfigureActivity
+
+        deleteConfirmation(context)
+    }
 
     private var onAddWidget = View.OnClickListener {
         try {
@@ -243,6 +251,8 @@ class ButtonWidgetConfigureActivity : AppCompatActivity(), IconDialog.Callback {
             widget_text_config_service.setText(serviceText)
             label.setText(buttonWidget.label)
             add_button.setText(R.string.update_widget)
+            delete_button.visibility = VISIBLE
+            delete_button.setOnClickListener(onDeleteWidget)
         }
         // Create an icon pack loader with application context.
         val loader = IconPackLoader(this)
@@ -361,5 +371,31 @@ class ButtonWidgetConfigureActivity : AppCompatActivity(), IconDialog.Callback {
                 widget_config_icon_selector.setImageBitmap(icon.toBitmap())
             }
         }
+    }
+
+    private fun deleteConfirmation(context: Context) {
+        val buttonWidgetDao = AppDatabase.getInstance(context).buttonWidgetDao()
+
+        val builder: android.app.AlertDialog.Builder = android.app.AlertDialog.Builder(context)
+
+        builder.setTitle(R.string.confirm_delete_this_widget_title)
+        builder.setMessage(R.string.confirm_delete_this_widget_message)
+
+        builder.setPositiveButton(
+            R.string.confirm_positive
+        ) { dialog, _ ->
+            buttonWidgetDao.delete(appWidgetId)
+            dialog.dismiss()
+            finish()
+        }
+
+        builder.setNegativeButton(
+            R.string.confirm_negative
+        ) { dialog, _ -> // Do nothing
+            dialog.dismiss()
+        }
+
+        val alert: android.app.AlertDialog? = builder.create()
+        alert?.show()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.widgets.entity
 import android.app.Activity
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -113,6 +114,8 @@ class EntityWidgetConfigureActivity : Activity() {
                 setupAttributes()
             }
             add_button.setText(R.string.update_widget)
+            delete_button.visibility = VISIBLE
+            delete_button.setOnClickListener(onDeleteWidget)
         }
         val entityAdapter = SingleItemArrayAdapter<Entity<Any>>(this) { it?.entityId ?: "" }
 
@@ -250,5 +253,36 @@ class EntityWidgetConfigureActivity : Activity() {
     override fun onDestroy() {
         mainScope.cancel()
         super.onDestroy()
+    }
+
+    private var onDeleteWidget = View.OnClickListener {
+        val context = this@EntityWidgetConfigureActivity
+        deleteConfirmation(context)
+    }
+
+    private fun deleteConfirmation(context: Context) {
+        val staticWidgetDao = AppDatabase.getInstance(context).staticWidgetDao()
+
+        val builder: android.app.AlertDialog.Builder = android.app.AlertDialog.Builder(context)
+
+        builder.setTitle(R.string.confirm_delete_this_widget_title)
+        builder.setMessage(R.string.confirm_delete_this_widget_message)
+
+        builder.setPositiveButton(
+            R.string.confirm_positive
+        ) { dialog, _ ->
+            staticWidgetDao.delete(appWidgetId)
+            dialog.dismiss()
+            finish()
+        }
+
+        builder.setNegativeButton(
+            R.string.confirm_negative
+        ) { dialog, _ -> // Do nothing
+            dialog.dismiss()
+        }
+
+        val alert: android.app.AlertDialog? = builder.create()
+        alert?.show()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.widgets.media_player_controls
 import android.app.Activity
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -19,6 +20,7 @@ import io.homeassistant.companion.android.widgets.DaggerProviderComponent
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.widget_media_controls_configure.add_button
+import kotlinx.android.synthetic.main.widget_media_controls_configure.delete_button
 import kotlinx.android.synthetic.main.widget_media_controls_configure.label
 import kotlinx.android.synthetic.main.widget_media_controls_configure.widget_show_seek_buttons_checkbox
 import kotlinx.android.synthetic.main.widget_media_controls_configure.widget_show_skip_buttons_checkbox
@@ -97,6 +99,8 @@ class MediaPlayerControlsWidgetConfigureActivity : Activity() {
             if (entity != null)
                 selectedEntity = entity as Entity<Any>?
             add_button.setText(R.string.update_widget)
+            delete_button.visibility = View.VISIBLE
+            delete_button.setOnClickListener(onDeleteWidget)
         }
         val entityAdapter = SingleItemArrayAdapter<Entity<Any>>(this) { it?.entityId ?: "" }
 
@@ -189,5 +193,36 @@ class MediaPlayerControlsWidgetConfigureActivity : Activity() {
     override fun onDestroy() {
         mainScope.cancel()
         super.onDestroy()
+    }
+
+    private var onDeleteWidget = View.OnClickListener {
+        val context = this@MediaPlayerControlsWidgetConfigureActivity
+        deleteConfirmation(context)
+    }
+
+    private fun deleteConfirmation(context: Context) {
+        val mediaPlayerControlsWidgetDao = AppDatabase.getInstance(context).mediaPlayCtrlWidgetDao()
+
+        val builder: android.app.AlertDialog.Builder = android.app.AlertDialog.Builder(context)
+
+        builder.setTitle(R.string.confirm_delete_this_widget_title)
+        builder.setMessage(R.string.confirm_delete_this_widget_message)
+
+        builder.setPositiveButton(
+            R.string.confirm_positive
+        ) { dialog, _ ->
+            mediaPlayerControlsWidgetDao.delete(appWidgetId)
+            dialog.dismiss()
+            finish()
+        }
+
+        builder.setNegativeButton(
+            R.string.confirm_negative
+        ) { dialog, _ -> // Do nothing
+            dialog.dismiss()
+        }
+
+        val alert: android.app.AlertDialog? = builder.create()
+        alert?.show()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -2,8 +2,11 @@ package io.homeassistant.companion.android.widgets.template
 
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
+import android.view.View.VISIBLE
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doAfterTextChanged
 import io.homeassistant.companion.android.R
@@ -70,6 +73,8 @@ class TemplateWidgetConfigureActivity : AppCompatActivity() {
             templateText.setText(templateWidget.template)
             add_button.setText(R.string.update_widget)
             renderTemplateText(templateWidget.template)
+            delete_button.visibility = VISIBLE
+            delete_button.setOnClickListener(onDeleteWidget)
         }
 
         templateText.doAfterTextChanged { editableText ->
@@ -116,5 +121,36 @@ class TemplateWidgetConfigureActivity : AppCompatActivity() {
                 add_button.isEnabled = enabled
             }
         }
+    }
+
+    private var onDeleteWidget = View.OnClickListener {
+        val context = this@TemplateWidgetConfigureActivity
+        deleteConfirmation(context)
+    }
+
+    private fun deleteConfirmation(context: Context) {
+        val templateWidgetDao = AppDatabase.getInstance(context).templateWidgetDao()
+
+        val builder: android.app.AlertDialog.Builder = android.app.AlertDialog.Builder(context)
+
+        builder.setTitle(R.string.confirm_delete_this_widget_title)
+        builder.setMessage(R.string.confirm_delete_this_widget_message)
+
+        builder.setPositiveButton(
+            R.string.confirm_positive
+        ) { dialog, _ ->
+            templateWidgetDao.delete(appWidgetId)
+            dialog.dismiss()
+            finish()
+        }
+
+        builder.setNegativeButton(
+            R.string.confirm_negative
+        ) { dialog, _ -> // Do nothing
+            dialog.dismiss()
+        }
+
+        val alert: android.app.AlertDialog? = builder.create()
+        alert?.show()
     }
 }

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -118,5 +118,14 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/delete_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/delete_widget" />
+
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -87,5 +87,13 @@
             android:layout_gravity="end"
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/delete_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/delete_widget" />
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -182,6 +182,14 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/delete_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/delete_widget" />
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -40,5 +40,14 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/delete_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/delete_widget" />
     </LinearLayout>
+
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,6 +172,8 @@ Home Assistant instance</string>
   <string name="manage_this_notification">Manage This Notification</string>
   <string name="delete_all_notifications">Delete all notifications from history</string>
   <string name="delete_this_notification">Delete this notification from history</string>
+  <string name="confirm_delete_this_widget_title">Confirm deleting this widget</string>
+  <string name="confirm_delete_this_widget_message">Are you sure? This cannot be undone. If you accidentally deleted the wrong widget you will need to remove the bad widget from the home screen and create a new one.</string>
   <string name="confirm_delete_this_notification_title">Confirm deleting this notification</string>
   <string name="confirm_delete_this_notification_message">Are you sure? This cannot be undone</string>
   <string name="confirm_delete_all_notification_title">Confirm deleting all notifications</string>
@@ -378,6 +380,7 @@ like to connect to:</string>
   <string name="list_media_player_widgets">List of Media Player Widgets</string>
   <string name="widgets">Widgets</string>
   <string name="manage_widgets">Manage Widgets</string>
+  <string name="delete_widget">Delete Widget</string>
   <string name="manage_widgets_summary">Edit your widgets, adding/deleting can only be done from the home screen</string>
   <string name="update_widget">Update Widget</string>
   <string name="widget_text_hint_label">Label</string>


### PR DESCRIPTION
Fixes: #1108 

Adds a delete button when editing a widget for cases when widgets are lost such as when we refactor them or the launcher lost them. Since this is irreversible there will be an alert dialog to make sure this is what the user wants.

![image](https://user-images.githubusercontent.com/1634145/97391088-a0b2c500-189b-11eb-844d-b30b2da19649.png)
