### PR TITLE
Improve getZones api call 

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -625,7 +625,13 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             .setInitialTrigger(GeofencingRequest.INITIAL_TRIGGER_ENTER)
 
         // TODO cache the zones on device so we don't need to reach out each time
-        val configuredZones = integrationUseCase.getZones()
+        var configuredZones: Array<Entity<ZoneAttributes>> = emptyArray()
+        try {
+            configuredZones = integrationUseCase.getZones()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error receiving zones from Home Assistant")
+        }
+
         val highAccuracyTriggerRange = getHighAccuracyModeTriggerRange()
         val highAccuracyZones = getHighAccuracyModeZones(false)
         configuredZones.forEach {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -629,7 +629,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
         try {
             configuredZones = integrationUseCase.getZones()
         } catch (e: Exception) {
-            Log.e(TAG, "Error receiving zones from Home Assistant")
+            Log.e(TAG, "Error receiving zones from Home Assistant", e)
         }
 
         val highAccuracyTriggerRange = getHighAccuracyModeTriggerRange()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -288,7 +288,7 @@ class SensorDetailFragment(
                             try {
                                 zones = integrationUseCase.getZones().map { z -> z.entityId }
                             } catch (e: Exception) {
-                                Log.e(TAG, "Error receiving zones from Home Assistant")
+                                Log.e(TAG, "Error receiving zones from Home Assistant", e)
                             }
                         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -8,6 +8,7 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.text.InputType
+import android.util.Log
 import androidx.preference.EditTextPreference
 import androidx.preference.ListPreference
 import androidx.preference.MultiSelectListPreference
@@ -43,6 +44,8 @@ class SensorDetailFragment(
         ): SensorDetailFragment {
             return SensorDetailFragment(sensorManager, basicSensor, integrationUseCase)
         }
+
+        private const val TAG = "SensorDetailFragment"
     }
 
     private lateinit var sensorDao: SensorDao
@@ -280,9 +283,13 @@ class SensorDetailFragment(
                         val pref = createListPreference(key, setting, sensorDao, btDevices)
                         if (!it.contains(pref)) it.addPreference(pref)
                     } else if (setting.valueType == "list-zones") {
-                        val zones: List<String>
+                        var zones: List<String> = emptyList()
                         runBlocking {
-                            zones = integrationUseCase.getZones().map { z -> z.entityId }
+                            try {
+                                zones = integrationUseCase.getZones().map { z -> z.entityId }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error receiving zones from Home Assistant")
+                            }
                         }
 
                         val pref = createListPreference(key, setting, sensorDao, zones)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationException.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationException.kt
@@ -1,3 +1,7 @@
 package io.homeassistant.companion.android.common.data.integration
 
-class IntegrationException : Exception()
+class IntegrationException : Exception {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -101,6 +101,7 @@ class IntegrationRepositoryImpl @Inject constructor(
                 "update_registration",
                 createUpdateRegistrationRequest(deviceRegistration)
             )
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 if (integrationService.callWebhook(it.toHttpUrlOrNull()!!, request).isSuccessful) {
@@ -108,11 +109,13 @@ class IntegrationRepositoryImpl @Inject constructor(
                     return
                 }
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request update_registration")
     }
 
     override suspend fun getRegistration(): DeviceRegistration {
@@ -137,6 +140,7 @@ class IntegrationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun renderTemplate(template: String, variables: Map<String, String>): String {
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 return integrationService.getTemplate(
@@ -147,15 +151,19 @@ class IntegrationRepositoryImpl @Inject constructor(
                     )
                 ).getValue("template")
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request render_template")
     }
 
     override suspend fun updateLocation(updateLocation: UpdateLocation) {
         val updateLocationRequest = createUpdateLocation(updateLocation)
+
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             var wasSuccess = false
             try {
@@ -165,14 +173,16 @@ class IntegrationRepositoryImpl @Inject constructor(
                         updateLocationRequest
                     ).isSuccessful
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
             // if we had a successful call we can return
             if (wasSuccess)
                 return
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request update_location")
     }
 
     override suspend fun callService(
@@ -189,6 +199,7 @@ class IntegrationRepositoryImpl @Inject constructor(
                 serviceData
             )
 
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 wasSuccess =
@@ -200,19 +211,22 @@ class IntegrationRepositoryImpl @Inject constructor(
                         )
                     ).isSuccessful
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
             // if we had a successful call we can return
             if (wasSuccess)
                 return
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request call_service")
     }
 
     override suspend fun scanTag(data: HashMap<String, Any>) {
         var wasSuccess = false
 
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 wasSuccess =
@@ -224,14 +238,16 @@ class IntegrationRepositoryImpl @Inject constructor(
                         )
                     ).isSuccessful
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
             // if we had a successful call we can return
             if (wasSuccess)
                 return
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request scan_tag")
     }
 
     override suspend fun fireEvent(eventType: String, eventData: Map<String, Any>) {
@@ -242,6 +258,7 @@ class IntegrationRepositoryImpl @Inject constructor(
             eventData.plus(Pair("device_id", deviceId))
         )
 
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 wasSuccess =
@@ -253,14 +270,16 @@ class IntegrationRepositoryImpl @Inject constructor(
                         )
                     ).isSuccessful
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
             // if we had a successful call we can return
             if (wasSuccess)
                 return
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request fire_event")
     }
 
     override suspend fun getZones(): Array<Entity<ZoneAttributes>> {
@@ -269,12 +288,14 @@ class IntegrationRepositoryImpl @Inject constructor(
                 "get_zones",
                 null
             )
+        var causeException: Exception? = null
         var zones: Array<EntityResponse<ZoneAttributes>>? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 zones = integrationService.getZones(it.toHttpUrlOrNull()!!, getZonesRequest)
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
 
             if (zones != null) {
@@ -282,7 +303,8 @@ class IntegrationRepositoryImpl @Inject constructor(
             }
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request get_zones")
     }
 
     override suspend fun setFullScreenEnabled(enabled: Boolean) {
@@ -314,15 +336,19 @@ class IntegrationRepositoryImpl @Inject constructor(
         val requestBody = RateLimitRequest(pushToken)
         var checkRateLimits: RateLimitResponse? = null
 
+        var causeException: Exception? = null
+
         try {
             checkRateLimits = integrationService.getRateLimit(RATE_LIMIT_URL, requestBody).rateLimits
         } catch (e: Exception) {
+            causeException = e
             Log.e(TAG, "Unable to get notification rate limits", e)
         }
         if (checkRateLimits != null)
             return checkRateLimits
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling checkRateLimits")
     }
 
     override suspend fun getThemeColor(): String {
@@ -331,19 +357,24 @@ class IntegrationRepositoryImpl @Inject constructor(
                 "get_config",
                 null
             )
+
         var response: GetConfigResponse? = null
+        var causeException: Exception? = null
+
         for (it in urlRepository.getApiUrls()) {
             try {
                 response = integrationService.getConfig(it.toHttpUrlOrNull()!!, getConfigRequest)
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
 
             if (response != null)
                 return response.themeColor
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request get_config/themeColor")
     }
 
     override suspend fun getHomeAssistantVersion(): String {
@@ -353,18 +384,22 @@ class IntegrationRepositoryImpl @Inject constructor(
                 null
             )
         var response: GetConfigResponse? = null
+        var causeException: Exception? = null
+
         for (it in urlRepository.getApiUrls()) {
             try {
                 response = integrationService.getConfig(it.toHttpUrlOrNull()!!, getConfigRequest)
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
 
             if (response != null)
                 return response.version
         }
 
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request get_config/version")
     }
 
     // TODO: Use websocket to get panels.
@@ -418,6 +453,7 @@ class IntegrationRepositoryImpl @Inject constructor(
             // Already registered
             return
         }
+
         val integrationRequest = IntegrationRequest(
             "register_sensor",
             SensorRequest(
@@ -431,6 +467,8 @@ class IntegrationRepositoryImpl @Inject constructor(
                 sensorRegistration.unitOfMeasurement
             )
         )
+
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 integrationService.callWebhook(it.toHttpUrlOrNull()!!, integrationRequest).let {
@@ -444,10 +482,12 @@ class IntegrationRepositoryImpl @Inject constructor(
                     }
                 }
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
         }
-        throw IntegrationException()
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration request register_sensor")
     }
 
     override suspend fun updateSensors(sensors: Array<SensorRegistration<Any>>): Boolean {
@@ -463,6 +503,8 @@ class IntegrationRepositoryImpl @Inject constructor(
                 )
             }
         )
+
+        var causeException: Exception? = null
         for (it in urlRepository.getApiUrls()) {
             try {
                 integrationService.updateSensors(it.toHttpUrlOrNull()!!, integrationRequest).let {
@@ -475,10 +517,13 @@ class IntegrationRepositoryImpl @Inject constructor(
                     return true
                 }
             } catch (e: Exception) {
-                // Ignore failure until we are out of URLS to try!
+                if (causeException == null) causeException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
             }
         }
-        throw IntegrationException()
+
+        if (causeException != null) throw IntegrationException(causeException)
+        else throw IntegrationException("Error calling integration update_sensor_states")
     }
 
     override suspend fun shouldNotifySecurityWarning(): Boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR improves the api call for getZones()

- Implement simple zones cache in the `SensorDetailFragment`, because otherwise the api is called every 5 seconds (Cache will be reset on entering sensor detail screen).
- Fixes double update of data in the `SensorDetailFragment` on entering sensor detail screen
- Fixes following crash by try/catch getZones():
```
io.homeassistant.companion.android.common.data.integration.IntegrationException: null
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.getZones(IntegrationRepositoryImpl.kt:285)
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$getZones$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
    at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
    at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
    at kotlinx.coroutines.BuildersKt.runBlocking
    at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
    at kotlinx.coroutines.BuildersKt.runBlocking$default
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData(SensorDetailFragment.kt:284)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.updateSensorEntity(SensorDetailFragment.kt:348)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.onCreatePreferences(SensorDetailFragment.kt:76)
    at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187)
    at androidx.fragment.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1255)
    at androidx.fragment.app.FragmentTransition.calculateFragments(FragmentTransition.java:1138)
    at androidx.fragment.app.FragmentTransition.startTransitions(FragmentTransition.java:136)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2001)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
    at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
    at android.os.Handler.handleCallback(Handler.java:888)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:213)
    at android.app.ActivityThread.main(ActivityThread.java:8178)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
java.lang.reflect.InvocationTargetException: null
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:523)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
```
- All api calls: Log at least the cause exception of the first failed api url, if all api urls didn't succeed. Maybe this way we can analyse what went really wrong in the exception above.

Example exception before PR:
```
2021-03-30 22:11:11.505 11990-11990/io.homeassistant.companion.android.debug E/SensorDetailFragment: Error receiving zones from Home Assistant
    io.homeassistant.companion.android.common.data.integration.IntegrationException
        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.getZones(IntegrationRepositoryImpl.kt:288)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment$refreshSensorData$$inlined$let$lambda$4.invokeSuspend(SensorDetailFragment.kt:301)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData(SensorDetailFragment.kt:299)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.updateSensorEntity(SensorDetailFragment.kt:373)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.onCreatePreferences(SensorDetailFragment.kt:86)
        at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160)
        at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685)
        at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187)
        at androidx.fragment.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1255)
        at androidx.fragment.app.FragmentTransition.calculateFragments(FragmentTransition.java:1138)
        at androidx.fragment.app.FragmentTransition.startTransitions(FragmentTransition.java:136)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2001)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
        at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

Example exception after PR:
```
2021-03-30 22:21:34.732 12627-12627/io.homeassistant.companion.android.debug E/SensorDetailFragment: Error receiving zones from Home Assistant
    io.homeassistant.companion.android.common.data.integration.IntegrationException: java.net.MalformedURLException: no protocol: wow
        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.getZones(IntegrationRepositoryImpl.kt:288)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment$refreshSensorData$$inlined$let$lambda$4.invokeSuspend(SensorDetailFragment.kt:301)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData(SensorDetailFragment.kt:299)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.updateSensorEntity(SensorDetailFragment.kt:373)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.onCreatePreferences(SensorDetailFragment.kt:86)
        at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160)
        at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685)
        at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187)
        at androidx.fragment.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1255)
        at androidx.fragment.app.FragmentTransition.calculateFragments(FragmentTransition.java:1138)
        at androidx.fragment.app.FragmentTransition.startTransitions(FragmentTransition.java:136)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2001)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
        at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7656)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
     Caused by: java.net.MalformedURLException: no protocol: wow
        at java.net.URL.<init>(URL.java:601)
        at java.net.URL.<init>(URL.java:498)
        at java.net.URL.<init>(URL.java:447)
        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.getZones(IntegrationRepositoryImpl.kt:277)
        at io.homeassistant.companion.android.sensors.SensorDetailFragment$refreshSensorData$$inlined$let$lambda$4.invokeSuspend(SensorDetailFragment.kt:301) 
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) 
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106) 
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:274) 
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:84) 
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59) 
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1) 
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38) 
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1) 
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData(SensorDetailFragment.kt:299) 
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.updateSensorEntity(SensorDetailFragment.kt:373) 
        at io.homeassistant.companion.android.sensors.SensorDetailFragment.onCreatePreferences(SensorDetailFragment.kt:86) 
        at androidx.preference.PreferenceFragmentCompat.onCreate(PreferenceFragmentCompat.java:160) 
        at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685) 
        at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280) 
        at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187) 
        at androidx.fragment.app.FragmentTransition.addToFirstInLastOut(FragmentTransition.java:1255) 
        at androidx.fragment.app.FragmentTransition.calculateFragments(FragmentTransition.java:1138) 
        at androidx.fragment.app.FragmentTransition.startTransitions(FragmentTransition.java:136) 
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2001) 
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959) 
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861) 
        at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413) 
        at android.os.Handler.handleCallback(Handler.java:938) 
        at android.os.Handler.dispatchMessage(Handler.java:99) 
        at android.os.Looper.loop(Looper.java:223) 
        at android.app.ActivityThread.main(ActivityThread.java:7656) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947) 
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->