### PR TITLE
Add a toast message for visual feedback when updating a shortcut

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -11,6 +11,7 @@ import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.Menu
+import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.graphics.drawable.toBitmap
@@ -197,6 +198,8 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                     shortcutManager!!.addDynamicShortcuts(listOf(shortcut))
                 }
                 dynamicShortcuts = shortcutManager.dynamicShortcuts
+                if (it.title == getString(R.string.update_shortcut))
+                    Toast.makeText(requireContext(), R.string.shortcut_updated, Toast.LENGTH_SHORT).show()
                 it.title = getString(R.string.update_shortcut)
                 deletePreference?.isVisible = true
                 return@setOnPreferenceClickListener true
@@ -342,6 +345,7 @@ class ManageShortcutsSettingsFragment : PreferenceFragmentCompat(), IconDialog.C
                             isNewPinned = false
                             Log.d(TAG, "Updating pinned shortcut $pinnedShortcutId")
                             shortcutManager.updateShortcuts(listOf(shortcut))
+                            Toast.makeText(requireContext(), R.string.shortcut_updated, Toast.LENGTH_SHORT).show()
                         }
                     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -561,4 +561,5 @@ like to connect to:</string>
   <string name="maximum">Maximum</string>
   <string name="resets_at">Resets at</string>
   <string name="shortcut_icon">Shortcut Icon</string>
+  <string name="shortcut_updated">Shortcut updated</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

When we add a shortcut the UI will update/respond however it does not do this when we update a shortcut. So anytime we update a shortcut we will post a toast message for some visual confirmation.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Thanks for the recommendation @chriss158 :)