### PR TITLE
Fix app crash on invalid chronometer notification data

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -455,7 +455,7 @@ class MessagingService : FirebaseMessagingService() {
         data: Map<String, String>
     ) {
         try { // Without this, a non-numeric when value will crash the app
-            val notificationWhen = data[WHEN]?.toLong()?.times(1000) ?: 0
+            val notificationWhen = data[WHEN]?.toLongOrNull()?.times(1000) ?: 0
             val usesChronometer = data[CHRONOMETER]?.toBoolean() ?: false
 
             if (notificationWhen != 0L) {

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -454,18 +454,22 @@ class MessagingService : FirebaseMessagingService() {
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        val notificationWhen = data[WHEN]?.toLong()?.times(1000) ?: 0
-        val usesChronometer = data[CHRONOMETER]?.toBoolean() ?: false
+        try { // Without this, a non-numeric when value will crash the app
+            val notificationWhen = data[WHEN]?.toLong()?.times(1000) ?: 0
+            val usesChronometer = data[CHRONOMETER]?.toBoolean() ?: false
 
-        if (notificationWhen != 0L) {
-            builder.setWhen(notificationWhen)
-            builder.setUsesChronometer(usesChronometer)
+            if (notificationWhen != 0L) {
+                builder.setWhen(notificationWhen)
+                builder.setUsesChronometer(usesChronometer)
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                val countdown = notificationWhen > System.currentTimeMillis()
-                builder.addExtras(Bundle()) // Without this builder.setChronometerCountDown throws a null reference exception
-                builder.setChronometerCountDown(countdown)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    val countdown = notificationWhen > System.currentTimeMillis()
+                    builder.addExtras(Bundle()) // Without this builder.setChronometerCountDown throws a null reference exception
+                    builder.setChronometerCountDown(countdown)
+                }
             }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error while handling chronometer notification", e)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR wraps handling of chronometer notifications in a try/catch to prevent the app from crashing when invalid data is received.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This PR is pretty basic and only prevents a hard crash. There's definitely room for improvement regarding usability
It might make sense to mark invalid notifications in the notification log or something like that