### PR TITLE
Add a small buffer for the location future check to avoid skipping valid updates

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -315,8 +315,8 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         val now = System.currentTimeMillis()
 
         Log.d(TAG, "Begin evaluating if location update should be skipped")
-        if (now < location.time) {
-            Log.d(TAG, "Skipping location update that came from the future. $now should always be greater than ${location.time}")
+        if (now + 5000 < location.time) {
+            Log.d(TAG, "Skipping location update that came from the future. ${now + 5000} should always be greater than ${location.time}")
             return
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had a user on discord point out that when they had Google Maps or Wave navigation engaged all updates seemed to get skipped by the future check.  The user pointed out the consistency was within the second.  I ran a similar test and found all my updates to be within 2 seconds.   This PR adds a 5 second buffer for only the future time check to avoid skipping valid updates.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
https://discord.com/channels/330944238910963714/562408603345092636/786337770305093652