### PR TITLE
Make service field description optional to match core integrations for service call widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -275,6 +275,7 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
                 integrationUseCase.getServices().forEach {
                     services[getServiceString(it)] = it
                 }
+                Log.d(TAG, "Services found: $services")
                 if (buttonWidget != null) {
                     serviceAdapter.add(services[serviceText])
                     val serviceData = services[serviceText]!!.serviceData
@@ -321,7 +322,8 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
             } catch (e: Exception) {
                 // Custom components can cause services to not load
                 // Display error text
-                widget_config_service_error.visibility = View.VISIBLE
+                Log.e(TAG, "Unable to load services from Home Assistant", e)
+                widget_config_service_error.visibility = VISIBLE
             }
 
             try {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ServiceFields.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ServiceFields.kt
@@ -2,7 +2,7 @@ package io.homeassistant.companion.android.common.data.integration
 
 data class ServiceFields(
     val name: String?,
-    val description: String,
+    val description: String?,
     val example: Any?,
     val values: List<String>?
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had a user on the forums hit the custom component error message when they did not have any custom components.  It turns out that the user had some `script` setup that did not have `description` under the `fields` and looking at the code we can see its indeed optional.

https://github.com/home-assistant/core/blob/dev/homeassistant/components/script/__init__.py#L70
https://community.home-assistant.io/t/unable-to-configure-a-widget/293451

So now the field is left optional, doesn't seem to cause any issues and I was able to reproduce the issue to confirm the fix. The field still loads and the example is shown.

Reproduced with the following `script`:

```
  wakeup:
    alias: "Wake Up"
    icon: "mdi:party-popper"
    description: "Turns on the bedroom lights and then the living room lights after a delay"
    variables:
      turn_on_entity: group.living_room
    fields:
      minutes:
        example: 1
    # If called again while still running (probably in delay step), start over.
    mode: restart
    sequence:
      # This is Home Assistant Script Syntax
      - event: LOGBOOK_ENTRY
        event_data:
          name: Paulus
          message: is waking up
          entity_id: device_tracker.paulus
          domain: light
```

and the accompanying error message:

```
2021-03-26 09:48:17.602 32076-32076/io.homeassistant.companion.android.debug E/ButtonWidgetConfigAct: Unable to load services from Home Assistant display error message
    com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class io.homeassistant.companion.android.common.data.integration.ServiceFields] value failed for JSON property description due to missing (therefore NULL) value for creator parameter description which is a non-nullable type
        at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 12304] (through reference chain: java.lang.Object[][13]->io.homeassistant.companion.android.common.data.integration.impl.entities.DomainResponse["services"]->java.util.LinkedHashMap["wakeup"]->io.homeassistant.companion.android.common.data.integration.ServiceData["fields"]->java.util.LinkedHashMap["minutes"]->io.homeassistant.companion.android.common.data.integration.ServiceFields["description"])
        at com.fasterxml.jackson.module.kotlin.KotlinValueInstantiator.createFromObjectWith(KotlinValueInstantiator.kt:116)
        at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:202)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:520)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:609)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:437)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
        at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:565)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:449)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:609)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:437)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
        at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:565)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:449)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:362)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:195)
        at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:214)
        at com.fasterxml.jackson.databind.deser.std.ObjectArrayDeserializer.deserialize(ObjectArrayDeserializer.java:24)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:322)
        at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2033)
        at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1458)
2021-03-26 09:48:17.602 32076-32076/io.homeassistant.companion.android.debug E/ButtonWidgetConfigAct:     at retrofit2.converter.jackson.JacksonResponseBodyConverter.convert(JacksonResponseBodyConverter.java:33)
        at retrofit2.converter.jackson.JacksonResponseBodyConverter.convert(JacksonResponseBodyConverter.java:23)
        at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:243)
        at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:153)
        at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:923)
```

Also we are now printing services and the error message to make finding the issue easier in the future

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->