### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+
+<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
+
+## Summary
+<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
+
+## Link to pull request in Documentation repository
+<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
+Documentation: home-assistant/companion.home-assistant#
+
+## Any other notes
+<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


### PR DESCRIPTION
We were having a discussion in https://github.com/home-assistant/companion.home-assistant/pull/376 and it was noted that PR's that need docs changes should have docs PR ready so they can be merged at the same time as the parent PR.  The hope is that with this PR we can start to leverage the bot in adding the proper labels like we do in the core repo.

Stolen from @TomBrien  PR in iOS 😄 : https://github.com/home-assistant/iOS/pull/1257

