### PR TITLE
Direct user to permissions to launch activity in background

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -18,6 +18,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.provider.Settings
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.text.Spanned
@@ -445,43 +446,13 @@ class MessagingService : FirebaseMessagingService() {
                 }
             }
             COMMAND_ACTIVITY -> {
-                try {
-                    val packageName = data["channel"]
-                    val action = data["group"]
-                    val intentUri = if (!title.isNullOrEmpty()) Uri.parse(title) else null
-                    val intent = if (intentUri != null) Intent(action, intentUri) else Intent(action)
-                    val type = data["subject"]
-                    if (!type.isNullOrEmpty())
-                        intent.type = type
-                    val extras = data["tag"]
-                    if (!extras.isNullOrEmpty()) {
-                        val items = extras.split(',')
-                        for (item in items) {
-                            val pair = item.split(":")
-                            intent.putExtra(pair[0], if (pair[1].isDigitsOnly()) pair[1].toInt() else pair[1])
-                        }
-                    }
-                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    if (!packageName.isNullOrEmpty()) {
-                        intent.setPackage(packageName)
-                        startActivity(intent)
-                    } else if (intent.resolveActivity(applicationContext.packageManager) != null)
-                        startActivity(intent)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    if (!Settings.canDrawOverlays(applicationContext))
+                        requestSystemAlertPermission()
                     else
-                        mainScope.launch {
-                            Log.d(TAG, "Posting notification as we do not have enough data to start the activity")
-                            sendNotification(data)
-                        }
-                } catch (e: Exception) {
-                    Log.e(TAG, "Unable to send activity intent please check command format", e)
-                    Handler(Looper.getMainLooper()).post {
-                        Toast.makeText(
-                            applicationContext,
-                            R.string.activity_intent_error,
-                            Toast.LENGTH_LONG
-                        ).show()
-                    }
-                }
+                        processActivityCommand(data)
+                } else
+                    processActivityCommand(data)
             }
             else -> Log.d(TAG, "No command received")
         }
@@ -1025,7 +996,15 @@ class MessagingService : FirebaseMessagingService() {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun requestDNDPermission() {
         val intent =
-            Intent(android.provider.Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+            Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    private fun requestSystemAlertPermission() {
+        val intent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+        Uri.parse("package:$packageName"))
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
     }
@@ -1074,6 +1053,45 @@ class MessagingService : FirebaseMessagingService() {
         }
     }
 
+    private fun processActivityCommand(data: Map<String, String>) {
+        try {
+            val packageName = data["channel"]
+            val action = data["group"]
+            val intentUri = if (!data[TITLE].isNullOrEmpty()) Uri.parse(data[TITLE]) else null
+            val intent = if (intentUri != null) Intent(action, intentUri) else Intent(action)
+            val type = data["subject"]
+            if (!type.isNullOrEmpty())
+                intent.type = type
+            val extras = data["tag"]
+            if (!extras.isNullOrEmpty()) {
+                val items = extras.split(',')
+                for (item in items) {
+                    val pair = item.split(":")
+                    intent.putExtra(pair[0], if (pair[1].isDigitsOnly()) pair[1].toInt() else pair[1])
+                }
+            }
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            if (!packageName.isNullOrEmpty()) {
+                intent.setPackage(packageName)
+                startActivity(intent)
+            } else if (intent.resolveActivity(applicationContext.packageManager) != null)
+                startActivity(intent)
+            else
+                mainScope.launch {
+                    Log.d(TAG, "Posting notification as we do not have enough data to start the activity")
+                    sendNotification(data)
+                }
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to send activity intent please check command format", e)
+            Handler(Looper.getMainLooper()).post {
+                Toast.makeText(
+                    applicationContext,
+                    R.string.activity_intent_error,
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
     /**
      * Called if InstanceID token is updated. This may occur if the security of
      * the previous token had been compromised. Note that this is called when the InstanceID token

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
-    
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>
     <uses-feature android:name="android.hardware.camera" android:required="false"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX = true
 
 # The default API URL used by the Home Assistant Android application.
 # Override these in your ${GRADLE_USER_HOME}/gradle.properties file if needed.
-homeAssistantAndroidPushUrl=https://mobile-apps.home-assistant.io/api/sendPush/android/v1
+homeAssistantAndroidPushUrl=https://us-central1-home-assistant-156520.cloudfunctions.net/androidV1
 homeAssistantAndroidRateLimitUrl=https://mobile-apps.home-assistant.io/api/checkRateLimits
 
 org.gradle.caching=true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had a user point out in discord that activities would not launch in the background.  Turns out we need to grant another permission to do so.  Without proper permission user will see a log like the following:

```
2021-01-31 10:23:57.341 24224-24695/io.homeassistant.companion.android.debug D/MessagingService: Processing device command
2021-01-31 10:23:57.345 1587-2148/? I/ActivityTaskManager: START u0 {act=android.intent.action.VIEW dat=google.navigation:q=arbys flg=0x10000000 pkg=com.google.android.apps.maps cmp=com.google.android.apps.maps/com.google.android.maps.MapsActivity} from uid 10419
2021-01-31 10:23:57.345 1587-1638/? D/EventSequenceValidator: inc AccIntentStartedEvents to 2
2021-01-31 10:23:57.346 1587-2148/? W/ActivityTaskManager: Background activity start [callingPackage: io.homeassistant.companion.android.debug; callingUid: 10419; isCallingUidForeground: false; callingUidHasAnyVisibleWindow: false; callingUidProcState: SERVICE; isCallingUidPersistentSystemProcess: false; realCallingUid: 10419; isRealCallingUidForeground: false; realCallingUidHasAnyVisibleWindow: false; realCallingUidProcState: SERVICE; isRealCallingUidPersistentSystemProcess: false; originatingPendingIntent: null; isBgStartWhitelisted: false; intent: Intent { act=android.intent.action.VIEW dat=google.navigation:q=arbys flg=0x10000000 pkg=com.google.android.apps.maps cmp=com.google.android.apps.maps/com.google.android.maps.MapsActivity }; callerApp: ProcessRecord{21e32ce 24224:io.homeassistant.companion.android.debug/u0a419}]
2021-01-31 10:23:57.353 24224-24296/io.homeassistant.companion.android.debug I/FA: Tag Manager is not found and thus will not be used
2021-01-31 10:23:57.358 1587-2148/? E/ActivityTaskManager: Abort background activity starts from 10419
```

As this is not a standard permission we will follow the same pattern as DND and ringer mode to first request if not granted, then subsequent request to process.  Once permission is granted the log looks like:

```
2021-01-31 10:26:44.214 24224-25547/io.homeassistant.companion.android.debug D/MessagingService: Processing device command
2021-01-31 10:26:44.215 1587-4020/? I/ActivityTaskManager: START u0 {act=android.intent.action.VIEW dat=google.navigation:q=arbys flg=0x10000000 pkg=com.google.android.apps.maps cmp=com.google.android.apps.maps/com.google.android.maps.MapsActivity} from uid 10419
2021-01-31 10:26:44.215 1587-1638/? D/EventSequenceValidator: inc AccIntentStartedEvents to 2
2021-01-31 10:26:44.215 1587-4020/? W/ActivityTaskManager: Background activity start for io.homeassistant.companion.android.debug allowed because SYSTEM_ALERT_WINDOW permission is granted.
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/106394872-c7f5c280-63b3-11eb-8b86-84b7fa75368a.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->