### PR TITLE
Fix bluetooth sentry exception

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothUtils.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/BluetoothUtils.kt
@@ -20,11 +20,13 @@ object BluetoothUtils {
             if (isBtOn) {
                 val bondedDevices = adapter.bondedDevices
                 for (btDev in bondedDevices) {
-                    devices.add(BluetoothDevice(btDev.address, btDev.name, true, isConnected(btDev)))
+                    val name = btDev.name ?: btDev.address
+                    devices.add(BluetoothDevice(btDev.address, name, true, isConnected(btDev)))
                 }
                 val btConnectedDevices = bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)
                 for (btDev in btConnectedDevices) {
-                    devices.add(BluetoothDevice(btDev.address, btDev.name, false, isConnected(btDev)))
+                    val name = btDev.name ?: btDev.address
+                    devices.add(BluetoothDevice(btDev.address, name, false, isConnected(btDev)))
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Should fix following sentry exception:
```java
java.lang.NullPointerException: btDev.name must not be null
    at io.homeassistant.companion.android.bluetooth.BluetoothUtils.getBluetoothDevices(BluetoothUtils.kt:27)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData(SensorDetailFragment.kt:275)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.updateSensorEntity(SensorDetailFragment.kt:323)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.onCreatePreferences(SensorDetailFragment.kt:71)
    at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2684)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1175)
    at androidx.fragment.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1255)
    at androidx.fragment.app.FragmentTransition.calculateFragments(FragmentTransition.java:1138)
    at androidx.fragment.app.FragmentTransition.startTransitions(FragmentTransition.java:136)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:1989)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1947)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1849)
    at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:214)
    at android.app.ActivityThread.main(ActivityThread.java:7710)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:516)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->