### PR TITLE
Fix clear_notification if notifications are in the auto group

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -44,7 +44,7 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
             Log.d(TAG, "Notification is in a group ($groupKey). Get all notifications for this group...")
 
             // Check if the group is the auto group of android ("ranker_group")
-            if (!groupKey.contains("ranker_group")) {
+            if (!groupKey.endsWith("|g:ranker_group")) {
 
                 // Nope it is a custom group. Get notifications of the group...
                 val groupNotifications =

--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationManagerExtensions.kt
@@ -40,47 +40,61 @@ fun NotificationManagerCompat.cancelGroupIfNeeded(tag: String?, id: Int): Boolea
 
         // Notification has a group?
         if (statusBarNotification != null && !groupKey.isNullOrBlank()) {
-            // Yes it has a group. Get notifications of the group...
-
+            // Yes it has a group.
             Log.d(TAG, "Notification is in a group ($groupKey). Get all notifications for this group...")
-            val groupNotifications =
-                currentActiveNotifications.filter { s -> s.groupKey == groupKey }
 
-            // Is the notification which should be deleted a group summary
-            var isGroupSummary = statusBarNotification.notification.flags and FLAG_GROUP_SUMMARY != 0
-            if (isGroupSummary) Log.d(TAG, "Notification is the group summary.")
-            else Log.d(TAG, "Notification is NOT the group summary.")
+            // Check if the group is the auto group of android ("ranker_group")
+            if (!groupKey.contains("ranker_group")) {
 
-            // If the notification which should be delete is NOT a group summary AND
-            // If there are only two left notifications, then this means only the current to be
-            // canceled notification AND the group of the notification is left
-            // If we cancel the group of the notification, the notifications inside of the group
-            // will be canceled too.
+                // Nope it is a custom group. Get notifications of the group...
+                val groupNotifications =
+                    currentActiveNotifications.filter { s -> s.groupKey == groupKey }
 
-            // If the notification which should be delete is A group summary AND
-            // If there are only one left notifications, then this means only the empty group of
-            // the notification is left.
-            if (isGroupSummary && groupNotifications.size == 1 ||
-                !isGroupSummary && groupNotifications.size == 2) {
-                val group = groupNotifications[0].notification.group
+                // Is the notification which should be deleted a group summary
+                var isGroupSummary = statusBarNotification.notification.flags and FLAG_GROUP_SUMMARY != 0
+                if (isGroupSummary) Log.d(TAG, "Notification is the group summary.")
+                else Log.d(TAG, "Notification is NOT the group summary.")
 
-                if (isGroupSummary) Log.d(TAG, "Notification is the group summary \"$group\" with no notifications inside. Try to cancel this group summary notification...")
-                else Log.d(TAG, "Notification is inside of group \"$group\", but is the last one in the group. Try to cancel the group notification....")
-                // If group is null, the group is a group which is generate by the system.
-                // This group can't be canceled, but it will be canceled by canceling the last notification inside of the group
-                // If the group isn't null, cancel the group
-                return if (group != null) {
-                    var groupId = group.hashCode()
-                    Log.d(TAG, "Cancel group notification with tag \"$group\"  and id \"$groupId\"")
-                    this.cancel(group, groupId)
-                    true
+                // If the notification which should be delete is NOT a group summary AND
+                // If there are only two left notifications, then this means only the current to be
+                // canceled notification AND the group of the notification is left
+                // If we cancel the group of the notification, the notifications inside of the group
+                // will be canceled too.
+
+                // If the notification which should be delete is A group summary AND
+                // If there are only one left notifications, then this means only the empty group of
+                // the notification is left.
+                if (isGroupSummary && groupNotifications.size == 1 ||
+                    !isGroupSummary && groupNotifications.size == 2
+                ) {
+                    val group = groupNotifications[0].notification.group
+
+                    if (isGroupSummary) Log.d(TAG, "Notification is the group summary \"$group\" with no notifications inside. Try to cancel this group summary notification...")
+                    else Log.d(TAG, "Notification is inside of group \"$group\", but is the last one in the group. Try to cancel the group notification....")
+                    // If group is null, the group is a group which is generate by the system.
+                    // This group can't be canceled, but it will be canceled by canceling the last notification inside of the group
+                    // If the group isn't null, cancel the group
+                    return if (group != null) {
+                        var groupId = group.hashCode()
+                        Log.d(TAG, "Cancel group notification with tag \"$group\"  and id \"$groupId\"")
+                        this.cancel(group, groupId)
+                        true
+                    } else {
+                        Log.d(TAG, "Cannot cancel group notification, because group tag is empty. Anyway cancel notification.")
+                        false
+                    }
                 } else {
-                    Log.d(TAG, "Cannot cancel group notification, because group tag is empty. Anyway cancel notification.")
-                    false
+                    if (isGroupSummary && groupNotifications.size != 1) Log.d(
+                        TAG,
+                        "Notification is the group summary, but the group has more than or no notifications inside (" + groupNotifications.size + "). Cancel notification"
+                    )
+                    else if (!isGroupSummary && groupNotifications.size != 2) Log.d(
+                        TAG,
+                        "Notification is in a group, but the group has more/less than 2 notifications inside (" + groupNotifications.size + "). Cancel notification"
+                    )
                 }
             } else {
-                if (isGroupSummary && groupNotifications.size != 1) Log.d(TAG, "Notification is the group summary, but the group has more than or no notifications inside (" + groupNotifications.size + "). Cancel notification")
-                else if (!isGroupSummary && groupNotifications.size != 2) Log.d(TAG, "Notification is in a group, but the group has more/less than 2 notifications inside (" + groupNotifications.size + "). Cancel notification")
+                Log.d(TAG, "Notification is in a group ($groupKey), but it is in the auto group. Cancel notification")
             }
         } else {
             if (statusBarNotification == null) Log.d(TAG, "Notification is not in a group. Cancel notification...")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

Fixes #1435

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes a problem that some notifications are not cleared. Reason: Android does group notifications at a certain timeout or at a certain notification count of a app. If the notifications are grouped by this auto group (internal named "ranked_group"), then the last notification of this group cannot be canceled.

Solution: Cancel the notification itself, if the notification is in the auto group. Android should cancel the auto group summary notification by itself.

To reproduce this issue, i needed to create four notifications.
```yaml
service: notify.mobile_app_xxx
data:
  title: Wow
  message: wowow1
  data:
    tag: wow1

service: notify.mobile_app_xxx
data:
  title: Wow
  message: wowow2
  data:
    tag: wow2

service: notify.mobile_app_xxx
data:
  title: Wow
  message: wowow3
  data:
    tag: wow3

service: notify.mobile_app_xxx
data:
  title: Wow
  message: wowow4
  data:
    tag: wow4
```

Then clear each one, after the auto group was created.
```yaml
service: notify.mobile_app_xxx
data:
  title: Wow
  message: clear_notification
  data:
    tag: wow1

service: notify.mobile_app_xxx
data:
  title: Wow
  message: clear_notification
  data:
    tag: wow2

service: notify.mobile_app_xxx
data:
  title: Wow
  message: clear_notification
  data:
    tag: wow3

service: notify.mobile_app_xxx
data:
  title: Wow
  message: clear_notification
  data:
    tag: wow4
``` 

I don't know when android decides to create the auto group. Maybe this is different for any manufacture/android system.
On the simulated Pixel 4 with Android 11, it works with four notifications. Also on my OnePlus 5T with Android 10.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->