### PR TITLE
Add ability to opt out of crash reporting.

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -9,9 +9,9 @@ import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
 import javax.net.ssl.SSLProtocolException
 
-fun initCrashReporting(context: Context) {
-    // Don't init on debug builds
-    if (BuildConfig.DEBUG)
+fun initCrashReporting(context: Context, enabled: Boolean) {
+    // Don't init on debug builds or when disabled
+    if (BuildConfig.DEBUG || !enabled)
         return
 
     SentryAndroid.init(context) { options ->

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -17,17 +17,24 @@ import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.widgets.entity.EntityWidget
 import io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget
 import io.homeassistant.companion.android.widgets.template.TemplateWidget
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 open class HomeAssistantApplication : Application(), GraphComponentAccessor {
 
     lateinit var graph: Graph
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + Job())
 
     override fun onCreate() {
         super.onCreate()
 
-        initCrashReporting(applicationContext)
-
         graph = Graph(this, 0)
+
+        ioScope.launch {
+            initCrashReporting(applicationContext, graph.appComponent.prefsUseCase().isCrashReporting())
+        }
 
         val sensorReceiver = SensorReceiver()
         // This will cause the sensor to be updated every time the OS broadcasts that a cable was plugged/unplugged.

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -172,6 +172,14 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
                         "\n\nRemaining/Maximum: ${rateLimits?.remaining}/${rateLimits?.maximum}" +
                         "\n\nResets at: ${rateLimits?.resetsAt}"
             }
+            findPreference<SwitchPreference>("crash_reporting")?.let {
+                it.isVisible = true
+                it.setOnPreferenceChangeListener { _, newValue ->
+                    val checked = newValue as Boolean
+
+                    true
+                }
+            }
         }
 
         findPreference<Preference>("changelog")?.let {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.common.data.authentication.Authenticat
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.settings.language.LanguagesManager
 import io.homeassistant.companion.android.themes.ThemesManager
@@ -22,6 +23,7 @@ class SettingsPresenterImpl @Inject constructor(
     private val urlUseCase: UrlRepository,
     private val integrationUseCase: IntegrationRepository,
     private val authenticationUseCase: AuthenticationRepository,
+    private val prefsRepository: PrefsRepository,
     private val themesManager: ThemesManager,
     private val langsManager: LanguagesManager
 ) : SettingsPresenter, PreferenceDataStore() {
@@ -37,6 +39,7 @@ class SettingsPresenterImpl @Inject constructor(
             return@runBlocking when (key) {
                 "fullscreen" -> integrationUseCase.isFullScreenEnabled()
                 "app_lock" -> authenticationUseCase.isLockEnabled()
+                "crash_reporting" -> prefsRepository.isCrashReporting()
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
             }
         }
@@ -47,6 +50,7 @@ class SettingsPresenterImpl @Inject constructor(
             when (key) {
                 "fullscreen" -> integrationUseCase.setFullScreenEnabled(value)
                 "app_lock" -> authenticationUseCase.setLockEnabled(value)
+                "crash_reporting" -> prefsRepository.setCrashReporting(value)
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
             }
         }

--- a/app/src/main/res/drawable/ic_android_debug_bridge.xml
+++ b/app/src/main/res/drawable/ic_android_debug_bridge.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@color/colorAccent"
+        android:pathData="M15,9A1,1 0 0,1 14,8A1,1 0 0,1 15,7A1,1 0 0,1 16,8A1,1 0 0,1 15,9M9,9A1,1 0 0,1 8,8A1,1 0 0,1 9,7A1,1 0 0,1 10,8A1,1 0 0,1 9,9M16.12,4.37L18.22,2.27L17.4,1.44L15.09,3.75C14.16,3.28 13.11,3 12,3C10.88,3 9.84,3.28 8.91,3.75L6.6,1.44L5.78,2.27L7.88,4.37C6.14,5.64 5,7.68 5,10V11H19V10C19,7.68 17.86,5.64 16.12,4.37M5,16C5,19.86 8.13,23 12,23A7,7 0 0,0 19,16V12H5V16Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -425,4 +425,6 @@ like to connect to:</string>
   <string name="state_opening">Opening</string>
   <string name="state_locked">Locked</string>
   <string name="state_unlocked">Unlocked</string>
+    <string name="crash_reporting">Crash Reporting</string>
+  <string name="crash_reporting_summary">Help the developers fix bugs and crashes by leaving this enabled. If the application crashes this will automatically generate and send a report. If you notice a crash also create an issue on Github!</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -139,6 +139,12 @@
             android:icon="@drawable/ic_incognito"
             android:title="@string/privacy_policy"
             android:summary="@string/privacy_url" />
+        <SwitchPreference
+            android:key="crash_reporting"
+            android:icon="@drawable/ic_android_debug_bridge"
+            app:isPreferenceVisible="false"
+            android:title="@string/crash_reporting"
+            android:summary="@string/crash_reporting_summary" />
     </PreferenceCategory>
 
 </androidx.preference.PreferenceScreen>

--- a/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -2,6 +2,6 @@ package io.homeassistant.companion.android
 
 import android.content.Context
 
-fun initCrashReporting(context: Context) {
+fun initCrashReporting(context: Context, enabled: Boolean) {
     // Noop
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -16,4 +16,8 @@ interface PrefsRepository {
     suspend fun getLocales(): String?
 
     suspend fun saveLocales(lang: String)
+
+    suspend fun isCrashReporting(): Boolean
+
+    suspend fun setCrashReporting(crash: Boolean)
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -13,6 +13,7 @@ class PrefsRepositoryImpl @Inject constructor(
         private const val PREF_THEME = "theme"
         private const val PREF_LANG = "lang"
         private const val PREF_LOCALES = "locales"
+        private const val PREF_CRASH_REPORTING_DISABLED = "crash_reporting"
     }
 
     override suspend fun getAppVersion(): String? {
@@ -45,5 +46,13 @@ class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun saveLocales(locales: String) {
         localStorage.putString(PREF_LOCALES, locales)
+    }
+
+    override suspend fun isCrashReporting(): Boolean {
+        return !localStorage.getBoolean(PREF_CRASH_REPORTING_DISABLED)
+    }
+
+    override suspend fun setCrashReporting(crashReportingEnabled: Boolean) {
+        localStorage.putBoolean(PREF_CRASH_REPORTING_DISABLED, !crashReportingEnabled)
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Allow users the option to opt out of Crash Reporting.
Fixes: https://github.com/home-assistant/android/issues/1140

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Screenshot_20201104-085203](https://user-images.githubusercontent.com/1051414/98120948-a3558180-1e7c-11eb-9b5e-21b633568a0f.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A


## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
