### PR TITLE
Allow notification icon to be changed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -195,6 +195,9 @@ dependencies {
     implementation("androidx.activity:activity-compose:1.3.1")
     implementation("com.google.android.material:compose-theme-adapter:1.0.4")
     implementation("com.google.accompanist:accompanist-appcompat-theme:0.20.0")
+
+    implementation("com.mikepenz:iconics-core:5.3.2")
+    implementation("com.mikepenz:community-material-typeface:5.8.55.0-kotlin@aar")
 }
 
 // Disable to fix memory leak and be compatible with the configuration cache.

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -38,6 +38,8 @@ import androidx.core.text.HtmlCompat
 import androidx.core.text.isDigitsOnly
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.utils.toAndroidIconCompat
 import com.vdurmont.emoji.EmojiParser
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.dagger.GraphComponentAccessor
@@ -84,6 +86,7 @@ class MessagingService : FirebaseMessagingService() {
         const val KEY_TEXT_REPLY = "key_text_reply"
         const val ALERT_ONCE = "alert_once"
         const val INTENT_CLASS_NAME = "intent_class_name"
+        const val NOTIFICATION_ICON = "notification_icon"
 
         // special action constants
         const val REQUEST_LOCATION_UPDATE = "request_location_update"
@@ -614,7 +617,8 @@ class MessagingService : FirebaseMessagingService() {
         val channelId = handleChannel(notificationManagerCompat, data)
 
         val notificationBuilder = NotificationCompat.Builder(this, channelId)
-            .setSmallIcon(R.drawable.ic_stat_ic_notification)
+
+        handleSmallIcon(notificationBuilder, data)
 
         handleSound(notificationBuilder, data)
 
@@ -688,6 +692,18 @@ class MessagingService : FirebaseMessagingService() {
         }
     }
 
+    private fun handleSmallIcon(
+        builder: NotificationCompat.Builder,
+        data: Map<String, String>
+    ) {
+        if (data[NOTIFICATION_ICON]?.startsWith("mdi") == true && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val iconName = data[NOTIFICATION_ICON]!!.split(":")[1]
+            val iconDrawable = IconicsDrawable(applicationContext, "cmd-$iconName").toAndroidIconCompat()
+            builder.setSmallIcon(iconDrawable)
+        } else
+            builder.setSmallIcon(R.drawable.ic_stat_ic_notification)
+    }
+
     private fun handleContentIntent(
         builder: NotificationCompat.Builder,
         messageId: Int,
@@ -753,7 +769,6 @@ class MessagingService : FirebaseMessagingService() {
     ): NotificationCompat.Builder {
 
         val groupNotificationBuilder = NotificationCompat.Builder(this, channelId)
-            .setSmallIcon(R.drawable.ic_stat_ic_notification)
             .setStyle(
                 NotificationCompat.BigTextStyle()
                     .setSummaryText(
@@ -766,6 +781,7 @@ class MessagingService : FirebaseMessagingService() {
         if (data[ALERT_ONCE].toBoolean())
             groupNotificationBuilder.setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_CHILDREN)
         handleColor(groupNotificationBuilder, data)
+        handleSmallIcon(groupNotificationBuilder, data)
         return groupNotificationBuilder
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1577 

Add a new option so the user can change the `notification_icon`

Example:

```
message: cellphone
data:
  notification_icon: mdi:cellphone
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/138816873-5d38c562-990c-4c01-b063-01aeb95281ca.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#601

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM: https://github.com/home-assistant/mobile-apps-fcm-push/pull/64