### PR TITLE
Add a 2s delay to more info pop-up for 2021.6

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -76,8 +76,11 @@ import javax.inject.Inject
 import kotlinx.android.synthetic.main.activity_webview.*
 import kotlinx.android.synthetic.main.exo_player_control_view.*
 import kotlinx.android.synthetic.main.exo_player_view.*
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -105,6 +108,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         private const val CONNECTION_DELAY = 10000L
     }
+
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     @Inject
     lateinit var presenter: WebViewPresenter
@@ -221,11 +226,17 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 }
 
                 override fun onPageFinished(view: WebView?, url: String?) {
-                    if (moreInfoEntity != "") {
-                        Log.d(TAG, "More info entity: $moreInfoEntity")
-                        webView.evaluateJavascript("document.querySelector(\"home-assistant\").dispatchEvent(new CustomEvent(\"hass-more-info\", { detail: { entityId: \"$moreInfoEntity\" }}))", null)
+                    if (moreInfoEntity != "" && view?.progress == 100 && isConnected) {
+                        ioScope.launch {
+                            delay(2000L)
+                            Log.d(TAG, "More info entity: $moreInfoEntity")
+                            webView.evaluateJavascript(
+                                "document.querySelector(\"home-assistant\").dispatchEvent(new CustomEvent(\"hass-more-info\", { detail: { entityId: \"$moreInfoEntity\" }}))",
+                                null
+                            )
+                            moreInfoEntity = ""
+                        }
                     }
-                    moreInfoEntity = ""
                 }
 
                 override fun onReceivedHttpError(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes #1583 by adding a 2 second delay (thanks to @chriss158 for finding this earlier 😂 albeit for a different issue at the time)

I noticed after 2021.6 core the pop-up was no longer coming up, the JS still worked but according to the logs we were sending the JS before the external bus was connected.  So now we wait for the connection and I added a delay to make sure everything is properly loaded. Might feel a bit odd but it works.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->