### PR TITLE
Support cookie-based authentication

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/CookieJarCookieManagerShim.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/CookieJarCookieManagerShim.kt
@@ -1,0 +1,38 @@
+package io.homeassistant.companion.android.common.data
+
+import android.webkit.CookieManager
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+// Use cookies collected by webkit in the okhttp client.
+//
+// This can be useful for HomeAssistant setups that require cookies
+// for authentication.
+//
+// By default okhttp doesn't handle cookies at all -- so here we use
+// the builtin webkit CookieManager to handle policy and
+// persistence. Any cookies that are set during the onboarding/login
+// workflow are persisted and can be used for future API calls.
+
+class CookieJarCookieManagerShim : CookieJar {
+
+    companion object {
+        private const val TAG = "CookieJarCookieManagerShim"
+    }
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        val cookies: String = CookieManager.getInstance()
+            ?.getCookie(url.toString()) ?: return emptyList()
+        return cookies.split("; ").map {
+            Cookie.parse(url, it)
+        }.filterNotNull()
+    }
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        val manager: CookieManager = CookieManager.getInstance() ?: return
+        for (cookie in cookies) {
+            manager.setCookie(url.toString(), cookie.toString(), null)
+        }
+    }
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantRetrofit.kt
@@ -54,6 +54,7 @@ class HomeAssistantRetrofit @Inject constructor(urlRepository: UrlRepository) {
                     it.proceed(it.request())
                 }
             }
+                .cookieJar(CookieJarCookieManagerShim())
                 .callTimeout(30L, TimeUnit.SECONDS)
                 .readTimeout(30L, TimeUnit.SECONDS)
                 .build()


### PR DESCRIPTION
## Summary

Support cookie-based authentication.

This change uses the webkit built-in CookieManager to provide cookie
policy and persistence for the okhttp client. The net effect is that
cookies that are set during the onboarding process are persisted and
used for subsequent API calls.

This allows users to secure their HomeAssistant instance using
alternate authentication mechanisms that rely on cookies
(e.g. Cloudflare Access).

## Screenshots

## Link to pull request in Documentation repository

N/A. The documentation currently doesn't describe support for cookies or lack thereof.

## Any other notes

