### PR TITLE
Show the domain when adding power menu controls

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -35,6 +35,7 @@ class ClimateControl {
             )
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_AC_HEATER)
+            control.setZone(context.getString(R.string.domain_climate))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -46,6 +46,7 @@ class CoverControl {
                 else -> DeviceTypes.TYPE_GENERIC_OPEN_CLOSE
             }
         )
+        control.setZone(context.getString(R.string.domain_cover))
         control.setStatus(Control.STATUS_OK)
         control.setStatusText(
             when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -10,6 +10,7 @@ import android.service.controls.actions.ControlAction
 import android.service.controls.actions.FloatAction
 import android.service.controls.templates.RangeTemplate
 import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.webview.WebViewActivity
@@ -33,6 +34,7 @@ class DefaultSliderControl {
             )
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_UNKNOWN)
+            control.setZone(context.getString(R.string.domain_input_number))
             control.setStatus(Control.STATUS_OK)
             control.setControlTemplate(
                 RangeTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -40,6 +40,14 @@ class DefaultSwitchControl {
                     else -> DeviceTypes.TYPE_GENERIC_ON_OFF
                 }
             )
+            control.setZone(
+                when (entity.entityId.split(".")[0]) {
+                    "automation" -> context.getString(R.string.domain_automation)
+                    "input_boolean" -> context.getString(R.string.domain_input_boolean)
+                    "switch" -> context.getString(R.string.domain_switch)
+                    else -> entity.entityId.split(".")[0].capitalize()
+                }
+            )
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(R.string.state_on))
             control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -14,6 +14,7 @@ import android.service.controls.templates.RangeTemplate
 import android.service.controls.templates.ToggleRangeTemplate
 import android.service.controls.templates.ToggleTemplate
 import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.webview.WebViewActivity
@@ -42,6 +43,7 @@ class FanControl {
             )
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_FAN)
+            control.setZone(context.getString(R.string.domain_fan))
             control.setStatus(Control.STATUS_OK)
             if (currentSpeed.isNotBlank()) {
                 control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -40,6 +40,7 @@ class LightControl {
             )
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_LIGHT)
+            control.setZone(context.getString(R.string.domain_light))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(
                 R.string.state_on))

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -37,6 +37,7 @@ class LockControl {
             control.setDeviceType(
                 DeviceTypes.TYPE_LOCK
             )
+            control.setZone(context.getString(R.string.domain_lock))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(if (entity.state == "locked") context.getString(R.string.state_locked) else context.getString(R.string.state_unlocked))
             control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
@@ -9,6 +9,7 @@ import android.service.controls.DeviceTypes
 import android.service.controls.actions.ControlAction
 import android.service.controls.templates.StatelessTemplate
 import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.webview.WebViewActivity
@@ -33,6 +34,13 @@ class SceneControl {
             )
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_ROUTINE)
+            control.setZone(
+                when (entity.entityId.split(".")[0]) {
+                    "scene" -> context.getString(R.string.domain_scene)
+                    "script" -> context.getString(R.string.domain_script)
+                    else -> entity.entityId.split(".")[0].capitalize()
+                }
+            )
             control.setStatus(Control.STATUS_OK)
             control.setControlTemplate(
                 StatelessTemplate(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,17 @@ integration enabled on your home assistant instance.</string>
   <string name="home_assistant_not_discover">Unable to find your 
 Home Assistant instance</string>
   <string name="icon">Icon</string>
+  <string name="domain_scene">Scene</string>
+  <string name="domain_script">Script</string>
+  <string name="domain_climate">Climate</string>
+  <string name="domain_cover">Cover</string>
+  <string name="domain_input_number">Input Number</string>
+  <string name="domain_switch">Switch</string>
+  <string name="domain_automation">Automation</string>
+  <string name="domain_fan">Fan</string>
+  <string name="domain_light">Light</string>
+  <string name="domain_lock">Lock</string>
+  <string name="domain_input_boolean">Input Boolean</string>
   <string name="input_url">Home Assistant URL</string>
   <string name="input_url_hint">https://example.duckdns.org:8123</string>
   <string name="label_attribute">Attribute:</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When you have a lot of entities it can become a bit difficult to determine what is what.  As we do not get `area` lets start to categorize by the `domain` so its easier to add more controls.  Especially useful if you use the same name for an entity against different domains like I do 😛  Using `setZone` only impacts the adding control part.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

Before
![image](https://user-images.githubusercontent.com/1634145/98608703-a0092e00-22a0-11eb-94be-a05875088a56.png)

After
![image](https://user-images.githubusercontent.com/1634145/98608720-adbeb380-22a0-11eb-9187-1eb2bc5b7989.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->