### PR TITLE
Switch to toLongOrNull for timeout to prevent user error

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -665,7 +665,7 @@ class MessagingService : FirebaseMessagingService() {
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        val timeout = data[TIMEOUT]?.toLong()?.times(1000) ?: -1
+        val timeout = data[TIMEOUT]?.toLongOrNull()?.times(1000) ?: -1
         if (timeout >= 0) builder.setTimeoutAfter(timeout)
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the following sentry error by ensuring we properly set `null` when we can:

```
java.lang.NumberFormatException: For input string: "00:00:05"
    at java.lang.Long.parseLong(Long.java:594)
    at java.lang.Long.parseLong(Long.java:636)
    at io.homeassistant.companion.android.notifications.MessagingService.handleTimeout(MessagingService.kt:668)
    at io.homeassistant.companion.android.notifications.MessagingService.sendNotification(MessagingService.kt:415)
    at io.homeassistant.companion.android.notifications.MessagingService$onMessageReceived$$inlined$let$lambda$6.invokeSuspend(MessagingService.kt:210)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at android.os.Handler.handleCallback(Handler.java:873)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7050)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:494)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:965)
```

```
java.lang.NumberFormatException: For input string: "00:02:00"
    at java.lang.Long.parseLong(Long.java:594)
    at java.lang.Long.parseLong(Long.java:636)
    at io.homeassistant.companion.android.notifications.MessagingService.handleTimeout(MessagingService.kt:668)
    at io.homeassistant.companion.android.notifications.MessagingService.sendNotification(MessagingService.kt:415)
    at io.homeassistant.companion.android.notifications.MessagingService$onMessageReceived$$inlined$let$lambda$6.invokeSuspend(MessagingService.kt:210)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8167)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->