### PR TITLE
Fix log fragment crash

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
@@ -80,20 +80,22 @@ class LogFragment() : Fragment() {
     }
 
     private fun refreshLog() = lifecycleScope.launch(Dispatchers.Main) {
-        val logTextView = requireView().findViewById<TextView>(R.id.logTextView)
-        val toolbar = requireActivity().findViewById<Toolbar>(R.id.toolbar)
+        if (view != null && activity != null) {
+            val logTextView = requireView().findViewById<TextView>(R.id.logTextView)
+            val toolbar = requireActivity().findViewById<Toolbar>(R.id.toolbar)
 
-        toolbar.menu.setGroupVisible(R.id.log_toolbar_group, false)
-        showHideLogLoader(true)
+            toolbar.menu.setGroupVisible(R.id.log_toolbar_group, false)
+            showHideLogLoader(true)
 
-        // Runs with Dispatcher IO
-        currentLog = LogcatReader.readLog()
+            // Runs with Dispatcher IO
+            currentLog = LogcatReader.readLog()
 
-        logTextView?.text = currentLog
-        toolbar.menu.setGroupVisible(R.id.log_toolbar_group, true)
-        showHideLogLoader(false)
-        (view?.findViewById<ScrollView>(R.id.logScrollview))?.apply {
-            post { fullScroll(ScrollView.FOCUS_DOWN) }
+            logTextView?.text = currentLog
+            toolbar.menu.setGroupVisible(R.id.log_toolbar_group, true)
+            showHideLogLoader(false)
+            (view?.findViewById<ScrollView>(R.id.logScrollview))?.apply {
+                post { fullScroll(ScrollView.FOCUS_DOWN) }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes following crash:
```
java.lang.IllegalStateException: Fragment LogFragment{734e4b0} (9ea226fd-a7ad-4317-9781-eaeb4bf03e50) id=0x7f0a0090} did not return a View from onCreateView() or this was called before onCreateView().
    at androidx.fragment.app.Fragment.requireView(Fragment.java:1781)
    at io.homeassistant.companion.android.settings.log.LogFragment$refreshLog$1.invokeSuspend(LogFragment.kt:83)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:223)
    at android.app.ActivityThread.main(ActivityThread.java:7660)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->