### PR TITLE
Try internal URL first if we can

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -32,20 +32,23 @@ class UrlRepositoryImpl @Inject constructor(
             return arrayOf()
         }
 
+        // If we are local then add the local URL in the first position, otherwise no reason to try
+        if (isInternal()) {
+            localStorage.getString(PREF_LOCAL_URL)?.let {
+                retVal.add(
+                    it.toHttpUrl().newBuilder()
+                        .addPathSegments("api/webhook/$webhook")
+                        .build()
+                        .toUrl()
+                )
+            }
+        }
+
         localStorage.getString(PREF_CLOUDHOOK_URL)?.let {
             retVal.add(it.toHttpUrl().toUrl())
         }
 
         localStorage.getString(PREF_REMOTE_URL)?.let {
-            retVal.add(
-                it.toHttpUrl().newBuilder()
-                    .addPathSegments("api/webhook/$webhook")
-                    .build()
-                    .toUrl()
-            )
-        }
-
-        localStorage.getString(PREF_LOCAL_URL)?.let {
             retVal.add(
                 it.toHttpUrl().newBuilder()
                     .addPathSegments("api/webhook/$webhook")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This is an attempt to fix: #1078 I believe the issue here is that we still try to use the remote URL first even if we are local for when we decide to loop through all URL's.  We now change this logic to only include the local URL first, if we are connected to a home SSID. 

I can't really test the exact scenario in the issue but when I do a test in my own setup where locally I'm under `https` (which we know fails) I do see local being tried before remote.  The call in my case still ends up being successful despite failing locally first so we at least attempt the local URL if we can.  This change only impacts calls that make use of `getApiUrls` which doesn't impact the WebView but does impact calls such as NFC, sensors etc..

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->