### PR TITLE
Fix statusbar color

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -310,6 +310,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
 
             webChromeClient = object : WebChromeClient() {
+                override fun onProgressChanged(view: WebView?, newProgress: Int) {
+                    if (newProgress == 100) {
+                        view?.loadUrl(
+                            "javascript:window.externalApp.getHeaderColor(" +
+                                    "document.getElementsByTagName('html')[0].computedStyleMap().get('--app-header-background-color')[0]);"
+                        )
+                    }
+                }
                 override fun onJsConfirm(
                     view: WebView,
                     url: String,
@@ -401,6 +409,10 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
 
             addJavascriptInterface(object : Any() {
+                @JavascriptInterface
+                fun getHeaderColor(color: String) {
+                    presenter.setStatusbarColor(color)
+                }
                 @JavascriptInterface
                 fun getExternalAuth(payload: String) {
                     JSONObject(payload).let {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -861,15 +861,18 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     override fun setStatusBarAndNavigationBarColor(color: Int) {
-        var flags = window.decorView.systemUiVisibility
-        flags = if (ColorUtils.calculateLuminance(color) < 0.5) { // If color is dark...
-            flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv() and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv() // Remove light flag
-        } else {
-            flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR // Add light flag
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            var flags = window.decorView.systemUiVisibility
+            flags = if (ColorUtils.calculateLuminance(color) < 0.5) { // If color is dark...
+                flags and View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR.inv() and View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR.inv() // Remove light flag
+            } else {
+                flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR // Add light flag
+            }
+
+            window.statusBarColor = color
+            window.navigationBarColor = color
+            window.decorView.systemUiVisibility = flags
         }
-        window.statusBarColor = color
-        window.navigationBarColor = color
-        window.decorView.systemUiVisibility = flags
     }
 
     override fun setExternalAuth(script: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -456,9 +456,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                     Log.d(TAG, "Callback $it")
                                 }
 
-                                //Set statusbar color
-                                webView.evaluateJavascript("document.getElementsByTagName('html')[0].computedStyleMap().get('--app-header-background-color')[0];")
-                                {
+                                // Set statusbar color
+                                webView.evaluateJavascript("document.getElementsByTagName('html')[0].computedStyleMap().get('--app-header-background-color')[0];") {
                                     presenter.setStatusbarColor(it)
                                 }
                             }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -310,14 +310,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
 
             webChromeClient = object : WebChromeClient() {
-                override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                    if (newProgress == 100) {
-                        view?.loadUrl(
-                            "javascript:window.externalApp.getHeaderColor(" +
-                                    "document.getElementsByTagName('html')[0].computedStyleMap().get('--app-header-background-color')[0]);"
-                        )
-                    }
-                }
                 override fun onJsConfirm(
                     view: WebView,
                     url: String,
@@ -410,10 +402,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
             addJavascriptInterface(object : Any() {
                 @JavascriptInterface
-                fun getHeaderColor(color: String) {
-                    presenter.setStatusbarColor(color)
-                }
-                @JavascriptInterface
                 fun getExternalAuth(payload: String) {
                     JSONObject(payload).let {
                         presenter.onGetExternalAuth(
@@ -466,6 +454,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                 Log.d(TAG, script)
                                 webView.evaluateJavascript(script) {
                                     Log.d(TAG, "Callback $it")
+                                }
+
+                                //Set statusbar color
+                                webView.evaluateJavascript("document.getElementsByTagName('html')[0].computedStyleMap().get('--app-header-background-color')[0];")
+                                {
+                                    presenter.setStatusbarColor(it)
                                 }
                             }
                             "config_screen/show" ->

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -24,4 +24,6 @@ interface WebViewPresenter {
     fun onFinish()
 
     fun isSsidUsed(): Boolean
+
+    fun setStatusbarColor(colorString: String)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -163,17 +163,16 @@ class WebViewPresenterImpl @Inject constructor(
     }
 
     override fun setStatusbarColor(colorString: String) {
-        var statusbarNavBarColor = 0
-        try {
-            statusbarNavBarColor = parseColorWithRgb(colorString)
-            statusbarNavBarColor = ColorUtils.blendARGB(statusbarNavBarColor, Color.BLACK, 0.2f)
-            view.setStatusBarAndNavigationBarColor(statusbarNavBarColor)
-            return
-        } catch (e: Exception) {
-            Log.e(TAG, "Issue getting/setting theme from webview. Get/Set theme from HA", e)
-        }
-
         mainScope.launch {
+            try {
+                val statusbarNavBarColor = parseColorWithRgb(colorString)
+                view.setStatusBarAndNavigationBarColor(statusbarNavBarColor)
+                return@launch
+            } catch (e: Exception) {
+                Log.e(TAG, "Issue getting/setting theme from webview. Get/Set theme from HA", e)
+            }
+
+
             try {
                 val colorString = integrationUseCase.getThemeColor()
                 // If color from theme found and if colorString is NOT #03A9F3.

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -164,7 +164,7 @@ class WebViewPresenterImpl @Inject constructor(
     override fun setStatusbarColor(colorString: String) {
         mainScope.launch {
             Log.d(TAG, "Try setting statusbar color with color string $colorString from webview")
-            if(!colorString.isNullOrBlank() && colorString.length >= 2) {
+            if (!colorString.isNullOrBlank() && colorString.length >= 2) {
                 val trimmedColorString = colorString.substring(1, colorString.length - 1).trim()
 
                 try {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -163,16 +163,23 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun setStatusbarColor(colorString: String) {
         mainScope.launch {
-            try {
-                val statusbarNavBarColor = parseColorWithRgb(colorString)
-                view.setStatusBarAndNavigationBarColor(statusbarNavBarColor)
-                return@launch
-            } catch (e: Exception) {
-                Log.e(TAG, "Issue getting/setting theme from webview. Get/Set theme from HA", e)
+            Log.d(TAG, "Try setting statusbar color with color string $colorString from webview")
+            if(!colorString.isNullOrBlank() && colorString.length >= 2) {
+                val trimmedColorString = colorString.substring(1, colorString.length - 1).trim()
+
+                try {
+                    val statusbarNavBarColor = parseColorWithRgb(trimmedColorString)
+                    Log.d(TAG, "Set statusbar color with color $statusbarNavBarColor")
+                    view.setStatusBarAndNavigationBarColor(statusbarNavBarColor)
+                    return@launch
+                } catch (e: Exception) {
+                    Log.e(TAG, "Issue getting/setting theme from webview. Get/Set theme from HA", e)
+                }
             }
 
             try {
                 val colorString = integrationUseCase.getThemeColor()
+                Log.d(TAG, "Try setting statusbar color with color string $colorString from HA")
                 // If color from theme found and if colorString is NOT #03A9F3.
                 // This means a custom theme is set and the theme has a app-header-background-color defined
                 // which we can use as navigation bar color and status bar color.
@@ -183,7 +190,9 @@ class WebViewPresenterImpl @Inject constructor(
                 // https://github.com/home-assistant/core/blob/ee64aafc3932ea0a7a76a33d1827db0c78fc0ed3/homeassistant/components/frontend/__init__.py#L362
                 // TODO: Implement proper check for detecting if a custom theme is set or not in HA
                 if (!colorString.isNullOrEmpty() && colorString != "#03A9F4") { // HA is using a custom theme
-                    view.setStatusBarAndNavigationBarColor(parseColorWithRgb(colorString))
+                    val statusbarNavBarColor = parseColorWithRgb(colorString)
+                    Log.d(TAG, "Set statusbar color with color $statusbarNavBarColor")
+                    view.setStatusBarAndNavigationBarColor(statusbarNavBarColor)
                 }
             } catch (e: Exception) {
                 Log.e(TAG, "Issue getting/setting theme from HA", e)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.webview
 import android.graphics.Color
 import android.net.Uri
 import android.util.Log
-import androidx.core.graphics.ColorUtils
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -171,7 +170,6 @@ class WebViewPresenterImpl @Inject constructor(
             } catch (e: Exception) {
                 Log.e(TAG, "Issue getting/setting theme from webview. Get/Set theme from HA", e)
             }
-
 
             try {
                 val colorString = integrationUseCase.getThemeColor()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->
Fixes #272
Fixes #1365

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR tries to get the statusbar color from the webview HTML directly. If the color can be parsed, then this color will be used as statusbar color. If not, then the HA backend theme color will be used like before.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->