### PR TITLE
Don't show toast error for screen on intent as it can be excessive

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -51,6 +51,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         internal const val EXTRA_LABEL = "EXTRA_LABEL"
         internal const val EXTRA_SHOW_SKIP = "EXTRA_INCLUDE_SKIP"
         internal const val EXTRA_SHOW_SEEK = "EXTRA_INCLUDE_SEEK"
+        private var lastIntent = ""
     }
 
     @Inject
@@ -269,7 +270,8 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
             entity = integrationUseCase.getEntity(entityId)
         } catch (e: Exception) {
             Log.d(TAG, "Failed to fetch entity or entity does not exist")
-            Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
+            if (lastIntent != Intent.ACTION_SCREEN_ON)
+                Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
             return null
         }
 
@@ -277,12 +279,12 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        val action = intent.action
+        lastIntent = intent.action.toString()
         val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
 
         Log.d(
             TAG, "Broadcast received: " + System.lineSeparator() +
-                    "Broadcast action: " + action + System.lineSeparator() +
+                    "Broadcast action: " + lastIntent + System.lineSeparator() +
                     "AppWidgetId: " + appWidgetId
         )
 
@@ -292,7 +294,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
         val mediaPlayerWidgetList = mediaPlayCtrlWidgetDao.getAll()
 
         super.onReceive(context, intent)
-        when (action) {
+        when (lastIntent) {
             RECEIVE_DATA -> saveEntityConfiguration(context, intent.extras, appWidgetId)
             UPDATE_MEDIA_IMAGE -> updateAppWidget(context, appWidgetId)
             CALL_PREV_TRACK -> callPreviousTrackService(appWidgetId)
@@ -380,7 +382,8 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                 currentEntityInfo = integrationUseCase.getEntity(entity.entityId)
             } catch (e: Exception) {
                 Log.d(TAG, "Failed to fetch entity or entity does not exist")
-                Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
+                if (lastIntent != Intent.ACTION_SCREEN_ON)
+                    Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
                 return@launch
             }
 
@@ -448,7 +451,8 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                 currentEntityInfo = integrationUseCase.getEntity(entity.entityId)
             } catch (e: Exception) {
                 Log.d(TAG, "Failed to fetch entity or entity does not exist")
-                Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
+                if (lastIntent != Intent.ACTION_SCREEN_ON)
+                    Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
                 return@launch
             }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -32,6 +32,7 @@ class TemplateWidget : AppWidgetProvider() {
             "io.homeassistant.companion.android.widgets.template.TemplateWidget.RECEIVE_DATA"
 
         internal const val EXTRA_TEMPLATE = "extra_template"
+        private var lastIntent = ""
     }
 
     @Inject
@@ -73,12 +74,12 @@ class TemplateWidget : AppWidgetProvider() {
     }
 
     override fun onReceive(context: Context, intent: Intent) {
-        val action = intent.action
+        lastIntent = intent.action.toString()
         val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
 
         Log.d(
             TAG, "Broadcast received: " + System.lineSeparator() +
-                    "Broadcast action: " + action + System.lineSeparator() +
+                    "Broadcast action: " + lastIntent + System.lineSeparator() +
                     "AppWidgetId: " + appWidgetId
         )
 
@@ -88,7 +89,7 @@ class TemplateWidget : AppWidgetProvider() {
         val templateWidgetList = templateWidgetDao.getAll()
 
         super.onReceive(context, intent)
-        when (action) {
+        when (lastIntent) {
             UPDATE_VIEW -> updateView(context, appWidgetId)
             RECEIVE_DATA -> saveEntityConfiguration(context, intent.extras, appWidgetId)
             Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, templateWidgetList)
@@ -125,7 +126,8 @@ class TemplateWidget : AppWidgetProvider() {
                     renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf())
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to render template: ${widget.template}", e)
-                    Toast.makeText(context, R.string.widget_template_error, Toast.LENGTH_LONG).show()
+                    if (lastIntent != Intent.ACTION_SCREEN_ON)
+                        Toast.makeText(context, R.string.widget_template_error, Toast.LENGTH_LONG).show()
                 }
                 setTextViewText(
                     R.id.widgetTemplateText,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

The other day my internet went out and I started to see a lot of toast errors.  The error was expected since I could not connect to my HA instance.  The problem is the screen on intent can become a bit excessive with these errors and if you know your HA instance is down it can become annoying.  Lets only show the toast error when the user taps on the widget to update or its part of the normal update.  This way we provide feedback when they ask for an update and we can't give them instead of when we proactively update the widgets.

I also had a friend hit a similar issue where he was on a flight and was connected to wifi without full data access so the errors still became excessive then.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Tested on my dev instance by creating widgets and shutting down the instance.