### PR TITLE
Allow notifications to only alert once if set

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -83,6 +83,7 @@ class MessagingService : FirebaseMessagingService() {
         const val WHEN = "when"
         const val GROUP_PREFIX = "group_"
         const val KEY_TEXT_REPLY = "key_text_reply"
+        const val ALERT_ONCE = "alert_once"
 
         // special action constants
         const val REQUEST_LOCATION_UPDATE = "request_location_update"
@@ -766,6 +767,8 @@ class MessagingService : FirebaseMessagingService() {
         } else {
             builder.setSound(RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION))
         }
+        if (data[ALERT_ONCE].toBoolean())
+            builder.setOnlyAlertOnce(true)
     }
 
     private fun handleColor(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1589 

Adds a new key for `alert_once` by default its set to `false` so we will process if set to `true`.

```yaml
  - alias: Notify one time
    trigger:
      ...
    action:
      - service: notify.mobile_app_<your_device_id_here>
        data:
          title: "One Time"
          message: "This will only alert me the first time"
          data:
            tag: "Alarm"
            alert_once: true
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#567

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM PR: https://github.com/home-assistant/mobile-apps-fcm-push/pull/59