### PR TITLE
Skip widget updates if the network connection is not active

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.util.Log
 import android.util.TypedValue
@@ -69,6 +70,11 @@ class EntityWidget : AppWidgetProvider() {
         appWidgetId: Int,
         appWidgetManager: AppWidgetManager = AppWidgetManager.getInstance(context)
     ) {
+        if (!isConnectionActive(context)) {
+            Log.d(TAG, "Skipping widget update since network connection is not active")
+            return
+        }
+
         mainScope.launch {
             val views = getWidgetRemoteViews(context, appWidgetId)
             appWidgetManager.updateAppWidget(appWidgetId, views)
@@ -234,5 +240,11 @@ class EntityWidget : AppWidgetProvider() {
         appWidgetIds.forEach { appWidgetId ->
             staticWidgetDao.delete(appWidgetId)
         }
+    }
+
+    private fun isConnectionActive(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val activeNetworkInfo = connectivityManager.activeNetworkInfo
+        return activeNetworkInfo?.isConnected ?: false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -80,6 +81,10 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         appWidgetId: Int,
         appWidgetManager: AppWidgetManager = AppWidgetManager.getInstance(context)
     ) {
+        if (!isConnectionActive(context)) {
+            Log.d(TAG, "Skipping widget update since network connection is not active")
+            return
+        }
         mainScope.launch {
             val views = getWidgetRemoteViews(context, appWidgetId)
             appWidgetManager.updateAppWidget(appWidgetId, views)
@@ -516,5 +521,11 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         } else {
             throw Exception("Application Context passed is not of our application!")
         }
+    }
+
+    private fun isConnectionActive(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val activeNetworkInfo = connectivityManager.activeNetworkInfo
+        return activeNetworkInfo?.isConnected ?: false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Bundle
 import android.util.Log
 import android.widget.RemoteViews
@@ -139,6 +140,11 @@ class TemplateWidget : AppWidgetProvider() {
         appWidgetId: Int,
         appWidgetManager: AppWidgetManager = AppWidgetManager.getInstance(context)
     ) {
+        if (!isConnectionActive(context)) {
+            Log.d(TAG, "Skipping widget update since network connection is not active")
+            return
+        }
+
         Log.d(TAG, "Updating Template Widget View: $appWidgetId")
         mainScope.launch {
             val views = getWidgetRemoteViews(context, appWidgetId)
@@ -188,5 +194,11 @@ class TemplateWidget : AppWidgetProvider() {
         } else {
             throw Exception("Application Context passed is not of our application!")
         }
+    }
+
+    private fun isConnectionActive(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        val activeNetworkInfo = connectivityManager.activeNetworkInfo
+        return activeNetworkInfo?.isConnected ?: false
     }
 }


### PR DESCRIPTION
Fixes: #1120 

No need to perform an update if we can't connect.