### PR TITLE
Add battery temperature sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -43,6 +43,15 @@ class BatterySensorManager : SensorManager {
             R.string.basic_sensor_name_battery_health,
             R.string.sensor_description_battery_health
         )
+
+        private val batteryTemperature = SensorManager.BasicSensor(
+            "battery_temperature",
+            "sensor",
+            R.string.basic_sensor_name_battery_temperature,
+            R.string.sensor_description_battery_temperature,
+            "temperature",
+            "°C"
+        )
     }
 
     override val enabledByDefault: Boolean
@@ -51,7 +60,7 @@ class BatterySensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_battery
     override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState)
+        get() = listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState, batteryTemperature)
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
@@ -67,6 +76,7 @@ class BatterySensorManager : SensorManager {
             updateIsCharging(context, intent)
             updateChargerType(context, intent)
             updateBatteryHealth(context, intent)
+            updateBatteryTemperature(context, intent)
         }
     }
 
@@ -177,6 +187,21 @@ class BatterySensorManager : SensorManager {
         )
     }
 
+    private fun updateBatteryTemperature(context: Context, intent: Intent) {
+        if (!isEnabled(context, batteryTemperature.id))
+            return
+
+        val batteryTemp = getBatteryTemperature(intent)
+
+        onSensorUpdated(
+                context,
+                batteryTemperature,
+                batteryTemp,
+                "mdi:battery",
+                mapOf()
+        )
+    }
+
     private fun getIsCharging(intent: Intent): Boolean {
         val status: Int = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1)
 
@@ -213,5 +238,9 @@ class BatterySensorManager : SensorManager {
             BatteryManager.BATTERY_HEALTH_UNSPECIFIED_FAILURE -> "failed"
             else -> "unknown"
         }
+    }
+
+    private fun getBatteryTemperature(intent: Intent): Float {
+        return intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0) / 10f
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -513,4 +513,6 @@ like to connect to:</string>
   <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
   <string name="what_is_this">What is this?</string>
   <string name="what_is_this_crash">Unable to load Home Assistant home page, do you have a browser installed?</string>
+  <string name="basic_sensor_name_battery_temperature">Battery Temperature</string>
+  <string name="sensor_description_battery_temperature">The current battery temperature</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1440 

Google provides the battery temperature in tenths of a degree Centigrade so we divide by 10 and send the data, a users HA instance will convert if needed.

https://android.googlesource.com/platform/frameworks/base/+/master/services/core/java/com/android/server/BatteryService.java#106
 
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/112524180-c4037280-8d5c-11eb-9dc7-bb4da25441d6.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#481

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->