### PR TITLE
Always send connection info as a string even if null

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -7,6 +7,6 @@ class WifiHelperImpl @Inject constructor(
     private val wifiManager: WifiManager
 ) : WifiHelper {
     override fun getWifiSsid(): String {
-        return wifiManager.connectionInfo.ssid
+        return wifiManager.connectionInfo?.ssid.toString()
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This fixes another sentry error that I saw, this may even already be addressed by the previous PR where we check location permission. I think it may be good to ensure we don't hit this error at all.  So instead of failing due to a null value we just ensure we always send a string even if its `null`

```
java.lang.NullPointerException: wifiManager.connectionInfo must not be null
    at io.homeassistant.companion.android.common.data.wifi.WifiHelperImpl.getWifiSsid(WifiHelperImpl.kt:10)
    at io.homeassistant.companion.android.common.data.url.UrlRepositoryImpl.isInternal(UrlRepositoryImpl.kt:108)
    at io.homeassistant.companion.android.common.data.url.UrlRepositoryImpl.getUrl(UrlRepositoryImpl.kt:76)
    at io.homeassistant.companion.android.common.data.url.UrlRepository$DefaultImpls.getUrl$default(UrlRepository.kt:11)
    at io.homeassistant.companion.android.common.data.authentication.impl.AuthenticationRepositoryImpl.getSessionState(AuthenticationRepositoryImpl.kt:60)
    at io.homeassistant.companion.android.webview.WebViewPresenterImpl$onGetExternalAuth$1.invokeSuspend(WebViewPresenterImpl.kt:89)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:55)
    at android.os.Handler.handleCallback(Handler.java:739)
    at android.os.Handler.dispatchMessage(Handler.java:95)
    at android.os.Looper.loop(Looper.java:135)
    at android.app.ActivityThread.main(ActivityThread.java:5597)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:984)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->