### PR TITLE
Write all published application IDs to NFC tags

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -82,21 +82,8 @@ android {
         }
 
         // Generate a list of application ids into BuildConfig
-        var values = ""
-        productFlavors.all { flavor ->
-            if (values.isNotEmpty())
-                values += ","
-
-            values += "\""
-            values += if (flavor.applicationId == null)
-                defaultConfig.applicationId
-            else
-                flavor.applicationId
-
-            flavor.applicationIdSuffix?.let { values += it }
-            values += "\""
-
-            true
+        val values = productFlavors.joinToString {
+            "\"${it.applicationId?: defaultConfig.applicationId}${it.applicationIdSuffix}\""
         }
 
         defaultConfig.buildConfigField("String[]", "APPLICATION_IDS", "{$values}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -83,7 +83,7 @@ android {
 
         // Generate a list of application ids into BuildConfig
         val values = productFlavors.joinToString {
-            "\"${it.applicationId?: defaultConfig.applicationId}${it.applicationIdSuffix}\""
+            "\"${it.applicationId ?: defaultConfig.applicationId}${it.applicationIdSuffix}\""
         }
 
         defaultConfig.buildConfigField("String[]", "APPLICATION_IDS", "{$values}")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,26 @@ android {
             applicationIdSuffix = ""
             versionNameSuffix = "-full"
         }
+
+        // Generate a list of application ids into BuildConfig
+        var values = ""
+        productFlavors.all { flavor ->
+            if (values.isNotEmpty())
+                values += ","
+
+            values += "\""
+            values += if (flavor.applicationId == null)
+                defaultConfig.applicationId
+            else
+                flavor.applicationId
+
+            flavor.applicationIdSuffix?.let { values += it }
+            values += "\""
+
+            true
+        }
+
+        defaultConfig.buildConfigField("String[]", "APPLICATION_IDS", "{$values}")
     }
 
     playConfigs {

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -17,8 +17,11 @@ object NFCUtil {
     @Throws(Exception::class)
     fun createNFCMessage(url: String, intent: Intent?): Boolean {
         val nfcRecord = NdefRecord.createUri(url)
-        val applicationRecord = NdefRecord.createApplicationRecord(BuildConfig.APPLICATION_ID)
-        val nfcMessage = NdefMessage(arrayOf(nfcRecord, applicationRecord))
+        val applicationRecords = BuildConfig.APPLICATION_IDS.map {
+            NdefRecord.createApplicationRecord(it)
+        }
+
+        val nfcMessage = NdefMessage(arrayOf(nfcRecord) + applicationRecords)
         val nfcFallbackMessage = NdefMessage(arrayOf(nfcRecord))
         intent?.let {
             val tag = it.getParcelableExtra<Tag>(NfcAdapter.EXTRA_TAG)


### PR DESCRIPTION
Signed-off-by: Nagy Tamás (T-bond) <tbondvagyok@gmail.com>


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
See #1505

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No frontend change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation not changed.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
If multiple favor is installed on the user's phone, then the OS will choose which one to open. I could not find documentation about the order they are read. I tested on 3 Samsung phone and on one One Plus, and it worked the order the record were on NFC:

1.  The full favored application
2. The minimal favored application

I don't know if it will work on every phone, as there was not so much documentation about it on the internet. (I also haven't checked the Android source code to see how it works)
The ones I tested it worked correctly, and only one application got triggered.

It should automatically add new favors and follow any application ID changes if they are introduced or modified in the future.

This PR does **not** add ARR records to the NFC tag for the debug variants, as I think keeping the data size to minimal is still better for the end user.