### PR TITLE
Allow template widgets to render as HTML for formatting

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
 import android.os.Bundle
+import android.text.Html.fromHtml
 import android.util.Log
 import android.widget.RemoteViews
 import android.widget.Toast
@@ -131,7 +132,7 @@ class TemplateWidget : AppWidgetProvider() {
                 }
                 setTextViewText(
                     R.id.widgetTemplateText,
-                    renderedTemplate
+                    fromHtml(renderedTemplate)
                 )
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.text.Html.fromHtml
 import android.view.View
 import android.view.View.VISIBLE
 import androidx.core.widget.doAfterTextChanged
@@ -117,7 +118,7 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
                 enabled = false
             }
             runOnUiThread {
-                renderedTemplate.text = templateText
+                renderedTemplate.text = fromHtml(templateText)
                 add_button.isEnabled = enabled
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #805 but instead of markdown we will render as HTML to better match the rest of the application like HTML formatted notifications.  The formatting will also render as a user builds the template so they can see what it can look like. 

Example: 

```
This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a <h1>new</h1> <h3>line</h3>
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/103178806-1fe05d00-483b-11eb-8150-60280412cba2.png)

![image](https://user-images.githubusercontent.com/1634145/103178807-27a00180-483b-11eb-983e-e26029188423.png)

![image](https://user-images.githubusercontent.com/1634145/103178811-2cfd4c00-483b-11eb-9673-93dd6d70a7a0.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#419

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->