### PR TITLE
Allow existing service call widgets be used as shortcuts

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationActionContentHandler.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationActionContentHandler.kt
@@ -25,6 +25,7 @@ object NotificationActionContentHandler {
             } ?: WebViewActivity.newInstance(context)
 
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            intent.flags = Intent.FLAG_ACTIVITY_MULTIPLE_TASK
             context.startActivity(intent)
             onComplete()
         }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -39,7 +39,7 @@ class WebViewPresenterImpl @Inject constructor(
             val oldUrl = url
             url = urlUseCase.getUrl()
 
-            if (path != null && !path.startsWith("entityId:")) {
+            if (path != null && !path.startsWith("entityId:") && !path.startsWith("widgetId:")) {
                 url = UrlHandler.handle(url, path)
             }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -36,7 +36,7 @@ import kotlinx.coroutines.launch
 class ButtonWidget : AppWidgetProvider() {
     companion object {
         private const val TAG = "ButtonWidget"
-        private const val CALL_SERVICE =
+        const val CALL_SERVICE =
             "io.homeassistant.companion.android.widgets.button.ButtonWidget.CALL_SERVICE"
         internal const val RECEIVE_DATA =
             "io.homeassistant.companion.android.widgets.button.ButtonWidget.RECEIVE_DATA"
@@ -193,6 +193,11 @@ class ButtonWidget : AppWidgetProvider() {
         val widget = buttonWidgetDao.get(appWidgetId)
 
         mainScope.launch {
+            if (widget == null) {
+                Log.d(TAG, "Widget not found for ID: $appWidgetId")
+                Toast.makeText(context, R.string.widget_not_found, Toast.LENGTH_LONG).show()
+                return@launch
+            }
             // Change color of background image for feedback
             var views = getWidgetRemoteViews(context, appWidgetId)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -555,4 +555,6 @@ like to connect to:</string>
   <string name="lovelace">Lovelace</string>
   <string name="entity_id">Entity ID</string>
   <string name="shortcut_type">Select Shortcut Type</string>
+  <string name="executed_service_call">Executed service call</string>
+  <string name="widget_not_found">Widget not found, please remove and readd the widget</string>
 </resources>

--- a/app/src/main/res/xml/manage_shortcuts.xml
+++ b/app/src/main/res/xml/manage_shortcuts.xml
@@ -22,11 +22,18 @@
         <ListPreference
             android:key="shortcut1_type"
             android:title="@string/shortcut_type"
+            android:defaultValue="@string/lovelace"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut1_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut1_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
@@ -60,11 +67,18 @@
         <ListPreference
             android:key="shortcut2_type"
             android:title="@string/shortcut_type"
+            android:defaultValue="@string/lovelace"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut2_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut2_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
@@ -98,11 +112,18 @@
         <ListPreference
             android:key="shortcut3_type"
             android:title="@string/shortcut_type"
+            android:defaultValue="@string/lovelace"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut3_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut3_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
@@ -136,11 +157,18 @@
         <ListPreference
             android:key="shortcut4_type"
             android:title="@string/shortcut_type"
+            android:defaultValue="@string/lovelace"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut4_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut4_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
@@ -179,11 +207,18 @@
         <ListPreference
             android:key="shortcut5_type"
             android:title="@string/shortcut_type"
+            android:defaultValue="@string/lovelace"
             app:useSimpleSummaryProvider="true"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut5_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut5_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
@@ -243,6 +278,12 @@
         <ListPreference
             android:key="pinned_shortcut_entity_list"
             android:title="@string/entity_id"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="pinned_shortcut_button_widget_list"
+            android:title="@string/widget_button_image_description"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Following on from the other shortcut PRs we will now allow users to create a shortcut to execute an existing service call widget.  As of now widgets are not being imported as I would like to do that in a separate PR where we will do an import and also allow users to pin a shortcut directly from the configure widget screen.  The plan is to reuse the same data and send an extra intent to know where to save the widget data to. Will probably require some more refactoring so a bit out of scope here.  This should allow users to move existing widgets to another screen and create shortcuts in their desired location while we work on importing and allowing the creation without needing a widget.

For now all button widgets can be selected and made into a shortcut. Shortcuts require an activity so the service call will execute in `onPageStarted` so users will see the activity briefly open then close. Toast messages are present for when the widget no longer exists and when the command was executed.

Video: https://photos.app.goo.gl/UVZzZNpLixw6ddwt9

Also fixes : #1472 by setting a new flag, same fix applied to actionable notifications


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/113361989-27177b00-9302-11eb-83a2-394657127cbd.png)

![image](https://user-images.githubusercontent.com/1634145/113362001-2b439880-9302-11eb-9f00-478b07c2d282.png)

![image](https://user-images.githubusercontent.com/1634145/113362010-30084c80-9302-11eb-8d98-4e0cb303463a.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#487

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->