### PR TITLE
Check for Galaxy Wearable app as well for Galaxy Watch 4 users

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -237,7 +237,8 @@ class SettingsFragment : PreferenceFragmentCompat(), SettingsView {
 
             val pm = requireContext().packageManager
             val hasWearApp = pm.getLaunchIntentForPackage("com.google.android.wearable.app")
-            findPreference<PreferenceCategory>("wear_category")?.isVisible = hasWearApp != null
+            val hasSamsungApp = pm.getLaunchIntentForPackage("com.samsung.android.app.watchmanager")
+            findPreference<PreferenceCategory>("wear_category")?.isVisible = hasWearApp != null || hasSamsungApp != null
             findPreference<Preference>("wear_settings")?.setOnPreferenceClickListener {
                 startActivity(SettingsWearActivity.newInstance(requireContext()))
                 return@setOnPreferenceClickListener true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Apparently the Galaxy Watch 4 which is a Wear OS device does not require the Wear OS app as all other Wear OS devices do. So we need to also check if the user has the Galaxy Wearable app installed. Given the name suggests Wear OS I don't think we need to update messaging here since it should be apparent that we can't find any other device :)

https://support.google.com/wearos/answer/6056630?hl=en&co=GENIE.Platform%3DAndroid



## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->