### PR TITLE
Add a notification command to launch an activity

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -237,7 +237,7 @@ class MessagingService : FirebaseMessagingService() {
                             }
                         }
                         COMMAND_ACTIVITY -> {
-                            if (!it[TITLE].isNullOrEmpty() && !it["channel"].isNullOrEmpty())
+                            if (!it[TITLE].isNullOrEmpty() && !it["channel"].isNullOrEmpty() && !it["group"].isNullOrEmpty())
                                 handleDeviceCommands(it)
                             else {
                                 mainScope.launch {
@@ -446,8 +446,9 @@ class MessagingService : FirebaseMessagingService() {
             COMMAND_ACTIVITY -> {
                 try {
                     val packageName = data["channel"]
+                    val action = data["group"]
                     val mapsIntentUri = Uri.parse(title)
-                    val mapIntent = Intent(Intent.ACTION_VIEW, mapsIntentUri)
+                    val mapIntent = Intent(action, mapsIntentUri)
                     mapIntent.setPackage(packageName)
                     mapIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     startActivity(mapIntent)

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -237,7 +237,7 @@ class MessagingService : FirebaseMessagingService() {
                             }
                         }
                         COMMAND_ACTIVITY -> {
-                            if (!it[TITLE].isNullOrEmpty())
+                            if (!it[TITLE].isNullOrEmpty() && !it["channel"].isNullOrEmpty())
                                 handleDeviceCommands(it)
                             else {
                                 mainScope.launch {

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -13,6 +13,7 @@ import android.graphics.Color
 import android.media.AudioAttributes
 import android.media.AudioManager
 import android.media.RingtoneManager
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Handler
@@ -82,6 +83,7 @@ class MessagingService : FirebaseMessagingService() {
         const val COMMAND_VOLUME_LEVEL = "command_volume_level"
         const val COMMAND_BLUETOOTH = "command_bluetooth"
         const val COMMAND_HIGH_ACCURACY_MODE = "command_high_accuracy_mode"
+        const val COMMAND_ACTIVITY = "command_activity"
 
         // DND commands
         const val DND_PRIORITY_ONLY = "priority_only"
@@ -107,7 +109,7 @@ class MessagingService : FirebaseMessagingService() {
 
         // Command groups
         val DEVICE_COMMANDS = listOf(COMMAND_DND, COMMAND_RINGER_MODE, COMMAND_BROADCAST_INTENT,
-            COMMAND_VOLUME_LEVEL, COMMAND_BLUETOOTH, COMMAND_HIGH_ACCURACY_MODE)
+            COMMAND_VOLUME_LEVEL, COMMAND_BLUETOOTH, COMMAND_HIGH_ACCURACY_MODE, COMMAND_ACTIVITY)
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
         val CHANNEL_VOLUME_STREAM = listOf(ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM)
@@ -227,7 +229,19 @@ class MessagingService : FirebaseMessagingService() {
                                 handleDeviceCommands(it)
                             else {
                                 mainScope.launch {
-                                    Log.d(TAG, "Invalid high accuracy mode command received, posting notification to device")
+                                    Log.d(
+                                        TAG,
+                                        "Invalid high accuracy mode command received, posting notification to device"
+                                    )
+                                }
+                            }
+                        }
+                        COMMAND_ACTIVITY -> {
+                            if (!it[TITLE].isNullOrEmpty())
+                                handleDeviceCommands(it)
+                            else {
+                                mainScope.launch {
+                                    Log.d(TAG, "Invalid navigation command received, posting notification to device")
                                     sendNotification(it)
                                 }
                             }
@@ -380,7 +394,13 @@ class MessagingService : FirebaseMessagingService() {
                     applicationContext.sendBroadcast(intent)
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to send broadcast intent please check command format", e)
-                    Toast.makeText(applicationContext, R.string.broadcast_intent_error, Toast.LENGTH_LONG).show()
+                    Handler(Looper.getMainLooper()).post {
+                        Toast.makeText(
+                            applicationContext,
+                            R.string.broadcast_intent_error,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                 }
             }
             COMMAND_VOLUME_LEVEL -> {
@@ -421,6 +441,25 @@ class MessagingService : FirebaseMessagingService() {
                 if (title == TURN_ON) {
                     HighAccuracyLocationService.startService(applicationContext, LocationSensorManager.getHighAccuracyModeIntervalSetting(applicationContext))
                     LocationSensorManager.setHighAccuracyModeSetting(applicationContext, true)
+                }
+            }
+            COMMAND_ACTIVITY -> {
+                try {
+                    val packageName = data["channel"]
+                    val mapsIntentUri = Uri.parse(title)
+                    val mapIntent = Intent(Intent.ACTION_VIEW, mapsIntentUri)
+                    mapIntent.setPackage(packageName)
+                    mapIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    startActivity(mapIntent)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unable to send activity intent please check command format", e)
+                    Handler(Looper.getMainLooper()).post {
+                        Toast.makeText(
+                            applicationContext,
+                            R.string.activity_intent_error,
+                            Toast.LENGTH_LONG
+                        ).show()
+                    }
                 }
             }
             else -> Log.d(TAG, "No command received")

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -447,11 +447,11 @@ class MessagingService : FirebaseMessagingService() {
                 try {
                     val packageName = data["channel"]
                     val action = data["group"]
-                    val mapsIntentUri = Uri.parse(title)
-                    val mapIntent = Intent(action, mapsIntentUri)
-                    mapIntent.setPackage(packageName)
-                    mapIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    startActivity(mapIntent)
+                    val intentUri = Uri.parse(title)
+                    val intent = Intent(action, intentUri)
+                    intent.setPackage(packageName)
+                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    startActivity(intent)
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to send activity intent please check command format", e)
                     Handler(Looper.getMainLooper()).post {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,4 +483,5 @@ like to connect to:</string>
   <string name="widget_text_size_label">Widget text size:</string>
   <string name="widgets">Widgets</string>
   <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
+  <string name="activity_intent_error">Unable to send activity intent, please check command format</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1326 

A new command `command_activity` is added to handle this specific intent as we need to do several things to properly launch an activity.  The `title` must contain the URI to send to the app.  The `channel` must be used to set the package name of where the intent needs to be sent to. The `group` must be set the intending action string. We handle generating the URI and launching the activity with the intent.

Example:

```
message: command_activity
title: "geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA"
data:
  channel: "com.google.android.apps.maps"
  group: "android.intent.action.VIEW"
```

```
message: command_activity
title: "google.navigation:q=arbys"
data:
  channel: "com.google.android.apps.maps"
  group: "android.intent.action.VIEW"
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#442

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM PR: https://github.com/home-assistant/mobile-apps-fcm-push/pull/36