### PR TITLE
Set proper values and defaults for shortcut type list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -96,7 +96,6 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                 .inject(this)
 
         val addNewShortcut = findPreference<PreferenceCategory>("pinned_shortcut_category")
-        val shortcutTypes = listOf(getString(R.string.entity_id), getString(R.string.lovelace))
         val shortcutManager = requireContext().getSystemService(ShortcutManager::class.java)
         var pinnedShortcuts = shortcutManager.pinnedShortcuts
         var dynamicShortcuts = shortcutManager.dynamicShortcuts
@@ -133,8 +132,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                 shortcutEntityList?.entries = entityList.sorted().toTypedArray()
                 shortcutEntityList?.entryValues = entityList.sorted().toTypedArray()
             }
-            shortcutType?.entries = shortcutTypes.toTypedArray()
-            shortcutType?.entryValues = shortcutTypes.toTypedArray()
+
             setDynamicShortcutType(shortcutType?.value.toString(), i)
             shortcutType?.setOnPreferenceChangeListener { _, newValue ->
                 setDynamicShortcutType(newValue.toString(), i)
@@ -230,9 +228,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                 pinnedShortcutEntityList?.entries = entityList.sorted().toTypedArray()
                 pinnedShortcutEntityList?.entryValues = entityList.sorted().toTypedArray()
             }
-            pinnedShortcutType?.entries = shortcutTypes.toTypedArray()
-            pinnedShortcutType?.entryValues = shortcutTypes.toTypedArray()
-            pinnedShortcutType?.setDefaultValue(getString(R.string.lovelace))
+
             setPinnedShortcutType(pinnedShortcutType?.value.toString())
             pinnedShortcutType?.setOnPreferenceChangeListener { _, newValue ->
                 setPinnedShortcutType(newValue.toString())

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,15 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string-array name="filter_notifications_entries">
-        <item>Show last 25 notifications</item>
-        <item>Show last 50 notifications</item>
-        <item>Show last 100 notifications</item>
-    </string-array>
-    <string-array name="filter_notifications_values">
-        <item>last25</item>
-        <item>last50</item>
-        <item>last100</item>
-    </string-array>
     <string-array name="setting_ble_emitter_transmit_power_labels">
         <item>@string/ble_transmit_power_label_high</item>
         <item>@string/ble_transmit_power_label_medium</item>
@@ -21,5 +11,9 @@
         <item>@string/ble_transmit_power_value_medium</item>
         <item>@string/ble_transmit_power_value_low</item>
         <item>@string/ble_transmit_power_value_ultra_low</item>
+    </string-array>
+    <string-array name="shortcutTypes">
+        <item>@string/entity_id</item>
+        <item>@string/lovelace</item>
     </string-array>
 </resources>

--- a/app/src/main/res/xml/manage_shortcuts.xml
+++ b/app/src/main/res/xml/manage_shortcuts.xml
@@ -27,6 +27,9 @@
             android:key="shortcut1_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut1_entity_list"
@@ -69,6 +72,9 @@
             android:key="shortcut2_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut2_entity_list"
@@ -111,6 +117,9 @@
             android:key="shortcut3_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut3_entity_list"
@@ -153,6 +162,9 @@
             android:key="shortcut4_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut4_entity_list"
@@ -200,6 +212,9 @@
             android:key="shortcut5_type"
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
+            android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="shortcut5_entity_list"
@@ -263,6 +278,8 @@
             android:title="@string/shortcut_type"
             app:useSimpleSummaryProvider="true"
             android:defaultValue="@string/lovelace"
+            android:entries="@array/shortcutTypes"
+            android:entryValues="@array/shortcutTypes"
             app:iconSpaceReserved="false" />
         <ListPreference
             android:key="pinned_shortcut_entity_list"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was looking into the causes of the below sentry error and @chriss158 had pointed out we may be providing a blank list so ensuring the list is always present. As the list is static we will just load it in the XML.  Also cleaning up some old unused arrays.

```
java.lang.IllegalStateException: ListPreference requires an entries array and an entryValues array.
    at androidx.preference.ListPreferenceDialogFragmentCompat.onCreate(ListPreferenceDialogFragmentCompat.java:53)
    at androidx.fragment.app.Fragment.performCreate(Fragment.java:2685)
    at androidx.fragment.app.FragmentStateManager.create(FragmentStateManager.java:280)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1187)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1368)
    at androidx.fragment.app.FragmentManager.moveFragmentToExpectedState(FragmentManager.java:1446)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1509)
    at androidx.fragment.app.BackStackRecord.executeOps(BackStackRecord.java:447)
    at androidx.fragment.app.FragmentManager.executeOps(FragmentManager.java:2181)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2004)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:1959)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:1861)
    at androidx.fragment.app.FragmentManager$4.run(FragmentManager.java:413)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:226)
    at android.app.ActivityThread.main(ActivityThread.java:7592)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->