### PR TITLE
Pause and resume the webview as needed

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -433,6 +433,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
     override fun onResume() {
         super.onResume()
+        webView.onResume()
+        webView.resumeTimers()
         if (currentLang != languagesManager.getCurrentLang())
             recreate()
         if (!unlocked && !presenter.isLockEnabled())
@@ -884,5 +886,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 showError()
             }
         }, CONNECTION_DELAY)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        webView.onPause()
+        webView.pauseTimers()
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This is an attempt to fix #979 from the app side.  I was looking at the WebView docs and it seems that webview itself can be paused and resumed as needed.  I think this might help out.  This is what I did for testing.

1. Ran `master` before these changes.  Loaded up a live view picture entity card, verified the camera was streaming.  Swiped to home screen.  Waited 10 minutes, came back to webview and it seemed like the video continued.  Performed a similar test with more info panel and saw the same results.
2. Ran these changes and did the same test.  After waiting 10 minutes and coming back to webview I noticed the whole page reloaded, I think this was caused by the connection restoring?  When I did the test on the more info popup I noticed that when I came back the video was paused at first and then resumed a second later.

Its possible that `webView.onPause` is what we need but I am not sure. Based on the docs it sounds like it can't hurt?

https://developer.android.com/reference/android/webkit/WebView#onPause()
https://developer.android.com/reference/android/webkit/WebView#onResume()

I am not sure if these are needed but since the app is in the background we probably don't need the timers running? (if we have them or if a custom card can?)
https://developer.android.com/reference/android/webkit/WebView#pauseTimers()
https://developer.android.com/reference/android/webkit/WebView#resumeTimers()

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->