### PR TITLE
Only show widget errors when selected, other widget fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -80,8 +80,8 @@
         <receiver android:name=".widgets.camera.CameraWidget" android:label="@string/widget_camera_description">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget.RECEIVE_DATA" />
-                <action android:name="io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidget.UPDATE_IMAGE" />
+                <action android:name="io.homeassistant.companion.android.widgets.camera.CameraWidget.RECEIVE_DATA" />
+                <action android:name="io.homeassistant.companion.android.widgets.camera.CameraWidget.UPDATE_IMAGE" />
             </intent-filter>
 
             <meta-data
@@ -117,7 +117,7 @@
                 android:resource="@xml/media_player_control_widget_info" />
         </receiver>
 
-        <receiver android:name=".widgets.template.TemplateWidget" android:label="Template Widget">
+        <receiver android:name=".widgets.template.TemplateWidget" android:label="@string/template_widget">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -177,7 +177,7 @@ class CameraWidget : AppWidgetProvider() {
             entity = integrationUseCase.getEntity(entityId)
         } catch (e: Exception) {
             Log.e(TAG, "Failed to fetch entity or entity does not exist", e)
-            if (lastIntent != Intent.ACTION_SCREEN_ON)
+            if (lastIntent == UPDATE_IMAGE)
                 Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
             return null
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -151,7 +151,7 @@ class EntityWidget : AppWidgetProvider() {
             entity = entityId?.let { integrationUseCase.getEntity(it) }
         } catch (e: Exception) {
             Log.e(TAG, "Unable to fetch entity", e)
-            if (lastIntent != Intent.ACTION_SCREEN_ON)
+            if (lastIntent == UPDATE_ENTITY)
                 Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
         }
         if (attributeIds == null) {
@@ -169,7 +169,7 @@ class EntityWidget : AppWidgetProvider() {
             return lastUpdate
         } catch (e: Exception) {
             Log.e(TAG, "Unable to fetch entity state and attributes", e)
-            if (lastIntent != Intent.ACTION_SCREEN_ON)
+            if (lastIntent == UPDATE_ENTITY)
                 Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
         }
         return staticWidgetDao.get(appWidgetId)?.lastUpdate

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -283,7 +283,7 @@ class MediaPlayerControlsWidget : AppWidgetProvider() {
             entity = integrationUseCase.getEntity(entityId)
         } catch (e: Exception) {
             Log.d(TAG, "Failed to fetch entity or entity does not exist")
-            if (lastIntent != Intent.ACTION_SCREEN_ON)
+            if (lastIntent == UPDATE_MEDIA_IMAGE)
                 Toast.makeText(context, R.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
             return null
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -128,7 +128,7 @@ class TemplateWidget : AppWidgetProvider() {
                     templateWidgetDao.updateTemplateWidgetLastUpdate(appWidgetId, renderedTemplate)
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to render template: ${widget.template}", e)
-                    if (lastIntent != Intent.ACTION_SCREEN_ON)
+                    if (lastIntent == UPDATE_VIEW)
                         Toast.makeText(context, R.string.widget_template_error, Toast.LENGTH_LONG).show()
                 }
                 setTextViewText(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,4 +592,5 @@ like to connect to:</string>
   <string name="tile_5">Tile 5</string>
   <string name="quick_settings">Quick Settings</string>
   <string name="manage_tiles_summary">Setup and manage Quick Setting tiles here. They will not function until you set them up here.</string>
+  <string name="template_widget">Template Widget</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes #1541 by only showing the toast error message when a user taps to update a widget. Error will not be shown for other updates, only interactions.

Also:
*  Correct camera widget manifest info
*  Use a string for template widget in widget picker
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->