### PR TITLE
Set approximation of correct power beacon transmitter power level in DBs.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
@@ -15,7 +15,7 @@ object TransmitterManager {
 
     private fun buildBeacon(haTransmitterI: io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter): Beacon {
         val builder = Beacon.Builder()
-        builder.setTxPower(-59)
+        builder.setTxPower(getReferencePowerInDbs(haTransmitterI))
         builder.setId1(haTransmitterI.uuid)
         builder.setId2(haTransmitterI.major)
         builder.setId3(haTransmitterI.minor)
@@ -94,6 +94,15 @@ object TransmitterManager {
             "medium" -> AdvertiseSettings.ADVERTISE_TX_POWER_MEDIUM
             "low" -> AdvertiseSettings.ADVERTISE_TX_POWER_LOW
             else -> AdvertiseSettings.ADVERTISE_TX_POWER_ULTRA_LOW
+        }
+
+    private fun getReferencePowerInDbs(haTransmitter: IBeaconTransmitter) =
+        // from altbeacon library, below values correspond to the PowerLevels, using reference phone of Nexus 5
+        when (haTransmitter.transmitPowerSetting) {
+            "high" -> -56
+            "medium" -> -66
+            "low" -> -75
+            else -> -99
         }
 
     fun stopTransmitting(haTransmitter: io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter) {

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
@@ -97,12 +97,12 @@ object TransmitterManager {
         }
 
     private fun getReferencePowerInDbs(haTransmitter: IBeaconTransmitter) =
-        // from altbeacon library, below values correspond to the PowerLevels, using reference phone of Nexus 5
+        // from https://github.com/home-assistant/android/issues/1715, below values correspond to the PowerLevels, using reference phone of S5
         when (haTransmitter.transmitPowerSetting) {
-            "high" -> -56
-            "medium" -> -66
-            "low" -> -75
-            else -> -99
+            "high" -> -74
+            "medium" -> -84
+            "low" -> -90
+            else -> -94
         }
 
     fun stopTransmitting(haTransmitter: io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
As per issue #1715 advertised power setting for Beacon should be set to correspond to the power level we have requested.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->