### PR TITLE
Update widgets with the screen on intent so they appear to be more up to date

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -14,6 +14,9 @@ import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import io.homeassistant.companion.android.widgets.entity.EntityWidget
+import io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget
+import io.homeassistant.companion.android.widgets.template.TemplateWidget
 
 open class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
@@ -102,6 +105,26 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
                 IntentFilter(NotificationManager.ACTION_INTERRUPTION_FILTER_CHANGED)
             )
         }
+
+        // Update widgets when the screen turns on, updates are skipped if widgets were not added
+        val entityWidget = EntityWidget()
+        val mediaPlayerWidget = MediaPlayerControlsWidget()
+        val templateWidget = TemplateWidget()
+
+        registerReceiver(
+            entityWidget,
+            IntentFilter(Intent.ACTION_SCREEN_ON)
+        )
+
+        registerReceiver(
+            mediaPlayerWidget,
+            IntentFilter(Intent.ACTION_SCREEN_ON)
+        )
+
+        registerReceiver(
+            templateWidget,
+            IntentFilter(Intent.ACTION_SCREEN_ON)
+        )
     }
 
     override val appComponent: AppComponent

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -75,6 +75,18 @@ class EntityWidget : AppWidgetProvider() {
         }
     }
 
+    private fun updateAllWidgets(
+        context: Context,
+        staticWidgetEntityList: Array<StaticWidgetEntity>?
+    ) {
+        if (staticWidgetEntityList != null) {
+            Log.d(TAG, "Updating all widgets")
+            for (item in staticWidgetEntityList) {
+                updateAppWidget(context, item.id)
+            }
+        }
+    }
+
     private suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
         val intent = Intent(context, EntityWidget::class.java).apply {
             action = UPDATE_ENTITY
@@ -160,12 +172,14 @@ class EntityWidget : AppWidgetProvider() {
         ensureInjected(context)
 
         staticWidgetDao = AppDatabase.getInstance(context).staticWidgetDao()
+        val staticWidgetList = staticWidgetDao.getAll()
 
         super.onReceive(context, intent)
 
         when (action) {
             RECEIVE_DATA -> saveEntityConfiguration(context, intent.extras, appWidgetId)
             UPDATE_ENTITY -> updateAppWidget(context, appWidgetId)
+            Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, staticWidgetList)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -86,6 +86,18 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         }
     }
 
+    private fun updateAllWidgets(
+        context: Context,
+        mediaPlayerWidgetList: Array<MediaPlayerControlsWidgetEntity>?
+    ) {
+        if (mediaPlayerWidgetList != null) {
+            Log.d(TAG, "Updating all widgets")
+            for (item in mediaPlayerWidgetList) {
+                updateAppWidget(context, item.id)
+            }
+        }
+    }
+
     private suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
         val updateMediaIntent = Intent(context, MediaPlayerControlsWidget::class.java).apply {
             action = UPDATE_MEDIA_IMAGE
@@ -272,6 +284,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         ensureInjected(context)
 
         mediaPlayCtrlWidgetDao = AppDatabase.getInstance(context).mediaPlayCtrlWidgetDao()
+        val mediaPlayerWidgetList = mediaPlayCtrlWidgetDao.getAll()
 
         super.onReceive(context, intent)
         when (action) {
@@ -282,6 +295,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
             CALL_PLAYPAUSE -> callPlayPauseService(appWidgetId)
             CALL_FASTFORWARD -> callFastForwardService(context, appWidgetId)
             CALL_NEXT_TRACK -> callNextTrackService(appWidgetId)
+            Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, mediaPlayerWidgetList)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -84,11 +84,13 @@ class TemplateWidget : AppWidgetProvider() {
         ensureInjected(context)
 
         templateWidgetDao = AppDatabase.getInstance(context).templateWidgetDao()
+        val templateWidgetList = templateWidgetDao.getAll()
 
         super.onReceive(context, intent)
         when (action) {
             UPDATE_VIEW -> updateView(context, appWidgetId)
             RECEIVE_DATA -> saveEntityConfiguration(context, intent.extras, appWidgetId)
+            Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, templateWidgetList)
         }
     }
 
@@ -141,6 +143,18 @@ class TemplateWidget : AppWidgetProvider() {
         mainScope.launch {
             val views = getWidgetRemoteViews(context, appWidgetId)
             appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+
+    private fun updateAllWidgets(
+        context: Context,
+        templateWidgetList: Array<TemplateWidgetEntity>?
+    ) {
+        if (templateWidgetList != null) {
+            Log.d(TAG, "Updating all widgets")
+            for (item in templateWidgetList) {
+                updateView(context, item.id)
+            }
         }
     }
 


### PR DESCRIPTION
Entity state, media player and template widgets will update when the screen comes on with this PR.  If those widgets don't exist the event is skipped.  This should help make them look more up to date when you grab your phone to check them quickly.