### PR TITLE
Location disabled notification

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -275,10 +275,16 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
                 } else openSsidDialog()
             } else {
                 if (presenter.isSsidUsed()) {
-                    DisabledLocationHandler.showLocationDisabledWarnDialog(requireActivity(), arrayOf(getString(R.string.pref_connection_wifi)), true) {
-                        presenter.clearSsids()
-                        preference.setSsids(emptySet())
-                    }
+                    DisabledLocationHandler.showLocationDisabledWarnDialog(
+                        requireActivity(),
+                        arrayOf(getString(R.string.pref_connection_wifi)),
+                        showAsNotification = false,
+                        withDisableOption = true,
+                        negativeCallback = fun() {
+                            presenter.clearSsids()
+                            preference.setSsids(emptySet())
+                        }
+                    )
                 } else {
                     DisabledLocationHandler.showLocationDisabledWarnDialog(requireActivity(), arrayOf(getString(R.string.pref_connection_wifi)))
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -275,16 +275,10 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
                 } else openSsidDialog()
             } else {
                 if (presenter.isSsidUsed()) {
-                    DisabledLocationHandler.showLocationDisabledWarnDialog(
-                        requireActivity(),
-                        arrayOf(getString(R.string.pref_connection_wifi)),
-                        showAsNotification = false,
-                        withDisableOption = true,
-                        negativeCallback = fun() {
-                            presenter.clearSsids()
-                            preference.setSsids(emptySet())
-                        }
-                    )
+                    DisabledLocationHandler.showLocationDisabledWarnDialog(requireActivity(), arrayOf(getString(R.string.pref_connection_wifi)), showAsNotification = false, withDisableOption = true) {
+                        presenter.clearSsids()
+                        preference.setSsids(emptySet())
+                    }
                 } else {
                     DisabledLocationHandler.showLocationDisabledWarnDialog(requireActivity(), arrayOf(getString(R.string.pref_connection_wifi)))
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/util/DisabledLocationHandler.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/DisabledLocationHandler.kt
@@ -46,16 +46,10 @@ object DisabledLocationHandler {
         NotificationManagerCompat.from(activity).cancel(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode())
     }
 
-    fun showLocationDisabledWarnDialog(
-        activity: Activity,
-        settings: Array<String>,
-        showAsNotification: Boolean = false,
-        withDisableOption: Boolean = false,
-        negativeCallback: (() -> Unit)? = null
-    ) {
+    fun showLocationDisabledWarnDialog(activity: Activity, settings: Array<String>, showAsNotification: Boolean = false, withDisableOption: Boolean = false, callback: (() -> Unit)? = null) {
         var positionTextId = R.string.confirm_positive
         var negativeTextId = R.string.confirm_negative
-        if (withDisableOption && negativeCallback != null) {
+        if (withDisableOption && callback != null) {
             negativeTextId = R.string.location_disabled_option_disable
         }
 
@@ -70,7 +64,7 @@ object DisabledLocationHandler {
         for (setting in settings)
             parameters += "- $setting\n"
 
-        if ((!withDisableOption || negativeCallback == null) && showAsNotification) {
+        if ((!withDisableOption || callback == null) && showAsNotification) {
             val notificationManager = NotificationManagerCompat.from(activity)
             if (notificationManager.getActiveNotification(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode()) == null) {
                 var channelID = "Location disabled"
@@ -107,8 +101,8 @@ object DisabledLocationHandler {
                     activity.applicationContext.startActivity(intent)
                 }
                 .setNegativeButton(negativeTextId) { _, _ ->
-                    if (withDisableOption && negativeCallback != null) {
-                        negativeCallback()
+                    if (withDisableOption && callback != null) {
+                        callback()
                     }
                 }.show()
         }

--- a/app/src/main/java/io/homeassistant/companion/android/util/DisabledLocationHandler.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/DisabledLocationHandler.kt
@@ -2,16 +2,24 @@ package io.homeassistant.companion.android.util
 
 import android.Manifest
 import android.app.Activity
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.location.LocationManager
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.provider.Settings
 import androidx.appcompat.app.AlertDialog
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import io.homeassistant.companion.android.R
 
 object DisabledLocationHandler {
+    private const val DISABLED_LOCATION_WARN_ID = "DisabledLocationWarning"
+
     fun isLocationEnabled(context: Context, fineLocation: Boolean): Boolean {
         val lm: LocationManager = context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
 
@@ -34,33 +42,75 @@ object DisabledLocationHandler {
         }
     }
 
-    fun showLocationDisabledWarnDialog(activity: Activity, settings: Array<String>, withDisableOption: Boolean = false, callback: (() -> Unit)? = null) {
+    fun removeLocationDisabledWarning(activity: Activity) {
+        NotificationManagerCompat.from(activity).cancel(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode())
+    }
+
+    fun showLocationDisabledWarnDialog(
+        activity: Activity,
+        settings: Array<String>,
+        showAsNotification: Boolean = false,
+        withDisableOption: Boolean = false,
+        negativeCallback: (() -> Unit)? = null
+    ) {
         var positionTextId = R.string.confirm_positive
         var negativeTextId = R.string.confirm_negative
-        if (withDisableOption && callback != null) {
+        if (withDisableOption && negativeCallback != null) {
             negativeTextId = R.string.location_disabled_option_disable
         }
+
+        val intent = Intent(
+            Settings.ACTION_LOCATION_SOURCE_SETTINGS
+        )
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
+        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
 
         var parameters = ""
         for (setting in settings)
             parameters += "- $setting\n"
-        AlertDialog.Builder(activity)
-            .setTitle(R.string.location_disabled_title)
-            .setMessage(activity.applicationContext.getString(R.string.location_disabled_message, parameters))
-            .setPositiveButton(positionTextId) { _, _ ->
-                val intent = Intent(
-                    Settings.ACTION_LOCATION_SOURCE_SETTINGS
-                )
-                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY)
-                intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
-                activity.applicationContext.startActivity(intent)
-            }
-            .setNegativeButton(negativeTextId) { _, _ ->
-                if (withDisableOption && callback != null) {
-                    callback()
+
+        if ((!withDisableOption || negativeCallback == null) && showAsNotification) {
+            val notificationManager = NotificationManagerCompat.from(activity)
+            if (notificationManager.getActiveNotification(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode()) == null) {
+                var channelID = "Location disabled"
+
+                if (VERSION.SDK_INT >= VERSION_CODES.O) {
+                    val channel = NotificationChannel(channelID, activity.applicationContext.getString(R.string.location_warn_channel), NotificationManager.IMPORTANCE_DEFAULT)
+                    notificationManager.createNotificationChannel(channel)
                 }
+
+                val pendingIntent = PendingIntent.getActivity(
+                    activity, 0,
+                    intent, 0
+                )
+
+                val notificationBuilder = NotificationCompat.Builder(activity, channelID)
+                    .setSmallIcon(R.drawable.ic_stat_ic_notification)
+                    .setColor(Color.RED)
+                    .setOngoing(true)
+                    .setContentTitle(activity.applicationContext.getString(R.string.location_disabled_title))
+                    .setContentText(activity.applicationContext.getString(R.string.location_disabled_notification_short_message))
+                    .setStyle(
+                        NotificationCompat.BigTextStyle()
+                            .bigText(activity.applicationContext.getString(R.string.location_disabled_notification_message, parameters))
+                    )
+                    .setContentIntent(pendingIntent)
+
+                NotificationManagerCompat.from(activity).notify(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode(), notificationBuilder.build())
             }
-            .show()
+        } else {
+            AlertDialog.Builder(activity)
+                .setTitle(R.string.location_disabled_title)
+                .setMessage(activity.applicationContext.getString(R.string.location_disabled_message, parameters))
+                .setPositiveButton(positionTextId) { _, _ ->
+                    activity.applicationContext.startActivity(intent)
+                }
+                .setNegativeButton(negativeTextId) { _, _ ->
+                    if (withDisableOption && negativeCallback != null) {
+                        negativeCallback()
+                    }
+                }.show()
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -446,7 +446,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
     private fun checkAndWarnForDisabledLocation() {
         var showLocationDisabledWarning = false
-
         var settingsWithLocationPermissions = mutableListOf<String>()
         if (!DisabledLocationHandler.isLocationEnabled(this, false) && presenter.isSsidUsed()) {
             showLocationDisabledWarning = true
@@ -462,7 +461,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
                     if ((fineLocation || coarseLocation)) {
                         if (!DisabledLocationHandler.isLocationEnabled(this, fineLocation))
-                        showLocationDisabledWarning = true
+                            showLocationDisabledWarning = true
                         settingsWithLocationPermissions.add(getString(basicSensor.name))
                     }
                 }
@@ -470,7 +469,9 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
 
         if (showLocationDisabledWarning) {
-            DisabledLocationHandler.showLocationDisabledWarnDialog(this@WebViewActivity, settingsWithLocationPermissions.toTypedArray())
+            DisabledLocationHandler.showLocationDisabledWarnDialog(this@WebViewActivity, settingsWithLocationPermissions.toTypedArray(), true)
+        } else {
+            DisabledLocationHandler.removeLocationDisabledWarning(this@WebViewActivity)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -460,8 +460,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     val coarseLocation = DisabledLocationHandler.containsLocationPermission(permissions, false)
 
                     if ((fineLocation || coarseLocation)) {
-                        if (!DisabledLocationHandler.isLocationEnabled(this, fineLocation))
-                            showLocationDisabledWarning = true
+                        if (!DisabledLocationHandler.isLocationEnabled(this, fineLocation)) showLocationDisabledWarning = true
                         settingsWithLocationPermissions.add(getString(basicSensor.name))
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -176,11 +176,14 @@ Home Assistant instance</string>
   <string name="list_media_player_widgets">List of Media Player Widgets</string>
   <string name="list_template_widgets">List of Template Widgets</string>
   <string name="location">Location</string>
-  <string name="location_disabled_message">The location is disabled. The following enabled option(s) require you to enable location. If you do not enable the location, the sensor(s)/setting(s) will not work!\n\n%1$s\nDo you want to enable location?</string>
+  <string name="location_warn_channel">Location disabled</string>
+  <string name="location_perm_info_title">Location access</string>
+  <string name="location_perm_info_message">Android set up restrictions for apps which want to use your Wifi, because Wifi can be theoretically used to determine your location.\n\nAlso to ensure the app can access Wifi in background (URL decision making, sensors) you need to allow location access all the time.\n\nTherefore, to use this option location access all the time is needed.\n\nContinue granting location access?</string>
   <string name="location_disabled_option_disable">Disable option</string>
   <string name="location_disabled_title">Location is disabled</string>
-  <string name="location_perm_info_message">Android set up restrictions for apps which want to use your Wifi, because Wifi can be theoretically used to determine your location.\n\nAlso to ensure the app can access Wifi in background (URL decision making, sensors) you need to allow location access all the time.\n\nTherefore, to use this option location access all the time is needed.\n\nContinue granting location access?</string>
-  <string name="location_perm_info_title">Location access</string>
+  <string name="location_disabled_notification_short_message">Some setting(s) do not work. Click to enable location.</string>
+  <string name="location_disabled_notification_message">The following enabled option(s) require you to enable location. If you do not enable the location, the sensor(s)/setting(s) will not work!\n\n%1$s\nClick to enable location.</string>
+  <string name="location_disabled_message">The location is disabled. The following enabled option(s) require you to enable location. If you do not enable the location, the sensor(s)/setting(s) will not work!\n\n%1$s\nDo you want to enable location?</string>
   <string name="lock_summary">Use biometric or screenlock credential to unlock app</string>
   <string name="lock_title">Lock app</string>
   <string name="lockscreen_message">Tap to unlock :</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
Fixes #1311 

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The message popup for disabled location can be quite annoying. With this PR the popup is replaced by a permanent notification message. 
Casual users will be still notified about the disabled location.
But power users can disabled the notification channel to ignore the warning.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img src="https://user-images.githubusercontent.com/12832850/105632123-fcb4c780-5e51-11eb-843f-28dd4309f445.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/105632150-0dfdd400-5e52-11eb-8f63-008ab7b9ef99.png" width="40%">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->