### PR TITLE
Add sleep as android sensors for users that have the app

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -40,6 +40,26 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
             }
         )
 
+        // Register for Sleep as Android intents
+        registerReceiver(
+            sensorReceiver, IntentFilter().apply {
+                addAction("com.urbandroid.sleep.alarmclock.SLEEP_TRACKING_STARTED_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.SLEEP_TRACKING_STOPPED_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.ALARM_ALERT_START_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.ALARM_ALERT_DISMISS_AUTO")
+                addAction("com.urbandroid.sleep.ACTION_LULLABY_START_PLAYBACK_AUTO")
+                addAction("com.urbandroid.sleep.ACTION_LULLABY_STOPPED_PLAYBACK_AUTO")
+                addAction("com.urbandroid.sleep.TRACKING_DEEP_SLEEP_AUTO")
+                addAction("com.urbandroid.sleep.TRACKING_LIGHT_SLEEP_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.ALARM_SNOOZE_CLICKED_ACTION_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.TIME_TO_BED_ALARM_ALERT_AUTO")
+                addAction("com.urbandroid.sleep.LUCID_CUE_ACTION_AUTO")
+                addAction("com.urbandroid.sleep.ANTISNORING_ACTION_AUTO")
+                addAction("com.urbandroid.sleep.audio.SOUND_EVENT_AUTO")
+                addAction("com.urbandroid.sleep.alarmclock.AUTO_START_SLEEP_TRACK_AUTO")
+            }
+        )
+
         // This will cause interactive and power save to update upon a state change
         registerReceiver(
             sensorReceiver, IntentFilter().apply {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SleepAsAndroidManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SleepAsAndroidManager.kt
@@ -1,0 +1,133 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Intent
+import io.homeassistant.companion.android.R
+
+class SleepAsAndroidManager : SensorManager {
+    companion object {
+        private const val TAG = "SleepAsAndroid"
+
+        val sleepTracking = SensorManager.BasicSensor(
+            "sleep_tracking",
+            "binary_sensor",
+            R.string.basic_sensor_sleep_tracking,
+            R.string.sensor_description_sleep_tracking
+        )
+
+        val lullaby = SensorManager.BasicSensor(
+            "lullaby",
+            "binary_sensor",
+            R.string.basic_sensor_lullaby,
+            R.string.sensor_description_lullaby
+        )
+
+        val sleepEvents = SensorManager.BasicSensor(
+            "sleep_events",
+            "sensor",
+            R.string.basic_sensor_sleep_events,
+            R.string.sensor_description_sleep_events
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_sleep_as_android
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(sleepTracking, lullaby, sleepEvents)
+
+    override fun hasSensor(context: Context): Boolean {
+        return try {
+            context.packageManager.getApplicationInfo("com.urbandroid.sleep", 0)
+            true
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        updateSleepTracking(context, null)
+        updateLullaby(context, null)
+        updateSleepEvents(context, null)
+    }
+
+    fun updateSleepTracking(context: Context, intent: Intent?) {
+
+        if (!isEnabled(context, sleepTracking.id))
+            return
+
+        if (intent == null)
+            return
+
+        val state: Boolean = intent.action == "com.urbandroid.sleep.alarmclock.SLEEP_TRACKING_STARTED_AUTO"
+
+        val icon = if (state) "mdi:sleep" else "mdi:sleep-off"
+
+        onSensorUpdated(context,
+            sleepTracking,
+            state,
+            icon,
+            mapOf()
+        )
+    }
+
+    fun updateLullaby(context: Context, intent: Intent?) {
+
+        if (!isEnabled(context, lullaby.id))
+            return
+
+        if (intent == null)
+            return
+
+        val state: Boolean = intent.action == "com.urbandroid.sleep.ACTION_LULLABY_START_PLAYBACK_AUTO"
+
+        val icon = if (state) "mdi:sleep" else "mdi:sleep-off"
+
+        onSensorUpdated(context,
+            lullaby,
+            state,
+            icon,
+            mapOf()
+        )
+    }
+
+    fun updateSleepEvents(context: Context, intent: Intent?) {
+
+        if (!isEnabled(context, sleepEvents.id))
+            return
+
+        if (intent == null)
+            return
+
+        val state = when (intent.action) {
+            "com.urbandroid.sleep.TRACKING_DEEP_SLEEP_AUTO" -> "Deep sleep phase started"
+            "com.urbandroid.sleep.TRACKING_LIGHT_SLEEP_AUTO" -> "Light sleep phase started"
+            "com.urbandroid.sleep.alarmclock.ALARM_SNOOZE_CLICKED_ACTION_AUTO" -> "Snoozed by user"
+            "com.urbandroid.sleep.alarmclock.TIME_TO_BED_ALARM_ALERT_AUTO" -> "Time to bed notification"
+            "com.urbandroid.sleep.LUCID_CUE_ACTION_AUTO" -> "Lucid dreaming cue"
+            "com.urbandroid.sleep.ANTISNORING_ACTION_AUTO" -> "Antisnoring sound"
+            "com.urbandroid.sleep.audio.SOUND_EVENT_AUTO" -> "Audio recognition"
+            "com.urbandroid.sleep.alarmclock.AUTO_START_SLEEP_TRACK_AUTO" -> "Automatic start of sleep tracking"
+            "com.urbandroid.sleep.alarmclock.ALARM_ALERT_START_AUTO" -> "Alarm triggered"
+            "com.urbandroid.sleep.alarmclock.ALARM_ALERT_DISMISS_AUTO" -> "Alarm dismissed"
+            else -> "unknown"
+        }
+
+        val icon = "mdi:power-sleep"
+
+        onSensorUpdated(context,
+            sleepEvents,
+            state,
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -175,6 +175,13 @@ Home Assistant instance</string>
   <string name="manage_this_notification">Manage This Notification</string>
   <string name="delete_all_notifications">Delete all notifications from history</string>
   <string name="delete_this_notification">Delete this notification from history</string>
+  <string name="basic_sensor_sleep_tracking">Sleep Tracking</string>
+  <string name="sensor_description_sleep_tracking">Sleep tracking status from Sleep as Android</string>
+  <string name="sensor_name_sleep_as_android">Sleep as Android Sensors</string>
+  <string name="basic_sensor_lullaby">Lullaby</string>
+  <string name="sensor_description_lullaby">If a lullaby is playing</string>
+  <string name="basic_sensor_sleep_events">Sleep Events</string>
+  <string name="sensor_description_sleep_events">Additional one time events from Sleep as Android</string>
   <string name="confirm_delete_this_widget_title">Confirm deleting this widget</string>
   <string name="confirm_delete_this_widget_message">Are you sure? This cannot be undone. If you accidentally deleted the wrong widget you will need to remove the bad widget from the home screen and create a new one.</string>
   <string name="confirm_delete_this_notification_title">Confirm deleting this notification</string>


### PR DESCRIPTION
Fixes: #483 

Integrates with the Intent API from sleep as android: https://docs.sleep.urbandroid.org/devs/intent_api.html#events-emitted-by-sleep

If the app is not installed then the sensors will not show up and the user won't be able to enable them.  The intents that we register to are only for sleep as android so they do not cause any harm if the app is not installed or if the user decides not to enable them.  We will also only process these events from sleep as android as they are received, all other updates are ignored.

I picked Sleep tracking and Lullaby to be binary sensors as I can reliably turn them on and off.  All other events are one time based and are better suited for a sensor of its own.

![image](https://user-images.githubusercontent.com/1634145/97666872-c971c080-1a3b-11eb-9239-88c6bca38139.png)
