### PR TITLE
Fix default theme statusbar color

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -953,10 +953,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     private fun isColorDark(color: Int): Boolean {
-        val whiteContrast = ColorUtils.calculateContrast(Color.WHITE, color)
-        val blackContrast = ColorUtils.calculateContrast(Color.BLACK, color)
-
-        return whiteContrast > blackContrast
+        return ColorUtils.calculateLuminance(color) < 0.5;
     }
 
     override fun setExternalAuth(script: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -953,7 +953,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     private fun isColorDark(color: Int): Boolean {
-        return ColorUtils.calculateLuminance(color) < 0.5;
+        return ColorUtils.calculateLuminance(color) < 0.5
     }
 
     override fun setExternalAuth(script: String) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes the the dark statusbar when using HA default light theme.
Looks like calculating the luminance of the color for checking the darkness of a color is better. I tested several theme colors. Looking good.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->