### PR TITLE
Fix notification command permissions not launching by directing user to open the app

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.notifications
 
+import android.app.ActivityManager
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -60,6 +61,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.net.URL
 import java.util.Locale
@@ -417,7 +419,7 @@ class MessagingService : FirebaseMessagingService() {
                     val notificationManager =
                         applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
                     if (!notificationManager.isNotificationPolicyAccessGranted) {
-                        requestDNDPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     } else {
                         when (title) {
                             DND_ALARMS_ONLY -> notificationManager.setInterruptionFilter(
@@ -441,7 +443,7 @@ class MessagingService : FirebaseMessagingService() {
                     val notificationManager =
                         applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
                     if (!notificationManager.isNotificationPolicyAccessGranted) {
-                        requestDNDPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     } else {
                         processRingerMode(audioManager, title)
                     }
@@ -494,7 +496,7 @@ class MessagingService : FirebaseMessagingService() {
                     val notificationManager =
                         applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
                     if (!notificationManager.isNotificationPolicyAccessGranted) {
-                        requestDNDPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     } else {
                         processStreamVolume(
                             audioManager,
@@ -537,7 +539,7 @@ class MessagingService : FirebaseMessagingService() {
             COMMAND_ACTIVITY -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.canDrawOverlays(applicationContext))
-                        requestSystemAlertPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     else
                         processActivityCommand(data)
                 } else
@@ -546,7 +548,7 @@ class MessagingService : FirebaseMessagingService() {
             COMMAND_WEBVIEW -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.canDrawOverlays(applicationContext))
-                        requestSystemAlertPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     else
                         openWebview(title)
                 } else
@@ -574,7 +576,7 @@ class MessagingService : FirebaseMessagingService() {
             COMMAND_MEDIA -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
                     if (!NotificationManagerCompat.getEnabledListenerPackages(applicationContext).contains(applicationContext.packageName))
-                        requestNotificationPermission()
+                        notifyMissingPermission(data[MESSAGE].toString())
                     else {
                         processMediaCommand(data)
                     }
@@ -1339,6 +1341,38 @@ class MessagingService : FirebaseMessagingService() {
             Log.e(TAG, "Unable to open webview", e)
         }
     }
+
+    private fun notifyMissingPermission(type: String) {
+        val appManager =
+            applicationContext.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val currentProcess = appManager.runningAppProcesses
+        if (currentProcess != null) {
+            for (item in currentProcess) {
+                if (applicationContext.applicationInfo.processName == item.processName) {
+                    if (item.importance != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                        val data =
+                            mutableMapOf(MESSAGE to getString(R.string.missing_command_permission))
+                        runBlocking {
+                            sendNotification(data)
+                        }
+                    } else {
+                        when (type) {
+                            COMMAND_WEBVIEW, COMMAND_ACTIVITY -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                requestSystemAlertPermission()
+                            }
+                            COMMAND_RINGER_MODE, COMMAND_DND, COMMAND_VOLUME_LEVEL -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                requestDNDPermission()
+                            }
+                            COMMAND_MEDIA -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
+                                requestNotificationPermission()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * Called if InstanceID token is updated. This may occur if the security of
      * the previous token had been compromised. Note that this is called when the InstanceID token

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -638,4 +638,5 @@ like to connect to:</string>
   <string name="entity_widget_desc">Current state and attribute of any entity</string>
   <string name="media_player_widget_desc">Control any media player and see current now playing image</string>
   <string name="template_widget_desc">Render any template with HTML formatting</string>
+  <string name="missing_command_permission">Please open the Home Assistant app and send the command again in order to grant the proper permissions.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We are unable to launch the special permission activities from the background so we now need to direct users to opening the app so we can trigger the proper permission screen.

Note: We need to still fix actionable and clickAction notifications, I don't think this approach makes sense there but this is the only approach that will work for these commands as they happen without posting a notification.

Current users will need to grant the Draw over other apps permission as a temporary workaround.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->