### PR TITLE
Catch exceptions when we have no cookie manager, like on a Wear device

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/CookieJarCookieManagerShim.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/CookieJarCookieManagerShim.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.data
 
+import android.util.Log
 import android.webkit.CookieManager
 import okhttp3.Cookie
 import okhttp3.CookieJar
@@ -18,21 +19,31 @@ import okhttp3.HttpUrl
 class CookieJarCookieManagerShim : CookieJar {
 
     companion object {
-        private const val TAG = "CookieJarCookieManagerShim"
+        private const val TAG = "CookieJarCookieManager"
     }
 
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
-        val cookies: String = CookieManager.getInstance()
-            ?.getCookie(url.toString()) ?: return emptyList()
-        return cookies.split("; ").map {
-            Cookie.parse(url, it)
-        }.filterNotNull()
+        try {
+            val cookies: String = CookieManager.getInstance()
+                ?.getCookie(url.toString()) ?: return emptyList()
+            return cookies.split("; ").map {
+                Cookie.parse(url, it)
+            }.filterNotNull()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get cookie manager", e)
+            return emptyList()
+        }
     }
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-        val manager: CookieManager = CookieManager.getInstance() ?: return
-        for (cookie in cookies) {
-            manager.setCookie(url.toString(), cookie.toString(), null)
+        try {
+            val manager: CookieManager = CookieManager.getInstance() ?: return
+            for (cookie in cookies) {
+                manager.setCookie(url.toString(), cookie.toString(), null)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get cookie manager", e)
+            return
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1812 by catching the exception so we don't crash and passing values as if they were null.  There might be a better way but I couldn't figure out how to get context in the common app folder.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->