### PR TITLE
Wear - Request focus on entity list for rotary input

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -49,6 +49,7 @@ class HomeActivity : AppCompatActivity(), HomeView {
         findViewById<WearableRecyclerView>(R.id.home_list)?.apply {
             layoutManager = LinearLayoutManager(this@HomeActivity)
             adapter = this@HomeActivity.adapter
+            requestFocus()
         }
 
         presenter.onViewReady()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

My fossil watches have a dial for rotary input, noticed it was not scrolling down the list of entities.  Requesting focus fixes this.

https://developer.android.com/training/wearables/user-input/rotary-input

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->