### PR TITLE
Fix null pointer for canceling group

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -53,8 +53,10 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
             if (isGroupSummary && groupNotifications.size == 1 ||
                 !isGroupSummary && groupNotifications.size == 2) {
                 val group = groupNotifications[0].notification.group
-                val groupId = group.hashCode()
-                this.cancel(group, groupId)
+                if (group != null) {
+                    val groupId = group.hashCode()
+                    this.cancel(group, groupId)
+                }
                 return true
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the following sentry error by preventing the case entirely:

``` 
java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.hashCode()' on a null object reference
    at io.homeassistant.companion.android.util.NotificationManagerExtensionsKt.cancelGroupIfNeeded(NotificationManagerExtensions.kt:56)
    at io.homeassistant.companion.android.util.NotificationManagerExtensionsKt.cancel(NotificationManagerExtensions.kt:66)
    at io.homeassistant.companion.android.notifications.MessagingService.clearNotification(MessagingService.kt:229)
    at io.homeassistant.companion.android.notifications.MessagingService.onMessageReceived(MessagingService.kt:144)
    at com.google.firebase.messaging.FirebaseMessagingService.dispatchMessage(com.google.firebase:firebase-messaging@@20.3.0:74)
    at com.google.firebase.messaging.FirebaseMessagingService.passMessageIntentToSdk(com.google.firebase:firebase-messaging@@20.3.0:44)
    at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(com.google.firebase:firebase-messaging@@20.3.0:27)
    at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(com.google.firebase:firebase-messaging@@20.3.0:17)
    at com.google.firebase.messaging.EnhancedIntentService.lambda$processIntent$0$EnhancedIntentService(com.google.firebase:firebase-messaging@@20.3.0:43)
    at com.google.firebase.messaging.EnhancedIntentService$$Lambda$0.run
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at com.google.android.gms.common.util.concurrent.zza.run(com.google.android.gms:play-services-basement@@17.3.0:6)
    at java.lang.Thread.run(Thread.java:923)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->