### PR TITLE
Bump exoplayer version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,6 +174,7 @@ dependencies {
     implementation(Config.Dependency.Misc.exoCore)
     implementation(Config.Dependency.Misc.exoHls)
     implementation(Config.Dependency.Misc.exoUi)
+    implementation(Config.Dependency.Misc.exoCronet)
 }
 
 // Disable to fix memory leak and be compatible with the configuration cache.

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -49,6 +49,9 @@ import androidx.webkit.WebViewCompat
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
+import com.google.android.exoplayer2.ext.cronet.CronetDataSource
+import com.google.android.exoplayer2.ext.cronet.CronetEngineWrapper
+import com.google.android.exoplayer2.source.DefaultMediaSourceFactory
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.PlayerView
 import com.google.android.exoplayer2.video.VideoSize
@@ -85,6 +88,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
+import java.util.concurrent.Executors
 import javax.inject.Inject
 
 class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webview.WebView {
@@ -634,8 +638,16 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         val uri = Uri.parse(payload.getString("url"))
         exoMute = payload.optBoolean("muted")
         runOnUiThread {
-            exoPlayer =
-                SimpleExoPlayer.Builder(applicationContext).build()
+            exoPlayer = SimpleExoPlayer.Builder(applicationContext).setMediaSourceFactory(
+                DefaultMediaSourceFactory(
+                    CronetDataSource.Factory(
+                        CronetEngineWrapper(
+                            applicationContext
+                        ),
+                        Executors.newSingleThreadExecutor()
+                    )
+                )
+            ).build()
             exoPlayer?.setMediaItem(MediaItem.fromUri(uri))
             exoPlayer?.playWhenReady = true
             exoPlayer?.addListener(object : Player.Listener {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -47,10 +47,11 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.webkit.WebViewCompat
 import com.google.android.exoplayer2.MediaItem
+import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
 import com.google.android.exoplayer2.ui.AspectRatioFrameLayout
 import com.google.android.exoplayer2.ui.PlayerView
-import com.google.android.exoplayer2.video.VideoListener
+import com.google.android.exoplayer2.video.VideoSize
 import com.google.android.material.textfield.TextInputEditText
 import eightbitlab.com.blurview.RenderScriptBlur
 import io.homeassistant.companion.android.BaseActivity
@@ -637,21 +638,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 SimpleExoPlayer.Builder(applicationContext).build()
             exoPlayer?.setMediaItem(MediaItem.fromUri(uri))
             exoPlayer?.playWhenReady = true
-            exoPlayer?.addVideoListener(object : VideoListener {
-                override fun onVideoSizeChanged(
-                    width: Int,
-                    height: Int,
-                    unappliedRotationDegrees: Int,
-                    pixelWidthHeightRatio: Float
-                ) {
-                    super.onVideoSizeChanged(
-                        width,
-                        height,
-                        unappliedRotationDegrees,
-                        pixelWidthHeightRatio
-                    )
+            exoPlayer?.addListener(object : Player.Listener {
+                override fun onVideoSizeChanged(videoSize: VideoSize) {
+                    super.onVideoSizeChanged(videoSize)
                     exoBottom =
-                        exoTop + ((exoRight - exoLeft) * height / width)
+                        exoTop + ((exoRight - exoLeft) * videoSize.height / videoSize.width)
                     runOnUiThread {
                         exoResizeLayout()
                     }

--- a/app/src/main/res/layout/exo_player_control_view.xml
+++ b/app/src/main/res/layout/exo_player_control_view.xml
@@ -2,8 +2,7 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:background="#00000000">
+    android:layout_height="match_parent">
     <LinearLayout android:id="@+id/exo_play_pause_button"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -106,9 +106,9 @@ object Config {
             const val iconDialog = "com.maltaisn:icondialog:3.3.0"
             const val iconDialogMaterial = "com.maltaisn:iconpack-community-material:5.3.45"
             const val emoji = "com.vdurmont:emoji-java:5.1.1"
-            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.13.3"
-            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.13.3"
-            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.13.3"
+            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.14.0"
+            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.14.0"
+            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.14.0"
             const val altBeacon =  "org.altbeacon:android-beacon-library:2+"
         }
     }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -106,10 +106,10 @@ object Config {
             const val iconDialog = "com.maltaisn:icondialog:3.3.0"
             const val iconDialogMaterial = "com.maltaisn:iconpack-community-material:5.3.45"
             const val emoji = "com.vdurmont:emoji-java:5.1.1"
-            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.14.0"
-            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.14.0"
-            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.14.0"
-            const val exoCronet = "com.google.android.exoplayer:extension-cronet:2.14.0"
+            const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.14.1"
+            const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.14.1"
+            const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.14.1"
+            const val exoCronet = "com.google.android.exoplayer:extension-cronet:2.14.1"
             const val altBeacon =  "org.altbeacon:android-beacon-library:2+"
         }
     }

--- a/buildSrc/src/main/kotlin/Config.kt
+++ b/buildSrc/src/main/kotlin/Config.kt
@@ -109,6 +109,7 @@ object Config {
             const val exoCore = "com.google.android.exoplayer:exoplayer-core:2.14.0"
             const val exoHls = "com.google.android.exoplayer:exoplayer-hls:2.14.0"
             const val exoUi = "com.google.android.exoplayer:exoplayer-ui:2.14.0"
+            const val exoCronet = "com.google.android.exoplayer:extension-cronet:2.14.0"
             const val altBeacon =  "org.altbeacon:android-beacon-library:2+"
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This PR does 3 things related to the ExoPlayer usage:
1) Updates the ExoPlayer version to ~2.14.0~ 2.14.1. In ~2.14.0~ 2.14.1 the VideoListener has been deprecated, so the VideoListener usage has been refactored to use Player.Listener instead.
2) Removes the transparent background from the layout file. This was causing flickering on some devices.
3) Adds http2 support via the Cronet extension.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

~v 2.14.0 was released almost a month ago. I'm not sure what the ExoPlayer release schedule is like, but I think it's likely the 2.14.1 patch version will be released soon. There is a useful PR in that patch that I think is worth waiting for. As such, I'll leave this PR in draft mode for the time being.~
v 2.14.1 was released today, and I tested it on my end. The PR has been updated and is now ready for review.