### PR TITLE
Allow control of volume level for audio streams

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -74,6 +74,7 @@ class MessagingService : FirebaseMessagingService() {
         const val COMMAND_DND = "command_dnd"
         const val COMMAND_RINGER_MODE = "command_ringer_mode"
         const val COMMAND_BROADCAST_INTENT = "command_broadcast_intent"
+        const val COMMAND_VOLUME_LEVEL = "command_volume_level"
 
         // DND commands
         const val DND_PRIORITY_ONLY = "priority_only"
@@ -86,10 +87,18 @@ class MessagingService : FirebaseMessagingService() {
         const val RM_SILENT = "silent"
         const val RM_VIBRATE = "vibrate"
 
+        // Channel streams
+        const val ALARM_STREAM = "alarm_stream"
+        const val ALARM_STREAM_MAX = "alarm_stream_max"
+        const val MUSIC_STREAM = "music_stream"
+        const val NOTIFICATION_STREAM = "notification_stream"
+        const val RING_STREAM = "ring_stream"
+
         // Command groups
-        val DEVICE_COMMANDS = listOf(COMMAND_DND, COMMAND_RINGER_MODE, COMMAND_BROADCAST_INTENT)
+        val DEVICE_COMMANDS = listOf(COMMAND_DND, COMMAND_RINGER_MODE, COMMAND_BROADCAST_INTENT, COMMAND_VOLUME_LEVEL)
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
+        val CHANNEL_VOLUME_STREAM = listOf(ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM)
     }
 
     @Inject
@@ -179,6 +188,17 @@ class MessagingService : FirebaseMessagingService() {
                                 }
                             }
                         }
+                        COMMAND_VOLUME_LEVEL -> {
+                            if (!it["channel"].isNullOrEmpty() && it["channel"] in CHANNEL_VOLUME_STREAM &&
+                                !it[TITLE].isNullOrEmpty() && it[TITLE]?.toIntOrNull() != null)
+                                handleDeviceCommands(it)
+                            else {
+                                mainScope.launch {
+                                    Log.d(TAG, "Invalid volume command received, posting notification to device")
+                                    sendNotification(it)
+                                }
+                            }
+                        }
                         else -> Log.d(TAG, "No command received")
                     }
                 }
@@ -229,26 +249,26 @@ class MessagingService : FirebaseMessagingService() {
             if (it == TextToSpeech.SUCCESS) {
                 val listener = object : UtteranceProgressListener() {
                     override fun onStart(p0: String?) {
-                        if (data["channel"] == "alarm_stream_max")
+                        if (data["channel"] == ALARM_STREAM_MAX)
                             audioManager.setStreamVolume(AudioManager.STREAM_ALARM, maxAlarmVolume, 0)
                     }
 
                     override fun onDone(p0: String?) {
                         textToSpeech?.stop()
                         textToSpeech?.shutdown()
-                        if (data["channel"] == "alarm_stream_max")
+                        if (data["channel"] == ALARM_STREAM_MAX)
                             audioManager.setStreamVolume(AudioManager.STREAM_ALARM, currentAlarmVolume, 0)
                     }
 
                     override fun onError(p0: String?) {
                         textToSpeech?.stop()
                         textToSpeech?.shutdown()
-                        if (data["channel"] == "alarm_stream_max")
+                        if (data["channel"] == ALARM_STREAM_MAX)
                             audioManager.setStreamVolume(AudioManager.STREAM_ALARM, currentAlarmVolume, 0)
                     }
                 }
                 textToSpeech?.setOnUtteranceProgressListener(listener)
-                if (data["channel"] == "alarm_stream" || data["channel"] == "alarm_stream_max") {
+                if (data["channel"] == ALARM_STREAM || data["channel"] == ALARM_STREAM_MAX) {
                     val audioAttributes = AudioAttributes.Builder()
                         .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
                         .setUsage(AudioAttributes.USAGE_ALARM)
@@ -320,6 +340,29 @@ class MessagingService : FirebaseMessagingService() {
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to send broadcast intent please check command format", e)
                     Toast.makeText(applicationContext, R.string.broadcast_intent_error, Toast.LENGTH_LONG).show()
+                }
+            }
+            COMMAND_VOLUME_LEVEL -> {
+                val audioManager =
+                    applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    val notificationManager =
+                        applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+                    if (!notificationManager.isNotificationPolicyAccessGranted) {
+                        requestDNDPermission()
+                    } else {
+                        processStreamVolume(
+                            audioManager,
+                            data["channel"].toString(),
+                            title!!.toInt()
+                        )
+                    }
+                } else {
+                    processStreamVolume(
+                        audioManager,
+                        data["channel"].toString(),
+                        title!!.toInt()
+                    )
                 }
             }
             else -> Log.d(TAG, "No command received")
@@ -485,7 +528,7 @@ class MessagingService : FirebaseMessagingService() {
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        if (data["channel"] == "alarm_stream") {
+        if (data["channel"] == ALARM_STREAM) {
             builder.setCategory(Notification.CATEGORY_ALARM)
             builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM), AudioManager.STREAM_ALARM)
         } else {
@@ -759,7 +802,7 @@ class MessagingService : FirebaseMessagingService() {
                 handleImportance(data)
             )
 
-            if (channelName == "alarm_stream")
+            if (channelName == ALARM_STREAM)
                 handleChannelSound(channel)
 
             setChannelLedColor(data, channel)
@@ -848,6 +891,41 @@ class MessagingService : FirebaseMessagingService() {
             RM_SILENT -> audioManager.ringerMode = AudioManager.RINGER_MODE_SILENT
             RM_VIBRATE -> audioManager.ringerMode = AudioManager.RINGER_MODE_VIBRATE
             else -> Log.d(TAG, "Skipping invalid command")
+        }
+    }
+
+    private fun processStreamVolume(audioManager: AudioManager, stream: String, volume: Int) {
+        var volumeLevel = volume
+        when (stream) {
+            ALARM_STREAM -> {
+                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM))
+                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM)
+                else if (volumeLevel < 0)
+                    volumeLevel = 0
+                audioManager.setStreamVolume(AudioManager.STREAM_ALARM, volumeLevel, AudioManager.FLAG_SHOW_UI)
+            }
+            MUSIC_STREAM -> {
+                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC))
+                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+                else if (volumeLevel < 0)
+                    volumeLevel = 0
+                audioManager.setStreamVolume(AudioManager.STREAM_MUSIC, volumeLevel, AudioManager.FLAG_SHOW_UI)
+            }
+            NOTIFICATION_STREAM -> {
+                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_NOTIFICATION))
+                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_NOTIFICATION)
+                else if (volumeLevel < 0)
+                    volumeLevel = 0
+                audioManager.setStreamVolume(AudioManager.STREAM_NOTIFICATION, volumeLevel, AudioManager.FLAG_SHOW_UI)
+            }
+            RING_STREAM -> {
+                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_RING))
+                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING)
+                else if (volumeLevel < 0)
+                    volumeLevel = 0
+                audioManager.setStreamVolume(AudioManager.STREAM_RING, volumeLevel, AudioManager.FLAG_SHOW_UI)
+            }
+            else -> Log.d(TAG, "Skipping command due to invalid channel stream")
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1166 as we cannot detect when the sound is being made for the notification. The user will need to control the level, they should be able to restore it using the cleared event we have.  They can store the previous value by using the provided volume sensors.

We need to request DND permissions here because changing the volume level will have a direct impact on DND and ringer mode.  As there are 4 different audio streams we will use `channel` to dictate which audio stream is to be adjusted.  `title` will be used for the actual volume level.  If the volume level is higher than the streams maximum then we will use the maximum, anything below 0 will default to 0 for that stream.  We will support alarm, music, notification and ring streams.  Any invalid value will result in the notification posting to the device.

Example:

```
message: command_volume_level
title: 20
data:
  channel: music_stream
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#389

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->