### PR TITLE
Fix retrieval of media player image in widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -14,10 +14,12 @@ import android.view.View
 import android.widget.RemoteViews
 import android.widget.Toast
 import com.squareup.picasso.Picasso
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetDao
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetEntity
@@ -56,6 +58,9 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
 
     @Inject
     lateinit var integrationUseCase: IntegrationRepository
+
+    @Inject
+    lateinit var urlUseCase: UrlRepository
 
     lateinit var mediaPlayCtrlWidgetDao: MediaPlayerControlsWidgetDao
 
@@ -148,6 +153,8 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                     label ?: entityId
                 )
                 val entityPictureUrl = retrieveMediaPlayerImageUrl(context, entityId)
+                val baseUrl = urlUseCase.getUrl().toString().removeSuffix("/")
+                val url = "$baseUrl$entityPictureUrl"
                 if (entityPictureUrl == null) {
                     setImageViewResource(
                         R.id.widgetMediaImage,
@@ -172,7 +179,9 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                     )
                     Log.d(TAG, "Fetching media preview image")
                     Handler(Looper.getMainLooper()).post {
-                        Picasso.get().load(entityPictureUrl).into(
+                        if (BuildConfig.DEBUG)
+                            Picasso.get().isLoggingEnabled = true
+                        Picasso.get().load(url).resize(1920, 1080).into(
                             this,
                             R.id.widgetMediaImage,
                             intArrayOf(appWidgetId)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I noticed that the media player widget image never updated, turns out it never would because the URL we were using was never correct, now we load the actual URL and if on debug build we will print more logging errors to help out.

```
2021-04-05 16:28:49.534 12796-12796/io.homeassistant.companion.android.debug D/Picasso: Main        errored      [R0]+336ms Unrecognized type of request: Request{/api/media_player_proxy/media_player.den_shield_tv?token=TOKEN&cache=CACHE
```

I also had to add a hard resize as my shield is in 4k and the image was too big, so sticking to 1920x1080 as it will load. 

```
2021-04-05 16:16:54.628 7665-7665/io.homeassistant.companion.android.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.homeassistant.companion.android.debug, PID: 7665
    java.lang.IllegalArgumentException: RemoteViews for widget update exceeds maximum bitmap memory usage (used: 33177600, max: 26265600)
        at android.os.Parcel.createExceptionOrNull(Parcel.java:2377)
        at android.os.Parcel.createException(Parcel.java:2357)
        at android.os.Parcel.readException(Parcel.java:2340)
        at android.os.Parcel.readException(Parcel.java:2282)
        at com.android.internal.appwidget.IAppWidgetService$Stub$Proxy.updateAppWidgetIds(IAppWidgetService.java:977)
        at android.appwidget.AppWidgetManager.updateAppWidget(AppWidgetManager.java:531)
        at com.squareup.picasso.RemoteViewsAction$AppWidgetAction.update(RemoteViewsAction.java:116)
        at com.squareup.picasso.RemoteViewsAction.complete(RemoteViewsAction.java:45)
        at com.squareup.picasso.Picasso.deliverAction(Picasso.java:576)
        at com.squareup.picasso.Picasso.complete(Picasso.java:528)
        at com.squareup.picasso.Picasso$1.handleMessage(Picasso.java:122)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:223)
        at android.app.ActivityThread.main(ActivityThread.java:7660)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
     Caused by: android.os.RemoteException: Remote stack trace:
        at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetInstanceLocked(AppWidgetServiceImpl.java:1961)
        at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetIds(AppWidgetServiceImpl.java:1780)
        at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetIds(AppWidgetServiceImpl.java:1530)
        at com.android.internal.appwidget.IAppWidgetService$Stub.onTransact(IAppWidgetService.java:420)
        at android.os.Binder.execTransactInternal(Binder.java:1154)
```

I had also opted not to change the `scaleType` because it either looks the way it does today or its very tiny, here is an example when we use `centerInside`


![image](https://user-images.githubusercontent.com/1634145/113640672-dae57700-9630-11eb-9a06-a423a6019a0e.png)

and what it looks like today obviously not ideal but a larger image looks better lol, also need to consider music players:

![image](https://user-images.githubusercontent.com/1634145/113640690-e3d64880-9630-11eb-8e11-5b3fc4899a9c.png)


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->