### PR TITLE
Ensure power menu light control values stays within range

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -44,6 +44,13 @@ class LightControl {
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(
                 R.string.state_on))
+            val minValue = 0f
+            val maxValue = 100f
+            var currentValue = (entity.attributes["brightness"] as? Number)?.toFloat()?.div(255f)?.times(100) ?: 0f
+            if (currentValue < minValue)
+                currentValue = minValue
+            if (currentValue > maxValue)
+                currentValue = maxValue
             control.setControlTemplate(
                     if ((entity.attributes["supported_features"] as Int) and SUPPORT_BRIGHTNESS == SUPPORT_BRIGHTNESS)
                         ToggleRangeTemplate(
@@ -52,12 +59,9 @@ class LightControl {
                                 "",
                                 RangeTemplate(
                                         entity.entityId,
-                                        0f,
-                                        100f,
-                                        (entity.attributes["brightness"] as? Number)
-                                                ?.toFloat()
-                                                ?.div(255f)
-                                                ?.times(100) ?: 0f,
+                                        minValue,
+                                        maxValue,
+                                        currentValue,
                                         1f,
                                         "%.0f%%"
                                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
We had a couple bug reports come in from what seems like integrations that don't respect the expected `brightness` range per the HA docs: https://developers.home-assistant.io/docs/core/entity/light as it should be between 0 and 255.  We do a conversion from brightness to brightness percentage so the slider works properly from 0-100% so its important the values are always as we expect.

See: #1179 and #1258 

We are going to put a sanity check in that always ensures current value is greater than or equal to min value and less than or equal to max value.

If we find any integration with an issue from this change then I think there is a bug with that integration in particular.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->