### PR TITLE
Prevent saving and rendering blank template widgets

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -73,7 +73,12 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
         if (templateWidget != null) {
             templateText.setText(templateWidget.template)
             add_button.setText(R.string.update_widget)
-            renderTemplateText(templateWidget.template)
+            if (templateWidget.template.isNotEmpty())
+                renderTemplateText(templateWidget.template)
+            else {
+                renderedTemplate.text = getString(R.string.empty_template)
+                add_button.isEnabled = false
+            }
             delete_button.visibility = VISIBLE
             delete_button.setOnClickListener(onDeleteWidget)
         }
@@ -81,7 +86,13 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
         templateText.doAfterTextChanged { editableText ->
             if (editableText == null)
                 return@doAfterTextChanged
-            renderTemplateText(editableText.toString())
+            if (editableText.isNotEmpty()) {
+                add_button.isEnabled = true
+                renderTemplateText(editableText.toString())
+            } else {
+                renderedTemplate.text = getString(R.string.empty_template)
+                add_button.isEnabled = false
+            }
         }
 
         add_button.setOnClickListener {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,4 +592,5 @@ like to connect to:</string>
   <string name="tile_5">Tile 5</string>
   <string name="quick_settings">Quick Settings</string>
   <string name="manage_tiles_summary">Setup and manage Quick Setting tiles here. They will not function until you set them up here.</string>
+  <string name="empty_template">Template value must not be blank</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the below sentry error by preventing rendering and saving blank templates. I don't see a reason to let users save a widget with no data and the failure was due to blank rendering. I assume we may have some blank templates saved out there so we may just avoid rendering blank templates in the widget itself.

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int java.lang.String.length()' on a null object reference
    at java.io.StringReader.<init>(StringReader.java:50)
    at android.text.HtmlToSpannedConverter.convert(Html.java:748)
    at android.text.Html.fromHtml(Html.java:243)
    at android.text.Html.fromHtml(Html.java:186)
    at io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigureActivity$renderTemplateText$1$1.run(TemplateWidgetConfigureActivity.kt:121)
    at android.os.Handler.handleCallback(Handler.java:883)
    at android.os.Handler.dispatchMessage(Handler.java:100)
    at android.os.Looper.loop(Looper.java:224)
    at android.app.ActivityThread.main(ActivityThread.java:7560)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:539)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:950)
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->