### PR TITLE
Catch crash when activity can't start due to missing default browser

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.net.nsd.NsdManager
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -25,6 +26,7 @@ class DiscoveryFragment : Fragment(), DiscoveryView {
 
     companion object {
 
+        private const val TAG = "DiscoveryFragment"
         private const val HOME_ASSISTANT = "https://www.home-assistant.io"
         fun newInstance(): DiscoveryFragment {
             return DiscoveryFragment()
@@ -88,7 +90,12 @@ class DiscoveryFragment : Fragment(), DiscoveryView {
                     val intent = Intent(Intent.ACTION_VIEW)
                     intent.data = Uri.parse(HOME_ASSISTANT)
                     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    startActivity(intent)
+                    try {
+                        startActivity(intent)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to load Home Assistant home page", e)
+                        Toast.makeText(context, R.string.what_is_this_crash, Toast.LENGTH_LONG).show()
+                    }
                 }
             }
             this.findViewById<Button>(R.id.manual_setup)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,4 +512,5 @@ like to connect to:</string>
   <string name="widgets">Widgets</string>
   <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
   <string name="what_is_this">What is this?</string>
+  <string name="what_is_this_crash">Unable to load Home Assistant home page, do you have a browser installed?</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the following sentry crash by catching the error and displaying a toast message to see if the device has a browser.  As I understand it when we use `Intent.ACTION_VIEW` with a properly parsed URI the default browser should load, at least it does on my Pixel.  I thought about trying to resolve the activity but since we require WebView or Chrome you would think the user would have the app? I am open to any other ideas on how to handle this error.  I personally did not expect to see this.

```
android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://www.home-assistant.io flg=0x10000000 }
    at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1776)
    at android.app.Instrumentation.execStartActivity(Instrumentation.java:1496)
    at android.app.Activity.startActivityForResult(Activity.java:3798)
    at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:675)
    at androidx.core.app.ActivityCompat.startActivityForResult(ActivityCompat.java:234)
    at androidx.fragment.app.FragmentActivity.startActivityFromFragment(FragmentActivity.java:790)
    at androidx.fragment.app.FragmentActivity$HostCallbacks.onStartActivityFromFragment(FragmentActivity.java:932)
    at androidx.fragment.app.Fragment.startActivity(Fragment.java:1258)
    at androidx.fragment.app.Fragment.startActivity(Fragment.java:1246)
    at io.homeassistant.companion.android.onboarding.discovery.DiscoveryFragment$onCreateView$$inlined$apply$lambda$2.onClick(DiscoveryFragment.kt:91)
    at android.view.View.performClick(View.java:4807)
    at android.view.View$PerformClick.run(View.java:20106)
    at android.os.Handler.handleCallback(Handler.java:815)
    at android.os.Handler.dispatchMessage(Handler.java:104)
    at android.os.Looper.loop(Looper.java:194)
    at android.app.ActivityThread.main(ActivityThread.java:5576)
    at java.lang.reflect.Method.invoke(Method.java)
    at java.lang.reflect.Method.invoke(Method.java:372)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:955)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:750)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->