### PR TITLE
Fixes button widget dark icon, really this time

### DIFF
--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/widgetLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,8 +24,8 @@
             android:src="@drawable/ic_flash_on_24dp"
             android:contentDescription="@string/widget_button_image_description"
             android:gravity="center"
-            app:tint="@color/colorIcon"
-            />
+            android:tint="@color/colorIcon"
+            tools:ignore="UseAppTint" />
 
         <LinearLayout
             android:id="@+id/widgetLabelLayout"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -33,7 +33,7 @@ object Config {
             const val dagger = "com.google.dagger:dagger:${daggerVersion}"
             const val daggerCompiler = "com.google.dagger:dagger-compiler:${daggerVersion}"
 
-            const val material = "com.google.android.material:material:1.2.0"
+            const val material = "com.google.android.material:material:1.2.1"
         }
 
         object AndroidX {


### PR DESCRIPTION
Fixes: #1132 which was actually introduced in #1083 and attempted to get fixed in #1130 

Dark theme:
![image](https://user-images.githubusercontent.com/1634145/97808034-1959ae80-1c19-11eb-99cf-cfdf4a3ab9b0.png)

Light theme:
![image](https://user-images.githubusercontent.com/1634145/97808043-21b1e980-1c19-11eb-84d2-00c71751f300.png)

Brings back the material library bump too.  Thanks for the good spot @JBassett !