### PR TITLE
Convert extras value to boolean when needed

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -388,7 +388,15 @@ class MessagingService : FirebaseMessagingService() {
                         val items = extras.split(',')
                         for (item in items) {
                             val pair = item.split(":")
-                            intent.putExtra(pair[0], if (pair[1].isDigitsOnly()) pair[1].toInt() else pair[1])
+                            intent.putExtra(
+                                pair[0],
+                                if (pair[1].isDigitsOnly())
+                                    pair[1].toInt()
+                                else if ((pair[1].toLowerCase() == "true") ||
+                                    (pair[1].toLowerCase() == "false"))
+                                    pair[1].toBoolean()
+                                else pair[1]
+                            )
                         }
                     }
                     intent.`package` = packageName
@@ -1068,7 +1076,15 @@ class MessagingService : FirebaseMessagingService() {
                 val items = extras.split(',')
                 for (item in items) {
                     val pair = item.split(":")
-                    intent.putExtra(pair[0], if (pair[1].isDigitsOnly()) pair[1].toInt() else pair[1])
+                    intent.putExtra(
+                        pair[0],
+                        if (pair[1].isDigitsOnly())
+                            pair[1].toInt()
+                        else if ((pair[1].toLowerCase() == "true") ||
+                            (pair[1].toLowerCase() == "false"))
+                            pair[1].toBoolean()
+                        else pair[1]
+                    )
                 }
             }
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We noticed in Discord that Sleep as Android was correctly enabling an alarm when we set the extra value to `true` but `false` was misbehaving.  We originally thought it might've been a bug in SAA but they mentioned the values needed to be in boolean.  Yup they do need to be so this PR fixes that.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->