### PR TITLE
Add a time zone sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -46,6 +46,7 @@ class SensorReceiver : BroadcastReceiver() {
             ProximitySensorManager(),
             StepsSensorManager(),
             StorageSensorManager(),
+            TimeZoneManager(),
             TrafficStatsManager()
         )
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.os.SystemClock
 import io.homeassistant.companion.android.R
 import java.util.Date
 import java.util.Locale
@@ -55,7 +56,8 @@ class TimeZoneManager : SensorManager {
                 "in_daylight_time" to timeZone.inDaylightTime(date),
                 "time_zone_id" to timeZone.id,
                 "time_zone_short" to timeZone.getDisplayName(timeZone.inDaylightTime(date), TimeZone.SHORT, Locale.ENGLISH),
-                "uses_daylight_time" to timeZone.useDaylightTime()
+                "uses_daylight_time" to timeZone.useDaylightTime(),
+                "utc_offset" to timeZone.getOffset(System.currentTimeMillis())
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
-import android.os.SystemClock
 import io.homeassistant.companion.android.R
 import java.util.Date
 import java.util.Locale

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -1,0 +1,62 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import io.homeassistant.companion.android.R
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class TimeZoneManager : SensorManager {
+    companion object {
+        private const val TAG = "TimeZone"
+
+        val currentTimeZone = SensorManager.BasicSensor(
+            "current_time_zone",
+            "sensor",
+            R.string.basic_sensor_name_current_time_zone,
+            R.string.sensor_description_current_time_zone
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_time_zone
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(currentTimeZone)
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        updateTimeZone(context)
+    }
+
+    private fun updateTimeZone(context: Context) {
+
+        if (!isEnabled(context, currentTimeZone.id))
+            return
+
+        val timeZone: TimeZone = TimeZone.getDefault()
+        val currentZone = timeZone.getDisplayName(Locale.ENGLISH)
+        val date = Date()
+
+        val icon = "mdi:map-clock"
+
+        onSensorUpdated(context,
+            currentTimeZone,
+            currentZone,
+            icon,
+            mapOf(
+                "in_daylight_time" to timeZone.inDaylightTime(date),
+                "time_zone_id" to timeZone.id,
+                "time_zone_short" to timeZone.getDisplayName(timeZone.inDaylightTime(date), TimeZone.SHORT, Locale.ENGLISH),
+                "uses_daylight_time" to timeZone.useDaylightTime()
+            )
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,9 @@ integration enabled on your home assistant instance.</string>
 Home Assistant instance</string>
   <string name="icon">Icon</string>
   <string name="input_url">Home Assistant URL</string>
+  <string name="basic_sensor_name_current_time_zone">Current Time Zone</string>
+  <string name="sensor_description_current_time_zone">The current time zone the device is in</string>
+  <string name="sensor_name_time_zone">Time Zone Sensor</string>
   <string name="input_url_hint">https://example.duckdns.org:8123</string>
   <string name="label_attribute">Attribute:</string>
   <string name="label_dynamic_data">Data:</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #1174 by providing a sensor that represents the current time zone. There are also a few attributes to help describe the time zone such as if its currently observing day light savings time, the ID of the zone (similar to that of HA), the short name and also if the time zone will ever observe day light savings.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/1634145/98632099-a5cc3700-22d3-11eb-9525-f7a7ff828ecf.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#392

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->