### PR TITLE
Fix for sensor attributes of data type Long

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
@@ -18,6 +18,7 @@ data class SensorWithAttributes(
             val attributeValue = when (it.valueType) {
                 "boolean" -> it.value.toBoolean()
                 "float" -> it.value.toFloat()
+                "long" -> it.value.toLong()
                 "int" -> it.value.toInt()
                 "string" -> it.value
                 else -> throw IllegalArgumentException("Attribute: ${it.name} is of unknown type: ${it.valueType}")

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -108,6 +108,7 @@ interface SensorManager {
             val valueType = when (item.value) {
                 is Boolean -> "boolean"
                 is Int -> "int"
+                is Long -> "long"
                 is Number -> "float"
                 else -> "string" // Always default to String for attributes
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The next alarm time sensors (and possibly others) has an attribute which is of type Long. This was being stored in the database with a value_type of "float" and converted to a Float when passed to Home Assistant, causing the value to change due to floating point conversion issues.

This PR changes the SensorManager to store Long attributes with a value_type of "long", which are converted to Long when passed to Home Assistant.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->