### PR TITLE
Add a call timeout and some debug logs

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -211,7 +211,9 @@ class ButtonWidget : AppWidgetProvider() {
                         }
                     }
 
+                    Log.d(TAG, "Sending service call to Home Assistant")
                     integrationUseCase.callService(domain, service, serviceDataMap)
+                    Log.d(TAG, "Service call sent successfully")
 
                     // If service call does not throw an exception, send positive feedback
                     feedbackColor = R.drawable.widget_button_background_green

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
@@ -48,6 +48,7 @@ class HomeAssistantRetrofit @Inject constructor(urlRepository: UrlRepository) {
                         it.proceed(it.request())
                     }
                 }
+                .callTimeout(30L, TimeUnit.SECONDS)
                 .readTimeout(30L, TimeUnit.SECONDS)
                 .build()
         )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This is an attempt to fix #653 by adding a `callTimeout`

By default OKHTTP sets this timeout to `0` which means the call will forever try to complete.  I am not sure if 30 seconds is too long or if it should be 10 seconds however, I opted for 30 seconds to match the `readTimeout`.  There are other timeouts that we do not set like `writeTimeout` and `connectTimeout` that both default to 10 seconds.

https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/
https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/-builder/call-timeout/

I have also added some debug logs in case it does not fix the issue so we can at least look at the logs to get a better idea of why it keeps spinning.

Testing involved making a few different calls to HA server like loading App Configuration, using a button widget, using a static widget.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->