### PR TITLE
Fix shortcut editing when selecting from pinned list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -257,9 +257,18 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                             pinnedShortcutLabel = item.shortLabel.toString()
                             findPreference<EditTextPreference>("pinned_shortcut_desc")?.text = item.longLabel.toString()
                             pinnedShortcutDesc = item.longLabel.toString()
-                            findPreference<EditTextPreference>("pinned_shortcut_path")?.text = item.intent?.action
-                            pinnedShortcutPath = item.intent?.action
-                            pinnedShortcutEntityList?.value = item.intent?.action?.removePrefix("entityId:")
+                            if (item.intent?.action?.startsWith("entityId:") == true) {
+                                val entityId = item.intent?.action?.removePrefix("entityId:")
+                                pinnedShortcutPath = entityId
+                                pinnedShortcutEntityList?.value = entityId
+                                pinnedShortcutType?.value = getString(R.string.entity_id)
+                                setPinnedShortcutType(getString(R.string.entity_id))
+                            } else {
+                                findPreference<EditTextPreference>("pinned_shortcut_path")?.text = item.intent?.action
+                                pinnedShortcutPath = item.intent?.action
+                                pinnedShortcutType?.value = getString(R.string.lovelace)
+                                setPinnedShortcutType(getString(R.string.lovelace))
+                            }
                             pinnedShortcutPref?.title = getString(R.string.update_pinned_shortcut)
                             pinnedShortcutPref?.isEnabled = true
                         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Found a bug when attempting to edit a saved shortcut. When switching between a saved lovelace shortcut to entity the shortcut type was not being set properly and the field type is not as expected. Now setting the data to be correct for editing.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->