### PR TITLE
Only load MDI icons on wear, otherwise load default

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/viewHolders/EntityButtonViewHolder.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/viewHolders/EntityButtonViewHolder.kt
@@ -22,7 +22,7 @@ class EntityButtonViewHolder(v: View, val onClick: (Entity<Any>) -> Unit) :
             val entityAttributes = value?.attributes as Map<String, String>
             txtName.text = entityAttributes["friendly_name"]
 
-            if (entityAttributes.containsKey("icon") && entityAttributes["icon"]!!.split(":")[0].startsWith("mdi")) {
+            if (entityAttributes["icon"]?.startsWith("mdi") == true) {
                 val icon: String = entityAttributes["icon"]!!.split(":")[1]
                 val iconDrawable = IconicsDrawable(imgIcon.context, "cmd-$icon").apply {
                     colorInt = Color.WHITE


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Only load MDI icons otherwise switch to default. Forgot other folks use different icon packs that they can load from HACS. As our library only has MDI lets only look load those icons.

Found on discord: https://discord.com/channels/330944238910963714/562408603345092636/900589019149250600

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->