### PR TITLE
Improvements to command activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <uses-permission android:name="android.permission.ACCESS_NOTIFICATION_POLICY" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

After reviewing more of Googles examples: https://developer.android.com/guide/components/intents-common found a few places to improve.

* `channel` is no longer required.  If we have it we will use it, otherwise we will make a best effort which can allow the user to pick more than 1 app or use the default app.  We will still post the notification if a package is not found.
* `title` is no longer required as not all activities require a URI
* `tag` is used for all the extras, extras now convert to integer as required for setting an alarm/timer.
* `SET_ALARM` permission is added so we can set timers on a device per the examples in the link
* `subject` will be used to specify the MIME type which may be required in some cases like composing a SMS


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#446

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->