### PR TITLE
Add additional logging for MessagingService and NotificationManagerExtensions

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -569,11 +569,14 @@ class MessagingService : FirebaseMessagingService() {
         }
 
         notificationManagerCompat.apply {
+            Log.d(TAG, "Show notification with tag \"$tag\" and id \"$messageId\"")
             notify(tag, messageId, notificationBuilder.build())
             if (group != null) {
+                Log.d(TAG, "Show group notification with tag \"$group\" and id \"$groupId\"")
                 notify(group, groupId, getGroupNotificationBuilder(channelId, group, data).build())
             } else {
                 if (!previousGroup.isBlank()) {
+                    Log.d(TAG, "Remove group notification with tag \"$previousGroup\" and id \"$previousGroupId\"")
                     notificationManagerCompat.cancelGroupIfNeeded(previousGroup, previousGroupId)
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -4,7 +4,10 @@ import android.app.Notification.FLAG_GROUP_SUMMARY
 import android.app.NotificationManager
 import android.os.Build
 import android.service.notification.StatusBarNotification
+import android.util.Log
 import androidx.core.app.NotificationManagerCompat
+
+const val TAG = "NotifManagerCompat"
 
 fun NotificationManagerCompat.getNotificationManager(): NotificationManager {
     val field = this.javaClass.declaredFields
@@ -24,8 +27,12 @@ fun NotificationManagerCompat.getActiveNotification(tag: String?, id: Int): Stat
 
 fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        Log.d(TAG, "Cancel notification with tag \"$tag\" and id \"$id\"")
+
         var currentActiveNotifications = this.getNotificationManager().activeNotifications
 
+
+        Log.d(TAG, "Check if the notification is in a group...")
         // Get group key from the current notification
         // to handle possible group deletion
         var statusBarNotification =
@@ -35,11 +42,15 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
         // Notification has a group?
         if (statusBarNotification != null && !groupKey.isNullOrBlank()) {
             // Yes it has a group. Get notifications of the group...
+
+            Log.d(TAG, "Notification is in a group ($groupKey). Get all notifications for this group...")
             val groupNotifications =
                 currentActiveNotifications.filter { s -> s.groupKey == groupKey }
 
             // Is the notification which should be deleted a group summary
             var isGroupSummary = statusBarNotification.notification.flags and FLAG_GROUP_SUMMARY != 0
+            if(isGroupSummary) Log.d(TAG, "Notification is the group summary.")
+            else Log.d(TAG, "Notification is NOT the group summary.")
 
             // If the notification which should be delete is NOT a group summary AND
             // If there are only two left notifications, then this means only the current to be
@@ -54,15 +65,31 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
                 !isGroupSummary && groupNotifications.size == 2) {
                 val group = groupNotifications[0].notification.group
 
+                if(isGroupSummary) Log.d(TAG, "Notification is the group summary \"$group\" with no notifications inside. Try to cancel this group summary notification...")
+                else Log.d(TAG, "Notification is inside of group \"$group\", but is the last one in the group. Try to cancel the group notification....")
                 // If group is null, the group is a group which is generate by the system.
                 // This group can't be canceled, but it will be canceled by canceling the last notification inside of the group
                 // If the group isn't null, cancel the group
                 return if (group != null) {
                     var groupId = group.hashCode()
+                    Log.d(TAG, "Cancel group notification with tag \"$group\"  and id \"$groupId\"")
                     this.cancel(group, groupId)
                     true
-                } else false
+                } else {
+                    Log.d(TAG, "Cannot cancel group notification, because group tag is empty. Anyway cancel notification.")
+                    false
+                }
             }
+            else
+            {
+                if(isGroupSummary && groupNotifications.size != 1) Log.d(TAG, "Notification is the group summary, but the group has more than or no notifications inside (" + groupNotifications.size + "). Cancel notification")
+                else if(!isGroupSummary && groupNotifications.size != 2) Log.d(TAG, "Notification is in a group, but the group has more/less than 2 notifications inside (" + groupNotifications.size + "). Cancel notification")
+            }
+        }
+        else
+        {
+            if(statusBarNotification == null) Log.d(TAG, "Notification is not in a group. Cancel notification...")
+            else if(groupKey.isNullOrBlank()) Log.d(TAG, "Notification is in a group but has no group key. Cancel notification")
         }
     }
     return false

--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -31,7 +31,6 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
 
         var currentActiveNotifications = this.getNotificationManager().activeNotifications
 
-
         Log.d(TAG, "Check if the notification is in a group...")
         // Get group key from the current notification
         // to handle possible group deletion
@@ -49,7 +48,7 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
 
             // Is the notification which should be deleted a group summary
             var isGroupSummary = statusBarNotification.notification.flags and FLAG_GROUP_SUMMARY != 0
-            if(isGroupSummary) Log.d(TAG, "Notification is the group summary.")
+            if (isGroupSummary) Log.d(TAG, "Notification is the group summary.")
             else Log.d(TAG, "Notification is NOT the group summary.")
 
             // If the notification which should be delete is NOT a group summary AND
@@ -65,7 +64,7 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
                 !isGroupSummary && groupNotifications.size == 2) {
                 val group = groupNotifications[0].notification.group
 
-                if(isGroupSummary) Log.d(TAG, "Notification is the group summary \"$group\" with no notifications inside. Try to cancel this group summary notification...")
+                if (isGroupSummary) Log.d(TAG, "Notification is the group summary \"$group\" with no notifications inside. Try to cancel this group summary notification...")
                 else Log.d(TAG, "Notification is inside of group \"$group\", but is the last one in the group. Try to cancel the group notification....")
                 // If group is null, the group is a group which is generate by the system.
                 // This group can't be canceled, but it will be canceled by canceling the last notification inside of the group
@@ -79,17 +78,13 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
                     Log.d(TAG, "Cannot cancel group notification, because group tag is empty. Anyway cancel notification.")
                     false
                 }
+            } else {
+                if (isGroupSummary && groupNotifications.size != 1) Log.d(TAG, "Notification is the group summary, but the group has more than or no notifications inside (" + groupNotifications.size + "). Cancel notification")
+                else if (!isGroupSummary && groupNotifications.size != 2) Log.d(TAG, "Notification is in a group, but the group has more/less than 2 notifications inside (" + groupNotifications.size + "). Cancel notification")
             }
-            else
-            {
-                if(isGroupSummary && groupNotifications.size != 1) Log.d(TAG, "Notification is the group summary, but the group has more than or no notifications inside (" + groupNotifications.size + "). Cancel notification")
-                else if(!isGroupSummary && groupNotifications.size != 2) Log.d(TAG, "Notification is in a group, but the group has more/less than 2 notifications inside (" + groupNotifications.size + "). Cancel notification")
-            }
-        }
-        else
-        {
-            if(statusBarNotification == null) Log.d(TAG, "Notification is not in a group. Cancel notification...")
-            else if(groupKey.isNullOrBlank()) Log.d(TAG, "Notification is in a group but has no group key. Cancel notification")
+        } else {
+            if (statusBarNotification == null) Log.d(TAG, "Notification is not in a group. Cancel notification...")
+            else if (groupKey.isNullOrBlank()) Log.d(TAG, "Notification is in a group but has no group key. Cancel notification")
         }
     }
     return false


### PR DESCRIPTION
This PR adds additional logging for MessagingService and NotificationManagerExtensions.

Maybe these logs help to solve the issue https://github.com/home-assistant/android/issues/1435

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->