### PR TITLE
Add support for toggle entities in quick setting tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -32,6 +32,10 @@ class ManageTilesFragment : PreferenceFragmentCompat(), IconDialog.Callback {
 
     companion object {
         private const val TAG = "TileFragment"
+        private val validDomains = listOf(
+            "cover", "fan", "humidifier", "input_boolean", "light",
+            "media_player", "remote", "siren", "scene", "script", "switch"
+        )
         fun newInstance(): ManageTilesFragment {
             return ManageTilesFragment()
         }
@@ -104,7 +108,7 @@ class ManageTilesFragment : PreferenceFragmentCompat(), IconDialog.Callback {
             try {
                 integrationUseCase.getEntities().forEach {
                     val split = it.entityId.split(".")
-                    if (split[0].startsWith("script") || split[0].startsWith("scene"))
+                    if (split[0] in validDomains)
                         entityList = entityList + it.entityId
                 }
             } catch (e: Exception) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -584,7 +584,7 @@ like to connect to:</string>
   <string name="tile_list">List of Tiles</string>
   <string name="tile_label">Tile Label</string>
   <string name="tile_subtitle">Tile Subtitle</string>
-  <string name="tile_entity">Select a Script or Scene to call</string>
+  <string name="tile_entity">Select a entity to toggle or call</string>
   <string name="tile_save">Update Tile Data</string>
   <string name="tile_updated">Tile Data Updated</string>
   <string name="tile_1">Tile 1</string>
@@ -602,8 +602,8 @@ like to connect to:</string>
   <string name="quick_settings">Quick Settings</string>
   <string name="manage_tiles_summary">Setup and manage Quick Setting tiles here. They will not function until you set them up here.</string>
   <string name="empty_template">Template value must not be blank</string>
-  <string name="tile_missing_entity_title">Missing Script or Scene</string>
-  <string name="tile_missing_entity_summary">Please add a script or scene to Home Assistant and revisit this screen to enable the below field</string>
+  <string name="tile_missing_entity_title">Missing Valid Entity Domains</string>
+  <string name="tile_missing_entity_summary">You must have one of the following domains in order to use this feature: cover, fan, input_boolean, light, remote, scene, script, switch</string>
   <string name="template_widget">Template Widget</string>
     <string name="basic_sensor_name_high_accuracy_mode">High Accuracy Mode</string>
   <string name="sensor_description_high_accuracy_mode">Whether or not high accuracy mode is active on the device</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1603 by allowing users to add entities that support the `toggle` service call. In addition the state of these tiles will reflect the state from HA (it is delayed but it works)

List of domains that are supported now:   "cover", "fan", "humidifier", "input_boolean", "light",  "media_player", "remote", "siren", "scene", "script", "switch"

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#595

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->