### PR TITLE
Apply system theme during onboarding authentication

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -17,6 +17,7 @@ import io.homeassistant.companion.android.DaggerPresenterComponent
 import io.homeassistant.companion.android.PresenterModule
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.themes.ThemesManager
 import io.homeassistant.companion.android.util.isStarted
 import javax.inject.Inject
 
@@ -32,6 +33,10 @@ class AuthenticationFragment : Fragment(), AuthenticationView {
 
     @Inject
     lateinit var presenter: AuthenticationPresenter
+
+    @Inject
+    lateinit var themesManager: ThemesManager
+
     private lateinit var webView: WebView
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -53,7 +58,7 @@ class AuthenticationFragment : Fragment(), AuthenticationView {
     ): View? {
         return inflater.inflate(R.layout.fragment_authentication, container, false).apply {
             webView = findViewById(R.id.webview)
-
+            activity?.applicationContext?.let { themesManager.setThemeForWebView(it, webView.settings) }
             webView.apply {
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Probably fixes: #931 

I've been noticing that in our app the login screen was still white while using chrome was dark to match the system theme, even windows had it right.  Discovered that we actually spun up a new webview instance so added the ThemesManager logic here.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/106370104-ea340580-630b-11eb-9a29-5edf0691173f.png)

![image](https://user-images.githubusercontent.com/1634145/106370109-eef8b980-630b-11eb-88e2-d43ebe0e27a3.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->