### PR TITLE
Add icons for notification action buttons

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -1031,7 +1031,12 @@ class MessagingService : FirebaseMessagingService() {
                         0
                     )
 
-                    builder.addAction(0, notificationAction.title, actionPendingIntent)
+                    val icon =
+                        if (notificationAction.key == "URI")
+                            R.drawable.ic_globe
+                        else
+                            R.drawable.ic_stat_ic_notification
+                    builder.addAction(icon, notificationAction.title, actionPendingIntent)
                 } else {
                     val remoteInput: RemoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).run {
                         setLabel(getString(R.string.action_reply))
@@ -1043,7 +1048,7 @@ class MessagingService : FirebaseMessagingService() {
                         actionIntent,
                         PendingIntent.FLAG_UPDATE_CURRENT
                     )
-                    val action: NotificationCompat.Action = NotificationCompat.Action.Builder(0, notificationAction.title, replyPendingIntent)
+                    val action: NotificationCompat.Action = NotificationCompat.Action.Builder(R.drawable.ic_baseline_reply_24, notificationAction.title, replyPendingIntent)
                         .addRemoteInput(remoteInput)
                         .build()
                     builder.addAction(action)

--- a/app/src/main/res/drawable/ic_baseline_reply_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_reply_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M10,9V5l-7,7 7,7v-4.1c5,0 8.5,1.6 11,5.1 -1,-5 -4,-10 -11,-11z"/>
+</vector>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Currently we do not have an icon set so on a Wear OS device it can look a bit plain according to #1209 so adding some default icons for the 3 types of actions we have.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![screen (3)](https://user-images.githubusercontent.com/1634145/137574712-58588ab7-ba3d-4a8a-812c-5660e75d968d.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->