### PR TITLE
Use min and max temp for climate range in power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -49,12 +49,21 @@ class ClimateControl {
                     else -> entity.state
                 }
             )
+            val minValue = (entity.attributes["min_temp"] as? Number)?.toFloat() ?: 0f
+            val maxValue = (entity.attributes["max_temp"] as? Number)?.toFloat() ?: 100f
+            var currentValue = (entity.attributes["temperature"] as? Number)?.toFloat() ?: (
+                    entity.attributes["current_temperature"] as? Number)?.toFloat() ?: 0f
+            // Ensure the current value is never lower than the minimum or higher than the maximum
+            if (currentValue < minValue)
+                currentValue = minValue
+            if (currentValue > maxValue)
+                currentValue = maxValue
             control.setControlTemplate(
                 RangeTemplate(
                     entity.entityId,
-                    0f,
-                    100f,
-                    (entity.attributes["temperature"] as? Number)?.toFloat() ?: 0f,
+                    minValue,
+                    maxValue,
+                    currentValue,
                     .5f,
                     "%.0f"
                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #1217 

We now set the climate range based on `min_temp` and `max_temp`.  For the current value we first try `temperature` then try `current_temperature` and then default to 0 if both are not provided.  My zwave thermostat does not have a `temperature` attribute when it is `off` but `current_temperature` is always there.  We also do a sanity check to ensure current value is always in the range to prevent loading errors.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant# N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->