### PR TITLE
Support custom icons in wear os

### DIFF
--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -85,4 +85,8 @@ dependencies {
 
     implementation("com.google.dagger:dagger:2.39.1")
     kapt("com.google.dagger:dagger-compiler:2.39.1")
+
+    implementation("com.mikepenz:iconics-core:5.3.2")
+    implementation("androidx.appcompat:appcompat:1.3.1")
+    implementation("com.mikepenz:community-material-typeface:5.8.55.0-kotlin@aar")
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/viewHolders/EntityButtonViewHolder.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/viewHolders/EntityButtonViewHolder.kt
@@ -1,9 +1,13 @@
 package io.homeassistant.companion.android.viewHolders
 
+import android.graphics.Color
 import android.view.View
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.colorInt
+import com.mikepenz.iconics.utils.sizeDp
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 
@@ -18,23 +22,31 @@ class EntityButtonViewHolder(v: View, val onClick: (Entity<Any>) -> Unit) :
             val entityAttributes = value?.attributes as Map<String, String>
             txtName.text = entityAttributes["friendly_name"]
 
-            // Set default icon
-            if (value.entityId.split(".")[0] == "script") {
-                imgIcon.setImageResource(R.drawable.ic_scripts)
-            } else if (value.entityId.split(".")[0] == "light") {
-                imgIcon.setImageResource(R.drawable.ic_light)
-            } else if (value.entityId.split(".")[0] == "cover") {
-                imgIcon.setImageResource(R.drawable.ic_garage)
+            if (entityAttributes.containsKey("icon")) {
+                val icon: String = entityAttributes["icon"]!!.split(":")[1]
+                val iconDrawable = IconicsDrawable(imgIcon.context, "cmd-$icon").apply {
+                    colorInt = Color.WHITE
+                    sizeDp = 24
+                }
+                imgIcon.setImageDrawable(iconDrawable)
             } else {
-                imgIcon.setImageResource(R.drawable.ic_scenes)
+                // Set default icon
+                when {
+                    value.entityId.split(".")[0] == "script" -> {
+                        imgIcon.setImageResource(R.drawable.ic_scripts)
+                    }
+                    value.entityId.split(".")[0] == "light" -> {
+                        imgIcon.setImageResource(R.drawable.ic_light)
+                    }
+                    value.entityId.split(".")[0] == "cover" -> {
+                        imgIcon.setImageResource(R.drawable.ic_garage)
+                    }
+                    else -> {
+                        imgIcon.setImageResource(R.drawable.ic_scenes)
+                    }
+                }
             }
 
-            /*if (entityAttributes.containsKey("icon")) {
-                Need to implement dynamic icon loading here
-                The default library used (com.maltaisn:icondialog) does not allow to get icons by the mdi: string
-                Alternative library: https://github.com/outadoc/mdi-android
-                This one requires a github access token...
-            }*/
             field = value
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Support custom icons for all entities in HomeActivity

## Screenshots
![wear-os-custom-icons](https://user-images.githubusercontent.com/34075651/137794948-b13d4162-bb1f-4370-a54c-7ae56705aa75.png)
