### PR TITLE
High accuracy mode for background location sensor

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -31,6 +31,11 @@
             </intent-filter>
         </service>
 
+        <service
+            android:name=".location.HighAccuracyLocationService"
+            android:enabled="true"
+            android:exported="true"/>
+
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_icon"
             android:resource="@drawable/ic_stat_ic_notification" />

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -23,6 +23,10 @@
             android:enabled="true"
             android:exported="true" />
 
+        <receiver android:name=".location.HighAccuracyLocationReceiver"
+            android:enabled="true"
+            android:exported="true" />
+
         <service
             android:name=".notifications.MessagingService"
             android:exported="false">

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
@@ -3,8 +3,6 @@ package io.homeassistant.companion.android.location
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import io.homeassistant.companion.android.database.AppDatabase
-import io.homeassistant.companion.android.database.sensor.Setting
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 
 class HighAccuracyLocationReceiver : BroadcastReceiver() {
@@ -18,8 +16,7 @@ class HighAccuracyLocationReceiver : BroadcastReceiver() {
             HIGH_ACCURACY_LOCATION_DISABLE ->
             {
                 HighAccuracyLocationService.stopService(context)
-                val sensorDao = AppDatabase.getInstance(context).sensorDao()
-                sensorDao.add(Setting(LocationSensorManager.backgroundLocation.id, LocationSensorManager.SETTING_HIGH_ACCURACY_MODE, "false", "toggle"))
+                LocationSensorManager.setHighAccuracyModeSetting(context, false)
             }
         }
     }

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
@@ -1,0 +1,26 @@
+package io.homeassistant.companion.android.location
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.homeassistant.companion.android.database.AppDatabase
+import io.homeassistant.companion.android.database.sensor.Setting
+import io.homeassistant.companion.android.sensors.LocationSensorManager
+
+class HighAccuracyLocationReceiver : BroadcastReceiver() {
+    companion object {
+        const val TAG = "HighAccuracyLocationReceiver"
+        const val HIGH_ACCURACY_LOCATION_DISABLE = "DISABLE_HIGH_ACCURACY_MODE"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            HIGH_ACCURACY_LOCATION_DISABLE ->
+            {
+                HighAccuracyLocationService.stopService(context)
+                val sensorDao = AppDatabase.getInstance(context).sensorDao()
+                sensorDao.add(Setting(LocationSensorManager.backgroundLocation.id, LocationSensorManager.SETTING_HIGH_ACCURACY_MODE, "false", "toggle"))
+            }
+        }
+    }
+}

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -104,7 +104,7 @@ class HighAccuracyLocationService : Service() {
             var channelID = "High accuracy location"
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val channel = NotificationChannel(channelID, context.getString(R.string.high_accuracy_mode_channel_name), NotificationManager.IMPORTANCE_HIGH)
+                val channel = NotificationChannel(channelID, context.getString(R.string.high_accuracy_mode_channel_name), NotificationManager.IMPORTANCE_DEFAULT)
                 notificationManager.createNotificationChannel(channel)
             }
 

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -1,0 +1,136 @@
+package io.homeassistant.companion.android.location
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.sensors.LocationSensorManager
+import java.util.Calendar
+
+class HighAccuracyLocationService : Service() {
+
+    companion object {
+        fun startService(context: Context, intervalInSeconds: Int) {
+            if (!isRunning) {
+                val startIntent = Intent(context, HighAccuracyLocationService::class.java)
+                startIntent.putExtra("intervalInSeconds", intervalInSeconds)
+                ContextCompat.startForegroundService(context, startIntent)
+            }
+        }
+        fun stopService(context: Context) {
+            val stopIntent = Intent(context, HighAccuracyLocationService::class.java)
+            context.stopService(stopIntent)
+        }
+
+        fun restartService(context: Context, intervalInSeconds: Int) {
+            stopService(context)
+
+            val restartIntent = Intent(context, HighAccuracyLocationService::class.java)
+            restartIntent.putExtra("intervalInSeconds", intervalInSeconds)
+            val restartServicePI = PendingIntent.getService(context, 1, restartIntent, PendingIntent.FLAG_ONE_SHOT)
+
+            val alarmManager: AlarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            val calendar: Calendar = Calendar.getInstance()
+            calendar.timeInMillis = System.currentTimeMillis()
+            calendar.add(Calendar.SECOND, 2)
+            alarmManager.set(AlarmManager.RTC_WAKEUP, calendar.timeInMillis, restartServicePI)
+        }
+
+        fun updateNotificationContentText(context: Context, text: String) {
+            if (isRunning) {
+                val notificationManager = NotificationManagerCompat.from(context)
+                val notificationId = HIGH_ACCURACY_LOCATION_NOTIFICATION_ID.hashCode()
+                notificationBuilder
+                    .setContentText(text)
+                    .setStyle(NotificationCompat.BigTextStyle().bigText(text))
+                notificationManager.notify(notificationId, notificationBuilder.build())
+            }
+        }
+
+        private fun createNotificationBuilder(context: Context) {
+            val notificationManager = NotificationManagerCompat.from(context)
+
+            var channelID = "High accuracy location"
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val channel = NotificationChannel(channelID, context.getString(R.string.high_accuracy_mode_channel_name), NotificationManager.IMPORTANCE_NONE)
+                notificationManager.createNotificationChannel(channel)
+            }
+
+            notificationBuilder = NotificationCompat.Builder(context, channelID)
+                .setSmallIcon(R.drawable.ic_stat_ic_notification)
+                .setColor(Color.GRAY)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setContentTitle(context.getString(R.string.high_accuracy_mode_notification_title))
+                .setCategory(Notification.CATEGORY_SERVICE)
+        }
+
+        private var isRunning = false
+        private lateinit var notificationBuilder: NotificationCompat.Builder
+
+        private const val DEFAULT_UPDATE_INTERVAL_SECONDS = 5
+        const val HIGH_ACCURACY_LOCATION_NOTIFICATION_ID = "HighAccuracyLocationNotification"
+    }
+
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+
+    override fun onCreate() {
+        super.onCreate()
+        isRunning = true
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        super.onStartCommand(intent, flags, startId)
+        val intervalInSeconds = intent?.getIntExtra("intervalInSeconds", DEFAULT_UPDATE_INTERVAL_SECONDS) ?: DEFAULT_UPDATE_INTERVAL_SECONDS
+        requestLocationUpdates(intervalInSeconds)
+        val notificationId = HIGH_ACCURACY_LOCATION_NOTIFICATION_ID.hashCode()
+        createNotificationBuilder(this)
+        startForeground(notificationId, notificationBuilder.build())
+        return START_REDELIVER_INTENT
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
+        isRunning = false
+    }
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    private fun getLocationUpdateIntent(): PendingIntent {
+        val intent = Intent(this, LocationSensorManager::class.java)
+        intent.action = LocationSensorManager.ACTION_PROCESS_LOCATION
+        return PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun requestLocationUpdates(intervalInSeconds: Int) {
+        val request = LocationRequest()
+
+        val intervalInMS = (intervalInSeconds * 1000).toLong()
+        request.interval = intervalInMS
+        request.fastestInterval = intervalInMS / 2
+        request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+        fusedLocationProviderClient.requestLocationUpdates(request, getLocationUpdateIntent())
+    }
+}

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -94,7 +94,7 @@ class GeocodeSensorManager : SensorManager {
 
             val prettyAddress = address?.getAddressLine(0) ?: "Unknown"
 
-            HighAccuracyLocationService.updateNotificationContentText(context, "$prettyAddress (~${location.accuracy}m)")
+            HighAccuracyLocationService.updateNotificationAddress(context, location, prettyAddress)
 
             onSensorUpdated(
                 context,

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -10,7 +10,7 @@ import com.google.android.gms.location.LocationServices
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Setting
-import java.lang.Exception
+import io.homeassistant.companion.android.location.HighAccuracyLocationService
 
 class GeocodeSensorManager : SensorManager {
 
@@ -92,10 +92,14 @@ class GeocodeSensorManager : SensorManager {
                 )
             }.orEmpty()
 
+            val prettyAddress = address?.getAddressLine(0) ?: "Unknown"
+
+            HighAccuracyLocationService.updateNotificationContentText(context, "$prettyAddress (~${location.accuracy}m)")
+
             onSensorUpdated(
                 context,
                 geocodedLocation,
-                address?.getAddressLine(0) ?: "Unknown",
+                prettyAddress,
                 "mdi:map",
                 attributes
             )

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -88,7 +88,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
             val sensorDao = AppDatabase.getInstance(context).sensorDao()
-            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, enabled.toString(), "toogle"))
+            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, enabled.toString(), "toggle"))
         }
 
         fun getHighAccuracyModeIntervalSetting(context: Context): Int {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -39,7 +39,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private const val SETTING_ACCURACY = "Minimum Accuracy"
         private const val SETTING_ACCURATE_UPDATE_TIME = "Minimum time between updates"
         private const val SETTING_INCLUDE_SENSOR_UPDATE = "Include in sensor update"
-        const val SETTING_HIGH_ACCURACY_MODE = "High accuracy mode (May drain battery fast)"
+        private const val SETTING_HIGH_ACCURACY_MODE = "High accuracy mode (May drain battery fast)"
         private const val SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL = "High accuracy mode update interval (seconds)"
         private const val SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES = "High accuracy mode only when connected to BT devices"
 
@@ -85,6 +85,17 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
         private var lastHighAccuracyMode = false
         private var lastHighAccuracyUpdateInterval = DEFAULT_MINIMUM_ACCURACY
+
+        fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
+            val sensorDao = AppDatabase.getInstance(context).sensorDao()
+            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, enabled.toString(), "toogle"))
+        }
+
+        fun getHighAccuracyModeIntervalSetting(context: Context): Int {
+            val sensorDao = AppDatabase.getInstance(context).sensorDao()
+            val sensorSettings = sensorDao.getSettings(backgroundLocation.id)
+            return sensorSettings.firstOrNull { it.name == SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL }?.value?.toIntOrNull() ?: DEFAULT_UPDATE_INTERVAL_HA_SECONDS
+        }
     }
 
     @Inject

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -210,7 +210,14 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             DEFAULT_UPDATE_INTERVAL_HA_SECONDS.toString()
         )
 
-        return updateIntervalHighAccuracySeconds.toInt()
+        var updateIntervalHighAccuracySecondsInt = updateIntervalHighAccuracySeconds.toInt()
+        if (updateIntervalHighAccuracySecondsInt < 5) {
+            updateIntervalHighAccuracySecondsInt = DEFAULT_UPDATE_INTERVAL_HA_SECONDS
+
+            val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
+            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL, updateIntervalHighAccuracySecondsInt.toString(), "number"))
+        }
+        return updateIntervalHighAccuracySecondsInt
     }
 
     private fun getHighAccuracyMode(): Boolean {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -19,12 +19,14 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.UpdateLocation
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Attribute
 import io.homeassistant.companion.android.database.sensor.Setting
+import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -37,8 +39,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private const val SETTING_ACCURACY = "Minimum Accuracy"
         private const val SETTING_ACCURATE_UPDATE_TIME = "Minimum time between updates"
         private const val SETTING_INCLUDE_SENSOR_UPDATE = "Include in sensor update"
+        private const val SETTING_HIGH_ACCURACY_MODE = "High accuracy mode (May drain battery fast)"
+        private const val SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL = "High accuracy mode update interval (seconds)"
+        private const val SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES = "High accuracy mode only when connected to BT devices"
 
         private const val DEFAULT_MINIMUM_ACCURACY = 200
+        private const val DEFAULT_UPDATE_INTERVAL_HA_SECONDS = 5
 
         const val ACTION_REQUEST_LOCATION_UPDATES =
             "io.homeassistant.companion.android.background.REQUEST_UPDATES"
@@ -76,6 +82,9 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private var lastUpdateLocation = ""
 
         private var geofenceRegistered = false
+
+        private var lastHighAccuracyMode = false
+        private var lastHighAccuracyUpdateInterval = DEFAULT_MINIMUM_ACCURACY
     }
 
     @Inject
@@ -133,12 +142,42 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 }
                 if (!backgroundEnabled && isBackgroundLocationSetup) {
                     removeBackgroundUpdateRequests()
+                    stopHighAccuracyService()
                     isBackgroundLocationSetup = false
                     Log.d(TAG, "Removing background update requests")
                 }
-                if (backgroundEnabled && !isBackgroundLocationSetup) {
-                    isBackgroundLocationSetup = true
-                    requestLocationUpdates()
+                if (backgroundEnabled) {
+
+                    val updateIntervalHighAccuracySeconds = getHighAccuracyModeUpdateInterval()
+                    val highAccuracyMode = getHighAccuracyMode()
+
+                    if (!isBackgroundLocationSetup) {
+                        isBackgroundLocationSetup = true
+                        if (highAccuracyMode) {
+                            startHighAccuracyService(updateIntervalHighAccuracySeconds)
+                        } else {
+                            requestLocationUpdates()
+                        }
+                    } else {
+                        if (highAccuracyMode != lastHighAccuracyMode ||
+                            updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval) {
+
+                            if (highAccuracyMode) {
+                                if (updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval) {
+                                    restartHighAccuracyService(updateIntervalHighAccuracySeconds)
+                                } else {
+                                    removeBackgroundUpdateRequests()
+                                    startHighAccuracyService(updateIntervalHighAccuracySeconds)
+                                }
+                            } else {
+                                stopHighAccuracyService()
+                                requestLocationUpdates()
+                            }
+                        }
+                    }
+
+                    lastHighAccuracyMode = highAccuracyMode
+                    lastHighAccuracyUpdateInterval = updateIntervalHighAccuracySeconds
                 }
                 if (zoneEnabled && !isZoneLocationSetup) {
                     isZoneLocationSetup = true
@@ -148,6 +187,59 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 Log.e(TAG, "Issue setting up location tracking", e)
             }
         }
+    }
+
+    private fun restartHighAccuracyService(intervalInSeconds: Int) {
+        HighAccuracyLocationService.restartService(latestContext, intervalInSeconds)
+    }
+
+    private fun startHighAccuracyService(intervalInSeconds: Int) {
+        HighAccuracyLocationService.startService(latestContext, intervalInSeconds)
+    }
+    private fun stopHighAccuracyService() {
+        HighAccuracyLocationService.stopService(latestContext)
+    }
+
+    private fun getHighAccuracyModeUpdateInterval(): Int {
+
+        val updateIntervalHighAccuracySeconds = getSetting(
+            latestContext,
+            LocationSensorManager.backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL,
+            "number",
+            DEFAULT_UPDATE_INTERVAL_HA_SECONDS.toString())
+
+        return updateIntervalHighAccuracySeconds.toInt()
+    }
+
+    private fun getHighAccuracyMode(): Boolean {
+
+        val highAccuracyModeBTDevices = getSetting(
+            latestContext,
+            LocationSensorManager.backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES,
+            "list-bluetooth",
+            "")
+
+        var lastHighAccuracyMode = getSetting(
+            latestContext,
+            LocationSensorManager.backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE,
+            "toggle",
+            "false").toBoolean()
+
+        var highAccuracyMode = lastHighAccuracyMode
+        if (!highAccuracyModeBTDevices.isNullOrEmpty()) {
+            val bluetoothDevices = BluetoothUtils.getBluetoothDevices(latestContext)
+            val highAccuracyBtDevConnected = bluetoothDevices.any { it.connected && highAccuracyModeBTDevices.contains(it.name) }
+
+            highAccuracyMode = highAccuracyBtDevConnected
+            if (highAccuracyMode != lastHighAccuracyMode) {
+                val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
+                sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, highAccuracyMode.toString(), "toggle"))
+            }
+        }
+        return highAccuracyMode
     }
 
     private fun removeAllLocationUpdateRequests() {
@@ -224,6 +316,10 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             if (location.accuracy > minAccuracy) {
                 Log.w(TAG, "Location accuracy didn't meet requirements, disregarding: $location")
             } else {
+                // Update GeoLocation Sensor (if enabled) with new Location
+                SensorReceiver.MANAGERS.firstOrNull { it.availableSensors.any { s -> s.name == R.string.basic_sensor_name_geolocation } }?.requestSensorUpdate(latestContext)
+
+                // Send new location to Home Assistant
                 sendLocationUpdate(location)
             }
         }
@@ -505,10 +601,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(
                 Manifest.permission.ACCESS_FINE_LOCATION,
-                Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION,
+                Manifest.permission.BLUETOOTH
             )
         } else {
-            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.BLUETOOTH)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothDevice.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothDevice.kt
@@ -1,0 +1,8 @@
+package io.homeassistant.companion.android.bluetooth
+
+data class BluetoothDevice(
+    val address: String,
+    val name: String,
+    val paired: Boolean,
+    val connected: Boolean
+)

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothUtils.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothUtils.kt
@@ -1,0 +1,51 @@
+package io.homeassistant.companion.android.bluetooth
+
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
+import android.content.Context
+import java.lang.reflect.Method
+
+object BluetoothUtils {
+    fun getBluetoothDevices(context: Context): List<BluetoothDevice> {
+        val devices: MutableList<BluetoothDevice> = ArrayList()
+
+        val bluetoothManager =
+            (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+
+        if (bluetoothManager.adapter != null) {
+
+            val adapter = bluetoothManager.adapter
+            val isBtOn = adapter.isEnabled
+
+            if (isBtOn) {
+                val bondedDevices = adapter.bondedDevices
+                for (btDev in bondedDevices) {
+                    devices.add(BluetoothDevice(btDev.address, btDev.name, true, isConnected(btDev)))
+                }
+                val btConnectedDevices = bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)
+                for (btDev in btConnectedDevices) {
+                    devices.add(BluetoothDevice(btDev.address, btDev.name, false, isConnected(btDev)))
+                }
+            }
+        }
+        return devices
+    }
+    fun isOn(context: Context): Boolean {
+        val bluetoothManager =
+            (context.applicationContext.getSystemService(Context.BLUETOOTH_SERVICE) as BluetoothManager)
+
+        if (bluetoothManager.adapter != null) {
+            val adapter = bluetoothManager.adapter
+            return adapter.isEnabled
+        }
+        return false
+    }
+    private fun isConnected(device: android.bluetooth.BluetoothDevice): Boolean {
+        return try {
+            val m: Method = device.javaClass.getMethod("isConnected")
+            m.invoke(device) as Boolean
+        } catch (e: Exception) {
+            throw IllegalStateException(e)
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -210,6 +210,8 @@ class SensorDetailFragment(
                             pref.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
                         else {
                             pref.summary = setting.value
+                        }
+                        if (pref.text != setting.value) {
                             pref.text = setting.value
                         }
                         pref.isIconSpaceReserved = false

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -16,6 +16,7 @@ import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.SwitchPreference
 import androidx.preference.contains
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Sensor
@@ -189,6 +190,7 @@ class SensorDetailFragment(
                         pref.title = setting.name
                         pref.isChecked = setting.value == "true"
                         pref.isIconSpaceReserved = false
+                        pref.isSingleLineTitle = false
                         pref.setOnPreferenceChangeListener { _, newState ->
                             val isEnabled = newState as Boolean
 
@@ -203,6 +205,7 @@ class SensorDetailFragment(
                         pref.key = key
                         pref.title = setting.name
                         pref.dialogTitle = setting.name
+                        pref.isSingleLineTitle = false
                         if (pref.text != null)
                             pref.summaryProvider = EditTextPreference.SimpleSummaryProvider.getInstance()
                         else {
@@ -247,6 +250,7 @@ class SensorDetailFragment(
                         pref.entryValues = packageName.toTypedArray()
                         pref.dialogTitle = setting.name
                         pref.isIconSpaceReserved = false
+                        pref.isSingleLineTitle = false
                         pref.setOnPreferenceChangeListener { _, newValue ->
                             sensorDao.add(
                                 Setting(
@@ -254,6 +258,35 @@ class SensorDetailFragment(
                                     setting.name,
                                     newValue.toString().replace("[", "").replace("]", ""),
                                     "list-apps"
+                                )
+                            )
+                            sensorManager.requestSensorUpdate(requireContext())
+                            return@setOnPreferenceChangeListener true
+                        }
+                        if (pref.values != null)
+                            pref.summary = pref.values.toString()
+                        else
+                            pref.summary = setting.value
+                        if (!it.contains(pref))
+                            it.addPreference(pref)
+                    } else if (setting.valueType == "list-bluetooth") {
+                        val btDevices = BluetoothUtils.getBluetoothDevices(requireContext()).map { b -> b.name }
+
+                        val pref = findPreference(key) ?: MultiSelectListPreference(requireContext())
+                        pref.key = key
+                        pref.title = setting.name
+                        pref.entries = btDevices.toTypedArray()
+                        pref.entryValues = btDevices.toTypedArray()
+                        pref.dialogTitle = setting.name
+                        pref.isIconSpaceReserved = false
+                        pref.isSingleLineTitle = false
+                        pref.setOnPreferenceChangeListener { _, newValue ->
+                            sensorDao.add(
+                                Setting(
+                                    basicSensor.id,
+                                    setting.name,
+                                    newValue.toString().replace("[", "").replace("]", ""),
+                                    "list-bluetooth"
                                 )
                             )
                             sensorManager.requestSensorUpdate(requireContext())

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@ integration enabled on your home assistant instance.</string>
   <string name="fullscreen">Fullscreen</string>
   <string name="fullscreen_def">Put application in full screen</string>
   <string name="grant_permission">Grant Permission</string>
+  <string name="high_accuracy_mode_notification_title">High accuracy (GPS) mode enabled</string>
+  <string name="high_accuracy_mode_channel_name">High accuracy location</string>
   <string name="history">History</string>
   <string name="home_assistant_not_discover">Unable to find your 
 Home Assistant instance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -117,6 +117,7 @@ to your home internet.</string>
   <string name="device_registration">Device Registration</string>
   <string name="dialog_add_panel_shortcut_content">Create a shortcut to this item?</string>
   <string name="dialog_add_panel_shortcut_title">Add Shortcut</string>
+  <string name="disable">Disable</string>
   <string name="disable_all_sensors">Disable All %1$d Sensors</string>
   <string name="documentation">Documentation</string>
   <string name="domain_automation">Automation</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
Fixes #973

PR for mobile-apps-fcm-push https://github.com/home-assistant/mobile-apps-fcm-push/pull/35

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To get accurate device tracking location results in home assistant you needed to use 3rd party apps like GPSLogger or Owntracks. To automate these apps (ex. Start GPSLogger when connected to car bluetooth) you needed also a 3rd party app like MacroDroid or Tasker. To top it off. Those apps are hard to configure for casual users.

So, to get accurate location results you need to install and configure two 3rd party apps for every smartphone in the household.

With this PR i tried to integrate those features into the companion app.

### High accuracy mode settings
Everything is controlled in the background location sensor settings. 
If you enable _High accuracy mode_ the high accuracy location service will be started with the interval settings defined in _High accuracy mode update interval_.
To inform the user that the app is using gps a ongoing notification will be shown.
To use the high accuracy mode, only when connected to a Bluetooth device, the user can choose devices with the _High accuracy mode only when connected to BT devices_. Then the high accuracy mode will only be used if connected to one of those defined devices. The _High accuracy mode_ needs to be enabled to use the other high accuracy options. So the _High accuracy mode_ switch acts like an master switch for the high accuracy mode.

### High accuracy mode notification
If the high accuracy mode is used, a notification will be shown. The notification shows the current address, if the geocoded sensor ist enabled. If the geocoded sensor is not enabled, the notification shows the current coordinates. Also the notification shows the current aprox. accuracy. 
The user can also disable the high accuracy mode right from the notification with the `Disable` button.

### Notification command for high accuracy mode
Turn off:
```
title: turn_off
message: command_high_accuracy_mode
```

Turn on:
```
title: turn_on
message: command_high_accuracy_mode
```

### Other changes

- On location update (high accuracy mode enabled or disabled) the geocoded sensor will be notified about the new location (if enabled)
- Refactored the `BluetoothSensorManager` to use the `BluetoothUtils` class. This is done because the `LocationSensorManager` also needs to know which bluetooth devices are connected/paired. So i unified this into one class.
- Every sensor setting is created with `isSingleLineTitle` to use longer title names in the settings which are not truncated.
- New value type for sensor settings added. `list-bluetooth` will list all bluetooth devices as a popup.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img src="https://user-images.githubusercontent.com/12832850/105958089-70d1b400-607a-11eb-88e4-091cb15264f9.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/105958093-729b7780-607a-11eb-80fe-7693f7c4e3cd.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/105958105-77f8c200-607a-11eb-8fe4-357537070583.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/105958620-26046c00-607b-11eb-942b-5585fd79f103.jpg" width="40%">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#439

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->