### PR TITLE
Shortcuts entity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsComponent.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsComponent.kt
@@ -3,9 +3,12 @@ package io.homeassistant.companion.android.settings
 import dagger.Component
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.dagger.AppComponent
+import io.homeassistant.companion.android.settings.shortcuts.ManageShortcutsSettingsFragment
 
 @Component(dependencies = [AppComponent::class])
 interface SettingsComponent {
 
     fun inject(activity: BaseActivity)
+
+    fun inject(fragment: ManageShortcutsSettingsFragment)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -14,7 +14,13 @@ import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.settings.DaggerSettingsComponent
 import io.homeassistant.companion.android.webview.WebViewActivity
+import java.lang.Exception
+import javax.inject.Inject
+import kotlinx.coroutines.runBlocking
 
 class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
 
@@ -27,11 +33,16 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
         private const val UPDATE_SUFFIX = "_update"
         private const val CATEGORY_SUFFIX = "_category"
         private const val DELETE_SUFFIX = "_delete"
+        private const val TYPE_SUFFIX = "_type"
+        private const val ENTITY_SUFFIX = "_entity_list"
         private const val TAG = "ManageShortcutFrag"
         fun newInstance(): ManageShortcutsSettingsFragment {
             return ManageShortcutsSettingsFragment()
         }
     }
+
+    @Inject
+    lateinit var integrationUseCase: IntegrationRepository
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         setPreferencesFromResource(R.xml.manage_shortcuts, rootKey)
@@ -41,10 +52,28 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
     override fun onResume() {
         super.onResume()
 
+        DaggerSettingsComponent.builder()
+                .appComponent((activity?.applicationContext as GraphComponentAccessor).appComponent)
+                .build()
+                .inject(this)
+
         val addNewShortcut = findPreference<PreferenceCategory>("pinned_shortcut_category")
+        val shortcutTypes = listOf(getString(R.string.entity_id), getString(R.string.lovelace))
         val shortcutManager = requireContext().getSystemService(ShortcutManager::class.java)
         var pinnedShortcuts = shortcutManager.pinnedShortcuts
         var dynamicShortcuts = shortcutManager.dynamicShortcuts
+        var entityList = listOf<String>()
+
+        runBlocking {
+            try {
+                integrationUseCase.getEntities().forEach {
+                    entityList = entityList + it.entityId
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Unable to fetch list of entity IDs", e)
+            }
+        }
+
         Log.d(TAG, "We have ${dynamicShortcuts.size} dynamic shortcuts")
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -59,8 +88,27 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
             var shortcutPath = findPreference<EditTextPreference>(SHORTCUT_PREFIX + i + PATH_SUFFIX)?.text
             val addUpdatePreference = findPreference<Preference>(SHORTCUT_PREFIX + i + UPDATE_SUFFIX)
             val deletePreference = findPreference<Preference>(SHORTCUT_PREFIX + i + DELETE_SUFFIX)
+            val shortcutType = findPreference<ListPreference>(SHORTCUT_PREFIX + i + TYPE_SUFFIX)
+            val shortcutEntityList = findPreference<ListPreference>(SHORTCUT_PREFIX + i + ENTITY_SUFFIX)
 
-            addUpdatePreference?.isEnabled = !(shortcutLabel.isNullOrEmpty() || shortcutDesc.isNullOrEmpty() || shortcutPath.isNullOrEmpty())
+            if (entityList.isNotEmpty()) {
+                shortcutEntityList?.entries = entityList.sorted().toTypedArray()
+                shortcutEntityList?.entryValues = entityList.sorted().toTypedArray()
+            }
+            shortcutType?.entries = shortcutTypes.toTypedArray()
+            shortcutType?.entryValues = shortcutTypes.toTypedArray()
+            setDynamicShortcutType(shortcutType?.value.toString(), i)
+            shortcutType?.setOnPreferenceChangeListener { _, newValue ->
+                setDynamicShortcutType(newValue.toString(), i)
+                addUpdatePreference?.isEnabled = !shortcutLabel.isNullOrEmpty() && !shortcutDesc.isNullOrEmpty() && !shortcutPath.isNullOrEmpty()
+                return@setOnPreferenceChangeListener true
+            }
+            shortcutEntityList?.setOnPreferenceChangeListener { _, newValue ->
+                shortcutPath = newValue.toString()
+                addUpdatePreference?.isEnabled = !shortcutLabel.isNullOrEmpty() && !shortcutDesc.isNullOrEmpty() && !shortcutPath.isNullOrEmpty()
+                return@setOnPreferenceChangeListener true
+            }
+            addUpdatePreference?.isEnabled = !(shortcutLabel.isNullOrEmpty() || shortcutDesc.isNullOrEmpty() && shortcutPath.isNullOrEmpty())
 
             for (item in dynamicShortcuts) {
                 if (item.id == SHORTCUT_PREFIX + i) {
@@ -100,6 +148,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
             addUpdatePreference?.setOnPreferenceClickListener {
                 Log.d(TAG, "Creating shortcut #: $i")
                 if (!shortcutLabel.isNullOrEmpty() && !shortcutDesc.isNullOrEmpty() && !shortcutPath.isNullOrEmpty()) {
+                    if (shortcutType?.value == getString(R.string.entity_id))
+                        shortcutPath = "entityId:${shortcutEntityList?.value}"
                     val shortcut = createShortcut(SHORTCUT_PREFIX + i, shortcutLabel!!, shortcutDesc!!, shortcutPath!!)
                     shortcutManager!!.addDynamicShortcuts(listOf(shortcut))
                 }
@@ -126,9 +176,29 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
             var pinnedShortcutDesc = findPreference<EditTextPreference>("pinned_shortcut_desc")?.text
             var pinnedShortcutPath = findPreference<EditTextPreference>("pinned_shortcut_path")?.text
             val pinnedShortcutPref = findPreference<Preference>("pinned_shortcut_pin")
+            val pinnedShortcutType = findPreference<ListPreference>("pinned_shortcut_type")
+            val pinnedShortcutEntityList = findPreference<ListPreference>("pinned_shortcut_entity_list")
             val pinnedList = findPreference<ListPreference>("pinned_shortcut_list")
             val pinnedShortcutIds = pinnedShortcuts.asSequence().map { it.id }.toList()
 
+            if (entityList.isNotEmpty()) {
+                pinnedShortcutEntityList?.entries = entityList.sorted().toTypedArray()
+                pinnedShortcutEntityList?.entryValues = entityList.sorted().toTypedArray()
+            }
+            pinnedShortcutType?.entries = shortcutTypes.toTypedArray()
+            pinnedShortcutType?.entryValues = shortcutTypes.toTypedArray()
+            pinnedShortcutType?.setDefaultValue(getString(R.string.lovelace))
+            setPinnedShortcutType(pinnedShortcutType?.value.toString())
+            pinnedShortcutType?.setOnPreferenceChangeListener { _, newValue ->
+                setPinnedShortcutType(newValue.toString())
+                pinnedShortcutPref?.isEnabled = !pinnedShortcutId.isNullOrEmpty() && !pinnedShortcutLabel.isNullOrEmpty() && !pinnedShortcutDesc.isNullOrEmpty() && !pinnedShortcutPath.isNullOrEmpty()
+                return@setOnPreferenceChangeListener true
+            }
+            pinnedShortcutEntityList?.setOnPreferenceChangeListener { _, newValue ->
+                pinnedShortcutPath = newValue.toString()
+                pinnedShortcutPref?.isEnabled = !pinnedShortcutId.isNullOrEmpty() && !pinnedShortcutLabel.isNullOrEmpty() && !pinnedShortcutDesc.isNullOrEmpty() && !pinnedShortcutPath.isNullOrEmpty()
+                return@setOnPreferenceChangeListener true
+            }
             if (pinnedShortcutIds.isNotEmpty()) {
                 pinnedList?.isVisible = true
                 pinnedList?.entries = pinnedShortcutIds.toTypedArray()
@@ -144,6 +214,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                             pinnedShortcutDesc = item.longLabel.toString()
                             findPreference<EditTextPreference>("pinned_shortcut_path")?.text = item.intent?.action
                             pinnedShortcutPath = item.intent?.action
+                            pinnedShortcutEntityList?.value = item.intent?.action?.removePrefix("entityId:")
                             pinnedShortcutPref?.title = getString(R.string.update_pinned_shortcut)
                             pinnedShortcutPref?.isEnabled = true
                         }
@@ -204,6 +275,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 it.setOnPreferenceClickListener {
 
                     Log.d(TAG, "Attempt to add $pinnedShortcutId")
+                    if (pinnedShortcutType?.value == getString(R.string.entity_id))
+                        pinnedShortcutPath = "entityId:${pinnedShortcutEntityList?.value}"
                     val shortcut = createShortcut(pinnedShortcutId!!, pinnedShortcutLabel!!, pinnedShortcutDesc!!, pinnedShortcutPath!!)
                     var isNewPinned = true
 
@@ -214,6 +287,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                             shortcutManager.updateShortcuts(listOf(shortcut))
                         }
                     }
+
 
                     if (isNewPinned) {
                         Log.d(TAG, "Requesting to pin shortcut $pinnedShortcutId")
@@ -239,5 +313,31 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 .setIcon(Icon.createWithResource(requireContext(), R.drawable.ic_stat_ic_notification_blue))
                 .setIntent(intent)
                 .build()
+    }
+
+    private fun setPinnedShortcutType(value: String) {
+        when (value) {
+            getString(R.string.entity_id) -> {
+                findPreference<EditTextPreference>("pinned_shortcut_path")?.isVisible = false
+                findPreference<ListPreference>("pinned_shortcut_entity_list")?.isVisible = true
+            }
+            getString(R.string.lovelace) -> {
+                findPreference<EditTextPreference>("pinned_shortcut_path")?.isVisible = true
+                findPreference<ListPreference>("pinned_shortcut_entity_list")?.isVisible = false
+            }
+        }
+    }
+
+    private fun setDynamicShortcutType(value: String, position: Int) {
+        when (value) {
+            getString(R.string.entity_id) -> {
+                findPreference<EditTextPreference>(SHORTCUT_PREFIX + position + PATH_SUFFIX)?.isVisible = false
+                findPreference<ListPreference>(SHORTCUT_PREFIX + position + ENTITY_SUFFIX)?.isVisible = true
+            }
+            getString(R.string.lovelace) -> {
+                findPreference<EditTextPreference>(SHORTCUT_PREFIX + position + PATH_SUFFIX)?.isVisible = true
+                findPreference<ListPreference>(SHORTCUT_PREFIX + position + ENTITY_SUFFIX)?.isVisible = false
+            }
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -26,7 +26,6 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
         private const val PATH_SUFFIX = "_path"
         private const val UPDATE_SUFFIX = "_update"
         private const val CATEGORY_SUFFIX = "_category"
-        private const val PIN_SUFFIX = "_pin"
         private const val DELETE_SUFFIX = "_delete"
         private const val TAG = "ManageShortcutFrag"
         fun newInstance(): ManageShortcutsSettingsFragment {
@@ -62,18 +61,12 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
             val deletePreference = findPreference<Preference>(SHORTCUT_PREFIX + i + DELETE_SUFFIX)
 
             addUpdatePreference?.isEnabled = !(shortcutLabel.isNullOrEmpty() || shortcutDesc.isNullOrEmpty() || shortcutPath.isNullOrEmpty())
-            val pinPreference = findPreference<Preference>(SHORTCUT_PREFIX + i + PIN_SUFFIX)
 
             for (item in dynamicShortcuts) {
                 if (item.id == SHORTCUT_PREFIX + i) {
                     addUpdatePreference?.title = getString(R.string.update_shortcut)
                     deletePreference?.isVisible = true
                 }
-            }
-
-            for (item in pinnedShortcuts) {
-                if (item.id == SHORTCUT_PREFIX + i)
-                    pinPreference?.title = getString(R.string.update_pinned_shortcut)
             }
 
             findPreference<EditTextPreference>(SHORTCUT_PREFIX + i + LABEL_SUFFIX)?.let {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -288,7 +288,6 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                         }
                     }
 
-
                     if (isNewPinned) {
                         Log.d(TAG, "Requesting to pin shortcut $pinnedShortcutId")
                         shortcutManager.requestPinShortcut(shortcut, null)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -26,6 +26,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
         private const val PATH_SUFFIX = "_path"
         private const val UPDATE_SUFFIX = "_update"
         private const val CATEGORY_SUFFIX = "_category"
+        private const val PIN_SUFFIX = "_pin"
         private const val DELETE_SUFFIX = "_delete"
         private const val TAG = "ManageShortcutFrag"
         fun newInstance(): ManageShortcutsSettingsFragment {
@@ -61,12 +62,18 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
             val deletePreference = findPreference<Preference>(SHORTCUT_PREFIX + i + DELETE_SUFFIX)
 
             addUpdatePreference?.isEnabled = !(shortcutLabel.isNullOrEmpty() || shortcutDesc.isNullOrEmpty() || shortcutPath.isNullOrEmpty())
+            val pinPreference = findPreference<Preference>(SHORTCUT_PREFIX + i + PIN_SUFFIX)
 
             for (item in dynamicShortcuts) {
                 if (item.id == SHORTCUT_PREFIX + i) {
                     addUpdatePreference?.title = getString(R.string.update_shortcut)
                     deletePreference?.isVisible = true
                 }
+            }
+
+            for (item in pinnedShortcuts) {
+                if (item.id == SHORTCUT_PREFIX + i)
+                    pinPreference?.title = getString(R.string.update_pinned_shortcut)
             }
 
             findPreference<EditTextPreference>(SHORTCUT_PREFIX + i + LABEL_SUFFIX)?.let {
@@ -152,6 +159,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 }
             }
 
+            pinnedShortcutPref?.isEnabled = !pinnedShortcutId.isNullOrEmpty() && !pinnedShortcutLabel.isNullOrEmpty() && !pinnedShortcutDesc.isNullOrEmpty() && !pinnedShortcutPath.isNullOrEmpty()
+
             for (item in pinnedShortcuts) {
                 if (item.id == pinnedShortcutId)
                     pinnedShortcutPref?.title = getString(R.string.update_pinned_shortcut)
@@ -198,31 +207,28 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 }
             }
 
-            if (!pinnedShortcutId.isNullOrEmpty() && !pinnedShortcutLabel.isNullOrEmpty() && !pinnedShortcutDesc.isNullOrEmpty() && !pinnedShortcutPath.isNullOrEmpty()) {
-                pinnedShortcutPref?.let {
-                    it.isEnabled = true
-                    it.setOnPreferenceClickListener {
+            pinnedShortcutPref?.let {
+                it.setOnPreferenceClickListener {
 
-                        Log.d(TAG, "Attempt to add $pinnedShortcutId")
-                        val shortcut = createShortcut(pinnedShortcutId!!, pinnedShortcutLabel!!, pinnedShortcutDesc!!, pinnedShortcutPath!!)
-                        var isNewPinned = true
+                    Log.d(TAG, "Attempt to add $pinnedShortcutId")
+                    val shortcut = createShortcut(pinnedShortcutId!!, pinnedShortcutLabel!!, pinnedShortcutDesc!!, pinnedShortcutPath!!)
+                    var isNewPinned = true
 
-                        for (item in pinnedShortcuts) {
-                            if (item.id == pinnedShortcutId) {
-                                isNewPinned = false
-                                Log.d(TAG, "Updating pinned shortcut $pinnedShortcutId")
-                                shortcutManager.updateShortcuts(listOf(shortcut))
-                            }
+                    for (item in pinnedShortcuts) {
+                        if (item.id == pinnedShortcutId) {
+                            isNewPinned = false
+                            Log.d(TAG, "Updating pinned shortcut $pinnedShortcutId")
+                            shortcutManager.updateShortcuts(listOf(shortcut))
                         }
-
-                        if (isNewPinned) {
-                            Log.d(TAG, "Requesting to pin shortcut $pinnedShortcutId")
-                            shortcutManager.requestPinShortcut(shortcut, null)
-                        }
-
-                        pinnedShortcuts = shortcutManager.pinnedShortcuts
-                        return@setOnPreferenceClickListener true
                     }
+
+                    if (isNewPinned) {
+                        Log.d(TAG, "Requesting to pin shortcut $pinnedShortcutId")
+                        shortcutManager.requestPinShortcut(shortcut, null)
+                    }
+
+                    pinnedShortcuts = shortcutManager.pinnedShortcuts
+                    return@setOnPreferenceClickListener true
                 }
             }
         } else

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -549,4 +549,7 @@ like to connect to:</string>
   <string name="show_share_logs_summary">Sharing logs with the Home Assistant team will help to solve issues. Please share the logs only if you have been asked to do so by a Home Assistant developer</string>
   <string name="refresh_log">Refresh logs</string>
   <string name="log_loader_text">Collecting logs...</string>
+  <string name="lovelace">Lovelace</string>
+  <string name="entity_id">Entity ID</string>
+  <string name="shortcut_type">Select Shortcut Type</string>
 </resources>

--- a/app/src/main/res/xml/manage_shortcuts.xml
+++ b/app/src/main/res/xml/manage_shortcuts.xml
@@ -238,6 +238,7 @@
             android:key="pinned_shortcut_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="pinned_shortcut_entity_list"

--- a/app/src/main/res/xml/manage_shortcuts.xml
+++ b/app/src/main/res/xml/manage_shortcuts.xml
@@ -19,6 +19,17 @@
             android:key="shortcut1_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="shortcut1_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="shortcut1_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="shortcut1_path"
             app:iconSpaceReserved="false"
@@ -46,6 +57,17 @@
             android:key="shortcut2_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="shortcut2_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="shortcut2_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="shortcut2_path"
             android:title="@string/lovelace_view_dashboard"
@@ -73,6 +95,17 @@
             android:key="shortcut3_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="shortcut3_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="shortcut3_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="shortcut3_path"
             android:title="@string/lovelace_view_dashboard"
@@ -100,6 +133,17 @@
             android:key="shortcut4_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="shortcut4_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="shortcut4_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="shortcut4_path"
             android:title="@string/lovelace_view_dashboard"
@@ -132,6 +176,17 @@
             android:key="shortcut5_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="shortcut5_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="shortcut5_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="shortcut5_path"
             android:title="@string/lovelace_view_dashboard"
@@ -179,6 +234,17 @@
             android:title="@string/shortcut_pinned_desc"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true" />
+        <ListPreference
+            android:key="pinned_shortcut_type"
+            android:title="@string/shortcut_type"
+            app:useSimpleSummaryProvider="true"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="pinned_shortcut_entity_list"
+            android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
         <EditTextPreference
             android:key="pinned_shortcut_path"
             android:title="@string/lovelace_view_dashboard"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Hopefully this branch is ok, I see a couple commits from the previous PR but the changes depicted are only from the branch as i have rebased the branch off master.

This now adds a shortcut type list preference so users can pick between Lovelace (default) and an Entity.  For the Entity we grab a list of all entities and let the user select the one they want. We will add in the proper logic to switch between entity and lovelace type along with providing the proper data in shortcut.

This also fixes a bug that I found where the Pin Shortcut is enabled but non-functional as the entire `setOnPreferenceClickListener` was incorrectly wrapped in a condition that would only succeed if the variables were met.  Now we do one check in `onResume` and let the rest of the preference listeners update the field as expected.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/113319120-fa457280-92c5-11eb-9b6e-046b4766fac8.png)

![image](https://user-images.githubusercontent.com/1634145/113319138-ff0a2680-92c5-11eb-94e0-d70f2c67e998.png)

![image](https://user-images.githubusercontent.com/1634145/113319156-03364400-92c6-11eb-8780-fbedbcef6962.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#485

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->