### PR TITLE
Account for color mode when determining brightness slider

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -42,14 +42,8 @@ class LightControl {
 
             // On HA Core 2021.5 and later brightness detection has changed
             // to simplify things in the app lets use both methods for now
-            var supportsBrightness = false
             val supportedColorModes = entity.attributes["supported_color_modes"] as? List<String>
-            if (supportedColorModes != null) {
-                for (item in supportedColorModes) {
-                    if (item !in NO_BRIGHTNESS_SUPPORT)
-                        supportsBrightness = true
-                }
-            }
+            val supportsBrightness = if (supportedColorModes == null) false else !(supportedColorModes - NO_BRIGHTNESS_SUPPORT).isEmpty()
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setDeviceType(DeviceTypes.TYPE_LIGHT)
             control.setZone(context.getString(R.string.domain_light))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1546 by checking the supported color modes on a device in addition to supported features. As we do not store the current HA version and users might be on a version earlier than 2021.5 we will account for both methods to make it easier.

For more details on the change: https://github.com/home-assistant/core/issues/50563#issuecomment-847251138

Also dev docs that cover which color modes support dimming/brightness: https://developers.home-assistant.io/docs/core/entity/light/#color-modes

I tested this with both a light that has brightness and one that doesn't.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->