### PR TITLE
Add haptic/vibration support from the external bus in webview

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+    <uses-permission android:name="android.permission.VIBRATE"/>
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -14,10 +14,13 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.util.Log
 import android.util.Rational
+import android.view.HapticFeedbackConstants
 import android.view.View
 import android.webkit.CookieManager
 import android.webkit.HttpAuthHandler
@@ -457,6 +460,47 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                             "exoplayer/play_hls" -> exoPlayHls(json)
                             "exoplayer/stop" -> exoStopHls()
                             "exoplayer/resize" -> exoResizeHls(json)
+                            "haptic" -> {
+                                val vm = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+                                val hapticType = json.getJSONObject("payload")
+                                    .getString("hapticType")
+                                Log.d(TAG, "Processing haptic tag for $hapticType")
+                                when (hapticType) {
+                                    "success" -> {
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                                            webView.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                                        else
+                                            vm.vibrate(500)
+                                    }
+                                    "warning" -> {
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                                            vm.vibrate(VibrationEffect.createOneShot(400, VibrationEffect.EFFECT_HEAVY_CLICK))
+                                        else
+                                            vm.vibrate(1500)
+                                    }
+                                    "failure" -> {
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                                            webView.performHapticFeedback(HapticFeedbackConstants.REJECT)
+                                        else
+                                            vm.vibrate(1000)
+                                    }
+                                    "light" -> {
+                                        webView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                    }
+                                    "medium" -> {
+                                        webView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+                                    }
+                                    "heavy" -> {
+                                        webView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+                                    }
+                                    "selection" -> {
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                                            webView.performHapticFeedback(HapticFeedbackConstants.GESTURE_START)
+                                        else
+                                            vm.vibrate(50)
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -460,47 +460,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                             "exoplayer/play_hls" -> exoPlayHls(json)
                             "exoplayer/stop" -> exoStopHls()
                             "exoplayer/resize" -> exoResizeHls(json)
-                            "haptic" -> {
-                                val vm = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
-                                val hapticType = json.getJSONObject("payload")
-                                    .getString("hapticType")
-                                Log.d(TAG, "Processing haptic tag for $hapticType")
-                                when (hapticType) {
-                                    "success" -> {
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-                                            webView.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
-                                        else
-                                            vm.vibrate(500)
-                                    }
-                                    "warning" -> {
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
-                                            vm.vibrate(VibrationEffect.createOneShot(400, VibrationEffect.EFFECT_HEAVY_CLICK))
-                                        else
-                                            vm.vibrate(1500)
-                                    }
-                                    "failure" -> {
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-                                            webView.performHapticFeedback(HapticFeedbackConstants.REJECT)
-                                        else
-                                            vm.vibrate(1000)
-                                    }
-                                    "light" -> {
-                                        webView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                                    }
-                                    "medium" -> {
-                                        webView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
-                                    }
-                                    "heavy" -> {
-                                        webView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
-                                    }
-                                    "selection" -> {
-                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-                                            webView.performHapticFeedback(HapticFeedbackConstants.GESTURE_START)
-                                        else
-                                            vm.vibrate(50)
-                                    }
-                                }
-                            }
+                            "haptic" -> processHaptic(json.getJSONObject("payload").getString("hapticType"))
                         }
                     }
                 }
@@ -707,6 +667,46 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         exoPlayerView.requestLayout()
     }
 
+    fun processHaptic(hapticType: String) {
+        val vm = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+
+        Log.d(TAG, "Processing haptic tag for $hapticType")
+        when (hapticType) {
+            "success" -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                    webView.performHapticFeedback(HapticFeedbackConstants.CONFIRM)
+                else
+                    vm.vibrate(500)
+            }
+            "warning" -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+                    vm.vibrate(VibrationEffect.createOneShot(400, VibrationEffect.EFFECT_HEAVY_CLICK))
+                else
+                    vm.vibrate(1500)
+            }
+            "failure" -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                    webView.performHapticFeedback(HapticFeedbackConstants.REJECT)
+                else
+                    vm.vibrate(1000)
+            }
+            "light" -> {
+                webView.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            }
+            "medium" -> {
+                webView.performHapticFeedback(HapticFeedbackConstants.VIRTUAL_KEY)
+            }
+            "heavy" -> {
+                webView.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            }
+            "selection" -> {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                    webView.performHapticFeedback(HapticFeedbackConstants.GESTURE_START)
+                else
+                    vm.vibrate(50)
+            }
+        }
+    }
     private fun authenticationResult(result: Int) {
         if (result == Authenticator.SUCCESS) {
             unlocked = true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes: #1091 by making a best effort to match the existing constants, vibration effects to what it sounds like for iOS.  For a first release these may be ok? We can always adjust as we see fit since we now handle each `hapticType` sent.  It was a bit difficult to map some of these 🙈 lol

https://developer.android.com/reference/android/view/HapticFeedbackConstants#constants_1
https://developer.android.com/reference/android/os/VibrationEffect.html#constants_1
https://developers.home-assistant.io/docs/frontend/external-bus/#trigger-haptic-haptic

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#456

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

Tested with: https://github.com/custom-cards/button-card

Example lovelace config
```
      - type: "custom:button-card"
        color_type: card
        color: rgb(223, 255, 97)
        icon: mdi:volume-minus
        tap_action:
          action: call-service
          service: light.toggle
          service_data:
            entity_id: light.corner_lamp
          haptic: "success"
```