### PR TITLE
Reduce image size to account for varying screen resolutions in media player widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -181,11 +181,15 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                     Handler(Looper.getMainLooper()).post {
                         if (BuildConfig.DEBUG)
                             Picasso.get().isLoggingEnabled = true
-                        Picasso.get().load(url).resize(1920, 1080).into(
-                            this,
-                            R.id.widgetMediaImage,
-                            intArrayOf(appWidgetId)
-                        )
+                        try {
+                            Picasso.get().load(url).resize(800, 400).into(
+                                this,
+                                R.id.widgetMediaImage,
+                                intArrayOf(appWidgetId)
+                            )
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Unable to load image", e)
+                        }
                         Log.d(TAG, "Fetch and load complete")
                     }
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -182,7 +182,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
                         if (BuildConfig.DEBUG)
                             Picasso.get().isLoggingEnabled = true
                         try {
-                            Picasso.get().load(url).resize(800, 400).into(
+                            Picasso.get().load(url).resize(1024, 600).into(
                                 this,
                                 R.id.widgetMediaImage,
                                 intArrayOf(appWidgetId)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Found the below sentry error and it seems like the resize attempt is not good enough as per this note from Google

```
The total Bitmap memory used by the RemoteViews object cannot exceed that required to fill the screen 1.5 times, ie. (screen width x screen height x 4 x 1.5) bytes.
```

So a fire tablet that has much smaller screen resolution than a pixel 4 will still have an error like:

```
java.lang.IllegalArgumentException: RemoteViews for widget update exceeds maximum bitmap memory usage (used: 8294400, max: 6912000)
    at android.os.Parcel.createExceptionOrNull(Parcel.java:2389)
    at android.os.Parcel.createException(Parcel.java:2369)
    at android.os.Parcel.readException(Parcel.java:2352)
    at android.os.Parcel.readException(Parcel.java:2294)
    at com.android.internal.appwidget.IAppWidgetService$Stub$Proxy.updateAppWidgetIds(IAppWidgetService.java:1079)
    at android.appwidget.AppWidgetManager.updateAppWidget(AppWidgetManager.java:617)
    at com.squareup.picasso.RemoteViewsAction$AppWidgetAction.update(RemoteViewsAction.java:116)
    at com.squareup.picasso.RemoteViewsAction.complete(RemoteViewsAction.java:45)
    at com.squareup.picasso.Picasso.deliverAction(Picasso.java:576)
    at com.squareup.picasso.Picasso.complete(Picasso.java:528)
    at com.squareup.picasso.Picasso$1.handleMessage(Picasso.java:122)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8512)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

1024x600 seems like a good compromise for now unless someone has a better solution.  My own error showed the bitmap values triple this size but with the same error. This resolution also maintains a better aspect ratio

also lets catch the error so we dont crash

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->