### PR TITLE
Adjust ExoPlayer scaling to better match hls.js

### DIFF
--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -106,9 +106,9 @@ object Config {
             const val iconDialog = "com.maltaisn:icondialog:3.3.0"
             const val iconDialogMaterial = "com.maltaisn:iconpack-community-material:5.3.45"
             const val emoji = "com.vdurmont:emoji-java:5.1.1"
-            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.13.2"
-            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.13.2"
-            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.13.2"
+            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.13.3"
+            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.13.3"
+            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.13.3"
             const val altBeacon =  "org.altbeacon:android-beacon-library:2+"
         }
     }


### PR DESCRIPTION
Set windowed height using video height
Set resizeMode to match hls.js behavior
Also remove loadControl
Bump ExoPlayer version to 2.13.3 (https://github.com/google/ExoPlayer/compare/r2.13.2...r2.13.3)


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
The ExoPlayer scaling behavior may have changed with the refactoring in #1448. This PR adjusts the scaling behavior to better match the behavior when using hls.js in the webview.
NB I am also waiting on a PR in the ExoPlayer repo to fix a problem with the starting time. Hopefully it gets merged soon and is available in the next ExoPlayer release due out in early May. We can wait on this PR until then or I can make a separate PR to bump the version once that is ready.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->