### PR TITLE
Save widget states so we can restore them when calls fail

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="io.homeassistant.companion.android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />

--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -282,8 +282,8 @@ abstract class AppDatabase : RoomDatabase() {
 
         private val MIGRATION_13_14 = object : Migration(13, 14) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `static_widget` ADD `last_update` TEXT")
-                database.execSQL("ALTER TABLE `template_widgets` ADD `last_update` TEXT")
+                database.execSQL("ALTER TABLE `static_widget` ADD `last_update` TEXT NOT NULL DEFAULT ''")
+                database.execSQL("ALTER TABLE `template_widgets` ADD `last_update` TEXT NOT NULL DEFAULT ''")
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.runBlocking
         TemplateWidgetEntity::class,
         NotificationItem::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -96,7 +96,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_9_10,
                     MIGRATION_10_11,
                     MIGRATION_11_12,
-                    MIGRATION_12_13
+                    MIGRATION_12_13,
+                    MIGRATION_13_14
                 )
                 .fallbackToDestructiveMigration()
                 .build()
@@ -276,6 +277,13 @@ abstract class AppDatabase : RoomDatabase() {
         private val MIGRATION_12_13 = object : Migration(12, 13) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("CREATE TABLE IF NOT EXISTS `notification_history` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL)")
+            }
+        }
+
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `static_widget` ADD `last_update` TEXT")
+                database.execSQL("ALTER TABLE `template_widgets` ADD `last_update` TEXT")
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
@@ -23,4 +23,7 @@ interface StaticWidgetDao {
 
     @Query("SELECT * FROM static_widget")
     fun getAll(): Array<StaticWidgetEntity>?
+
+    @Query("UPDATE static_widget SET last_update = :lastUpdate WHERE id = :widgetId")
+    fun updateWidgetLastUpdate(widgetId: Int, lastUpdate: String)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetEntity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetEntity.kt
@@ -19,5 +19,7 @@ data class StaticWidgetEntity(
     @ColumnInfo(name = "state_separator")
     val stateSeparator: String = "",
     @ColumnInfo(name = "attribute_separator")
-    val attributeSeparator: String = ""
+    val attributeSeparator: String = "",
+    @ColumnInfo(name = "last_update")
+    val lastUpdate: String
 )

--- a/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
@@ -23,4 +23,7 @@ interface TemplateWidgetDao {
 
     @Query("SELECT * FROM template_widgets")
     fun getAll(): Array<TemplateWidgetEntity>?
+
+    @Query("UPDATE template_widgets SET last_update = :lastUpdate WHERE id = :widgetId")
+    fun updateTemplateWidgetLastUpdate(widgetId: Int, lastUpdate: String)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
@@ -9,5 +9,7 @@ data class TemplateWidgetEntity(
     @PrimaryKey
     val id: Int,
     @ColumnInfo(name = "template")
-    val template: String
+    val template: String,
+    @ColumnInfo(name = "last_update")
+    val lastUpdate: String
 )

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -122,9 +122,10 @@ class TemplateWidget : AppWidgetProvider() {
                 )
             )
             if (widget != null) {
-                var renderedTemplate = "Loading"
+                var renderedTemplate = templateWidgetDao.get(appWidgetId)?.lastUpdate ?: "Loading"
                 try {
                     renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf())
+                    templateWidgetDao.updateTemplateWidgetLastUpdate(appWidgetId, renderedTemplate)
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to render template: ${widget.template}", e)
                     if (lastIntent != Intent.ACTION_SCREEN_ON)
@@ -181,7 +182,8 @@ class TemplateWidget : AppWidgetProvider() {
             templateWidgetDao.add(
                 TemplateWidgetEntity(
                     appWidgetId,
-                    template
+                    template,
+                    templateWidgetDao.get(appWidgetId)?.lastUpdate ?: "Loading"
                 )
             )
             onUpdate(context, AppWidgetManager.getInstance(context), intArrayOf(appWidgetId))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1410 by saving the last update text for entity state and template widgets so we can default to retrieving them when things fail.

I have tested this change by first checking out master, setting up one of each widget type that is updated and then upgrading to this branch to ensure no crashes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->