### PR TITLE
Clear out preference value if the value does not match the provided entry list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -450,6 +450,15 @@ class SensorDetailFragment(
             return@setOnPreferenceChangeListener true
         }
 
+        if (pref.values != null) {
+            for (item in pref.values.toList()) {
+                if (!entries.contains(item.toString().removeSurrounding("[", "]")))
+                    pref.values = setOf()
+            }
+            pref.summary = pref.values.toString()
+        } else
+            pref.summary = setting.value
+
         return pref
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1515 by clearing out the preference value if we detect a mismatch between the entries and the selected value.

Tested this by creating a zone, adding it to high accuracy, removing the zone and coming back to sensor setting screen.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->