### PR TITLE
Make icon optional for zone attributes

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ZoneAttributes.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ZoneAttributes.kt
@@ -6,5 +6,5 @@ data class ZoneAttributes(
     val longitude: Double,
     val radius: Float,
     val friendlyName: String,
-    val icon: String
+    val icon: String?
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1596 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

Apparently the HA frontend makes this field required however it is not required in YAML configuration so I have opened a bug for the frontend to fix this behavior as it should match the backend docs

https://github.com/home-assistant/frontend/issues/9645

https://www.home-assistant.io/integrations/zone/#icon