### PR TITLE
Enable high accuracy mode when entering zone

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -46,8 +46,8 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private const val SETTING_HIGH_ACCURACY_MODE = "High accuracy mode (May drain battery fast)"
         private const val SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL = "High accuracy mode update interval (seconds)"
         private const val SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES = "High accuracy mode only when connected to BT devices"
-        private const val SETTING_HIGH_ACCURACY_MODE_GEOZONE = "High accuracy mode only when entering geozone"
-        private const val SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS = "High accuracy mode geozone expanded radius (meters)"
+        private const val SETTING_HIGH_ACCURACY_MODE_ZONE = "High accuracy mode only when entering zone"
+        private const val SETTING_HIGH_ACCURACY_MODE_EXP_ZONE_RADIUS = "High accuracy mode zone expanded radius (meters)"
 
         private const val DEFAULT_MINIMUM_ACCURACY = 200
         private const val DEFAULT_UPDATE_INTERVAL_HA_SECONDS = 5
@@ -99,8 +99,8 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private var lastEnteredGeoZones: MutableList<String> = ArrayList()
         private var lastExitedGeoZones: MutableList<String> = ArrayList()
 
-        private var lastHighAccuracyExpandedGeozoneRadius: Int = 0
-        private var lastHighAccuracyGeozones: List<String> = ArrayList()
+        private var lastHighAccuracyExpandedZoneRadius: Int = 0
+        private var lastHighAccuracyZones: List<String> = ArrayList()
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
             val sensorDao = AppDatabase.getInstance(context).sensorDao()
@@ -194,7 +194,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         if (isBackgroundEnabled) {
             val updateIntervalHighAccuracySeconds = getHighAccuracyModeUpdateInterval()
             val highAccuracyMode = getHighAccuracyMode()
-            val highAccuracyExpGeoRadius = getHighAccuracyModeExpandedGeozoneRadius()
+            val highAccuracyExpGeoRadius = getHighAccuracyModeExpandedZoneRadius()
             val highAccuracyZones = getHighAccuracyModeZones(false)
 
             if (!isBackgroundLocationSetup) {
@@ -224,8 +224,8 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                     }
                 }
 
-                if (highAccuracyExpGeoRadius != lastHighAccuracyExpandedGeozoneRadius ||
-                    highAccuracyZones != lastHighAccuracyGeozones
+                if (highAccuracyExpGeoRadius != lastHighAccuracyExpandedZoneRadius ||
+                    highAccuracyZones != lastHighAccuracyZones
                 ) {
                     Log.d(TAG, "High accuracy mode geo parameters changed. Reconfigure zones.")
                     removeGeofenceUpdateRequests()
@@ -236,11 +236,11 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             val highAccuracyModeSettingEnabled = getHighAccuracyModeSetting()
             enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL, highAccuracyModeSettingEnabled)
             enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES, highAccuracyModeSettingEnabled)
-            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_GEOZONE, highAccuracyModeSettingEnabled && isZoneEnable)
-            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS, highAccuracyModeSettingEnabled && isZoneEnable)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_ZONE, highAccuracyModeSettingEnabled && isZoneEnable)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_EXP_ZONE_RADIUS, highAccuracyModeSettingEnabled && isZoneEnable)
 
-            lastHighAccuracyGeozones = highAccuracyZones
-            lastHighAccuracyExpandedGeozoneRadius = highAccuracyExpGeoRadius
+            lastHighAccuracyZones = highAccuracyZones
+            lastHighAccuracyExpandedZoneRadius = highAccuracyExpGeoRadius
             lastHighAccuracyMode = highAccuracyMode
             lastHighAccuracyUpdateInterval = updateIntervalHighAccuracySeconds
         }
@@ -291,7 +291,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             ""
         )
 
-        val useExpendedZones = getHighAccuracyModeExpandedGeozoneRadius() > 0
+        val useExpendedZones = getHighAccuracyModeExpandedZoneRadius() > 0
         val highAccuracyZones = getHighAccuracyModeZones(false)
         var highAccuracyExpZones = highAccuracyZones
         if (useExpendedZones) {
@@ -609,7 +609,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
         // TODO cache the zones on device so we don't need to reach out each time
         val configuredZones = integrationUseCase.getZones()
-        val highAccuracyExpGeoZoneRadius = getHighAccuracyModeExpandedGeozoneRadius()
+        val highAccuracyExpGeoZoneRadius = getHighAccuracyModeExpandedZoneRadius()
         val highAccuracyZones = getHighAccuracyModeZones(false)
         configuredZones.forEach {
             addGeofenceToBuilder(geofencingRequestBuilder, it)
@@ -643,28 +643,28 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             )
     }
 
-    private fun getHighAccuracyModeExpandedGeozoneRadius(): Int {
+    private fun getHighAccuracyModeExpandedZoneRadius(): Int {
         val enabled = isEnabled(latestContext, zoneLocation.id)
 
         if (!enabled) return 0
 
-        val highAccuracyExpandedGeozoneRadius = getSetting(
+        val highAccuracyExpandedZoneRadius = getSetting(
             latestContext,
             backgroundLocation,
-            SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS,
+            SETTING_HIGH_ACCURACY_MODE_EXP_ZONE_RADIUS,
             "number",
             DEFAULT_EXPANDED_RADIUS_METERS.toString()
         )
 
-        var highAccuracyExpandedGeozoneRadiusInt = highAccuracyExpandedGeozoneRadius.toInt()
-        if (highAccuracyExpandedGeozoneRadiusInt < 0) {
-            highAccuracyExpandedGeozoneRadiusInt = DEFAULT_EXPANDED_RADIUS_METERS
+        var highAccuracyExpandedZoneRadiusInt = highAccuracyExpandedZoneRadius.toInt()
+        if (highAccuracyExpandedZoneRadiusInt < 0) {
+            highAccuracyExpandedZoneRadiusInt = DEFAULT_EXPANDED_RADIUS_METERS
 
             val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
-            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS, highAccuracyExpandedGeozoneRadiusInt.toString(), "number"))
+            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_EXP_ZONE_RADIUS, highAccuracyExpandedZoneRadiusInt.toString(), "number"))
         }
 
-        return highAccuracyExpandedGeozoneRadius.toInt()
+        return highAccuracyExpandedZoneRadius.toInt()
     }
 
     private fun getHighAccuracyModeZones(expandedZones: Boolean): List<String> {
@@ -675,7 +675,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         val highAccuracyZones = getSetting(
             latestContext,
             backgroundLocation,
-            SETTING_HIGH_ACCURACY_MODE_GEOZONE,
+            SETTING_HIGH_ACCURACY_MODE_ZONE,
             "list-zones",
             ""
         )

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -11,7 +11,9 @@ import android.os.PowerManager
 import android.util.Log
 import android.widget.Toast
 import androidx.core.content.ContextCompat.getSystemService
+import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.Geofence
+import com.google.android.gms.location.GeofencingClient
 import com.google.android.gms.location.GeofencingEvent
 import com.google.android.gms.location.GeofencingRequest
 import com.google.android.gms.location.LocationCallback
@@ -21,8 +23,10 @@ import com.google.android.gms.location.LocationServices
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.UpdateLocation
+import io.homeassistant.companion.android.common.data.integration.ZoneAttributes
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Attribute
 import io.homeassistant.companion.android.database.sensor.Setting
@@ -42,9 +46,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         private const val SETTING_HIGH_ACCURACY_MODE = "High accuracy mode (May drain battery fast)"
         private const val SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL = "High accuracy mode update interval (seconds)"
         private const val SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES = "High accuracy mode only when connected to BT devices"
+        private const val SETTING_HIGH_ACCURACY_MODE_GEOZONE = "High accuracy mode only when entering geozone"
+        private const val SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS = "High accuracy mode geozone expanded radius (meters)"
 
         private const val DEFAULT_MINIMUM_ACCURACY = 200
         private const val DEFAULT_UPDATE_INTERVAL_HA_SECONDS = 5
+        private const val DEFAULT_EXPANDED_RADIUS_METERS = 0
 
         const val ACTION_REQUEST_LOCATION_UPDATES =
             "io.homeassistant.companion.android.background.REQUEST_UPDATES"
@@ -75,6 +82,9 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         )
         internal const val TAG = "LocBroadcastReceiver"
 
+        private lateinit var geofencingClient: GeofencingClient
+        private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+
         private var isBackgroundLocationSetup = false
         private var isZoneLocationSetup = false
 
@@ -85,6 +95,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
         private var lastHighAccuracyMode = false
         private var lastHighAccuracyUpdateInterval = DEFAULT_MINIMUM_ACCURACY
+
+        private var lastEnteredGeoZones: MutableList<String> = ArrayList()
+        private var lastExitedGeoZones: MutableList<String> = ArrayList()
+
+        private var lastHighAccuracyExpandedGeozoneRadius: Int = 0
+        private var lastHighAccuracyGeozones: List<String> = ArrayList()
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
             val sensorDao = AppDatabase.getInstance(context).sensorDao()
@@ -157,46 +173,76 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                     isBackgroundLocationSetup = false
                     Log.d(TAG, "Removing background update requests")
                 }
-                if (backgroundEnabled) {
-
-                    val updateIntervalHighAccuracySeconds = getHighAccuracyModeUpdateInterval()
-                    val highAccuracyMode = getHighAccuracyMode()
-
-                    if (!isBackgroundLocationSetup) {
-                        isBackgroundLocationSetup = true
-                        if (highAccuracyMode) {
-                            startHighAccuracyService(updateIntervalHighAccuracySeconds)
-                        } else {
-                            requestLocationUpdates()
-                        }
-                    } else {
-                        if (highAccuracyMode != lastHighAccuracyMode ||
-                            updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval) {
-
-                            if (highAccuracyMode) {
-                                if (updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval) {
-                                    restartHighAccuracyService(updateIntervalHighAccuracySeconds)
-                                } else {
-                                    removeBackgroundUpdateRequests()
-                                    startHighAccuracyService(updateIntervalHighAccuracySeconds)
-                                }
-                            } else {
-                                stopHighAccuracyService()
-                                requestLocationUpdates()
-                            }
-                        }
-                    }
-
-                    lastHighAccuracyMode = highAccuracyMode
-                    lastHighAccuracyUpdateInterval = updateIntervalHighAccuracySeconds
-                }
                 if (zoneEnabled && !isZoneLocationSetup) {
                     isZoneLocationSetup = true
                     requestZoneUpdates()
                 }
+
+                setupBackgroundLocation(backgroundEnabled, zoneEnabled)
             } catch (e: Exception) {
                 Log.e(TAG, "Issue setting up location tracking", e)
             }
+        }
+    }
+
+    private suspend fun setupBackgroundLocation(backgroundEnabled: Boolean? = null, zoneEnabled: Boolean? = null) {
+        var isBackgroundEnabled = backgroundEnabled
+        var isZoneEnable = zoneEnabled
+        if (isBackgroundEnabled == null) isBackgroundEnabled = isEnabled(latestContext, backgroundLocation.id)
+        if (isZoneEnable == null) isZoneEnable = isEnabled(latestContext, zoneLocation.id)
+
+        if (isBackgroundEnabled) {
+            val updateIntervalHighAccuracySeconds = getHighAccuracyModeUpdateInterval()
+            val highAccuracyMode = getHighAccuracyMode()
+            val highAccuracyExpGeoRadius = getHighAccuracyModeExpandedGeozoneRadius()
+            val highAccuracyZones = getHighAccuracyModeZones(false)
+
+            if (!isBackgroundLocationSetup) {
+                isBackgroundLocationSetup = true
+                if (highAccuracyMode) {
+                    startHighAccuracyService(updateIntervalHighAccuracySeconds)
+                } else {
+                    requestLocationUpdates()
+                }
+            } else {
+                if (highAccuracyMode != lastHighAccuracyMode ||
+                    updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval
+                ) {
+
+                    if (highAccuracyMode) {
+                        Log.d(TAG, "High accuracy mode parameters changed. Enable high accuracy mode.")
+                        if (updateIntervalHighAccuracySeconds != lastHighAccuracyUpdateInterval) {
+                            restartHighAccuracyService(updateIntervalHighAccuracySeconds)
+                        } else {
+                            removeBackgroundUpdateRequests()
+                            startHighAccuracyService(updateIntervalHighAccuracySeconds)
+                        }
+                    } else {
+                        Log.d(TAG, "High accuracy mode parameters changed. Disable high accuracy mode.")
+                        stopHighAccuracyService()
+                        requestLocationUpdates()
+                    }
+                }
+
+                if (highAccuracyExpGeoRadius != lastHighAccuracyExpandedGeozoneRadius ||
+                    highAccuracyZones != lastHighAccuracyGeozones
+                ) {
+                    Log.d(TAG, "High accuracy mode geo parameters changed. Reconfigure zones.")
+                    removeGeofenceUpdateRequests()
+                    requestZoneUpdates()
+                }
+            }
+
+            val highAccuracyModeSettingEnabled = getHighAccuracyModeSetting()
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL, highAccuracyModeSettingEnabled)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES, highAccuracyModeSettingEnabled)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_GEOZONE, highAccuracyModeSettingEnabled && isZoneEnable)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS, highAccuracyModeSettingEnabled && isZoneEnable)
+
+            lastHighAccuracyGeozones = highAccuracyZones
+            lastHighAccuracyExpandedGeozoneRadius = highAccuracyExpGeoRadius
+            lastHighAccuracyMode = highAccuracyMode
+            lastHighAccuracyUpdateInterval = updateIntervalHighAccuracySeconds
         }
     }
 
@@ -207,12 +253,12 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     private fun startHighAccuracyService(intervalInSeconds: Int) {
         HighAccuracyLocationService.startService(latestContext, intervalInSeconds)
     }
+
     private fun stopHighAccuracyService() {
         HighAccuracyLocationService.stopService(latestContext)
     }
 
     private fun getHighAccuracyModeUpdateInterval(): Int {
-
         val updateIntervalHighAccuracySeconds = getSetting(
             latestContext,
             LocationSensorManager.backgroundLocation,
@@ -233,6 +279,10 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
     private fun getHighAccuracyMode(): Boolean {
 
+        var highAccuracyMode = getHighAccuracyModeSetting()
+
+        if (!highAccuracyMode) return false
+
         val highAccuracyModeBTDevices = getSetting(
             latestContext,
             LocationSensorManager.backgroundLocation,
@@ -241,13 +291,13 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             ""
         )
 
-        var highAccuracyMode = getSetting(
-            latestContext,
-            LocationSensorManager.backgroundLocation,
-            SETTING_HIGH_ACCURACY_MODE,
-            "toggle",
-            "false"
-        ).toBoolean()
+        val useExpendedZones = getHighAccuracyModeExpandedGeozoneRadius() > 0
+        val highAccuracyZones = getHighAccuracyModeZones(false)
+        var highAccuracyExpZones = highAccuracyZones
+        if (useExpendedZones) {
+            // Use expanded zones, if radius is defined
+            highAccuracyExpZones = getHighAccuracyModeZones(true)
+        }
 
         if (highAccuracyMode) {
             if (!highAccuracyModeBTDevices.isNullOrEmpty()) {
@@ -255,9 +305,36 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 val highAccuracyBtDevConnected = bluetoothDevices.any { it.connected && highAccuracyModeBTDevices.contains(it.name) }
 
                 highAccuracyMode = highAccuracyBtDevConnected
+                if (!highAccuracyMode) Log.d(TAG, "High accuracy mode disabled, because bluetooth device(s) ($highAccuracyBtDevConnected) not connected")
+                else Log.d(TAG, "High accuracy mode enabled, because bluetooth device(s) ($highAccuracyBtDevConnected) connected")
+            }
+
+            if (highAccuracyZones.isNotEmpty()) {
+                // (Expanded) Zone entered
+                val zoneExpEntered = lastEnteredGeoZones.isNotEmpty() && highAccuracyExpZones.containsAll(lastEnteredGeoZones)
+
+                // Exits events are only used if expended zones are used. The exit events are used to determine the enter of the expanded zone from the original zone
+                // Zone exited
+                val zoneExited = useExpendedZones && lastExitedGeoZones.isNotEmpty() && highAccuracyZones.containsAll(lastExitedGeoZones)
+
+                val inGeoZone = zoneExpEntered || zoneExited
+
+                highAccuracyMode = inGeoZone
+                if (!highAccuracyMode) Log.d(TAG, "High accuracy mode disabled, because not in zone $highAccuracyExpZones")
+                else Log.d(TAG, "High accuracy mode enabled, because in zone $highAccuracyExpZones")
             }
         }
         return highAccuracyMode
+    }
+
+    private fun getHighAccuracyModeSetting(): Boolean {
+        return getSetting(
+            latestContext,
+            backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE,
+            "toggle",
+            "false"
+        ).toBoolean()
     }
 
     private fun removeAllLocationUpdateRequests() {
@@ -267,17 +344,19 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     }
 
     private fun removeBackgroundUpdateRequests() {
-        val fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(latestContext)
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(latestContext)
         val backgroundIntent = getLocationUpdateIntent(false)
 
         fusedLocationProviderClient.removeLocationUpdates(backgroundIntent)
     }
 
     private fun removeGeofenceUpdateRequests() {
-        val geofencingClient = LocationServices.getGeofencingClient(latestContext)
+        geofencingClient = LocationServices.getGeofencingClient(latestContext)
         val zoneIntent = getLocationUpdateIntent(true)
         geofencingClient.removeGeofences(zoneIntent)
         geofenceRegistered = false
+        lastEnteredGeoZones.clear()
+        lastExitedGeoZones.clear()
     }
 
     private fun requestLocationUpdates() {
@@ -287,7 +366,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         }
         Log.d(TAG, "Registering for location updates.")
 
-        val fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(latestContext)
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(latestContext)
         val intent = getLocationUpdateIntent(false)
 
         fusedLocationProviderClient.requestLocationUpdates(
@@ -310,7 +389,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         Log.d(TAG, "Registering for zone based location updates")
 
         try {
-            val geofencingClient = LocationServices.getGeofencingClient(latestContext)
+            geofencingClient = LocationServices.getGeofencingClient(latestContext)
             val intent = getLocationUpdateIntent(true)
             val geofencingRequest = createGeofencingRequest()
             geofencingClient.addGeofences(
@@ -371,25 +450,42 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 Geofence.GEOFENCE_TRANSITION_EXIT -> "android.zone_exited"
                 else -> ""
             }
-            val zoneAttr = mapOf(
-                "accuracy" to geofencingEvent.triggeringLocation.accuracy,
-                "altitude" to geofencingEvent.triggeringLocation.altitude,
-                "bearing" to geofencingEvent.triggeringLocation.bearing,
-                "latitude" to geofencingEvent.triggeringLocation.latitude,
-                "longitude" to geofencingEvent.triggeringLocation.longitude,
-                "provider" to geofencingEvent.triggeringLocation.provider,
-                "time" to geofencingEvent.triggeringLocation.time,
-                "vertical_accuracy" to if (Build.VERSION.SDK_INT >= 26) geofencingEvent.triggeringLocation.verticalAccuracyMeters.toInt() else 0,
-                "zone" to geofencingEvent.triggeringGeofences[0].requestId
-            )
-            runBlocking {
-                try {
-                    integrationUseCase.fireEvent(zoneStatusEvent, zoneAttr as Map<String, Any>)
-                    Log.d(TAG, "Event sent to Home Assistant")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Unable to send event to Home Assistant", e)
-                    Toast.makeText(latestContext, R.string.zone_event_failure, Toast.LENGTH_LONG)
-                        .show()
+
+            for (triggeringGeofence in geofencingEvent.triggeringGeofences) {
+                val zone = triggeringGeofence.requestId
+
+                if (zoneStatusEvent == "android.zone_entered") {
+                    lastEnteredGeoZones.add(zone)
+                } else {
+                    lastEnteredGeoZones.remove(zone)
+                }
+
+                if (zoneStatusEvent == "android.zone_exited") {
+                    lastExitedGeoZones.add(zone)
+                } else {
+                    lastExitedGeoZones.remove(zone)
+                }
+
+                val zoneAttr = mapOf(
+                    "accuracy" to geofencingEvent.triggeringLocation.accuracy,
+                    "altitude" to geofencingEvent.triggeringLocation.altitude,
+                    "bearing" to geofencingEvent.triggeringLocation.bearing,
+                    "latitude" to geofencingEvent.triggeringLocation.latitude,
+                    "longitude" to geofencingEvent.triggeringLocation.longitude,
+                    "provider" to geofencingEvent.triggeringLocation.provider,
+                    "time" to geofencingEvent.triggeringLocation.time,
+                    "vertical_accuracy" to if (Build.VERSION.SDK_INT >= 26) geofencingEvent.triggeringLocation.verticalAccuracyMeters.toInt() else 0,
+                    "zone" to zone
+                )
+                runBlocking {
+                    try {
+                        integrationUseCase.fireEvent(zoneStatusEvent, zoneAttr as Map<String, Any>)
+                        Log.d(TAG, "Event sent to Home Assistant")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to send event to Home Assistant", e)
+                        Toast.makeText(latestContext, R.string.zone_event_failure, Toast.LENGTH_LONG)
+                            .show()
+                    }
                 }
             }
         }
@@ -409,6 +505,10 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             requestSingleAccurateLocation()
         } else {
             sendLocationUpdate(geofencingEvent.triggeringLocation, "", true)
+        }
+
+        ioScope.launch {
+            setupBackgroundLocation()
         }
     }
 
@@ -505,23 +605,87 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
 
     private suspend fun createGeofencingRequest(): GeofencingRequest {
         val geofencingRequestBuilder = GeofencingRequest.Builder()
+            .setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER)
+
         // TODO cache the zones on device so we don't need to reach out each time
-        integrationUseCase.getZones().forEach {
-            geofencingRequestBuilder.addGeofence(
+        val configuredZones = integrationUseCase.getZones()
+        val highAccuracyExpGeoZoneRadius = getHighAccuracyModeExpandedGeozoneRadius()
+        val highAccuracyZones = getHighAccuracyModeZones(false)
+        configuredZones.forEach {
+            addGeofenceToBuilder(geofencingRequestBuilder, it)
+            if (highAccuracyExpGeoZoneRadius > 0 && highAccuracyZones.contains(it.entityId)) {
+                addGeofenceToBuilder(geofencingRequestBuilder, it, highAccuracyExpGeoZoneRadius)
+            }
+        }
+
+        geofenceRegistered = true
+        return geofencingRequestBuilder.build()
+    }
+
+    private fun addGeofenceToBuilder(
+        geofencingRequestBuilder: GeofencingRequest.Builder,
+        zone: Entity<ZoneAttributes>,
+        zoneRadiusExpandedMeters: Int = 0
+    ) {
+        val postRequestId = if (zoneRadiusExpandedMeters > 0)"_expanded" else ""
+        geofencingRequestBuilder
+            .addGeofence(
                 Geofence.Builder()
-                    .setRequestId(it.entityId)
+                    .setRequestId(zone.entityId + postRequestId)
                     .setCircularRegion(
-                        it.attributes.latitude,
-                        it.attributes.longitude,
-                        it.attributes.radius
+                        zone.attributes.latitude,
+                        zone.attributes.longitude,
+                        zone.attributes.radius + zoneRadiusExpandedMeters
                     )
                     .setExpirationDuration(Geofence.NEVER_EXPIRE)
                     .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER or Geofence.GEOFENCE_TRANSITION_EXIT)
                     .build()
             )
+    }
+
+    private fun getHighAccuracyModeExpandedGeozoneRadius(): Int {
+        val enabled = isEnabled(latestContext, zoneLocation.id)
+
+        if (!enabled) return 0
+
+        val highAccuracyExpandedGeozoneRadius = getSetting(
+            latestContext,
+            backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS,
+            "number",
+            DEFAULT_EXPANDED_RADIUS_METERS.toString()
+        )
+
+        var highAccuracyExpandedGeozoneRadiusInt = highAccuracyExpandedGeozoneRadius.toInt()
+        if (highAccuracyExpandedGeozoneRadiusInt < 0) {
+            highAccuracyExpandedGeozoneRadiusInt = DEFAULT_EXPANDED_RADIUS_METERS
+
+            val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
+            sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_EXP_GEOZONE_RADIUS, highAccuracyExpandedGeozoneRadiusInt.toString(), "number"))
         }
-        geofenceRegistered = true
-        return geofencingRequestBuilder.build()
+
+        return highAccuracyExpandedGeozoneRadius.toInt()
+    }
+
+    private fun getHighAccuracyModeZones(expandedZones: Boolean): List<String> {
+        val enabled = isEnabled(latestContext, zoneLocation.id)
+
+        if (!enabled) return emptyList()
+
+        val highAccuracyZones = getSetting(
+            latestContext,
+            backgroundLocation,
+            SETTING_HIGH_ACCURACY_MODE_GEOZONE,
+            "list-zones",
+            ""
+        )
+
+        return if (highAccuracyZones.isNotEmpty()) {
+            val expanded = if (expandedZones) "_expanded" else ""
+            highAccuracyZones.split(",").map { it.trim() + expanded }
+        } else {
+            emptyList()
+        }
     }
 
     private fun requestSingleAccurateLocation() {

--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.runBlocking
         TemplateWidgetEntity::class,
         NotificationItem::class
     ],
-    version = 14,
+    version = 15,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -97,7 +97,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_10_11,
                     MIGRATION_11_12,
                     MIGRATION_12_13,
-                    MIGRATION_13_14
+                    MIGRATION_13_14,
+                    MIGRATION_14_15
                 )
                 .fallbackToDestructiveMigration()
                 .build()
@@ -279,16 +280,17 @@ abstract class AppDatabase : RoomDatabase() {
                 database.execSQL("CREATE TABLE IF NOT EXISTS `notification_history` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL)")
             }
         }
-        private val MIGRATION_13_14 = object : Migration(13, 14) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("ALTER TABLE `sensor_settings` ADD `enabled` INTEGER NOT NULL DEFAULT '1'")
-            }
-        }
 
         private val MIGRATION_13_14 = object : Migration(13, 14) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("ALTER TABLE `static_widget` ADD `last_update` TEXT NOT NULL DEFAULT ''")
                 database.execSQL("ALTER TABLE `template_widgets` ADD `last_update` TEXT NOT NULL DEFAULT ''")
+            }
+        }
+
+        private val MIGRATION_14_15 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `sensor_settings` ADD `enabled` INTEGER NOT NULL DEFAULT '1'")
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.runBlocking
         TemplateWidgetEntity::class,
         NotificationItem::class
     ],
-    version = 13,
+    version = 14,
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -96,7 +96,8 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_9_10,
                     MIGRATION_10_11,
                     MIGRATION_11_12,
-                    MIGRATION_12_13
+                    MIGRATION_12_13,
+                    MIGRATION_13_14
                 )
                 .fallbackToDestructiveMigration()
                 .build()
@@ -276,6 +277,11 @@ abstract class AppDatabase : RoomDatabase() {
         private val MIGRATION_12_13 = object : Migration(12, 13) {
             override fun migrate(database: SupportSQLiteDatabase) {
                 database.execSQL("CREATE TABLE IF NOT EXISTS `notification_history` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL)")
+            }
+        }
+        private val MIGRATION_13_14 = object : Migration(13, 14) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE `sensor_settings` ADD `enabled` INTEGER NOT NULL DEFAULT '1'")
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -39,6 +39,9 @@ interface SensorDao {
     @Query("DELETE FROM sensor_attributes WHERE sensor_id = :sensorId")
     fun clearAttributes(sensorId: String)
 
+    @Query("UPDATE sensor_settings SET enabled = :enabled WHERE sensor_id = :sensorId AND name = :settingName")
+    fun updateSettingEnabled(sensorId: String, settingName: String, enabled: Boolean)
+
     @Query("UPDATE sensors SET last_sent_state = :state WHERE id = :sensorId")
     fun updateLastSendState(sensorId: String, state: String)
 

--- a/app/src/main/java/io/homeassistant/companion/android/database/sensor/Setting.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/database/sensor/Setting.kt
@@ -12,5 +12,7 @@ data class Setting(
     @ColumnInfo(name = "value")
     var value: String,
     @ColumnInfo(name = "value_type")
-    var valueType: String
+    var valueType: String,
+    @ColumnInfo(name = "enabled")
+    var enabled: Boolean = true
 )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -19,25 +19,29 @@ import androidx.preference.contains
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.sensor.Setting
 import io.homeassistant.companion.android.util.DisabledLocationHandler
 import io.homeassistant.companion.android.util.LocationPermissionInfoHandler
+import kotlinx.coroutines.runBlocking
 
 class SensorDetailFragment(
     private val sensorManager: SensorManager,
-    private val basicSensor: SensorManager.BasicSensor
+    private val basicSensor: SensorManager.BasicSensor,
+    private val integrationUseCase: IntegrationRepository
 ) :
         PreferenceFragmentCompat() {
 
     companion object {
         fun newInstance(
             sensorManager: SensorManager,
-            basicSensor: SensorManager.BasicSensor
+            basicSensor: SensorManager.BasicSensor,
+            integrationUseCase: IntegrationRepository
         ): SensorDetailFragment {
-            return SensorDetailFragment(sensorManager, basicSensor)
+            return SensorDetailFragment(sensorManager, basicSensor, integrationUseCase)
         }
     }
 
@@ -188,6 +192,7 @@ class SensorDetailFragment(
                     if (setting.valueType == "toggle") {
                         val pref = findPreference(key) ?: SwitchPreference(requireContext())
                         pref.key = key
+                        pref.isEnabled = setting.enabled
                         pref.title = setting.name
                         pref.isChecked = setting.value == "true"
                         pref.isIconSpaceReserved = false
@@ -195,7 +200,7 @@ class SensorDetailFragment(
                         pref.setOnPreferenceChangeListener { _, newState ->
                             val isEnabled = newState as Boolean
 
-                            sensorDao.add(Setting(basicSensor.id, setting.name, isEnabled.toString(), "toggle"))
+                            sensorDao.add(Setting(basicSensor.id, setting.name, isEnabled.toString(), "toggle", setting.enabled))
                             sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
@@ -204,6 +209,7 @@ class SensorDetailFragment(
                     } else if (setting.valueType == "list") {
                         val pref = findPreference(key) ?: ListPreference(requireContext())
                         pref.key = key
+                        pref.isEnabled = setting.enabled
                         val titleId = resources.getIdentifier(key + "_title", "string", requireContext().packageName)
                         pref.title = resources.getString(titleId)
                         pref.dialogTitle = resources.getString(titleId)
@@ -216,7 +222,7 @@ class SensorDetailFragment(
                         pref.isIconSpaceReserved = false
                         pref.isSingleLineTitle = false
                         pref.setOnPreferenceChangeListener { _, newState ->
-                            sensorDao.add(Setting(basicSensor.id, setting.name, newState as String, "list"))
+                            sensorDao.add(Setting(basicSensor.id, setting.name, newState as String, "list", setting.enabled))
                             sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
@@ -225,6 +231,7 @@ class SensorDetailFragment(
                     } else if (setting.valueType == "string" || setting.valueType == "number") {
                         val pref = findPreference(key) ?: EditTextPreference(requireContext())
                         pref.key = key
+                        pref.isEnabled = setting.enabled
                         pref.title = setting.name
                         pref.dialogTitle = setting.name
                         pref.isSingleLineTitle = false
@@ -249,7 +256,8 @@ class SensorDetailFragment(
                                             basicSensor.id,
                                             setting.name,
                                             newValue as String,
-                                            setting.valueType
+                                            setting.valueType,
+                                            setting.enabled
                                     )
                             )
                             sensorManager.requestSensorUpdate(requireContext())
@@ -267,61 +275,23 @@ class SensorDetailFragment(
                             }
                             packageName.sort()
                         }
-                        val pref = findPreference(key)
-                                ?: MultiSelectListPreference(requireContext())
-                        pref.key = key
-                        pref.title = setting.name
-                        pref.entries = packageName.toTypedArray()
-                        pref.entryValues = packageName.toTypedArray()
-                        pref.dialogTitle = setting.name
-                        pref.isIconSpaceReserved = false
-                        pref.isSingleLineTitle = false
-                        pref.setOnPreferenceChangeListener { _, newValue ->
-                            sensorDao.add(
-                                    Setting(
-                                            basicSensor.id,
-                                            setting.name,
-                                            newValue.toString().replace("[", "").replace("]", ""),
-                                            "list-apps"
-                                    )
-                            )
-                            sensorManager.requestSensorUpdate(requireContext())
-                            return@setOnPreferenceChangeListener true
-                        }
-                        if (pref.values != null)
-                            pref.summary = pref.values.toString()
-                        else
-                            pref.summary = setting.value
+
+                        val pref = createListPreference(key, setting, sensorDao, packageName)
                         if (!it.contains(pref))
                             it.addPreference(pref)
                     } else if (setting.valueType == "list-bluetooth") {
                         val btDevices = BluetoothUtils.getBluetoothDevices(requireContext()).map { b -> b.name }
 
-                        val pref = findPreference(key)
-                                ?: MultiSelectListPreference(requireContext())
-                        pref.key = key
-                        pref.title = setting.name
-                        pref.entries = btDevices.toTypedArray()
-                        pref.entryValues = btDevices.toTypedArray()
-                        pref.dialogTitle = setting.name
-                        pref.isIconSpaceReserved = false
-                        pref.isSingleLineTitle = false
-                        pref.setOnPreferenceChangeListener { _, newValue ->
-                            sensorDao.add(
-                                    Setting(
-                                            basicSensor.id,
-                                            setting.name,
-                                            newValue.toString().replace("[", "").replace("]", ""),
-                                            "list-bluetooth"
-                                    )
-                            )
-                            sensorManager.requestSensorUpdate(requireContext())
-                            return@setOnPreferenceChangeListener true
+                        val pref = createListPreference(key, setting, sensorDao, btDevices)
+                        if (!it.contains(pref))
+                            it.addPreference(pref)
+                    } else if (setting.valueType == "list-zones") {
+                        val zones: List<String>
+                        runBlocking {
+                            zones = integrationUseCase.getZones().map { z -> z.entityId }
                         }
-                        if (pref.values != null)
-                            pref.summary = pref.values.toString()
-                        else
-                            pref.summary = setting.value
+
+                        val pref = createListPreference(key, setting, sensorDao, zones)
                         if (!it.contains(pref))
                             it.addPreference(pref)
                     }
@@ -330,6 +300,44 @@ class SensorDetailFragment(
             } else
                 it.isVisible = false
         }
+    }
+
+    private fun createListPreference(
+        key: String,
+        setting: Setting,
+        sensorDao: SensorDao,
+        entries: List<String>
+    ): Preference {
+
+        val pref = findPreference(key)
+            ?: MultiSelectListPreference(requireContext())
+        pref.key = key
+        pref.isEnabled = setting.enabled
+        pref.title = setting.name
+        pref.entries = entries.toTypedArray()
+        pref.entryValues = entries.toTypedArray()
+        pref.dialogTitle = setting.name
+        pref.isIconSpaceReserved = false
+        pref.isSingleLineTitle = false
+        pref.setOnPreferenceChangeListener { _, newValue ->
+            sensorDao.add(
+                Setting(
+                    basicSensor.id,
+                    setting.name,
+                    newValue.toString().replace("[", "").replace("]", ""),
+                    setting.valueType,
+                    setting.enabled
+                )
+            )
+            sensorManager.requestSensorUpdate(requireContext())
+            return@setOnPreferenceChangeListener true
+        }
+        if (pref.values != null)
+            pref.summary = pref.values.toString()
+        else
+            pref.summary = setting.value
+
+        return pref
     }
 
     private fun updateSensorEntity(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -177,8 +177,7 @@ class SensorDetailFragment(
                     pref.summary = attribute.value
                     pref.isIconSpaceReserved = false
 
-                    if (!it.contains(pref))
-                        it.addPreference(pref)
+                    if (!it.contains(pref)) it.addPreference(pref)
                 }
                 it.isVisible = true
             } else
@@ -204,8 +203,7 @@ class SensorDetailFragment(
                             sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "list") {
                         val pref = findPreference(key) ?: ListPreference(requireContext())
                         pref.key = key
@@ -226,8 +224,7 @@ class SensorDetailFragment(
                             sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "string" || setting.valueType == "number") {
                         val pref = findPreference(key) ?: EditTextPreference(requireContext())
                         pref.key = key
@@ -263,8 +260,7 @@ class SensorDetailFragment(
                             sensorManager.requestSensorUpdate(requireContext())
                             return@setOnPreferenceChangeListener true
                         }
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "list-apps") {
                         val packageManager: PackageManager? = context?.packageManager
                         val packages = packageManager?.getInstalledApplications(PackageManager.GET_META_DATA)
@@ -277,14 +273,12 @@ class SensorDetailFragment(
                         }
 
                         val pref = createListPreference(key, setting, sensorDao, packageName)
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "list-bluetooth") {
                         val btDevices = BluetoothUtils.getBluetoothDevices(requireContext()).map { b -> b.name }
 
                         val pref = createListPreference(key, setting, sensorDao, btDevices)
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "list-zones") {
                         val zones: List<String>
                         runBlocking {
@@ -292,8 +286,7 @@ class SensorDetailFragment(
                         }
 
                         val pref = createListPreference(key, setting, sensorDao, zones)
-                        if (!it.contains(pref))
-                            it.addPreference(pref)
+                        if (!it.contains(pref)) it.addPreference(pref)
                     }
                 }
                 it.isVisible = true

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -68,9 +68,27 @@ interface SensorManager {
         sensor: BasicSensor,
         settingName: String,
         settingType: String,
-        default: String
+        default: String,
+        enabled: Boolean = true
     ) {
-        getSetting(context, sensor, settingName, settingType, default)
+        getSetting(context, sensor, settingName, settingType, default, enabled)
+    }
+
+    fun isSettingEnabled(context: Context, sensor: BasicSensor, settingName: String): Boolean {
+        val sensorDao = AppDatabase.getInstance(context).sensorDao()
+        val setting = sensorDao
+            .getSettings(sensor.id)
+            .firstOrNull { it.name == settingName }
+        return setting?.enabled ?: false
+    }
+
+    fun enableDisableSetting(context: Context, sensor: BasicSensor, settingName: String, enabled: Boolean) {
+        val sensorDao = AppDatabase.getInstance(context).sensorDao()
+        val settingEnabled = isSettingEnabled(context, sensor, settingName)
+        if (enabled && !settingEnabled ||
+            !enabled && settingEnabled) {
+            sensorDao.updateSettingEnabled(sensor.id, settingName, enabled)
+        }
     }
 
     fun getSetting(
@@ -78,7 +96,8 @@ interface SensorManager {
         sensor: BasicSensor,
         settingName: String,
         settingType: String,
-        default: String
+        default: String,
+        enabled: Boolean = true
     ): String {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val setting = sensorDao
@@ -86,7 +105,7 @@ interface SensorManager {
                 .firstOrNull { it.name == settingName }
                 ?.value
         if (setting == null)
-            sensorDao.add(Setting(sensor.id, settingName, default, settingType))
+            sensorDao.add(Setting(sensor.id, settingName, default, settingType, enabled))
 
         return setting ?: default
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -173,7 +173,8 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
                             R.id.content,
                             SensorDetailFragment.newInstance(
                                 manager,
-                                basicSensor
+                                basicSensor,
+                                integrationUseCase
                             )
                         )
                         .addToBackStack("Sensor Detail")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds the possibility to enable the high accuracy mode, when entering a specific zone (Requires an enabled location zone sensor).
In addition, the user can specify a radius in meters that extends the selected zone by the specified radius. This way the zone is entered X meters before the real zone.

To accomplish that, an internal expanded zone from the original zone is created (ex. `zone.home_expanded`) which adds the defined radius to the original radius. If the radius (Default 0) is 0, then the original zone is used.

If the user decides to use an expanded zone, ONLY the expanded zone, minus the original zone will be used (The blue zone in the image below).
**Example:**
Arriving zone.home
User enters `zone.home_expanded` (1000m radius around `zone.home`) -> High accuracy mode enabled
User enters `zone.home` -> High accuracy mode disabled

Leaving zone.home
User exits `zone.home`, therefore enters `zone.home_expanded` -> High accuracy mode enabled
User exits `zone.home_expanded` -> High accuracy mode disabled

![Zone](https://user-images.githubusercontent.com/12832850/110376465-7f38c580-8053-11eb-9889-a61cd926c774.png)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img src="https://user-images.githubusercontent.com/12832850/110377221-6d0b5700-8054-11eb-8c09-39c482aab995.png" width="40%">
<img src="https://user-images.githubusercontent.com/12832850/110377227-6ed51a80-8054-11eb-82bb-21057a7b71cf.png" width="40%">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: https://github.com/home-assistant/companion.home-assistant/pull/472

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Additional changes:

- A sensor setting can now be enabled/disabled which is reflected in the settings screen as a greyed out preference
- Refactored "creating a list setting" into a method `createListPreference`. Now `list-bluetooth`, `list-zones` and `list-apps` uses this method.
- Fire HA Event for every Zone Entered/Exited and not only for the first one