### PR TITLE
Revert material bump as it introduced a dark theme issue with the widgets

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -33,7 +33,7 @@ object Config {
             const val dagger = "com.google.dagger:dagger:${daggerVersion}"
             const val daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
 
-            const val material = "com.google.android.material:material:1.2.1"
+            const val material = "com.google.android.material:material:1.2.0"
         }
 
         object AndroidX {


### PR DESCRIPTION
The icon for the service button widget was coming in as light theme when the device theme was set to dark, reverting the library bump fixes the issue.  Seems the new library version introduced an issue where the night theme color is not being read properly.

Ref: https://discord.com/channels/330944238910963714/562408603345092636/772138149395824661