### PR TITLE
Add a media session sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -203,10 +203,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         val mediaSessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager
         val mediaList = mediaSessionManager.getActiveSessions(ComponentName(context, NotificationSensorManager::class.java))
         val sessionCount = mediaList.size
-        var primaryTitle = mediaList[0].metadata?.getString(MediaMetadata.METADATA_KEY_TITLE)
-            ?: if (sessionCount > 0) getPlaybackState(mediaList[0].playbackState?.state) else "Unavailable"
-        if (sessionCount > 0 && getPlaybackState(mediaList[0].playbackState?.state) != "Playing")
-            primaryTitle = getPlaybackState(mediaList[0].playbackState?.state)
+        val primaryPlaybackState = if (sessionCount > 0) getPlaybackState(mediaList[0].playbackState?.state) else "Unavailable"
         val attr: MutableMap<String, Any?> = mutableMapOf()
         val icon = "mdi:play-circle"
         if (mediaList.size > 0) {
@@ -226,7 +223,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         onSensorUpdated(
             context,
             mediaSession,
-            primaryTitle,
+            primaryPlaybackState,
             icon,
             attr
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -202,7 +202,9 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         val mediaSessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager
         val mediaList = mediaSessionManager.getActiveSessions(ComponentName(context, NotificationSensorManager::class.java))
         val sessionCount = mediaList.size
-        val primaryTitle = mediaList[0].metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "Unavailable"
+        var primaryTitle = mediaList[0].metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "Unavailable"
+        if (getPlaybackState(mediaList[0].playbackState?.state) != "Playing")
+            primaryTitle = getPlaybackState(mediaList[0].playbackState?.state)
         val attr: MutableMap<String, Any?> = mutableMapOf()
         val icon = "mdi:play-circle"
         if (mediaList.size > 0) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -42,7 +42,8 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             "media_session",
             "sensor",
             R.string.basic_sensor_name_media_session,
-            R.string.sensor_description_media_session
+            R.string.sensor_description_media_session,
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#media-session-sensor"
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -202,8 +202,9 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         val mediaSessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE) as MediaSessionManager
         val mediaList = mediaSessionManager.getActiveSessions(ComponentName(context, NotificationSensorManager::class.java))
         val sessionCount = mediaList.size
-        var primaryTitle = mediaList[0].metadata?.getString(MediaMetadata.METADATA_KEY_TITLE) ?: "Unavailable"
-        if (getPlaybackState(mediaList[0].playbackState?.state) != "Playing")
+        var primaryTitle = mediaList[0].metadata?.getString(MediaMetadata.METADATA_KEY_TITLE)
+            ?: if (sessionCount > 0) getPlaybackState(mediaList[0].playbackState?.state) else "Unavailable"
+        if (sessionCount > 0 && getPlaybackState(mediaList[0].playbackState?.state) != "Playing")
             primaryTitle = getPlaybackState(mediaList[0].playbackState?.state)
         val attr: MutableMap<String, Any?> = mutableMapOf()
         val icon = "mdi:play-circle"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,5 +569,5 @@ like to connect to:</string>
   <string name="widget_camera_description">Camera Widget</string>
   <string name="widget_media_player_description">Media Player Widget</string>
   <string name="basic_sensor_name_media_session">Media Session</string>
-  <string name="sensor_description_media_session">The total count of media sessions on the device along with some attributes for media identification</string>
+  <string name="sensor_description_media_session">The state will either be the title of the media when it is actively playing or it will be the playback state, it can also be unavailable when you have no active sessions. Attributes will include data from all active sessions including total count.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -568,4 +568,6 @@ like to connect to:</string>
   <string name="shortcut_updated">Shortcut updated</string>
   <string name="widget_camera_description">Camera Widget</string>
   <string name="widget_media_player_description">Media Player Widget</string>
+  <string name="basic_sensor_name_media_session">Media Session</string>
+  <string name="sensor_description_media_session">The total count of media sessions on the device along with some attributes for media identification</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -569,5 +569,5 @@ like to connect to:</string>
   <string name="widget_camera_description">Camera Widget</string>
   <string name="widget_media_player_description">Media Player Widget</string>
   <string name="basic_sensor_name_media_session">Media Session</string>
-  <string name="sensor_description_media_session">The state will either be the title of the media when it is actively playing or it will be the playback state, it can also be unavailable when you have no active sessions. Attributes will include data from all active sessions including total count.</string>
+  <string name="sensor_description_media_session">The state will either be the playback state of the primary media session or it will be unavailable when you have no active sessions. Attributes will include data from all active sessions including total count.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1475 

So this is an interesting sensor because the media sessions require either a system only permission, which we won't qualify for, or the notification listener (aka notification manager).  This listener is required for getting the data so this sensor is like a notification sensor but only for media sessions.

For the state I had a few considerations. First keeping the state as the total count of sessions won't work because when the user has 1 session (primary) none of the attributes will update.  Keeping the state as just the playback state of the primary controller wont update the attributes often either especially when playing for a long period of time. Things like artist and title won't change so almost whats the point in including them.  We will first attempt to set the state as the title of the media when it is actively playing. Otherwise, the state will be the playback state or unavailable if we have no active sessions.  I figure the more updates we get in the better for users.

Attributes will include data from all active media sessions including a total count of active media sessions. The attributes will have the package name appended.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/114260821-f2ec2c00-998b-11eb-95df-848bac43161a.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#492

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->