### PR TITLE
Map dpad down key to tab key in webviews

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.onboarding
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
@@ -20,6 +21,7 @@ class OnboardingActivity : BaseActivity(), DiscoveryListener, ManualSetupListene
 
     companion object {
         const val SESSION_CONNECTED = "is_registered"
+        private const val AUTHENTICATION_FRAGMENT = "authentication_fragment"
         private const val TAG = "OnboardingActivity"
 
         fun newInstance(context: Context): Intent {
@@ -73,7 +75,7 @@ class OnboardingActivity : BaseActivity(), DiscoveryListener, ManualSetupListene
         authenticationFragment.retainInstance = true
         supportFragmentManager
             .beginTransaction()
-            .replace(R.id.content, authenticationFragment)
+            .replace(R.id.content, authenticationFragment, AUTHENTICATION_FRAGMENT)
             .addToBackStack(null)
             .commit()
     }
@@ -83,7 +85,7 @@ class OnboardingActivity : BaseActivity(), DiscoveryListener, ManualSetupListene
         authenticationFragment.retainInstance = true
         supportFragmentManager
             .beginTransaction()
-            .replace(R.id.content, authenticationFragment)
+            .replace(R.id.content, authenticationFragment, AUTHENTICATION_FRAGMENT)
             .addToBackStack(null)
             .commit()
     }
@@ -105,5 +107,17 @@ class OnboardingActivity : BaseActivity(), DiscoveryListener, ManualSetupListene
     private fun startWebView() {
         startActivity(WebViewActivity.newInstance(this))
         finish()
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        // Temporary workaround to sideload on Android TV and use a remote for basic navigation in WebView
+        val fragmentManager = supportFragmentManager.findFragmentByTag(AUTHENTICATION_FRAGMENT)
+        if (event?.keyCode == KeyEvent.KEYCODE_DPAD_DOWN && event.action == KeyEvent.ACTION_DOWN &&
+            fragmentManager != null && fragmentManager.isVisible) {
+            dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_TAB))
+            return true
+        }
+
+        return super.dispatchKeyEvent(event)
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1036,4 +1036,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
         }, CONNECTION_DELAY)
     }
+
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        // Temporary workaround to sideload on Android TV and use a remote for basic navigation in WebView
+        if (event?.keyCode == KeyEvent.KEYCODE_DPAD_DOWN && event.action == KeyEvent.ACTION_DOWN) {
+            dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_TAB))
+            return true
+        }
+
+        return super.dispatchKeyEvent(event)
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

The purpose of this change is to map the DPAD_DOWN key which is commonly found on remote controls to the TAB key.  This will allow users to login to the HA app using the remote control.  This is an unsupported experience and therefore we will not be publishing for Android TV.  This is for sideloading only and we will not be doing any support here as we are only sending the TAB key.  Both the android app and HA frontend are not optimized for the TV experience however, there are some users who just want to sideload the app and use it in its current form.  At least with this change a user can do some VERY basic navigation (only one direction forward).  Users should not expect bugs to be fixed until someone comes and adds support for DPAD keys in the front end (if that were to be accepted).

We will remove this workaround once someone spends the time to develop this feature there and its accepted.  Until then the TAB key it will be.

This mapping only takes place in our authentication fragment and the webview.  In all other screens the remote will function as normal.  It will be a nuisance for anyone who wants to use this feature however it is there for those who absolutely need it.

Notifications will not work on Android TV as the app needs to support that feature and normal FCM messages are received but cannot be displayed.  Widgets also are not supported.  Some or most sensors should work.

So to reiterate this is an unsupported experience and users should not expect bugs to be fixed by the app as the frontend needs to support it.  The frontend may also decide not to support it so users will need to keep that into consideration.  This is why the app is not being published for those devices.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->