### PR TITLE
Fix crash for high accuracy service

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -132,7 +132,7 @@ class HighAccuracyLocationService : Service() {
         }
     }
 
-    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+    private var fusedLocationProviderClient: FusedLocationProviderClient? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -163,7 +163,7 @@ class HighAccuracyLocationService : Service() {
     override fun onDestroy() {
         super.onDestroy()
 
-        if (fusedLocationProviderClient != null) fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
+        fusedLocationProviderClient?.removeLocationUpdates(getLocationUpdateIntent())
 
         LAUNCHER.onServiceDestroy(this)
 
@@ -190,6 +190,6 @@ class HighAccuracyLocationService : Service() {
         request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
 
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
-        fusedLocationProviderClient.requestLocationUpdates(request, getLocationUpdateIntent())
+        fusedLocationProviderClient?.requestLocationUpdates(request, getLocationUpdateIntent())
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -163,7 +163,7 @@ class HighAccuracyLocationService : Service() {
     override fun onDestroy() {
         super.onDestroy()
 
-        if(fusedLocationProviderClient != null) fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
+        if (fusedLocationProviderClient != null) fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
 
         LAUNCHER.onServiceDestroy(this)
 

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -163,7 +163,7 @@ class HighAccuracyLocationService : Service() {
     override fun onDestroy() {
         super.onDestroy()
 
-        fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
+        if(fusedLocationProviderClient != null) fusedLocationProviderClient.removeLocationUpdates(getLocationUpdateIntent())
 
         LAUNCHER.onServiceDestroy(this)
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes a crash when the high accuracy service is destroy, but the service is not yet started. Also when the `fusedLocationProviderClient` is null we do not need to remove the location updates anyway.

```
kotlin.UninitializedPropertyAccessException: lateinit property fusedLocationProviderClient has not been initialized
    at io.homeassistant.companion.android.location.HighAccuracyLocationService.onDestroy(HighAccuracyLocationService.kt:166)
    at android.app.ActivityThread.handleStopService(ActivityThread.java:4449)
    at android.app.ActivityThread.access$2100(ActivityThread.java:257)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:233)
    at android.app.ActivityThread.main(ActivityThread.java:8056)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
java.lang.RuntimeException: Unable to stop service io.homeassistant.companion.android.location.HighAccuracyLocationService@a19d2b4: kotlin.UninitializedPropertyAccessException: lateinit property fusedLocationProviderClient has not been initialized
    at android.app.ActivityThread.handleStopService(ActivityThread.java:4474)
    at android.app.ActivityThread.access$2100(ActivityThread.java:257)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2016)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:233)
    at android.app.ActivityThread.main(ActivityThread.java:8056)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->