### PR TITLE
Fix frozen webview when lock app timeout is changed from the default

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -438,7 +438,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         super.onResume()
         if (currentLang != languagesManager.getCurrentLang())
             recreate()
-        if (!unlocked && !presenter.isLockEnabled())
+        if ((!unlocked && !presenter.isLockEnabled()) ||
+            (!unlocked && presenter.isLockEnabled() && System.currentTimeMillis() < presenter.getSessionExpireMillis()))
             unlocked = true
 
         checkAndWarnForDisabledLocation()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1294 

As per the steps given in a comment the issue only happens when the session timeout is changed from the default.  We now do an evaluation during `onResume` to set `unlocked = true` if the timeout has not been reached yet.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->