### PR TITLE
Prevent crash when removing default channel

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -166,7 +166,7 @@ class MessagingService : FirebaseMessagingService() {
                     clearNotification(it["tag"]!!)
                 }
                 it[MESSAGE] == REMOVE_CHANNEL && !it["channel"].isNullOrBlank() -> {
-                    Log.d(TAG, "Removing Notification channel ${it["tag"]}")
+                    Log.d(TAG, "Removing Notification channel ${it["channel"]}")
                     removeNotificationChannel(it["channel"]!!)
                 }
                 it[MESSAGE] == TTS -> {
@@ -301,7 +301,7 @@ class MessagingService : FirebaseMessagingService() {
 
         val channelID: String = createChannelID(channelName)
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && channelID != NotificationChannel.DEFAULT_CHANNEL_ID) {
             notificationManagerCompat.deleteNotificationChannel(channelID)
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry error that I was able to reproduce:

```
java.lang.IllegalArgumentException: Cannot delete default channel
    at android.os.Parcel.createExceptionOrNull(Parcel.java:2377)
    at android.os.Parcel.createException(Parcel.java:2357)
    at android.os.Parcel.readException(Parcel.java:2340)
    at android.os.Parcel.readException(Parcel.java:2282)
    at android.app.INotificationManager$Stub$Proxy.deleteNotificationChannel(INotificationManager.java:4004)
    at android.app.NotificationManager.deleteNotificationChannel(NotificationManager.java:906)
    at androidx.core.app.NotificationManagerCompat.deleteNotificationChannel(NotificationManagerCompat.java:341)
    at io.homeassistant.companion.android.notifications.MessagingService.removeNotificationChannel(MessagingService.kt:305)
    at io.homeassistant.companion.android.notifications.MessagingService.onMessageReceived(MessagingService.kt:170)
    at com.google.firebase.messaging.FirebaseMessagingService.dispatchMessage(com.google.firebase:firebase-messaging@@20.3.0:74)
    at com.google.firebase.messaging.FirebaseMessagingService.passMessageIntentToSdk(com.google.firebase:firebase-messaging@@20.3.0:44)
    at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(com.google.firebase:firebase-messaging@@20.3.0:27)
    at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(com.google.firebase:firebase-messaging@@20.3.0:17)
    at com.google.firebase.messaging.EnhancedIntentService.lambda$processIntent$0$EnhancedIntentService(com.google.firebase:firebase-messaging@@20.3.0:43)
    at com.google.firebase.messaging.EnhancedIntentService$$Lambda$0.run
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at com.google.android.gms.common.util.concurrent.zza.run(com.google.android.gms:play-services-basement@@17.5.0:6)
    at java.lang.Thread.run(Thread.java:923)
```

Basically added a conditional check: https://android.googlesource.com/platform/frameworks/base.git/+/master/services/core/java/com/android/server/notification/NotificationManagerService.java#3412

Not sure if we should print a logger for this, it seemed best to just skip the error unless we decide to notify the user.

For the record our default channel seems to be `miscellaneous`

Also fixes an incorrect variable in debug logs

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->