### PR TITLE
Fix toast message during database migration failure

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -5,6 +5,8 @@ import android.app.NotificationManager
 import android.content.ContentValues
 import android.content.Context
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import android.widget.Toast
 import androidx.core.app.NotificationCompat
@@ -308,7 +310,13 @@ abstract class AppDatabase : RoomDatabase() {
                     Log.d(TAG, "Event sent to Home Assistant")
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to send event to Home Assistant", e)
-                    Toast.makeText(appContext, R.string.database_event_failure, Toast.LENGTH_LONG).show()
+                    Handler(Looper.getMainLooper()).post {
+                        Toast.makeText(
+                            appContext,
+                            R.string.database_event_failure,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the following error that appears during a database migration failure where the event to home assistant fails to send successfully.

```
RuntimeException
Can't toast on a thread that has not called Looper.prepare()
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->