### PR TITLE
Fix uninitialized property access error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -249,11 +249,10 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
         if (preference is SsidPreference) {
-            lateinit var permissionsToCheck: Array<String>
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+            val permissionsToCheck: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            } else {
+                arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
             }
 
             val fineLocation = DisabledLocationHandler.containsLocationPermission(permissionsToCheck, true)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was looking at the Sentry logs and came across the following error, we probably want to make sure all supported versions have some location permission to check here:

```
kotlin.UninitializedPropertyAccessException: lateinit property permissionsToCheck has not been initialized
    at io.homeassistant.companion.android.settings.SettingsFragment.onDisplayPreferenceDialog(SettingsFragment.kt:259)
    at androidx.preference.PreferenceManager.showDialog(PreferenceManager.java:537)
    at androidx.preference.DialogPreference.onClick(DialogPreference.java:257)
    at androidx.preference.Preference.performClick(Preference.java:1182)
    at androidx.preference.Preference.performClick(Preference.java:1166)
    at androidx.preference.Preference$1.onClick(Preference.java:181)
    at android.view.View.performClick(View.java:5204)
    at android.view.View$PerformClick.run(View.java:21153)
    at android.os.Handler.handleCallback(Handler.java:739)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:148)
    at android.app.ActivityThread.main(ActivityThread.java:5417)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->