### PR TITLE
Prevent converting NaN values in pressure sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -75,7 +75,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
 
     override fun onSensorChanged(event: SensorEvent?) {
         if (event != null) {
-            if (event.sensor.type == Sensor.TYPE_PRESSURE) {
+            if (event.sensor.type == Sensor.TYPE_PRESSURE && !event.values[0].isNaN()) {
                 onSensorUpdated(
                     latestContext,
                     pressureSensor,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes below sentry error since some devices appear to like to send `NaN` instead of just reporting the sensor does not exist.

```
java.lang.NumberFormatException: For input string: "NaN"
    at java.lang.Long.parseLong(Long.java:443)
    at java.lang.Long.parseLong(Long.java:485)
    at java.math.BigDecimal.<init>(BigDecimal.java:344)
    at java.math.BigDecimal.<init>(BigDecimal.java:425)
    at io.homeassistant.companion.android.sensors.PressureSensorManager.onSensorChanged(PressureSensorManager.kt:82)
    at android.hardware.SystemSensorManager$SensorEventQueue.dispatchSensorEvent(SystemSensorManager.java:701)
    at android.os.MessageQueue.nativePollOnce(MessageQueue.java)
    at android.os.MessageQueue.next(MessageQueue.java:323)
    at android.os.Looper.loop(Looper.java:136)
    at android.app.ActivityThread.main(ActivityThread.java:6119)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->