### PR TITLE
Power menu vacuum

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -63,6 +63,8 @@ class HaControlsProviderService : ControlsProviderService() {
         "climate" to ClimateControl,
         "cover" to CoverControl,
         "fan" to FanControl,
+        "input_boolean" to DefaultSwitchControl,
+        "input_number" to DefaultSliderControl,
         "light" to LightControl,
         "lock" to LockControl,
         "media_player" to null,
@@ -70,8 +72,7 @@ class HaControlsProviderService : ControlsProviderService() {
         "scene" to SceneControl,
         "script" to SceneControl,
         "switch" to DefaultSwitchControl,
-        "input_boolean" to DefaultSwitchControl,
-        "input_number" to DefaultSliderControl
+        "vacuum" to VacuumControl
     )
 
     override fun onCreate() {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -53,7 +53,7 @@ class VacuumControl {
                             "paused" -> context.getString(R.string.state_paused)
                             "returning" -> context.getString(R.string.state_returning)
                             "unavailable" -> context.getString(R.string.state_unavailable)
-                            else -> "unknown"
+                            else -> context.getString(R.string.state_unknown)
                         }
                     )
             control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -1,0 +1,92 @@
+package io.homeassistant.companion.android.controls
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.ToggleTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.runBlocking
+
+@RequiresApi(Build.VERSION_CODES.R)
+class VacuumControl {
+    companion object : HaControl {
+        private const val SUPPORT_TURN_ON = 1
+        private var entitySupportedFeatures = 0
+
+        override fun createControl(
+            context: Context,
+            entity: Entity<Map<String, Any>>
+        ): Control {
+            entitySupportedFeatures = entity.attributes["supported_features"] as Int
+            val control = Control.StatefulBuilder(
+                entity.entityId,
+                PendingIntent.getActivity(
+                    context,
+                    0,
+                    WebViewActivity.newInstance(context.applicationContext).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                    PendingIntent.FLAG_CANCEL_CURRENT
+                )
+            )
+            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
+            control.setDeviceType(DeviceTypes.TYPE_VACUUM)
+            control.setZone(context.getString(R.string.domain_vacuum))
+            control.setStatus(Control.STATUS_OK)
+            control.setStatusText(
+                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
+                        if (entity.state == "off") context.getString(R.string.state_off) else context.getString(R.string.state_on)
+                    else
+                        when (entity.state) {
+                            "cleaning" -> context.getString(R.string.state_cleaning)
+                            "docked" -> context.getString(R.string.state_docked)
+                            "error" -> context.getString(R.string.state_error)
+                            "idle" -> context.getString(R.string.state_idle)
+                            "paused" -> context.getString(R.string.state_paused)
+                            "returning" -> context.getString(R.string.state_returning)
+                            "unavailable" -> context.getString(R.string.state_unavailable)
+                            else -> "unknown"
+                        }
+                    )
+            control.setControlTemplate(
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
+                        if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
+                            entity.state == "on"
+                        else
+                            entity.state == "cleaning",
+                            "Description"
+                    )
+                )
+            )
+            return control.build()
+        }
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return runBlocking {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
+                        if ((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off"
+                    else if ((action as? BooleanAction)?.newState == true) "start" else "return_to_base",
+                    hashMapOf(
+                        "entity_id" to action.templateId
+                    )
+                )
+                true
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -483,4 +483,12 @@ like to connect to:</string>
   <string name="widget_text_size_label">Widget text size:</string>
   <string name="widgets">Widgets</string>
   <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
+  <string name="domain_vacuum">Vacuum</string>
+  <string name="state_cleaning">Cleaning</string>
+  <string name="state_docked">Docked</string>
+  <string name="state_error">Error</string>
+  <string name="state_idle">Idle</string>
+  <string name="state_paused">Paused</string>
+  <string name="state_returning">Returning</string>
+  <string name="state_unavailable">Unavailable</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -491,4 +491,5 @@ like to connect to:</string>
   <string name="state_paused">Paused</string>
   <string name="state_returning">Returning</string>
   <string name="state_unavailable">Unavailable</string>
+  <string name="state_unknown">Unknown</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1318 

There are 2 state models for vacuums, this PR takes care of both of them.  There are some vacuums that only support on/off and others that support multiple states.  I have chosen to add `start` and `return_to_base`  as those are the closest to `turn_on` and `turn_off`


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/106217683-9d74f100-618a-11eb-9dbe-b2e0e2ee825a.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#444

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->