### PR TITLE
Add some debug logs for next alarm sensor update logic

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -87,8 +87,7 @@ class NextAlarmManager : SensorManager {
                 val sdf = SimpleDateFormat(dateFormat)
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
-            }
-            else
+            } else
                 Log.d(TAG, "No alarm is scheduled, sending unavailable")
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -66,15 +66,18 @@ class NextAlarmManager : SensorManager {
 
             if (alarmClockInfo != null) {
                 pendingIntent = alarmClockInfo.showIntent?.creatorPackage ?: "Unknown"
+                triggerTime = alarmClockInfo.triggerTime
 
+                Log.d(TAG, "Next alarm is scheduled by $pendingIntent with trigger time $triggerTime")
                 if (allowPackageList != "") {
                     val allowPackageListing = allowPackageList.split(", ")
-                    if (pendingIntent !in allowPackageListing)
+                    if (pendingIntent !in allowPackageListing) {
+                        Log.d(TAG, "Skipping update from $pendingIntent as it is not in the allow list")
                         return
+                    }
                 } else {
                     sensorDao.add(Setting(nextAlarm.id, ALLOW_LIST, allowPackageList, "list-apps"))
                 }
-                triggerTime = alarmClockInfo.triggerTime
 
                 val cal: Calendar = GregorianCalendar()
                 cal.timeInMillis = triggerTime
@@ -85,6 +88,8 @@ class NextAlarmManager : SensorManager {
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
             }
+            else
+                Log.d(TAG, "No alarm is scheduled, sending unavailable")
         } catch (e: Exception) {
             Log.e(TAG, "Error getting the next alarm info", e)
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This sensor can cause a lot of confusion with users because we have no control over what the next scheduled alarm is. Adding some debug logs so users can follow the update logic to understand when they are skipped due to the allow list.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->