### PR TITLE
Fix crash when run on Android 7.1 or earlier

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -249,13 +249,17 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
     override fun onDisplayPreferenceDialog(preference: Preference) {
         if (preference is SsidPreference) {
-            lateinit var permissionsToCheck: Array<String>
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                permissionsToCheck = arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+            val permissionsToCheck: Array<String> = when {
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
+                    arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                }
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O -> {
+                    arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+                }
+                else -> {
+                    arrayOf()
+                }
             }
-
             val fineLocation = DisabledLocationHandler.containsLocationPermission(permissionsToCheck, true)
 
             if (DisabledLocationHandler.isLocationEnabled(requireContext(), fineLocation)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
There was a missing else to set the value of a variable, which meant that the code crashed when run on Android 7.1 or earlier.  Rather than just add that in to the if statement, switch to a when statement which better allows Kotlin to police when variables are not being set.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->