### PR TITLE
Show lock states jammed, locking and unlocking in the power menu

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -41,8 +41,11 @@ class LockControl {
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {
+                    "jammed" -> context.getString(R.string.state_jammed)
                     "locked" -> context.getString(R.string.state_locked)
+                    "locking" -> context.getString(R.string.state_locking)
                     "unlocked" -> context.getString(R.string.state_unlocked)
+                    "unlocking" -> context.getString(R.string.state_unlocking)
                     "unavailable" -> context.getString(R.string.state_unavailable)
                     else -> context.getString(R.string.state_unknown)
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -439,7 +439,9 @@ like to connect to:</string>
   <string name="state_heat">Heat</string>
   <string name="state_heat_cool">Heat Cool</string>
   <string name="state_idle">Idle</string>
+  <string name="state_jammed">Jammed</string>
   <string name="state_locked">Locked</string>
+  <string name="state_locking">Locking</string>
   <string name="state_off">Off</string>
   <string name="state_on">On</string>
   <string name="state_open">Open</string>
@@ -449,6 +451,7 @@ like to connect to:</string>
   <string name="state_unavailable">Unavailable</string>
   <string name="state_unknown">Unknown</string>
   <string name="state_unlocked">Unlocked</string>
+  <string name="state_unlocking">Unlocking</string>
   <string name="states">Overview</string>
   <string name="status_of_mobile_app_integration">Status of mobile app integration:</string>
   <string name="tag_reader_title">Processing Tag</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In [June](https://github.com/home-assistant/core/commit/9b705ad6dfddaa97ea135b93ce570a284c5ae731#diff-7505c733e3166b2ffb62662df64a1dc9bbb177af2a0df573676fc4f165a9cd42R18) the LockEntity in core got 3 new states:

- Jammed
- Locking
- Unlocking

This PR adds support in the Android app in the power menu to show these states for locks.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
The relevant page in the documentation seems to be [android-power-menu.md](https://github.com/home-assistant/companion.home-assistant/blob/e3dba71b276dc1c7be758c6e2b5d376f54de1588/docs/integrations/android-power-menu.md?plain=1#L18) which currently does not state which states the controls will show. Therefore a change in the documentation have not been requested.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->