### PR TITLE
Set group alert behavior based on alert_once notification parameter

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -608,7 +608,7 @@ class MessagingService : FirebaseMessagingService() {
 
         handleLargeIcon(notificationBuilder, data)
 
-        handleGroup(notificationBuilder, group)
+        handleGroup(notificationBuilder, group, data[ALERT_ONCE].toBoolean())
 
         handleTimeout(notificationBuilder, data)
 
@@ -749,6 +749,8 @@ class MessagingService : FirebaseMessagingService() {
             .setGroup(group)
             .setGroupSummary(true)
 
+        if (data[ALERT_ONCE].toBoolean())
+            groupNotificationBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
         handleColor(groupNotificationBuilder, data)
         return groupNotificationBuilder
     }
@@ -878,10 +880,13 @@ class MessagingService : FirebaseMessagingService() {
 
     private fun handleGroup(
         builder: NotificationCompat.Builder,
-        group: String?
+        group: String?,
+        alertOnce: Boolean?
     ) {
         if (!group.isNullOrBlank()) {
             builder.setGroup(group)
+            if (alertOnce == true)
+                builder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1754  by setting the group alert behavior so it does not get ignored. The reason as to why I have it in 2 locations is because the `notify` call takes place twice for group notifications. `GROUP_ALERT_CHILDREN` is desired here as the group summary is always the first notification posted to the group. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->