### PR TITLE
Add mobile data sensors

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
@@ -1,0 +1,70 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.provider.Settings
+import android.provider.Settings.Global.getInt
+import android.telephony.TelephonyManager
+import io.homeassistant.companion.android.R
+
+class MobileDataManager : SensorManager {
+
+    companion object {
+        val mobileDataState = SensorManager.BasicSensor(
+            "mobile_data",
+            "binary_sensor",
+            R.string.basic_sensor_name_mobile_data,
+            R.string.sensor_description_mobile_data
+        )
+        val mobileDataRoaming = SensorManager.BasicSensor(
+            "mobile_data_roaming",
+            "binary_sensor",
+            R.string.basic_sensor_name_mobile_data_roaming,
+            R.string.sensor_description_mobile_data_roaming
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = R.string.sensor_name_mobile_data
+
+    override val availableSensors: List<SensorManager.BasicSensor>
+        get() = listOf(mobileDataState, mobileDataRoaming)
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return arrayOf()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        checkState(context, mobileDataState, "mobile_data", "mdi:signal")
+        checkState(context, mobileDataRoaming, Settings.Global.DATA_ROAMING, "mdi:toggle-switch")
+    }
+
+    private fun checkState(
+        context: Context,
+        sensor: SensorManager.BasicSensor,
+        settingKey: String,
+        icon: String
+    ) {
+        if (!isEnabled(context, sensor.id))
+            return
+
+        var enabled = false
+        if (checkPermission(context, sensor.id)) {
+            val telephonyManager =
+                (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+            if (telephonyManager.simState == TelephonyManager.SIM_STATE_READY) {
+                enabled = getInt(context.contentResolver, settingKey, 0) == 1
+            }
+        }
+        onSensorUpdated(
+            context,
+            sensor,
+            enabled,
+            if (enabled) icon else "$icon-off",
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.provider.Settings
 import android.provider.Settings.Global.getInt
 import android.telephony.TelephonyManager
@@ -33,6 +34,10 @@ class MobileDataManager : SensorManager {
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf()
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return context.packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY)
     }
 
     override fun requestSensorUpdate(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
@@ -57,12 +57,10 @@ class MobileDataManager : SensorManager {
             return
 
         var enabled = false
-        if (checkPermission(context, sensor.id)) {
-            val telephonyManager =
-                (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
-            if (telephonyManager.simState == TelephonyManager.SIM_STATE_READY) {
-                enabled = getInt(context.contentResolver, settingKey, 0) == 1
-            }
+        val telephonyManager =
+            (context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager)
+        if (telephonyManager.simState == TelephonyManager.SIM_STATE_READY) {
+            enabled = getInt(context.contentResolver, settingKey, 0) == 1
         }
         onSensorUpdated(
             context,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -47,7 +47,8 @@ class SensorReceiver : BroadcastReceiver() {
             StepsSensorManager(),
             StorageSensorManager(),
             TimeZoneManager(),
-            TrafficStatsManager()
+            TrafficStatsManager(),
+            MobileDataManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -37,6 +37,7 @@ class SensorReceiver : BroadcastReceiver() {
             LastUpdateManager(),
             LightSensorManager(),
             LocationSensorManager(),
+            MobileDataManager(),
             NetworkSensorManager(),
             NextAlarmManager(),
             NotificationSensorManager(),
@@ -47,8 +48,7 @@ class SensorReceiver : BroadcastReceiver() {
             StepsSensorManager(),
             StorageSensorManager(),
             TimeZoneManager(),
-            TrafficStatsManager(),
-            MobileDataManager()
+            TrafficStatsManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,8 +48,6 @@
   <string name="basic_sensor_name_location_accurate">Einzelne genaue Position</string>
   <string name="basic_sensor_name_location_background">Hintergrund Standort</string>
   <string name="basic_sensor_name_location_zone">Standortzone</string>
-  <string name="basic_sensor_name_mobile_data">Mobile Daten</string>
-  <string name="basic_sensor_name_mobile_data_roaming">Mobile Daten Roaming</string>
   <string name="basic_sensor_name_mobile_rx_gb">Empfangene Daten über Mobilfunk (GB)</string>
   <string name="basic_sensor_name_mobile_tx_gb">Gesendete Daten über Mobilfunk (GB)</string>
   <string name="basic_sensor_name_phone">Telefonstatus</string>
@@ -298,8 +296,6 @@
   <string name="sensor_description_location_zone">Importiert die vorhandene Home Assistant-Zonen als Geofences für die zonenbasierte Standorterkennung.</string>
   <string name="sensor_description_lullaby">Wenn ein Schlaflied gespielt wird</string>
   <string name="sensor_description_mic_muted">Gibt an, ob das Mikrofon am Gerät stummgeschaltet ist</string>
-  <string name="sensor_description_mobile_data">Gibt an, ob mobile Daten auf dem Gerät aktiviert sind</string>
-  <string name="sensor_description_mobile_data_roaming">Gibt an, ob das Roaming für mobile Daten auf dem Gerät aktiviert ist</string>
   <string name="sensor_description_mobile_rx_gb">Insgesamt über Mobilfunk gesendete Daten seit dem letzten Neustart (GB)</string>
   <string name="sensor_description_mobile_tx_gb">Insgesamt über Mobilfunk empfangene Daten seit dem letzten Neustart (GB)</string>
   <string name="sensor_description_music_active">Gibt an, ob auf dem Gerät aktiv Musik abgespielt wird</string>
@@ -347,7 +343,6 @@
   <string name="sensor_name_light">Helligkeitssensor</string>
   <string name="sensor_name_location">Standortsensoren</string>
   <string name="sensor_name_mic_muted">Mikrofon stummgeschaltet</string>
-  <string name="sensor_name_mobile_data">Mobile Daten Sensoren</string>
   <string name="sensor_name_music_active">Musik wird abgespielt</string>
   <string name="sensor_name_network">Netzwerksensoren</string>
   <string name="sensor_name_phone">Telefonsensoren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -48,6 +48,8 @@
   <string name="basic_sensor_name_location_accurate">Einzelne genaue Position</string>
   <string name="basic_sensor_name_location_background">Hintergrund Standort</string>
   <string name="basic_sensor_name_location_zone">Standortzone</string>
+  <string name="basic_sensor_name_mobile_data">Mobile Daten</string>
+  <string name="basic_sensor_name_mobile_data_roaming">Mobile Daten Roaming</string>
   <string name="basic_sensor_name_mobile_rx_gb">Empfangene Daten über Mobilfunk (GB)</string>
   <string name="basic_sensor_name_mobile_tx_gb">Gesendete Daten über Mobilfunk (GB)</string>
   <string name="basic_sensor_name_phone">Telefonstatus</string>
@@ -296,6 +298,8 @@
   <string name="sensor_description_location_zone">Importiert die vorhandene Home Assistant-Zonen als Geofences für die zonenbasierte Standorterkennung.</string>
   <string name="sensor_description_lullaby">Wenn ein Schlaflied gespielt wird</string>
   <string name="sensor_description_mic_muted">Gibt an, ob das Mikrofon am Gerät stummgeschaltet ist</string>
+  <string name="sensor_description_mobile_data">Gibt an, ob mobile Daten auf dem Gerät aktiviert sind</string>
+  <string name="sensor_description_mobile_data_roaming">Gibt an, ob das Roaming für mobile Daten auf dem Gerät aktiviert ist</string>
   <string name="sensor_description_mobile_rx_gb">Insgesamt über Mobilfunk gesendete Daten seit dem letzten Neustart (GB)</string>
   <string name="sensor_description_mobile_tx_gb">Insgesamt über Mobilfunk empfangene Daten seit dem letzten Neustart (GB)</string>
   <string name="sensor_description_music_active">Gibt an, ob auf dem Gerät aktiv Musik abgespielt wird</string>
@@ -343,6 +347,7 @@
   <string name="sensor_name_light">Helligkeitssensor</string>
   <string name="sensor_name_location">Standortsensoren</string>
   <string name="sensor_name_mic_muted">Mikrofon stummgeschaltet</string>
+  <string name="sensor_name_mobile_data">Mobile Daten Sensoren</string>
   <string name="sensor_name_music_active">Musik wird abgespielt</string>
   <string name="sensor_name_network">Netzwerksensoren</string>
   <string name="sensor_name_phone">Telefonsensoren</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
   <string name="basic_sensor_name_location_accurate">Single Accurate Location</string>
   <string name="basic_sensor_name_location_background">Background Location</string>
   <string name="basic_sensor_name_location_zone">Location Zone</string>
+  <string name="basic_sensor_name_mobile_data">Mobile Data</string>
+  <string name="basic_sensor_name_mobile_data_roaming">Mobile Data Roaming</string>
   <string name="basic_sensor_name_mobile_rx_gb">Mobile Rx GB</string>
   <string name="basic_sensor_name_mobile_tx_gb">Mobile Tx GB</string>
   <string name="basic_sensor_name_phone">Phone State</string>
@@ -318,6 +320,8 @@ like to connect to:</string>
   <string name="sensor_description_location_zone">Import existing Home Assistant zones as geofences for zone based tracking.  The Minimum Accuracy setting will allow you to decide how accurate the device location (in meters) has to be in order to send to Home Assistant.</string>
   <string name="sensor_description_lullaby">If a lullaby is playing</string>
   <string name="sensor_description_mic_muted">Whether or not the microphone is muted on the device</string>
+  <string name="sensor_description_mobile_data">Whether or not mobile data is enabled on the device</string>
+  <string name="sensor_description_mobile_data_roaming">Whether or not mobile data roaming is enabled on the device</string>
   <string name="sensor_description_mobile_rx_gb">Total Rx GB on cellular data since last device reboot</string>
   <string name="sensor_description_mobile_tx_gb">Total Tx GB on cellular data since last device reboot</string>
   <string name="sensor_description_music_active">Whether or not music is actively playing on the device</string>
@@ -365,6 +369,7 @@ like to connect to:</string>
   <string name="sensor_name_light">Light Sensor</string>
   <string name="sensor_name_location">Location Sensors</string>
   <string name="sensor_name_mic_muted">Mic Muted</string>
+  <string name="sensor_name_mobile_data">Mobile Data Sensors</string>
   <string name="sensor_name_music_active">Music Active</string>
   <string name="sensor_name_network">Network Sensors</string>
   <string name="sensor_name_phone">Phone Sensors</string>


### PR DESCRIPTION
## Summary
New mobile data sensors to check whether some mobile data settings are enabled or not.

## Screenshots
![Screenshot_Dark](https://user-images.githubusercontent.com/3511114/105635528-8caf3d00-5e63-11eb-8f1d-54026b99065a.png)
![Screenshot_Light](https://user-images.githubusercontent.com/3511114/105635529-8de06a00-5e63-11eb-9030-3c9e88bc3da5.png)

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#435

## Any other notes
Used to remind family members to switch of mobile data when they are back home to save costs for prepaid data subscription.