### PR TITLE
Increase the total amount of quick settings tiles to 12

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -353,6 +353,83 @@
                     android:name="android.service.quicksettings.action.QS_TILE"/>
             </intent-filter>
         </service>
+
+        <service
+            android:name=".qs.Tile6Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile7Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile8Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile9Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile10Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile11Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".qs.Tile12Service"
+            android:icon="@drawable/ic_stat_ic_notification"
+            android:label="@string/tile_not_setup"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action
+                    android:name="android.service.quicksettings.action.QS_TILE"/>
+            </intent-filter>
+        </service>
     </application>
 
 </manifest>

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile10Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile10Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile10Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_10"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile11Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile11Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile11Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_11"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile12Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile12Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile12Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_12"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile6Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile6Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile6Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_6"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile7Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile7Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile7Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_7"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile8Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile8Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile8Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_8"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/Tile9Service.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/Tile9Service.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.qs
+
+import android.os.Build
+import android.service.quicksettings.Tile
+import androidx.annotation.RequiresApi
+
+@RequiresApi(Build.VERSION_CODES.N)
+class Tile9Service : TileExtensions() {
+
+    companion object {
+        private const val TILE_ID = "tile_9"
+    }
+
+    override fun getTile(): Tile? {
+        return if (qsTile != null)
+            qsTile
+        else
+            null
+    }
+
+    override fun getTileId(): String {
+        return TILE_ID
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,6 +22,13 @@
         <item>tile_3</item>
         <item>tile_4</item>
         <item>tile_5</item>
+        <item>tile_6</item>
+        <item>tile_7</item>
+        <item>tile_8</item>
+        <item>tile_9</item>
+        <item>tile_10</item>
+        <item>tile_11</item>
+        <item>tile_12</item>
     </string-array>
     <string-array name="tile_name">
         <item>@string/tile_1</item>
@@ -29,5 +36,12 @@
         <item>@string/tile_3</item>
         <item>@string/tile_4</item>
         <item>@string/tile_5</item>
+        <item>@string/tile_6</item>
+        <item>@string/tile_7</item>
+        <item>@string/tile_8</item>
+        <item>@string/tile_9</item>
+        <item>@string/tile_10</item>
+        <item>@string/tile_11</item>
+        <item>@string/tile_12</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -590,6 +590,13 @@ like to connect to:</string>
   <string name="tile_3">Tile 3</string>
   <string name="tile_4">Tile 4</string>
   <string name="tile_5">Tile 5</string>
+  <string name="tile_6">Tile 6</string>
+  <string name="tile_7">Tile 7</string>
+  <string name="tile_8">Tile 8</string>
+  <string name="tile_9">Tile 9</string>
+  <string name="tile_10">Tile 10</string>
+  <string name="tile_11">Tile 11</string>
+  <string name="tile_12">Tile 12</string>
   <string name="quick_settings">Quick Settings</string>
   <string name="manage_tiles_summary">Setup and manage Quick Setting tiles here. They will not function until you set them up here.</string>
   <string name="empty_template">Template value must not be blank</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1668 by increasing the limit to 12

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#582

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->