### PR TITLE
Override certain URLs to launch an app or intent scheme

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -80,6 +80,9 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         private const val AUDIO_REQUEST_CODE = 42
         private const val NFC_COMPLETE = 1
         private const val FILE_CHOOSER_RESULT_CODE = 15
+        private const val APP_PREFIX = "app://"
+        private const val INTENT_PREFIX = "intent://"
+        private const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
 
         fun newInstance(context: Context, path: String? = null): Intent {
             return Intent(context, WebViewActivity::class.java).apply {
@@ -240,10 +243,51 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     request: WebResourceRequest?
                 ): Boolean {
                     request?.url?.let {
-                        if (!webView.url.toString().contains(it.toString())) {
-                            val browserIntent = Intent(Intent.ACTION_VIEW, it)
-                            startActivity(browserIntent)
-                            return true
+                        try {
+                            if (it.toString().startsWith(APP_PREFIX)) {
+                                Log.d(TAG, "Launching the app")
+                                val intent = packageManager.getLaunchIntentForPackage(
+                                    it.toString().substringAfter(APP_PREFIX)
+                                )
+                                if (intent != null) {
+                                    intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                                    startActivity(intent)
+                                } else {
+                                    Log.w(TAG, "No intent to launch app found, opening app store")
+                                    val marketIntent = Intent(Intent.ACTION_VIEW)
+                                    marketIntent.data = Uri.parse(
+                                        MARKET_PREFIX + it.toString().substringAfter(APP_PREFIX)
+                                    )
+                                    startActivity(marketIntent)
+                                }
+                                return true
+                            } else if (it.toString().startsWith(INTENT_PREFIX)) {
+                                Log.d(TAG, "Launching the intent")
+                                val intent =
+                                    Intent.parseUri(it.toString(), Intent.URI_INTENT_SCHEME)
+                                val intentPackage = intent.`package`?.let { it1 ->
+                                    packageManager.getLaunchIntentForPackage(
+                                        it1
+                                    )
+                                }
+                                if (intentPackage != null)
+                                    startActivity(intent)
+                                else {
+                                    Log.w(TAG, "No app found for intent prefix, opening app store")
+                                    val marketIntent = Intent(Intent.ACTION_VIEW)
+                                    marketIntent.data =
+                                        Uri.parse(MARKET_PREFIX + intent.`package`.toString())
+                                    startActivity(marketIntent)
+                                }
+                                return true
+                            } else if (!webView.url.toString().contains(it.toString())) {
+                                val browserIntent = Intent(Intent.ACTION_VIEW, it)
+                                startActivity(browserIntent)
+                                return true
+                            } else
+                                Log.w(TAG, "No unique cases found to override")
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Unable to override the URL", e)
                         }
                     }
                     return false

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -285,7 +285,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                 startActivity(browserIntent)
                                 return true
                             } else
-                                Log.w(TAG, "No unique cases found to override")
+                                Log.d(TAG, "No unique cases found to override")
                         } catch (e: Exception) {
                             Log.e(TAG, "Unable to override the URL", e)
                         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #569 

We now accept `app://` and `intent://` prefix.  When testing in a desktop a blank tab opens so nothing harmful appears to happen elsewhere.

When we detect that a link starts with `app://` we will grab the android package and attempt to launch it, if the package does not exist we take the user to the play store (app or website)

When we detect the link starts with `intent://` we will parse the Uri with the intent scheme and attempt to launch the activity, if the app is not found we will also take the user to the play store (app or website)

Examples using lovelace weblink entity card type:

This example will launch Twitter if it is installed on the device, otherwise it will open the Google Play store app or website.
```yaml
- type: weblink
  name: Twitter
  url: "app://com.twitter.android"
```

This example will launch the barcode scanning app ready to scan via the Intent scheme, if the app is not installed the user will be directed to installing it.
```yaml
- type: weblink
  name: Scan
  url: "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
video: https://photos.app.goo.gl/Q93ppHcNB7u8djY97
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#450

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->