### PR TITLE
Set menu options when we evaluate enable all toggle

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -71,6 +71,8 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
                     it.title = getString(R.string.disable_all_sensors, totalEnabledSensors)
                     it.summary = ""
                     it.isChecked = permissionsAllGranted
+                    enableAllSensors = permissionsAllGranted
+                    activity?.invalidateOptionsMenu()
                 } else {
                     if (totalEnabledSensors == 0)
                         it.title = getString(R.string.enable_all_sensors)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Enable all toggle defaults to false and only got set when a user would toggle it. If the app were updated the variable would reset and never get set again. So once we set the variable, if it evaluates to `true` we will revalidate the menu options.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->