### PR TITLE
Fix button widget view getting stuck when screen turns off

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.dagger.AppComponent
 import io.homeassistant.companion.android.common.dagger.Graph
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import io.homeassistant.companion.android.widgets.button.ButtonWidget
 import io.homeassistant.companion.android.widgets.entity.EntityWidget
 import io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget
 import io.homeassistant.companion.android.widgets.template.TemplateWidget
@@ -116,9 +117,15 @@ open class HomeAssistantApplication : Application(), GraphComponentAccessor {
         }
 
         // Update widgets when the screen turns on, updates are skipped if widgets were not added
+        val buttonWidget = ButtonWidget()
         val entityWidget = EntityWidget()
         val mediaPlayerWidget = MediaPlayerControlsWidget()
         val templateWidget = TemplateWidget()
+
+        registerReceiver(
+            buttonWidget,
+            IntentFilter(Intent.ACTION_SCREEN_ON)
+        )
 
         registerReceiver(
             entityWidget,

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -72,6 +72,29 @@ class ButtonWidget : AppWidgetProvider() {
         }
     }
 
+    private fun updateAllWidgets(
+        context: Context,
+        buttonWidgetEntityList: Array<ButtonWidgetEntity>?
+    ) {
+        if (buttonWidgetEntityList != null) {
+            Log.d(TAG, "Updating all widgets")
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            for (item in buttonWidgetEntityList) {
+                val views = getWidgetRemoteViews(context, item.id)
+
+                views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
+                views.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
+                views.setViewVisibility(R.id.widgetLabelLayout, View.VISIBLE)
+                views.setInt(
+                    R.id.widgetLayout,
+                    "setBackgroundResource",
+                    R.drawable.widget_button_background
+                )
+                appWidgetManager.updateAppWidget(item.id, views)
+            }
+        }
+    }
+
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {
         buttonWidgetDao = AppDatabase.getInstance(context).buttonWidgetDao()
         // When the user deletes the widget, delete the preference associated with it.
@@ -101,11 +124,13 @@ class ButtonWidget : AppWidgetProvider() {
         ensureInjected(context)
 
         buttonWidgetDao = AppDatabase.getInstance(context).buttonWidgetDao()
+        val buttonWidgetList = buttonWidgetDao.getAll()
 
         super.onReceive(context, intent)
         when (action) {
             CALL_SERVICE -> callConfiguredService(context, appWidgetId)
             RECEIVE_DATA -> saveServiceCallConfiguration(context, intent.extras, appWidgetId)
+            Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, buttonWidgetList)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #653 for real this time

The actual issue was that the screen was turning off before the widget was reset.  This would cause the widget to get stuck in a state where the user can no longer interact with it.  Now we reset back to normal when the screen turns on to ensure it can be interacted with.

Going forward we should probably make sure all widgets get some type of needed update with the screen on intent to either update the state or set things back to normal.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->