### PR TITLE
Update sensors when the app is resumed or in the background

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -442,7 +442,13 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             (!unlocked && presenter.isLockEnabled() && System.currentTimeMillis() < presenter.getSessionExpireMillis()))
             unlocked = true
 
+        SensorWorker.start(this)
         checkAndWarnForDisabledLocation()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        SensorWorker.start(this)
     }
 
     private fun checkAndWarnForDisabledLocation() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Performs a sensor update when the webview is paused and resumed.  This will help keep the app importance sensor up to date to properly reflect if the app is in active use or not.  Also kinda nice to update sensors whenever we are back in the app.  Quick way to trigger an update.

https://github.com/home-assistant/android/issues/1288#issuecomment-764627490
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->