### PR TITLE
Allow extras with broadcast intent command

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -355,6 +355,14 @@ class MessagingService : FirebaseMessagingService() {
                 try {
                     val packageName = data["channel"]
                     val intent = Intent(title)
+                    val extras = data["group"]
+                    if (!extras.isNullOrEmpty()) {
+                        val items = extras.split(',')
+                        for (item in items) {
+                            val pair = item.split(":")
+                            intent.putExtra(pair[0], pair[1])
+                        }
+                    }
                     intent.`package` = packageName
                     Log.d(TAG, "Sending broadcast intent")
                     applicationContext.sendBroadcast(intent)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds support for `extras` by allowing users to enter them under the `group` parameter.  We will split the extras by a comma `,` and then split the key/values by the colon `:`.  This will allow users to add/remove fields dynamically in an automation using templates.

Example to turn on a sleep as android alarm labeled as `work`:

```
message: command_broadcast_intent
title: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
data:
  channel: "com.urbandroid.sleep"
  group: "alarm_label:work,alarm_enabled:true"
```

There is a potential for users to discover bugs with other applications here as well lol.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#440

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


One important thing to note is that all value are sent as a string from firebase so this PR does work around that.

https://github.com/home-assistant/mobile-apps-fcm-push/blob/master/functions/android.js#L53

Special thanks to @antlarr https://github.com/home-assistant/android/issues/1306#issuecomment-763004212 for the suggestion :)