### PR TITLE
Allow sending broadcast intents to other apps via notification

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -73,6 +73,7 @@ class MessagingService : FirebaseMessagingService() {
         const val TTS = "TTS"
         const val COMMAND_DND = "command_dnd"
         const val COMMAND_RINGER_MODE = "command_ringer_mode"
+        const val COMMAND_BROADCAST_INTENT = "command_broadcast_intent"
 
         // DND commands
         const val DND_PRIORITY_ONLY = "priority_only"
@@ -86,7 +87,7 @@ class MessagingService : FirebaseMessagingService() {
         const val RM_VIBRATE = "vibrate"
 
         // Command groups
-        val DEVICE_COMMANDS = listOf(COMMAND_DND, COMMAND_RINGER_MODE)
+        val DEVICE_COMMANDS = listOf(COMMAND_DND, COMMAND_RINGER_MODE, COMMAND_BROADCAST_INTENT)
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
     }
@@ -164,6 +165,16 @@ class MessagingService : FirebaseMessagingService() {
                             } else {
                                 mainScope.launch {
                                     Log.d(TAG, "Invalid ringer mode command received, posting notification to device")
+                                    sendNotification(it)
+                                }
+                            }
+                        }
+                        COMMAND_BROADCAST_INTENT -> {
+                            if (!it[TITLE].isNullOrEmpty() && it[TITLE]!!.contains("-"))
+                                handleDeviceCommands(it[MESSAGE], it[TITLE])
+                            else {
+                                mainScope.launch {
+                                    Log.d(TAG, "Invalid broadcast command received, posting notification to device")
                                     sendNotification(it)
                                 }
                             }
@@ -287,6 +298,19 @@ class MessagingService : FirebaseMessagingService() {
                     }
                 } else {
                     processRingerMode(audioManager, title)
+                }
+            }
+            COMMAND_BROADCAST_INTENT -> {
+                try {
+                    val packageName = title!!.split("-")[0]
+                    val actionName = title.split("-")[1]
+                    val intent = Intent(actionName)
+                    intent.`package` = packageName
+                    Log.d(TAG, "Sending broadcast intent")
+                    applicationContext.sendBroadcast(intent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unable to send broadcast intent please check command format", e)
+                    Toast.makeText(applicationContext, R.string.broadcast_intent_error, Toast.LENGTH_LONG).show()
                 }
             }
             else -> Log.d(TAG, "No command received")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,6 +176,7 @@ Home Assistant instance</string>
   <string name="delete_all_notifications">Delete all notifications from history</string>
   <string name="delete_this_notification">Delete this notification from history</string>
   <string name="confirm_delete_this_widget_title">Confirm deleting this widget</string>
+  <string name="broadcast_intent_error">Unable to send broadcast intent, please check the command format</string>
   <string name="confirm_delete_this_widget_message">Are you sure? This cannot be undone. If you accidentally deleted the wrong widget you will need to remove the bad widget from the home screen and create a new one.</string>
   <string name="confirm_delete_this_notification_title">Confirm deleting this notification</string>
   <string name="confirm_delete_this_notification_message">Are you sure? This cannot be undone</string>


### PR DESCRIPTION
Fixes: #1020 

We must set `message: command_broadcast_intent` and the `title` must contain the Action and `channel` must contain the Package name.

Format:

```
message: command_broadcast_intent
title: ACTION
data:
  channel: PACKAGE_NAME
```

Tested with sleep as android API: https://docs.sleep.urbandroid.org/devs/intent_api.html#action-intents-to-control-sleep

Example:

```
message: command_broadcast_intent
title: com.urbandroid.sleep.alarmclock.STOP_SLEEP_TRACK
data:
  channel: com.urbandroid.sleep
```

If `title` or `channel` is not provided we post the notification to the device as normal, otherwise if there is another failure we show a toast.

Docs: https://github.com/home-assistant/companion.home-assistant/pull/376
FCM: pending