### PR TITLE
Improve Themes

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
@@ -63,7 +63,7 @@ class ThemesManager @Inject constructor(
                         WebSettingsCompat.FORCE_DARK_ON
                     )
                 }
-                "system" -> {
+                "android", "system" -> {
                     val nightModeFlags =
                         context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
                     if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
@@ -93,7 +93,7 @@ class ThemesManager @Inject constructor(
             "dark" -> {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
             }
-            "system" -> {
+            "android", "system" -> {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             }
             else -> {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -25,5 +25,5 @@ interface WebViewPresenter {
 
     fun isSsidUsed(): Boolean
 
-    fun setStatusbarColor(colorString: String)
+    suspend fun getStatusBarAndNavigationBarColor(webViewColor: String): Int
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources>
   <string-array name="pref_theme_option_labels">
+    <item>@string/themes_option_label_system</item>
+    <item>@string/themes_option_label_android</item>
     <item>@string/themes_option_label_light</item>
     <item>@string/themes_option_label_dark</item>
-    <item>@string/themes_option_label_system</item>
   </string-array>
   <string-array name="pref_theme_option_values">
+    <item>@string/themes_option_value_system</item>
+    <item>@string/themes_option_value_android</item>
     <item>@string/themes_option_value_light</item>
     <item>@string/themes_option_value_dark</item>
-    <item>@string/themes_option_value_system</item>
   </string-array>
   <string name="action_reply">Reply</string>
   <string name="activity_intent_error">Unable to send activity intent, please check command format</string>
@@ -472,10 +474,12 @@ like to connect to:</string>
   <string name="template_widget_default">Enter Template Here</string>
   <string name="themes_option_label_dark">Dark</string>
   <string name="themes_option_label_light">Light</string>
-  <string name="themes_option_label_system">Follow System Settings</string>
+  <string name="themes_option_label_system">Follow Home Assistant</string>
+  <string name="themes_option_label_android">Follow System Settings</string>
   <string name="themes_option_value_dark">dark</string>
   <string name="themes_option_value_light">light</string>
   <string name="themes_option_value_system">system</string>
+  <string name="themes_option_value_android">android</string>
   <string name="themes_title_settings">Theme</string>
   <string name="tts_error">Unable to process notification \"%1$s\" as text to speech.</string>
   <string name="tts_no_title">Please set a title for text to speech to process</string>


### PR DESCRIPTION
Fixes #1496


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR improves the themes and the coloring of the status bar/navigation bar.

* **Add "Follow Home Assistant" theme setting**
  Default theme option is now "Follow Home Assistant". This one will color the status bar/navigation bar like the `app-header-background-color` variable of the set HA Theme. This is exactly the same behavior as we have now, except that the option is now called "Follow Home Assistant" instead of "Follow System-Settings".
I decided to do this, because with the option "Follow system-settings" you can choose if the statusbar ALWAYS colors according to the system, no matter which color the HA theme has (See #1496). Also at the moment it is so, that the theme setting only colors the settings of the app. That is kind of pointless. So, now you can also color the status bar/nav bar in the WebView.

* **Add instant status bar/nav bar color change, when change HA theme**
  Now the status bar/nav bar color is changed immediately with the change of the HA theme
* **Fix status bar coloring when using a light theme**
   I noticed a bug which colors a light status bar background with a light status bar text. This was caused by the method `showSystemUI`, because it removes the flag `SYSTEM_UI_FLAG_LIGHT_STATUS_BAR`
* **Use new WindowInsets API on >= Android 11**
  Since setting `window.decorView.systemUiVisibility` is marked as deprecated as of Android 11, I implemented the WindowInset API for coloring the status bar/nav bar. However, `systemUiVisibility` is also used for toggling fullscreen mode. This should be adapted to the WindowInset API with another PR in the future.
* **Color status bar/nav bar a bit darker, than HA Theme**
  To follow the design guidelines here: https://material.io/design/color/the-color-system.html , the status bar/nav bar is now colored a little bit darker than the HA theme color.

* **Enhance logging**

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->