### PR TITLE
Fix BLE Transmitter Power setting - bug was causing settings to be ignored and default of High be used 

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
@@ -59,7 +59,7 @@ object TransmitterManager {
         if (bluetoothOn) {
             val beacon = buildBeacon(haTransmitter)
             if (!physicalTransmitter.isStarted) {
-                physicalTransmitter.advertiseTxPowerLevel
+                physicalTransmitter.advertiseTxPowerLevel = getPowerLevel(haTransmitter)
                 physicalTransmitter.startAdvertising(beacon, object : AdvertiseCallback() {
                     override fun onStartSuccess(settingsInEffect: AdvertiseSettings) {
                         haTransmitter.transmitting = true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix a silly edit bug, Power level for BLE transmitter was never being used, and defaulted to high.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->