### PR TITLE
Allow shortcuts to execute scripts

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -127,8 +127,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 shortcutScriptList?.entries = scriptList.sorted().toTypedArray()
                 shortcutScriptList?.entryValues = scriptList.sorted().toTypedArray()
             }
-            shortcutType?.entries = shortcutTypes.toTypedArray()
-            shortcutType?.entryValues = shortcutTypes.toTypedArray()
+            shortcutType?.entries = shortcutTypes.sorted().toTypedArray()
+            shortcutType?.entryValues = shortcutTypes.sorted().toTypedArray()
             setDynamicShortcutType(shortcutType?.value.toString(), i)
             shortcutType?.setOnPreferenceChangeListener { _, newValue ->
                 setDynamicShortcutType(newValue.toString(), i)
@@ -232,8 +232,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat() {
                 pinnedShortcutScriptList?.entries = scriptList.sorted().toTypedArray()
                 pinnedShortcutScriptList?.entryValues = scriptList.sorted().toTypedArray()
             }
-            pinnedShortcutType?.entries = shortcutTypes.toTypedArray()
-            pinnedShortcutType?.entryValues = shortcutTypes.toTypedArray()
+            pinnedShortcutType?.entries = shortcutTypes.sorted().toTypedArray()
+            pinnedShortcutType?.entryValues = shortcutTypes.sorted().toTypedArray()
             pinnedShortcutType?.setDefaultValue(getString(R.string.lovelace))
             setPinnedShortcutType(pinnedShortcutType?.value.toString())
             pinnedShortcutType?.setOnPreferenceChangeListener { _, newValue ->

--- a/app/src/main/java/io/homeassistant/companion/android/util/NotificationActionContentHandler.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/NotificationActionContentHandler.kt
@@ -25,6 +25,7 @@ object NotificationActionContentHandler {
             } ?: WebViewActivity.newInstance(context)
 
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            intent.flags = Intent.FLAG_ACTIVITY_MULTIPLE_TASK
             context.startActivity(intent)
             onComplete()
         }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -6,6 +6,8 @@ interface WebViewPresenter {
 
     fun onGetExternalAuth(callback: String, force: Boolean)
 
+    fun executeScript(script: String): Boolean
+
     fun checkSecurityVersion()
 
     fun onRevokeExternalAuth(callback: String)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -39,7 +39,7 @@ class WebViewPresenterImpl @Inject constructor(
             val oldUrl = url
             url = urlUseCase.getUrl()
 
-            if (path != null && !path.startsWith("entityId:")) {
+            if (path != null && !path.startsWith("entityId:") && !path.startsWith("executeScript:")) {
                 url = UrlHandler.handle(url, path)
             }
 
@@ -59,6 +59,19 @@ class WebViewPresenterImpl @Inject constructor(
                 )
             }
         }
+    }
+
+    override fun executeScript(script: String): Boolean {
+        var success = false
+        runBlocking {
+            try {
+                integrationUseCase.callService(script.split('.')[0], script.split('.')[1], hashMapOf())
+                success = true
+            } catch (e: Exception) {
+                Log.e(TAG, "Unable to execute script: $script", e)
+            }
+        }
+        return success
     }
 
     override fun checkSecurityVersion() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -555,4 +555,8 @@ like to connect to:</string>
   <string name="lovelace">Lovelace</string>
   <string name="entity_id">Entity ID</string>
   <string name="shortcut_type">Select Shortcut Type</string>
+  <string name="select_script">Select Script</string>
+  <string name="execute_script">Execute Script</string>
+  <string name="script_executed">Script executed successfully</string>
+  <string name="script_failed">Script failed to execute</string>
 </resources>

--- a/app/src/main/res/xml/manage_shortcuts.xml
+++ b/app/src/main/res/xml/manage_shortcuts.xml
@@ -30,6 +30,12 @@
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut1_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="shortcut1_path"
             app:iconSpaceReserved="false"
@@ -68,6 +74,12 @@
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut2_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="shortcut2_path"
             android:title="@string/lovelace_view_dashboard"
@@ -106,6 +118,12 @@
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut3_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="shortcut3_path"
             android:title="@string/lovelace_view_dashboard"
@@ -144,6 +162,12 @@
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut4_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="shortcut4_path"
             android:title="@string/lovelace_view_dashboard"
@@ -187,6 +211,12 @@
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false"
             app:useSimpleSummaryProvider="true"/>
+        <ListPreference
+            android:key="shortcut5_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false" />
         <EditTextPreference
             android:key="shortcut5_path"
             android:title="@string/lovelace_view_dashboard"
@@ -239,6 +269,12 @@
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
             android:defaultValue="@string/lovelace"
+            app:iconSpaceReserved="false" />
+        <ListPreference
+            android:key="pinned_shortcut_script_list"
+            android:title="@string/select_script"
+            app:useSimpleSummaryProvider="true"
+            app:isPreferenceVisible="false"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="pinned_shortcut_entity_list"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

So I am not too sure how #1473 will feel to users as its a bit odd to create a widget just for a shortcut and also if you add a widget to a shortcut you can't remove it. To me the button widget is very static in data, once you set them up thats the data being used for the one service call every time its used.  I think scripts are probably a good and quick use case as most of the time they can be ran without any additional data and can include more than one service call :)

So in this PR we will show a list of scripts if a user has at least one script added.  As we need to link to an activity it will also use webview to quickly launch and execute the service call.  A toast message will be shown whether or not the call was successful.

In the interest of review time I will mark #1473 as draft and have also imported the fix for #1472
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/113384311-a032c480-933a-11eb-9b2c-b3fc1d72cc98.png)

![image](https://user-images.githubusercontent.com/1634145/113383991-ea677600-9339-11eb-89fd-60f14800fcd7.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#488

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->