### PR TITLE
Allow retry attempts for biometric prompt, enable skip confirmation for faster access

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/authenticator/Authenticator.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/authenticator/Authenticator.kt
@@ -42,6 +42,7 @@ class Authenticator(context: Context, fragmentActivity: FragmentActivity, callba
     fun authenticate() {
         val promptDialog = BiometricPrompt.PromptInfo.Builder()
             .setTitle(title)
+            .setConfirmationRequired(false)
             .setDeviceCredentialAllowed(true)
             .build()
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -725,10 +725,18 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
     }
     private fun authenticationResult(result: Int) {
-        if (result == Authenticator.SUCCESS) {
-            unlocked = true
-            blurView.setBlurEnabled(false)
-        } else finishAffinity()
+        when (result) {
+            Authenticator.SUCCESS -> {
+                Log.d(TAG, "Authentication successful, unlocking app")
+                unlocked = true
+                blurView.setBlurEnabled(false)
+            }
+            Authenticator.CANCELED -> {
+                Log.d(TAG, "Authentication canceled by user, closing activity")
+                finishAffinity()
+            }
+            else -> Log.d(TAG, "Authentication failed, retry attempts allowed")
+        }
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1402 by allowing retry attempts until the android system deems it necessary to stop.  We will only close the activity if the user cancels the action by tapping outside of the biometric prompt.  As we are using device credentials we cannot supply a negative button.

User is no longer required to press "Confirm" upon successful authentication

Added some debug logging in case we encounter any issues.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

Unable to take screenshots of biometric prompt changes but they can be viewed here: https://developer.android.com/training/sign-in/biometric-auth#no-explicit-user-action

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->