### PR TITLE
Add write settings permission for troubleshooting certain devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WRITE_SETTINGS"
+        tools:ignore="ProtectedPermissions" />
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Attempt to fix #1465 users who get no sound when using `channel: alarm_stream` will need to go in to the application info to grant the Write Settings permission to see if it fixes the issue.

Based on the below sentry error I think its a safe assumption this is the issue.

I did not opt to check for this permission as it is not required by all devices and per the comments in #1465 it does not impact all samsung devices.  It does not make sense to prevent already working notifications just for this permission check, imagine the users who have grown to be dependent on it.  It makes sense to leave it as a troubleshooting step.

If in the future we add a new notification command that requires this setting then we can add the check there as we normally do.

```
java.lang.SecurityException: io.homeassistant.companion.android was not granted  this permission: android.permission.WRITE_SETTINGS.
    at android.os.Parcel.createExceptionOrNull(Parcel.java:2385)
    at android.os.Parcel.createException(Parcel.java:2369)
    at android.os.Parcel.readException(Parcel.java:2352)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
    at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:142)
    at android.content.ContentProviderProxy.call(ContentProviderNative.java:732)
    at android.provider.Settings$NameValueCache.putStringForUser(Settings.java:2794)
    at android.provider.Settings$System.putStringForUser(Settings.java:3422)
    at android.provider.Settings$System.putStringForUser(Settings.java:3406)
    at android.media.RingtoneManager.setActualDefaultRingtoneUri(RingtoneManager.java:910)
    at android.media.RingtoneManager.setRingtonesAsInitValue(RingtoneManager.java:1439)
    at android.media.RingtoneManager.getActualDefaultRingtoneUri(RingtoneManager.java:860)
    at io.homeassistant.companion.android.notifications.MessagingService.handleChannelSound(MessagingService.kt:1047)
    at io.homeassistant.companion.android.notifications.MessagingService.handleChannel(MessagingService.kt:1002)
    at io.homeassistant.companion.android.notifications.MessagingService.sendNotification(MessagingService.kt:547)
    at io.homeassistant.companion.android.notifications.MessagingService$onMessageReceived$$inlined$let$lambda$9.invokeSuspend(MessagingService.kt:282)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8443)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:596)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending approval

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

Its important to note that even Tasker has this permission so we should also hopefully qualify.