### PR TITLE
Update the high accuracy sensor when we receive a notification command

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -51,7 +51,6 @@ import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.sensors.NotificationSensorManager
-import io.homeassistant.companion.android.sensors.SensorManager
 import io.homeassistant.companion.android.util.UrlHandler
 import io.homeassistant.companion.android.util.cancel
 import io.homeassistant.companion.android.util.cancelGroupIfNeeded
@@ -66,7 +65,7 @@ import java.net.URL
 import java.util.Locale
 import javax.inject.Inject
 
-class MessagingService : FirebaseMessagingService(), SensorManager {
+class MessagingService : FirebaseMessagingService() {
     companion object {
         const val TAG = "MessagingService"
         const val TITLE = "title"
@@ -1363,23 +1362,5 @@ class MessagingService : FirebaseMessagingService(), SensorManager {
                 Log.e(TAG, "Issue updating token", e)
             }
         }
-    }
-
-    // The below is only necessary so we can update the high accuracy sensor
-    override val name: Int
-        get() = 0
-    override val enabledByDefault: Boolean
-        get() = false
-
-    override fun requiredPermissions(sensorId: String): Array<String> {
-        return emptyArray()
-    }
-
-    override fun requestSensorUpdate(context: Context) {
-        // No op
-    }
-
-    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return emptyList()
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was notified in the forums that the sensor is not updating when a notification command is received. So now we update the sensor based on the command as well.

Ref: https://community.home-assistant.io/t/forcing-high-accuracy-doesnt-update-the-binary-sensor/349306

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->