### PR TITLE
Fix cancel notification if last notification in group

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -53,11 +53,15 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
             if (isGroupSummary && groupNotifications.size == 1 ||
                 !isGroupSummary && groupNotifications.size == 2) {
                 val group = groupNotifications[0].notification.group
-                if (group != null) {
-                    val groupId = group.hashCode()
+
+                // If group is null, the group is a group which is generate by the system.
+                // This group can't be canceled, but it will be canceled by canceling the last notification inside of the group
+                // If the group isn't null, cancel the group
+                return if (group != null) {
+                    var groupId = group.hashCode()
                     this.cancel(group, groupId)
-                }
-                return true
+                    true
+                } else false
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

Fixes #1346

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If a notification is the last one in a group, which is generated by the system and not the user, the notification cannot be canceled.
This is because the group which should be canceled has no groupId.
To fix this issue, we just cancel the last notification in the group. That way, the system removes the group by itself.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->