### PR TITLE
Added settings option to keep screen on for webview activity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -39,6 +39,7 @@ class SettingsPresenterImpl @Inject constructor(
         return runBlocking {
             return@runBlocking when (key) {
                 "fullscreen" -> integrationUseCase.isFullScreenEnabled()
+                "keep_screen_on" -> integrationUseCase.isKeepScreenOnEnabled()
                 "app_lock" -> authenticationUseCase.isLockEnabled()
                 "crash_reporting" -> prefsRepository.isCrashReporting()
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
@@ -50,6 +51,7 @@ class SettingsPresenterImpl @Inject constructor(
         mainScope.launch {
             when (key) {
                 "fullscreen" -> integrationUseCase.setFullScreenEnabled(value)
+                "keep_screen_on" -> integrationUseCase.setKeepScreenOnEnabled(value)
                 "app_lock" -> authenticationUseCase.setLockEnabled(value)
                 "crash_reporting" -> prefsRepository.setCrashReporting(value)
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -25,6 +25,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowInsetsController
+import android.view.WindowManager
 import android.webkit.CookieManager
 import android.webkit.HttpAuthHandler
 import android.webkit.JavascriptInterface
@@ -541,6 +542,9 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     hideSystemUI()
         }
 
+        if (presenter.isKeepScreenOnEnabled())
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+
         currentLang = languagesManager.getCurrentLang()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -572,6 +576,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             unlocked = true
             blurView.setBlurEnabled(false)
         }
+
+        if (presenter.isKeepScreenOnEnabled())
+            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        else
+            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
 
         SensorWorker.start(this)
         checkAndWarnForDisabledLocation()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -14,6 +14,8 @@ interface WebViewPresenter {
 
     fun isFullScreen(): Boolean
 
+    fun isKeepScreenOnEnabled(): Boolean
+
     fun isLockEnabled(): Boolean
 
     fun sessionTimeOut(): Int

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -129,6 +129,12 @@ class WebViewPresenterImpl @Inject constructor(
         }
     }
 
+    override fun isKeepScreenOnEnabled(): Boolean {
+        return runBlocking {
+            integrationUseCase.isKeepScreenOnEnabled()
+        }
+    }
+
     override fun isLockEnabled(): Boolean {
         return runBlocking {
             authenticationUseCase.isLockEnabled()

--- a/app/src/main/res/drawable/ic_phone_check.xml
+++ b/app/src/main/res/drawable/ic_phone_check.xml
@@ -1,0 +1,9 @@
+
+<!-- drawable/cellphone_check.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="@color/colorAccent" android:pathData="M14.54 23H7C5.9 23 5 22.11 5 21V3C5 1.89 5.89 1 7 1H17C18.1 1 19 1.89 19 3V13C18.3 13 17.63 13.13 17 13.35V5H7V19H13C13 20.54 13.58 21.94 14.54 23M17.75 22.16L15 19.16L16.16 18L17.75 19.59L21.34 16L22.5 17.41L17.75 22.16" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -153,6 +153,8 @@ integration enabled on your home assistant instance.</string>
   <string name="firebase_error_title">Firebase Error</string>
   <string name="fullscreen">Fullscreen</string>
   <string name="fullscreen_def">Put application in full screen</string>
+  <string name="keep_screen_on">Keep screen On</string>
+  <string name="keep_screen_on_def">Do not lock screen when Lovelace dashboard is active</string>
   <string name="grant_permission">Grant Permission</string>
   <string name="high_accuracy_mode_channel_name">High accuracy location</string>
   <string name="high_accuracy_mode_notification_title">High accuracy (GPS) mode enabled</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -59,6 +59,11 @@
             android:icon="@drawable/ic_fullscreen"
             android:title="@string/fullscreen"
             android:summary="@string/fullscreen_def"/>
+        <SwitchPreference
+            android:key="keep_screen_on"
+            android:icon="@drawable/ic_phone_check"
+            android:title="@string/keep_screen_on"
+            android:summary="@string/keep_screen_on_def"/>
         <Preference
             android:key="nfc_tags"
             android:icon="@drawable/ic_nfc"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -20,6 +20,9 @@ interface IntegrationRepository {
     suspend fun setFullScreenEnabled(enabled: Boolean)
     suspend fun isFullScreenEnabled(): Boolean
 
+    suspend fun setKeepScreenOnEnabled(enabled: Boolean)
+    suspend fun isKeepScreenOnEnabled(): Boolean
+
     suspend fun sessionTimeOut(value: Int)
     suspend fun getSessionTimeOut(): Int
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -53,6 +53,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_SECRET = "secret"
 
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
+        private const val PREF_KEEP_SCREEN_ON_ENABLED = "keep_screen_on_enabled"
         private const val PREF_SESSION_TIMEOUT = "session_timeout"
         private const val PREF_SESSION_EXPIRE = "session_expire"
         private const val PREF_SENSORS_REGISTERED = "sensors_registered"
@@ -301,6 +302,14 @@ class IntegrationRepositoryImpl @Inject constructor(
 
     override suspend fun isFullScreenEnabled(): Boolean {
         return localStorage.getBoolean(PREF_FULLSCREEN_ENABLED)
+    }
+
+    override suspend fun setKeepScreenOnEnabled(enabled: Boolean) {
+        localStorage.putBoolean(PREF_KEEP_SCREEN_ON_ENABLED, enabled)
+    }
+
+    override suspend fun isKeepScreenOnEnabled(): Boolean {
+        return localStorage.getBoolean(PREF_KEEP_SCREEN_ON_ENABLED)
     }
 
     override suspend fun sessionTimeOut(value: Int) {


### PR DESCRIPTION
## Summary
Fixes: #1727 
PR adds settings option to keep screen always on while webview activity is active. 

## Screenshots
![SmartSelect_20211007-202149_Home Assistant](https://user-images.githubusercontent.com/3670941/136433744-21e4a721-a6b4-48d3-baee-d1a031bf3900.jpg)

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#586

## Any other notes
In the further PR I'm also going to extend existing `Screen On` notification command in the full flavor to optionally enable\disable this. 