### PR TITLE
Add exception handling and correct null values in fan control for power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -53,9 +53,9 @@ class FanControl {
                             entity.entityId,
                             0f,
                             speeds.size.toFloat() - 1,
-                            speeds.indexOf(currentSpeed).toFloat(),
+                            if (entity.state == "on") speeds.indexOf(currentSpeed).toFloat() else 0f,
                             1f,
-                            ""
+                            "%.0f"
                         )
                     )
                 )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -53,7 +53,7 @@ class FanControl {
                             entity.entityId,
                             0f,
                             speeds.size.toFloat() - 1,
-                            if (entity.state == "on") speeds.indexOf(currentSpeed).toFloat() else 0f,
+                            if (speeds.contains(currentSpeed)) speeds.indexOf(currentSpeed).toFloat() else 0f,
                             1f,
                             "%.0f"
                         )


### PR DESCRIPTION
Fixes #1127 and adds some exception handling so the app doesn't crash if we get more unexpected instances.  I have an air purifier here as well and tested the change against `on` `off` and `unavailable` states.