### PR TITLE
Add sensors for app data and memory usage

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
@@ -24,14 +24,24 @@ class AppSensorManager : SensorManager {
             "app_rx_gb",
             "sensor",
             R.string.basic_sensor_name_app_rx_gb,
-            R.string.sensor_description_app_rx_gb
+            R.string.sensor_description_app_rx_gb,
+            unitOfMeasurement = "GB"
         )
 
         val app_tx_gb = SensorManager.BasicSensor(
             "app_tx_gb",
             "sensor",
             R.string.basic_sensor_name_app_tx_gb,
-            R.string.sensor_description_app_tx_gb
+            R.string.sensor_description_app_tx_gb,
+            unitOfMeasurement = "GB"
+        )
+
+        val app_memory = SensorManager.BasicSensor(
+            "app_memory",
+            "sensor",
+            R.string.basic_sensor_name_app_memory,
+            R.string.sensor_description_app_memory,
+            unitOfMeasurement = "GB"
         )
     }
 
@@ -41,7 +51,7 @@ class AppSensorManager : SensorManager {
         get() = R.string.sensor_name_app_sensor
 
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(currentVersion, app_rx_gb, app_tx_gb)
+        get() = listOf(currentVersion, app_rx_gb, app_tx_gb, app_memory)
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
@@ -52,6 +62,7 @@ class AppSensorManager : SensorManager {
     ) {
         val myUid = Process.myUid()
         updateCurrentVersion(context)
+        updateAppMemory(context)
         updateAppRxGb(context, myUid)
         updateAppTxGb(context, myUid)
     }
@@ -113,6 +124,30 @@ class AppSensorManager : SensorManager {
             appTx.toBigDecimal().setScale(4, RoundingMode.HALF_EVEN),
             icon,
             mapOf()
+        )
+    }
+
+    private fun updateAppMemory(context: Context) {
+
+        if (!isEnabled(context, app_memory.id))
+            return
+
+        val runTime = Runtime.getRuntime()
+        val freeSize = runTime.freeMemory().toFloat() / GB
+        val totalSize = runTime.totalMemory().toFloat() / GB
+        val usedSize = totalSize - freeSize
+
+        val icon = "mdi:memory"
+
+        onSensorUpdated(
+            context,
+            app_memory,
+            usedSize.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf(
+                "free_memory" to freeSize.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN),
+                "total_memory" to totalSize.toBigDecimal().setScale(3, RoundingMode.HALF_EVEN)
+            )
         )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
@@ -1,18 +1,37 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.net.TrafficStats
+import android.os.Process
+import android.util.Log
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
+import java.math.RoundingMode
 
 class AppSensorManager : SensorManager {
     companion object {
         private const val TAG = "AppSensor"
+        private const val GB = 1000000000
 
         val currentVersion = SensorManager.BasicSensor(
             "current_version",
             "sensor",
             R.string.basic_sensor_name_current_version,
             R.string.sensor_description_current_version
+        )
+
+        val app_rx_gb = SensorManager.BasicSensor(
+            "app_rx_gb",
+            "sensor",
+            R.string.basic_sensor_name_app_rx_gb,
+            R.string.sensor_description_app_rx_gb
+        )
+
+        val app_tx_gb = SensorManager.BasicSensor(
+            "app_tx_gb",
+            "sensor",
+            R.string.basic_sensor_name_app_tx_gb,
+            R.string.sensor_description_app_tx_gb
         )
     }
 
@@ -22,7 +41,7 @@ class AppSensorManager : SensorManager {
         get() = R.string.sensor_name_app_sensor
 
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(currentVersion)
+        get() = listOf(currentVersion, app_rx_gb, app_tx_gb)
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
@@ -31,7 +50,10 @@ class AppSensorManager : SensorManager {
     override fun requestSensorUpdate(
         context: Context
     ) {
+        val myUid = Process.myUid()
         updateCurrentVersion(context)
+        updateAppRxGb(context, myUid)
+        updateAppTxGb(context, myUid)
     }
 
     private fun updateCurrentVersion(context: Context) {
@@ -45,6 +67,50 @@ class AppSensorManager : SensorManager {
         onSensorUpdated(context,
             currentVersion,
             state,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateAppRxGb(context: Context, appUid: Int) {
+
+        if (!isEnabled(context, app_rx_gb.id))
+            return
+
+        val appRx = try {
+            TrafficStats.getUidRxBytes(appUid).toFloat() / GB
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting app rx bytes", e)
+            return
+        }
+        val icon = "mdi:radio-tower"
+
+        onSensorUpdated(
+            context,
+            app_rx_gb,
+            appRx.toBigDecimal().setScale(4, RoundingMode.HALF_EVEN),
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateAppTxGb(context: Context, appUid: Int) {
+
+        if (!isEnabled(context, app_tx_gb.id))
+            return
+
+        val appTx = try {
+            TrafficStats.getUidTxBytes(appUid).toFloat() / GB
+        } catch (e: Exception) {
+            Log.e(TAG, "Error getting app tx bytes", e)
+            return
+        }
+        val icon = "mdi:radio-tower"
+
+        onSensorUpdated(
+            context,
+            app_tx_gb,
+            appTx.toBigDecimal().setScale(4, RoundingMode.HALF_EVEN),
             icon,
             mapOf()
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,8 @@
   <string name="basic_sensor_name_location_accurate">Single Accurate Location</string>
   <string name="basic_sensor_name_location_background">Background Location</string>
   <string name="basic_sensor_name_location_zone">Location Zone</string>
+  <string name="basic_sensor_name_app_rx_gb">App Rx GB</string>
+  <string name="basic_sensor_name_app_tx_gb">App Tx GB</string>
   <string name="basic_sensor_name_mobile_rx_gb">Mobile Rx GB</string>
   <string name="basic_sensor_name_mobile_tx_gb">Mobile Tx GB</string>
   <string name="basic_sensor_name_phone">Phone State</string>
@@ -311,6 +313,8 @@ like to connect to:</string>
   <string name="sensor_description_storage_sensor">Information about the total and available storage space internally and externally</string>
   <string name="sensor_description_total_rx_gb">Total Rx GB since last device reboot</string>
   <string name="sensor_description_total_tx_gb">Total Tx GB since last device reboot</string>
+  <string name="sensor_description_app_rx_gb">App Rx GB since last device reboot</string>
+  <string name="sensor_description_app_tx_gb">App Tx GB since last device reboot</string>
   <string name="sensor_description_volume_alarm">Volume level for alarms on the device</string>
   <string name="sensor_description_volume_call">Volume level for calls on the device</string>
   <string name="sensor_description_volume_music">Volume level for music on the device</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -313,6 +313,8 @@ like to connect to:</string>
   <string name="sensor_description_storage_sensor">Information about the total and available storage space internally and externally</string>
   <string name="sensor_description_total_rx_gb">Total Rx GB since last device reboot</string>
   <string name="sensor_description_total_tx_gb">Total Tx GB since last device reboot</string>
+  <string name="basic_sensor_name_app_memory">App Memory</string>
+  <string name="sensor_description_app_memory">Total used and available memory for the app</string>
   <string name="sensor_description_app_rx_gb">App Rx GB since last device reboot</string>
   <string name="sensor_description_app_tx_gb">App Tx GB since last device reboot</string>
   <string name="sensor_description_volume_alarm">Volume level for alarms on the device</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds some app data sensors that represent how much data was sent and received by the app.  Stats reset on each device reboot.  These are similar to the Traffic Stat sensors we have however as these are more diagnostic sensors I felt they fit better under App Sensors.  As my app data usage is very low I opted for 4 decimal places.

There is also a sensor that represents how much memory has been used by the app and how much is available to it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/1634145/99350743-f0116300-2853-11eb-8e63-3e34f6f9195f.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#397

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->