### PR TITLE
Render HTML for the message in notification history

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationDetailFragment.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.settings.notification
 
 import android.os.Bundle
+import android.text.Html.fromHtml
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
 import io.homeassistant.companion.android.R
@@ -33,7 +34,7 @@ class NotificationDetailFragment(
         }
 
         findPreference<Preference>("message")?.let {
-            it.summary = notification.message
+            it.summary = fromHtml(notification.message)
         }
 
         findPreference<Preference>("data")?.let {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.settings.notification
 
 import android.app.AlertDialog
 import android.os.Bundle
+import android.text.Html.fromHtml
 import androidx.preference.DropDownPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -121,7 +122,7 @@ class NotificationHistoryFragment : PreferenceFragmentCompat() {
                 cal.timeInMillis = item.received
                 pref.key = item.id.toString()
                 pref.title = cal.time.toString()
-                pref.summary = item.message
+                pref.summary = fromHtml(item.message)
                 pref.isIconSpaceReserved = false
 
                 pref.setOnPreferenceClickListener {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #1165 by rendering `message` in HTML.  We will not render `data` to keep it as raw data.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/1634145/98709052-b9f55000-2336-11eb-99d9-e6ee548ec443.png)

![image](https://user-images.githubusercontent.com/1634145/98709062-bf529a80-2336-11eb-80bd-724f5ad9f9ff.png)

![image](https://user-images.githubusercontent.com/1634145/98709087-c5e11200-2336-11eb-866e-58614dbb9394.png)

![image](https://user-images.githubusercontent.com/1634145/98709108-cbd6f300-2336-11eb-8521-83c5485c5387.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant# n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->