### PR TITLE
Invoke error display on main thread to avoid crashing

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterBase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterBase.kt
@@ -47,7 +47,9 @@ open class MobileAppIntegrationPresenterBase constructor(
                 integrationUseCase.registerDevice(deviceRegistration)
             } catch (e: Exception) {
                 Log.e(TAG, "Unable to register with Home Assistant", e)
-                view.showError()
+                withContext(mainScope.coroutineContext) {
+                    view.showError()
+                }
                 return@launch
             }
             view.deviceRegistered()


### PR DESCRIPTION
Failing to run the view change on the main thread may cause a
CalledFromWrongThread exception as the view may not have been created
from a thread in the IO pool.


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
The app was failing to start up for me, I looked into the exception being thrown and it looks like the view is being changed from a different thread than it was created, this change will force the view to be modified by the same context that is used in a successful case.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->