### PR TITLE
Remove location request if background is disabled by itself

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -125,10 +125,15 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                     isBackgroundLocationSetup = false
                     isZoneLocationSetup = false
                 }
-                if (backgroundEnabled && !zoneEnabled && isZoneLocationSetup) {
+                if (!zoneEnabled && isZoneLocationSetup) {
                     removeGeofenceUpdateRequests()
                     isZoneLocationSetup = false
                     Log.d(TAG, "Removing geofence update requests")
+                }
+                if (!backgroundEnabled && isBackgroundLocationSetup) {
+                    removeBackgroundUpdateRequests()
+                    isBackgroundLocationSetup = false
+                    Log.d(TAG, "Removing background update requests")
                 }
                 if (backgroundEnabled && !isBackgroundLocationSetup) {
                     isBackgroundLocationSetup = true
@@ -146,12 +151,15 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
     private fun removeAllLocationUpdateRequests() {
         Log.d(TAG, "Removing all location requests.")
+        removeBackgroundUpdateRequests()
+        removeGeofenceUpdateRequests()
+    }
+
+    private fun removeBackgroundUpdateRequests() {
         val fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(latestContext)
         val backgroundIntent = getLocationUpdateIntent(false)
 
         fusedLocationProviderClient.removeLocationUpdates(backgroundIntent)
-
-        removeGeofenceUpdateRequests()
     }
 
     private fun removeGeofenceUpdateRequests() {


### PR DESCRIPTION
Noticed that if a user just disables background location but leaves zone tracking on we don't remove updates.  We only did the removal if both sensors were turned off.  With this change a user can leave zone tracking on without needing background location enabled to only get geofencing updates based on zones