### PR TITLE
Allow users to add reply button to actionable notification

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -27,6 +27,7 @@ import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.RemoteInput
 import androidx.core.content.ContextCompat
 import androidx.core.text.HtmlCompat
 import androidx.core.text.isDigitsOnly
@@ -73,6 +74,7 @@ class MessagingService : FirebaseMessagingService() {
         const val CHRONOMETER = "chronometer"
         const val WHEN = "when"
         const val GROUP_PREFIX = "group_"
+        const val KEY_TEXT_REPLY = "key_text_reply"
 
         // special action constants
         const val REQUEST_LOCATION_UPDATE = "request_location_update"
@@ -891,14 +893,31 @@ class MessagingService : FirebaseMessagingService() {
                         notificationAction
                     )
                 }
-                val actionPendingIntent = PendingIntent.getBroadcast(
-                    this,
-                    (notificationAction.title.hashCode() + System.currentTimeMillis()).toInt(),
-                    actionIntent,
-                    0
-                )
+                if (notificationAction.key != "REPLY") {
+                    val actionPendingIntent = PendingIntent.getBroadcast(
+                        this,
+                        (notificationAction.title.hashCode() + System.currentTimeMillis()).toInt(),
+                        actionIntent,
+                        0
+                    )
 
-                builder.addAction(0, notificationAction.title, actionPendingIntent)
+                    builder.addAction(0, notificationAction.title, actionPendingIntent)
+                } else {
+                    val remoteInput: RemoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).run {
+                        setLabel(getString(R.string.action_reply))
+                        build()
+                    }
+                    val replyPendingIntent = PendingIntent.getBroadcast(
+                        this,
+                        0,
+                        actionIntent,
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    )
+                    val action: NotificationCompat.Action = NotificationCompat.Action.Builder(0, "reply", replyPendingIntent)
+                        .addRemoteInput(remoteInput)
+                        .build()
+                    builder.addAction(action)
+                }
             }
         }
     }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationAction.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/NotificationAction.kt
@@ -8,5 +8,5 @@ data class NotificationAction(
     val key: String,
     val title: String,
     val uri: String?,
-    val data: Map<String, String>
+    var data: Map<String, String>
 ) : Parcelable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,4 +493,5 @@ like to connect to:</string>
   <string name="state_unavailable">Unavailable</string>
   <string name="state_unknown">Unknown</string>
   <string name="activity_intent_error">Unable to send activity intent, please check command format</string>
+  <string name="action_reply">Reply</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

When an `action` is set to `REPLY` we will create a reply button in the action.  The user can then enter any text and receive the reply back in the same event that we send for `mobile_app_notification_action`.  It made the most sense to attach this to our actions because android only allows [3 actions](https://developer.android.com/training/notify-user/build-notification#Actions) and reply can be one of them.  Given that a reply is an actionable button and we have to get the data back to HA might as well send it back in the event.

Example service call data:

```
message: reply test
data:
  actions:
  - action: REPLY
    title: reply
```

Example event data:

```
{
    "event_type": "mobile_app_notification_action",
    "data": {
        "message": "reply test",
        "action_1_title": "reply",
        "action_1_key": "REPLY",
        "action": "REPLY",
        "reply_text": "This is a reply",
        "device_id": "DEV_ID"
    },
    "origin": "REMOTE",
    "time_fired": "2021-02-05T05:08:08.883377+00:00",
    "context": {
        "id": "ID",
        "parent_id": null,
        "user_id": "USER_ID"
    }
}
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/1634145/106992753-14336080-672e-11eb-9dfb-295d1de93efe.png)

![image](https://user-images.githubusercontent.com/1634145/106992763-1a294180-672e-11eb-832b-8e50d794d6bd.png)

![image](https://user-images.githubusercontent.com/1634145/106992770-201f2280-672e-11eb-8b14-4469bac62c80.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#453

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->