### PR TITLE
Register sensor names as English only

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -6,6 +6,7 @@ import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.media.AudioManager
 import android.os.PowerManager
 import android.util.Log
@@ -13,6 +14,7 @@ import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.SensorRegistration
 import io.homeassistant.companion.android.database.AppDatabase
+import java.util.Locale
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -159,7 +161,10 @@ class SensorReceiver : BroadcastReceiver() {
                 // Register Sensors if needed
                 if (sensor?.enabled == true && !sensor.registered && !sensor.type.isBlank()) {
                     val reg = fullSensor.toSensorRegistration()
-                    reg.name = context.getString(basicSensor.name)
+                    val config = Configuration(context.resources.configuration)
+                    config.setLocale(Locale("en"))
+                    reg.name = context.createConfigurationContext(config).resources.getString(basicSensor.name)
+
                     try {
                         integrationUseCase.registerSensor(reg)
                         sensor.registered = true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1373 by forcing English as the locale being used to pull the string for sensor registration name.

I was unable to properly test this by changing my language however I did not get any errors nor see any indication that the code failed.  As we do not have our strings locally anymore its a bit difficult to properly test however I would imagine if the code didnt work I would see an error which I did not.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->