### PR TITLE
Fix missing context for availableSensors in LocationSensorManager

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -186,8 +186,9 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     override val name: Int
         get() = R.string.sensor_name_activity
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(activity, sleepConfidence, sleepSegment)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(activity, sleepConfidence, sleepSegment)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -30,8 +30,9 @@ class GeocodeSensorManager : SensorManager {
         get() = false
     override val name: Int
         get() = R.string.sensor_name_geolocation
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(geocodedLocation)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(geocodedLocation)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -431,7 +431,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 Log.w(TAG, "Location accuracy didn't meet requirements, disregarding: $location")
             } else {
                 // Update GeoLocation Sensor (if enabled) with new Location
-                val geoSensorManager = SensorReceiver.MANAGERS.firstOrNull { it.availableSensors.any { s -> s.name == R.string.basic_sensor_name_geolocation } }
+                val geoSensorManager = SensorReceiver.MANAGERS.firstOrNull { it.getAvailableSensors(latestContext).any { s -> s.name == R.string.basic_sensor_name_geolocation } }
                 if (geoSensorManager != null) {
                     if (geoSensorManager.isEnabled(latestContext, "geocoded_location")) {
                         geoSensorManager.requestSensorUpdate(latestContext)
@@ -443,6 +443,14 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
                 // Send new location to Home Assistant
                 sendLocationUpdate(location)
             }
+        }
+    }
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return if (DisabledLocationHandler.hasGPS(context)) {
+            listOf(singleAccurateLocation, backgroundLocation, zoneLocation)
+        } else {
+            listOf(backgroundLocation, zoneLocation)
         }
     }
 
@@ -800,14 +808,6 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     override val name: Int
         get() = R.string.sensor_name_location
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() {
-            return if (DisabledLocationHandler.hasGPS(latestContext)) {
-                listOf(singleAccurateLocation, backgroundLocation, zoneLocation)
-            } else {
-                listOf(backgroundLocation, zoneLocation)
-            }
-        }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -808,7 +808,6 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
     override val name: Int
         get() = R.string.sensor_name_location
 
-
     override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             arrayOf(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AppSensorManager.kt
@@ -75,16 +75,22 @@ class AppSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_app_sensor
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = when {
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return when {
             (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) ->
-                listOf(currentVersion, app_rx_gb, app_tx_gb, app_memory, app_inactive,
-                    app_standby_bucket, app_importance)
+                listOf(
+                    currentVersion, app_rx_gb, app_tx_gb, app_memory, app_inactive,
+                    app_standby_bucket, app_importance
+                )
             (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ->
-                listOf(currentVersion, app_rx_gb, app_tx_gb, app_memory, app_inactive,
-                    app_importance)
+                listOf(
+                    currentVersion, app_rx_gb, app_tx_gb, app_memory, app_inactive,
+                    app_importance
+                )
             else -> listOf(currentVersion, app_rx_gb, app_tx_gb, app_memory, app_importance)
         }
+    }
+
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -78,8 +78,9 @@ class AudioSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_audio
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(audioSensor, audioState, headphoneState, micMuted, speakerphoneState, musicActive, volAlarm, volCall, volMusic, volRing)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(audioSensor, audioState, headphoneState, micMuted, speakerphoneState, musicActive, volAlarm, volCall, volMusic, volRing)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BatterySensorManager.kt
@@ -59,8 +59,9 @@ class BatterySensorManager : SensorManager {
 
     override val name: Int
         get() = R.string.sensor_name_battery
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState, batteryTemperature)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(batteryLevel, batteryState, isChargingState, chargerTypeState, batteryHealthState, batteryTemperature)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -66,8 +66,9 @@ class BluetoothSensorManager : SensorManager {
         get() = false
     override val name: Int
         get() = R.string.sensor_name_bluetooth
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(bluetoothConnection, bluetoothState, bleTransmitter)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+       return listOf(bluetoothConnection, bluetoothState, bleTransmitter)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf(Manifest.permission.BLUETOOTH)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -67,7 +67,7 @@ class BluetoothSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_bluetooth
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-       return listOf(bluetoothConnection, bluetoothState, bleTransmitter)
+        return listOf(bluetoothConnection, bluetoothState, bleTransmitter)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -22,8 +22,9 @@ class DNDSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_dnd
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(dndSensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(dndSensor)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/KeyguardSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/KeyguardSensorManager.kt
@@ -41,11 +41,12 @@ class KeyguardSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_keyguard
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = when {
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return when {
             (Build.VERSION.SDK_INT >= 23) -> listOf(deviceLocked, deviceSecure, keyguardLocked, keyguardSecure)
             (Build.VERSION.SDK_INT >= 22) -> listOf(deviceLocked, keyguardLocked, keyguardSecure)
             else -> listOf(keyguardLocked, keyguardSecure)
+        }
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
@@ -35,8 +35,9 @@ class LastRebootSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_last_reboot
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(lastRebootSensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(lastRebootSensor)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastUpdateManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastUpdateManager.kt
@@ -24,8 +24,9 @@ class LastUpdateManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_last_update
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(lastUpdate)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(lastUpdate)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -32,8 +32,9 @@ class LightSensorManager : SensorManager, SensorEventListener {
     override val name: Int
         get() = R.string.sensor_name_light
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(lightSensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(lightSensor)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/MobileDataManager.kt
@@ -29,8 +29,9 @@ class MobileDataManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_mobile_data
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(mobileDataState, mobileDataRoaming)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(mobileDataState, mobileDataRoaming)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NetworkSensorManager.kt
@@ -79,8 +79,8 @@ class NetworkSensorManager : SensorManager {
         get() = false
     override val name: Int
         get() = R.string.sensor_name_network
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(
             wifiConnection,
             bssidState,
             wifiIp,
@@ -90,6 +90,7 @@ class NetworkSensorManager : SensorManager {
             wifiSignalStrength,
             publicIp
         )
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return when {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -31,8 +31,9 @@ class NextAlarmManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_alarm
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(nextAlarm)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(nextAlarm)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -34,8 +34,9 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     }
     override val name: Int
         get() = R.string.sensor_name_last_notification
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(lastNotification, lastRemovedNotification, activeNotificationCount)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(lastNotification, lastRemovedNotification, activeNotificationCount)
+    }
     override val enabledByDefault: Boolean
         get() = false
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PhoneStateSensorManager.kt
@@ -39,10 +39,11 @@ class PhoneStateSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_phone
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1)
             listOf(phoneState, sim_1, sim_2)
         else listOf(phoneState)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf(Manifest.permission.READ_PHONE_STATE)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -37,12 +37,13 @@ class PowerSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_power
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             listOf(interactiveDevice, doze, powerSave)
         } else {
             listOf(interactiveDevice, powerSave)
         }
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -35,8 +35,9 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     override val name: Int
         get() = R.string.sensor_name_pressure
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(pressureSensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(pressureSensor)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -34,8 +34,9 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     override val name: Int
         get() = R.string.sensor_name_proximity
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(proximitySensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(proximitySensor)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -13,7 +13,6 @@ import io.homeassistant.companion.android.database.sensor.Setting
 interface SensorManager {
 
     val name: Int
-    val availableSensors: List<BasicSensor>
     val enabledByDefault: Boolean
 
     data class BasicSensor(
@@ -54,6 +53,8 @@ interface SensorManager {
     }
 
     fun requestSensorUpdate(context: Context)
+
+    fun getAvailableSensors(context: Context):  List<BasicSensor>
 
     fun hasSensor(context: Context): Boolean {
         return true

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorManager.kt
@@ -54,7 +54,7 @@ interface SensorManager {
 
     fun requestSensorUpdate(context: Context)
 
-    fun getAvailableSensors(context: Context):  List<BasicSensor>
+    fun getAvailableSensors(context: Context): List<BasicSensor>
 
     fun hasSensor(context: Context): Boolean {
         return true

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -152,7 +152,7 @@ class SensorReceiver : BroadcastReceiver() {
             } catch (e: Exception) {
                 Log.e(TAG, "Issue requesting updates for ${context.getString(manager.name)}", e)
             }
-            manager.availableSensors.forEach { basicSensor ->
+            manager.getAvailableSensors(context).forEach { basicSensor ->
                 val fullSensor = sensorDao.getFull(basicSensor.id)
                 val sensor = fullSensor?.sensor
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -41,7 +41,7 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
             totalEnabledSensors = 0
             val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
             SensorReceiver.MANAGERS.forEach { managers ->
-                managers.availableSensors.forEach { basicSensor ->
+                managers.getAvailableSensors(requireContext()).forEach { basicSensor ->
                     findPreference<Preference>(basicSensor.id)?.let {
                         val sensorEntity = sensorDao.get(basicSensor.id)
                         if (sensorEntity?.enabled == true) {
@@ -118,7 +118,7 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
                 val locationEnabled = DisabledLocationHandler.isLocationEnabled(context)
 
                 SensorReceiver.MANAGERS.forEach { managers ->
-                    managers.availableSensors.forEach { basicSensor ->
+                    managers.getAvailableSensors(context).forEach { basicSensor ->
                         val requiredPermissions = managers.requiredPermissions(basicSensor.id)
 
                         val locationPermissionCoarse = DisabledLocationHandler.containsLocationPermission(requiredPermissions, false)
@@ -169,7 +169,7 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
             prefCategory.title = getString(manager.name)
             preferenceScreen.addPreference(prefCategory)
 
-            manager.availableSensors.sortedBy { getString(it.name) }.forEach { basicSensor ->
+            manager.getAvailableSensors(requireContext()).sortedBy { getString(it.name) }.forEach { basicSensor ->
                 val pref = Preference(preferenceScreen.context)
                 pref.key = basicSensor.id
                 pref.title = getString(basicSensor.name)
@@ -245,7 +245,7 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
 
     private fun filterSensors(searchQuery: String? = "") {
         SensorReceiver.MANAGERS.filter { m -> m.hasSensor(requireContext()) }.forEach { manager ->
-            manager.availableSensors.forEach { sensor ->
+            manager.getAvailableSensors(requireContext()).forEach { sensor ->
                 val pref = findPreference<Preference>(sensor.id)
                 if (pref != null) {
                     pref.isVisible = true
@@ -358,7 +358,7 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
         val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
 
         SensorReceiver.MANAGERS.forEach { managers ->
-            managers.availableSensors.forEach { basicSensor ->
+            managers.getAvailableSensors(requireContext()).forEach { basicSensor ->
                 val sensorTurnsOnWithGroupToggle = managers.enableToggleAll(requireContext(), basicSensor.id)
                 if (!sensorTurnsOnWithGroupToggle) {
                     return@forEach

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -33,8 +33,9 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     override val name: Int
         get() = R.string.sensor_name_steps
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(stepsSensor)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(stepsSensor)
+    }
 
     private lateinit var latestContext: Context
     private lateinit var mySensorManager: android.hardware.SensorManager

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -64,8 +64,9 @@ class StorageSensorManager : SensorManager {
         get() = false
     override val name: Int
         get() = R.string.sensor_name_storage
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(storageSensor, externalStorage)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(storageSensor, externalStorage)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -23,8 +23,9 @@ class TimeZoneManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_time_zone
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf(currentTimeZone)
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(currentTimeZone)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TrafficStatsManager.kt
@@ -50,10 +50,11 @@ class TrafficStatsManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_traffic_stats
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = if (hasCellular) {
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return if (hasCellular) {
             listOf(rxBytesMobile, txBytesMobile, rxBytesTotal, txBytesTotal)
         } else listOf(rxBytesTotal, txBytesTotal)
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -538,7 +538,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             settingsWithLocationPermissions.add(getString(R.string.pref_connection_wifi))
         }
         for (manager in SensorReceiver.MANAGERS) {
-            for (basicSensor in manager.availableSensors) {
+            for (basicSensor in manager.getAvailableSensors(this)) {
                 if (manager.isEnabled(this, basicSensor.id)) {
                     var permissions = manager.requiredPermissions(basicSensor.id)
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -16,8 +16,9 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     override val name: Int
         get() = R.string.sensor_name_activity
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf()
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf()
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         // Noop

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -20,8 +20,9 @@ class GeocodeSensorManager : SensorManager {
     override val name: Int
         get() = R.string.sensor_name_geolocation
 
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf()
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf()
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -48,8 +48,10 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         get() = false
     override val name: Int
         get() = R.string.sensor_name_location
-    override val availableSensors: List<SensorManager.BasicSensor>
-        get() = listOf()
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf()
+    }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         // Noop


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes following crash:
```
kotlin.UninitializedPropertyAccessException: lateinit property latestContext has not been initialized
    at io.homeassistant.companion.android.sensors.LocationSensorManager.getAvailableSensors(LocationSensorManager.kt:805)
    at io.homeassistant.companion.android.webview.WebViewActivity.checkAndWarnForDisabledLocation(WebViewActivity.kt:541)
    at io.homeassistant.companion.android.webview.WebViewActivity.onResume(WebViewActivity.kt:525)
    at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1456)
    at android.app.Activity.performResume(Activity.java:8344)
    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4854)
    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4901)
    at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8506)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
java.lang.RuntimeException: Unable to resume activity {io.homeassistant.companion.android/io.homeassistant.companion.android.webview.WebViewActivity}: kotlin.UninitializedPropertyAccessException: lateinit property latestContext has not been initialized
    at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4864)
    at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4901)
    at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:52)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8506)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

`latestContext` is first available when `onReceive` was called. So if `onReceive` wasn't called by then, method `getAvailableSensors` will crash, because `latextContext` is not set. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->