### PR TITLE
Prevent selecting an entity for a tile if they are missing

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -118,6 +118,8 @@ class ManageTilesFragment : PreferenceFragmentCompat(), IconDialog.Callback {
             tileEntityPref?.entryValues = sortedEntities
         }
 
+        findPreference<ListPreference>("tile_entity")?.isEnabled = entityList.isNotEmpty()
+        findPreference<Preference>("tile_missing_entity")?.isVisible = entityList.isEmpty()
         tileSavePref?.isEnabled = !tileEntity.isNullOrEmpty() && !tileLabel.isNullOrEmpty()
 
         findPreference<ListPreference>("tile_list")?.setOnPreferenceChangeListener { _, newValue ->
@@ -145,6 +147,8 @@ class ManageTilesFragment : PreferenceFragmentCompat(), IconDialog.Callback {
                                 }
                             }
                         }
+                        findPreference<ListPreference>("tile_entity")?.isEnabled = entityList.isNotEmpty()
+                        findPreference<Preference>("tile_missing_entity")?.isVisible = entityList.isEmpty()
                         tileSavePref?.isEnabled = !tileEntity.isNullOrEmpty() && !tileLabel.isNullOrEmpty()
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,4 +592,6 @@ like to connect to:</string>
   <string name="tile_5">Tile 5</string>
   <string name="quick_settings">Quick Settings</string>
   <string name="manage_tiles_summary">Setup and manage Quick Setting tiles here. They will not function until you set them up here.</string>
+  <string name="tile_missing_entity_title">Missing Script or Scene</string>
+  <string name="tile_missing_entity_summary">Please add a script or scene to Home Assistant and revisit this screen to enable the below field</string>
 </resources>

--- a/app/src/main/res/xml/quick_setting_tiles.xml
+++ b/app/src/main/res/xml/quick_setting_tiles.xml
@@ -31,10 +31,18 @@
             app:useSimpleSummaryProvider="true"
             app:isPreferenceVisible="false"
             app:iconSpaceReserved="false" />
+        <Preference
+            android:key="tile_missing_entity"
+            android:title="@string/tile_missing_entity_title"
+            android:summary="@string/tile_missing_entity_summary"
+            app:isPreferenceVisible="false"
+            app:iconSpaceReserved="false"
+            android:selectable="false" />
         <ListPreference
             android:key="tile_entity"
             android:title="@string/tile_entity"
             app:useSimpleSummaryProvider="true"
+            app:enabled="false"
             app:iconSpaceReserved="false" />
         <Preference
             android:key="tile_save"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1556 by disabling the entity selection field when the user does not have any `script` or `scene` setup.  We will show a friendly message mentioning whats missing and update when we detect an entity was added.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->