### PR TITLE
Try the other URL when refreshing webview on a connection error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -917,8 +917,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             alert.setPositiveButton(R.string.settings) { _, _ ->
                 startActivity(SettingsActivity.newInstance(this))
             }
+            val isInternal = runBlocking {
+                urlRepository.isInternal()
+            }
             alert.setNegativeButton(
-                if (failedConnection == "external")
+                if (failedConnection == "external" && isInternal)
                     R.string.refresh_internal
                 else
                     R.string.refresh_external

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -917,7 +917,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             alert.setPositiveButton(R.string.settings) { _, _ ->
                 startActivity(SettingsActivity.newInstance(this))
             }
-            alert.setNegativeButton(R.string.refresh) { _, _ ->
+            alert.setNegativeButton(
+                if (failedConnection == "external")
+                    R.string.refresh_internal
+                else
+                    R.string.refresh_external
+                    ) { _, _ ->
                 runBlocking {
                     failedConnection = if (failedConnection == "external") {
                         webView.loadUrl(urlRepository.getUrl(true).toString())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,7 +445,7 @@ like to connect to:</string>
   <string name="username">Username</string>
   <string name="view_password">View Password</string>
   <string name="wait">Wait</string>
-  <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again. If you use the Internal Connection URL try hitting refresh a couple of times to cycle through the URLs.</string>
+  <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again. We will attempt to try another provided URL when you click on Refresh.</string>
   <string name="webview_error_description">Encountered error :</string>
   <string name="webview_error_SSL_DATE_INVALID">The date of the Home Assistant certificate is invalid, please review the Home Assistant certificate or the connection settings and try again.</string>
   <string name="webview_error_SSL_EXPIRED">The Home Assistant certificate has expired, please review the Home Assistant certificate or the connection settings and try again.</string>
@@ -494,4 +494,6 @@ like to connect to:</string>
   <string name="state_unknown">Unknown</string>
   <string name="activity_intent_error">Unable to send activity intent, please check command format</string>
   <string name="action_reply">Reply</string>
+  <string name="refresh_internal">Refresh Internal URL</string>
+  <string name="refresh_external">Refresh External URL</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -445,7 +445,7 @@ like to connect to:</string>
   <string name="username">Username</string>
   <string name="view_password">View Password</string>
   <string name="wait">Wait</string>
-  <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again.</string>
+  <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again. If you use the Internal Connection URL try hitting refresh a couple of times to cycle through the URLs.</string>
   <string name="webview_error_description">Encountered error :</string>
   <string name="webview_error_SSL_DATE_INVALID">The date of the Home Assistant certificate is invalid, please review the Home Assistant certificate or the connection settings and try again.</string>
   <string name="webview_error_SSL_EXPIRED">The Home Assistant certificate has expired, please review the Home Assistant certificate or the connection settings and try again.</string>

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
@@ -15,4 +15,6 @@ interface UrlRepository {
     suspend fun getHomeWifiSsids(): Set<String>
 
     suspend fun saveHomeWifiSsids(ssid: Set<String>)
+
+    suspend fun isInternal(): Boolean
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -107,7 +107,7 @@ class UrlRepositoryImpl @Inject constructor(
         localStorage.putStringSet(PREF_WIFI_SSIDS, ssid)
     }
 
-    private suspend fun isInternal(): Boolean {
+    override suspend fun isInternal(): Boolean {
         val formattedSsid = wifiHelper.getWifiSsid().removeSurrounding("\"")
         val wifiSsids = getHomeWifiSsids()
         val usesInternalSsid = formattedSsid in wifiSsids

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -76,7 +76,7 @@ class UrlRepositoryImpl @Inject constructor(
         val internal = localStorage.getString(PREF_LOCAL_URL)?.toHttpUrlOrNull()?.toUrl()
         val external = localStorage.getString(PREF_REMOTE_URL)?.toHttpUrlOrNull()?.toUrl()
 
-        return if (isInternal ?: isInternal()) {
+        return if (isInternal ?: isInternal() && internal != null) {
             internal
         } else {
             external

--- a/common/src/test/java/io/homeassistant/companion/android/common/data/HomeAssistantMockService.kt
+++ b/common/src/test/java/io/homeassistant/companion/android/common/data/HomeAssistantMockService.kt
@@ -34,6 +34,10 @@ class HomeAssistantMockService<T>(private val c: Class<T>) {
 
         override suspend fun saveHomeWifiSsids(ssid: Set<String>) {
         }
+
+        override suspend fun isInternal(): Boolean {
+            return true
+        }
     }).retrofit
 
     fun get(): T {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #678 by switching between internal and external URL when the user clicks on refresh.  If the user does not have an internal connection URL then we will default to the external one always.  Also updated the error message to let users to know that refreshing more than one does something 😄 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/107101787-4e077400-67cd-11eb-8faa-31cff83ffc86.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->