### PR TITLE
Add some more app sensors

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -315,6 +315,10 @@ like to connect to:</string>
   <string name="sensor_description_total_tx_gb">Total Tx GB since last device reboot</string>
   <string name="basic_sensor_name_app_memory">App Memory</string>
   <string name="sensor_description_app_memory">Total used and available memory for the app</string>
+  <string name="basic_sensor_name_app_inactive">App Inactive</string>
+  <string name="sensor_description_app_inactive">Whether or not the app is currently considered inactive by the system</string>
+  <string name="basic_sensor_name_app_standby">App Standby Bucket</string>
+  <string name="sensor_description_app_standby">The apps current standby bucket. Standby buckets determine how much an app will be restricted from running background tasks such as jobs and alarms.</string>
   <string name="sensor_description_app_rx_gb">App Rx GB since last device reboot</string>
   <string name="sensor_description_app_tx_gb">App Tx GB since last device reboot</string>
   <string name="sensor_description_volume_alarm">Volume level for alarms on the device</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Just adding some more app sensors from Usage Stats Manager to determine if the app is considered inactive and also the current app standby bucket. These should be helpful as well to determine why the app misbehaves at times.

The `app_inactive` sensor will be available for devices on Android M or higher, while the `app_standby_bucket` sensor is for Android P and higher.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/1634145/99921303-5d067c00-2cde-11eb-988e-4107b52a29e4.png)

![image](https://user-images.githubusercontent.com/1634145/99921306-61cb3000-2cde-11eb-8383-32ac2337fef8.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->