### PR TITLE
Switch to a different method to get alarm ringtone, default to normal ringtone if alarm is null

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -688,7 +688,10 @@ class MessagingService : FirebaseMessagingService() {
     ) {
         if (data["channel"] == ALARM_STREAM) {
             builder.setCategory(Notification.CATEGORY_ALARM)
-            builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM), AudioManager.STREAM_ALARM)
+            builder.setSound(
+                RingtoneManager.getActualDefaultRingtoneUri(applicationContext, RingtoneManager.TYPE_ALARM)
+                    ?: RingtoneManager.getActualDefaultRingtoneUri(applicationContext, RingtoneManager.TYPE_RINGTONE),
+                AudioManager.STREAM_ALARM)
         } else {
             builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
         }
@@ -1023,7 +1026,9 @@ class MessagingService : FirebaseMessagingService() {
             .setLegacyStreamType(AudioManager.STREAM_ALARM)
             .setUsage(AudioAttributes.USAGE_ALARM)
             .build()
-        channel.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_ALARM), audioAttributes)
+        channel.setSound(RingtoneManager.getActualDefaultRingtoneUri(applicationContext, RingtoneManager.TYPE_ALARM)
+            ?: RingtoneManager.getActualDefaultRingtoneUri(applicationContext, RingtoneManager.TYPE_RINGTONE),
+            audioAttributes)
     }
 
     private fun parseVibrationPattern(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Another attempt to fix #1186 

This time we switch from `getDefaultUri()` to `getActualDefaultUri()` as the first option returns a symbolic link where as the latter does not.

https://developer.android.com/reference/android/media/RingtoneManager#getDefaultUri(int)

`Rather than returning the actual ringtone's sound Uri, this will return the symbolic Uri which will resolved to the actual sound when played.`

https://developer.android.com/reference/android/media/RingtoneManager#getActualDefaultRingtoneUri(android.content.Context,%20int)

`This will give the actual sound Uri, instead of using this, most clients can use System#DEFAULT_RINGTONE_URI.`

Then if the alarm ringtone URI comes in as `null` we will then default to the normal ringtone type.  A stackoverflow thread said its possible the value can come as `null`

https://stackoverflow.com/a/5687023

There are other fixes mentioned in the thread but so far this makes the most sense to me and the alarm stream channel still works on my Pixel 4 XL so this can't hurt :)

If the issue is still there then its time to add more debug logs to further diagnose the issue.

Another potential fix is trying to use: https://developer.android.com/reference/android/provider/Settings.System#DEFAULT_RINGTONE_URI instead of RingtoneManager but will need to test if that is what we want to do. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->