### PR TITLE
Fix button widget icon crash

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -55,8 +55,6 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
     @Inject
     lateinit var integrationUseCase: IntegrationRepository
 
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
-
     private lateinit var iconPack: IconPack
 
     private var services = HashMap<String, Service>()

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -347,7 +347,7 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
         widget_config_fields_layout.layoutManager = LinearLayoutManager(this)
 
         // Do this off the main thread, takes a second or two...
-        ioScope.launch {
+        runOnUiThread {
             // Create an icon pack and load all drawables.
             iconPack = createMaterialDesignIconPack(loader)
             iconPack.loadDrawables(loader.drawableLoader)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed the following sentry error and came to realize that the button widget configure activity was crashing on launch in the latest beta, this might have been caused by one of the dependency updates.  The error was pretty specific in this case and since I was able to reproduce the issue I can also confirm the fix.

```
java.lang.IllegalStateException: Method addObserver must be called on the main thread
    at androidx.lifecycle.LifecycleRegistry.enforceMainThreadIfNeeded(LifecycleRegistry.java:317)
    at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:172)
    at androidx.fragment.app.Fragment.initLifecycle(Fragment.java:496)
    at androidx.fragment.app.Fragment.<init>(Fragment.java:476)
    at androidx.fragment.app.DialogFragment.<init>(DialogFragment.java:138)
    at com.maltaisn.icondialog.IconDialog.<init>(IconDialog.kt:52)
    at com.maltaisn.icondialog.IconDialog$Companion.newInstance(IconDialog.kt:475)
    at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity$onCreate$2.invokeSuspend(ButtonWidgetConfigureActivity.kt:357)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->