### PR TITLE
Add unavailable state to power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -46,6 +46,7 @@ class ClimateControl {
                     "heat" -> context.getString(R.string.state_heat)
                     "heat_cool" -> context.getString(R.string.state_heat_cool)
                     "off" -> context.getString(R.string.state_off)
+                    "unavailable" -> context.getString(R.string.state_unavailable)
                     else -> entity.state
                 }
             )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -61,6 +61,7 @@ class CoverControl {
                         "closing" -> context.getString(R.string.state_closing)
                         "open" -> context.getString(R.string.state_open)
                         "opening" -> context.getString(R.string.state_opening)
+                        "unavailable" -> context.getString(R.string.state_unavailable)
                         else -> entity.state
                     }
             )
@@ -76,7 +77,7 @@ class CoverControl {
                     if ((entity.attributes["supported_features"] as Int) and SUPPORT_SET_POSITION == SUPPORT_SET_POSITION)
                         ToggleRangeTemplate(
                                 entity.entityId,
-                                entity.state !in listOf("closed", "closing"),
+                                entity.state in listOf("open", "opening"),
                                 "",
                                 RangeTemplate(
                                         entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -49,7 +49,14 @@ class DefaultSwitchControl {
                 }
             )
             control.setStatus(Control.STATUS_OK)
-            control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(R.string.state_on))
+            control.setStatusText(
+                when (entity.state) {
+                    "off" -> context.getString(R.string.state_off)
+                    "on" -> context.getString(R.string.state_on)
+                    "unavailable" -> context.getString(R.string.state_unavailable)
+                    else -> context.getString(R.string.state_unknown)
+                }
+            )
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -45,11 +45,19 @@ class FanControl {
             control.setDeviceType(DeviceTypes.TYPE_FAN)
             control.setZone(context.getString(R.string.domain_fan))
             control.setStatus(Control.STATUS_OK)
+            control.setStatusText(
+                when (entity.state) {
+                    "off" -> context.getString(R.string.state_off)
+                    "on" -> context.getString(R.string.state_on)
+                    "unavailable" -> context.getString(R.string.state_unavailable)
+                    else -> context.getString(R.string.state_unknown)
+                }
+            )
             if (currentSpeed.isNotBlank()) {
                 control.setControlTemplate(
                     ToggleRangeTemplate(
                         entity.entityId,
-                        entity.state != "off",
+                        entity.state == "on",
                         "",
                         RangeTemplate(
                             entity.entityId,
@@ -66,7 +74,7 @@ class FanControl {
                     ToggleTemplate(
                         entity.entityId,
                         ControlButton(
-                            entity.state != "off",
+                            entity.state == "on",
                             ""
                         )
                     )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -42,8 +42,14 @@ class LightControl {
             control.setDeviceType(DeviceTypes.TYPE_LIGHT)
             control.setZone(context.getString(R.string.domain_light))
             control.setStatus(Control.STATUS_OK)
-            control.setStatusText(if (entity.state == "off") context.getString(R.string.state_off) else context.getString(
-                R.string.state_on))
+            control.setStatusText(
+                when (entity.state) {
+                    "off" -> context.getString(R.string.state_off)
+                    "on" -> context.getString(R.string.state_on)
+                    "unavailable" -> context.getString(R.string.state_unavailable)
+                    else -> context.getString(R.string.state_unknown)
+                }
+            )
             val minValue = 0f
             val maxValue = 100f
             var currentValue = (entity.attributes["brightness"] as? Number)?.toFloat()?.div(255f)?.times(100) ?: 0f
@@ -55,7 +61,7 @@ class LightControl {
                     if ((entity.attributes["supported_features"] as Int) and SUPPORT_BRIGHTNESS == SUPPORT_BRIGHTNESS)
                         ToggleRangeTemplate(
                                 entity.entityId,
-                                entity.state != "off",
+                                entity.state == "on",
                                 "",
                                 RangeTemplate(
                                         entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -39,7 +39,14 @@ class LockControl {
             )
             control.setZone(context.getString(R.string.domain_lock))
             control.setStatus(Control.STATUS_OK)
-            control.setStatusText(if (entity.state == "locked") context.getString(R.string.state_locked) else context.getString(R.string.state_unlocked))
+            control.setStatusText(
+                when (entity.state) {
+                    "locked" -> context.getString(R.string.state_locked)
+                    "unlocked" -> context.getString(R.string.state_unlocked)
+                    "unavailable" -> context.getString(R.string.state_unavailable)
+                    else -> context.getString(R.string.state_unknown)
+                }
+            )
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -42,9 +42,14 @@ class VacuumControl {
             control.setZone(context.getString(R.string.domain_vacuum))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
-                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
-                        if (entity.state == "off") context.getString(R.string.state_off) else context.getString(R.string.state_on)
-                    else
+                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON) {
+                        when (entity.state) {
+                            "off" -> context.getString(R.string.state_off)
+                            "on" -> context.getString(R.string.state_on)
+                            "unavailable" -> context.getString(R.string.state_unavailable)
+                            else -> context.getString(R.string.state_unknown)
+                        }
+                    } else {
                         when (entity.state) {
                             "cleaning" -> context.getString(R.string.state_cleaning)
                             "docked" -> context.getString(R.string.state_docked)
@@ -55,7 +60,8 @@ class VacuumControl {
                             "unavailable" -> context.getString(R.string.state_unavailable)
                             else -> context.getString(R.string.state_unknown)
                         }
-                    )
+                    }
+            )
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds the `unavailable` state to power menu and changes behavior of tile appearance so this state is not `checked`

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->