### PR TITLE
Add extras to the event data when we receive intents

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -106,13 +106,13 @@ class SensorReceiver : BroadcastReceiver() {
             val allSettings = sensorDao.getSettings(LastUpdateManager.lastUpdate.id)
             for (setting in allSettings) {
                 if (setting.value != "" && intent.action == setting.value) {
+                    val eventData = intent.extras?.keySet()?.map { it to intent.extras?.get(it) }?.toMap()?.plus("intent" to intent.action.toString())
+                        ?: mapOf("intent" to intent.action.toString())
                     ioScope.launch {
                         try {
                             integrationUseCase.fireEvent(
                                 "android.intent_received",
-                                mapOf(
-                                    "intent" to intent.action.toString()
-                                )
+                                eventData as Map<String, Any>
                             )
                             Log.d(TAG, "Event successfully sent to Home Assistant")
                         } catch (e: Exception) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

If `extras` are part of a received intent we will add all the extras as event data, otherwise we will send the intent action like we currently do.

Example of an intent with extra data (tested from: http://www.mibandnotify.com/help/tasker_send_intent.php):

```
{
    "event_type": "android.intent_received",
    "data": {
        "value": 8693,
        "intent": "com.mc.miband.stepsGot",
        "device_id": "DEVICE_ID"
    },
    "origin": "REMOTE",
    "time_fired": "2021-01-30T07:59:48.081242+00:00",
    "context": {
        "id": "ID",
        "parent_id": null,
        "user_id": "USER_ID"
    }
}
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#447

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->