### PR TITLE
Convert intent extras to a string so they can be sent without error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -106,8 +106,9 @@ class SensorReceiver : BroadcastReceiver() {
             val allSettings = sensorDao.getSettings(LastUpdateManager.lastUpdate.id)
             for (setting in allSettings) {
                 if (setting.value != "" && intent.action == setting.value) {
-                    val eventData = intent.extras?.keySet()?.map { it to intent.extras?.get(it) }?.toMap()?.plus("intent" to intent.action.toString())
+                    val eventData = intent.extras?.keySet()?.map { it.toString() to intent.extras?.get(it).toString() }?.toMap()?.plus("intent" to intent.action.toString())
                         ?: mapOf("intent" to intent.action.toString())
+                    Log.d(TAG, "Event data: $eventData")
                     ioScope.launch {
                         try {
                             integrationUseCase.fireEvent(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes issue reported in the forums where the event was not firing since the data was not as expected:
https://community.home-assistant.io/t/android-intents-sending-receiving-list-starting-activities-too/276192/10?u=dshokouhi

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->