### PR TITLE
Update ExoPlayer load and playback options

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -47,6 +47,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import androidx.webkit.WebViewCompat
+import com.google.android.exoplayer2.DefaultLoadControl
 import com.google.android.exoplayer2.MediaItem
 import com.google.android.exoplayer2.Player
 import com.google.android.exoplayer2.SimpleExoPlayer
@@ -649,10 +650,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             exoPlayer = SimpleExoPlayer.Builder(applicationContext).setMediaSourceFactory(
                 DefaultMediaSourceFactory(
                     CronetDataSource.Factory(
-                        CronetEngine.Builder(applicationContext).build(),
+                        CronetEngine.Builder(applicationContext).enableQuic(true).build(),
                         Executors.newSingleThreadExecutor()
                     )
-                )
+                ).setLiveMaxSpeed(8.0f)
+            ).setLoadControl(
+                DefaultLoadControl.Builder().setBufferDurationsMs(
+                    0, 30000, 0, 0
+                ).build()
             ).build()
             exoPlayer?.setMediaItem(MediaItem.fromUri(uri))
             exoPlayer?.playWhenReady = true
@@ -689,7 +694,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     fun exoStopHls() {
         runOnUiThread {
             exoPlayerView.visibility = View.GONE
-            exoPlayerView.setPlayer(null)
+            exoPlayerView.player = null
             exoPlayer?.release()
             exoPlayer = null
         }
@@ -705,7 +710,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             // only set exoBottom if we can't calculate it from the video
             exoBottom = (rect.getInt("bottom") * displayMetrics.density).toInt()
         } else {
-            exoBottom = exoTop + (exoRight - exoLeft) * exoPlayer!!.videoFormat!!.height / exoPlayer!!.videoFormat!!.width
+            exoBottom = exoTop + (exoRight - exoLeft) * exoPlayer!!.videoFormat!!.height /
+                exoPlayer!!.videoFormat!!.width
         }
         runOnUiThread {
             exoResizeLayout()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A delayed initial load (or subsequent delay) can push the ExoPlayer player back away from the live edge of a live HLS stream. This PR
1) uses `setLiveMaxSpeed` to increase the rate at which the player can recover which should improve live latency.
In addition, this PR
2) adjusts the minimum buffer thresholds to 0 so that rebuffers don't take as long.
3) It also enables QUIC for ExoPlayer requests.

Note there is a bug in `stream` which causes HLS playback problems in ExoPlayer. This should be fixed with https://github.com/home-assistant/core/pull/58036

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->