### PR TITLE
Finish null check for tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile1Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile1Service.kt
@@ -7,8 +7,11 @@ import androidx.annotation.RequiresApi
 @RequiresApi(Build.VERSION_CODES.N)
 class Tile1Service : TileExtensions() {
 
-    override fun getTile(): Tile {
-        return qsTile
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
     }
 
     override fun getTileId(): String {

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile2Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile2Service.kt
@@ -7,8 +7,11 @@ import androidx.annotation.RequiresApi
 @RequiresApi(Build.VERSION_CODES.N)
 class Tile2Service : TileExtensions() {
 
-    override fun getTile(): Tile {
-        return qsTile
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
     }
 
     override fun getTileId(): String {

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile3Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile3Service.kt
@@ -7,8 +7,11 @@ import androidx.annotation.RequiresApi
 @RequiresApi(Build.VERSION_CODES.N)
 class Tile3Service : TileExtensions() {
 
-    override fun getTile(): Tile {
-        return qsTile
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
     }
 
     override fun getTileId(): String {

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile4Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile4Service.kt
@@ -11,8 +11,11 @@ class Tile4Service : TileExtensions() {
         private const val TILE_ID = "tile_4"
     }
 
-    override fun getTile(): Tile {
-        return qsTile
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
     }
 
     override fun getTileId(): String {

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile5Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile5Service.kt
@@ -11,8 +11,11 @@ class Tile5Service : TileExtensions() {
         private const val TILE_ID = "tile_5"
     }
 
-    override fun getTile(): Tile {
-        return qsTile
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
     }
 
     override fun getTileId(): String {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This should properly send the expected `null` values (that #1548 expected) to hopefully fix:

```
java.lang.NullPointerException: qsTile must not be null
    at io.homeassistant.companion.android.qs.Tile2Service.getTile(Tile2Service.kt:11)
    at io.homeassistant.companion.android.qs.TileExtensions.onTileAdded(TileExtensions.kt:46)
    at android.service.quicksettings.TileService$H.handleMessage(TileService.java:404)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:241)
    at android.app.ActivityThread.main(ActivityThread.java:7582)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:941)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->