### PR TITLE
Add measured power setting to BLE transmitter

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconTransmitter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconTransmitter.kt
@@ -8,6 +8,7 @@ data class IBeaconTransmitter(
     var transmitRequested: Boolean = false,
     var state: String,
     var transmitPowerSetting: String,
+    var measuredPowerSetting: Int,
     var advertiseModeSetting: String,
     var restartRequired: Boolean = false,
     val manufacturer: Int = 0x004c,

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
@@ -15,7 +15,7 @@ object TransmitterManager {
 
     private fun buildBeacon(haTransmitterI: IBeaconTransmitter): Beacon {
         val builder = Beacon.Builder()
-        builder.setTxPower(getReferencePowerInDbs(haTransmitterI))
+        builder.setTxPower(haTransmitterI.measuredPowerSetting)
         builder.setId1(haTransmitterI.uuid)
         builder.setId2(haTransmitterI.major)
         builder.setId3(haTransmitterI.minor)
@@ -31,11 +31,11 @@ object TransmitterManager {
     private fun validateInputs(haTransmitter: IBeaconTransmitter): Boolean {
         try {
             UUID.fromString(haTransmitter.uuid)
-            if (haTransmitter.major.toInt() < 0 || haTransmitter.major.toInt() > 65535 || haTransmitter.minor.toInt() < 0 || haTransmitter.minor.toInt() > 65535)
+            if (haTransmitter.major.toInt() < 0 || haTransmitter.major.toInt() > 65535 || haTransmitter.minor.toInt() < 0 || haTransmitter.minor.toInt() > 65535 || haTransmitter.measuredPowerSetting >=0 )
                 throw IllegalArgumentException("Invalid Major or Minor")
         } catch (e: IllegalArgumentException) {
             stopTransmitting(haTransmitter)
-            haTransmitter.state = "Invalid parameters, check UUID, Major and Minor"
+            haTransmitter.state = "Invalid parameters, check UUID, Major and Minor, and Measured Power settings."
             return false
         }
         return true
@@ -103,14 +103,6 @@ object TransmitterManager {
             else -> AdvertiseSettings.ADVERTISE_TX_POWER_ULTRA_LOW
         }
 
-    private fun getReferencePowerInDbs(haTransmitter: IBeaconTransmitter) =
-        // from https://github.com/home-assistant/android/issues/1715, below values correspond to the PowerLevels, using reference phone of S5
-        when (haTransmitter.transmitPowerSetting) {
-            "high" -> -74
-            "medium" -> -84
-            "low" -> -90
-            else -> -94
-        }
 
     fun stopTransmitting(haTransmitter: IBeaconTransmitter) {
         if (haTransmitter.transmitting && this::physicalTransmitter.isInitialized) {

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/TransmitterManager.kt
@@ -31,7 +31,7 @@ object TransmitterManager {
     private fun validateInputs(haTransmitter: IBeaconTransmitter): Boolean {
         try {
             UUID.fromString(haTransmitter.uuid)
-            if (haTransmitter.major.toInt() < 0 || haTransmitter.major.toInt() > 65535 || haTransmitter.minor.toInt() < 0 || haTransmitter.minor.toInt() > 65535 || haTransmitter.measuredPowerSetting >=0 )
+            if (haTransmitter.major.toInt() < 0 || haTransmitter.major.toInt() > 65535 || haTransmitter.minor.toInt() < 0 || haTransmitter.minor.toInt() > 65535 || haTransmitter.measuredPowerSetting >= 0)
                 throw IllegalArgumentException("Invalid Major or Minor")
         } catch (e: IllegalArgumentException) {
             stopTransmitting(haTransmitter)
@@ -102,7 +102,6 @@ object TransmitterManager {
             "low" -> AdvertiseSettings.ADVERTISE_TX_POWER_LOW
             else -> AdvertiseSettings.ADVERTISE_TX_POWER_ULTRA_LOW
         }
-
 
     fun stopTransmitting(haTransmitter: IBeaconTransmitter) {
         if (haTransmitter.transmitting && this::physicalTransmitter.isInitialized) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -22,15 +22,17 @@ class BluetoothSensorManager : SensorManager {
         private const val SETTING_BLE_ADVERTISE_MODE = "ble_advertise_mode"
         private const val SETTING_BLE_TRANSMIT_ENABLED = "ble_transmit_enabled"
         private const val SETTING_BLE_ENABLE_TOGGLE_ALL = "ble_enable_toggle_all"
+        private const val SETTING_BLE_MEASURED_POWER = "ble_measured_power_at_1m"
 
         private const val DEFAULT_BLE_TRANSMIT_POWER = "ultraLow"
         private const val DEFAULT_BLE_ADVERTISE_MODE = "lowPower"
         private const val DEFAULT_BLE_MAJOR = "100"
         private const val DEFAULT_BLE_MINOR = "1"
+        private const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
         private var priorBluetoothStateEnabled = false
 
         // private const val TAG = "BluetoothSM"
-        private var bleTransmitterDevice = IBeaconTransmitter("", "", "", transmitPowerSetting = "", advertiseModeSetting = "", transmitting = false, state = "", restartRequired = false)
+        private var bleTransmitterDevice = IBeaconTransmitter("", "", "", transmitPowerSetting = "", measuredPowerSetting = 0,  advertiseModeSetting = "", transmitting = false, state = "", restartRequired = false)
         val bluetoothConnection = SensorManager.BasicSensor(
             "bluetooth_connection",
             "sensor",
@@ -157,13 +159,15 @@ class BluetoothSensorManager : SensorManager {
         val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, "string", UUID.randomUUID().toString())
         val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, "string", DEFAULT_BLE_MAJOR)
         val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, "string", DEFAULT_BLE_MINOR)
+        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number",  DEFAULT_MEASURED_POWER_AT_1M).toInt()
         val transmitPower = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_POWER, "list", listOf("ultraLow", "low", "medium", "high"), DEFAULT_BLE_TRANSMIT_POWER)
         val advertiseMode = getSetting(context, bleTransmitter, SETTING_BLE_ADVERTISE_MODE, "list", listOf("lowPower", "balanced", "lowLatency"), DEFAULT_BLE_ADVERTISE_MODE)
+
         bleTransmitterDevice.restartRequired = false
         if (bleTransmitterDevice.uuid != uuid || bleTransmitterDevice.major != major ||
             bleTransmitterDevice.minor != minor || bleTransmitterDevice.transmitPowerSetting != transmitPower ||
             bleTransmitterDevice.advertiseModeSetting != advertiseMode || bleTransmitterDevice.transmitRequested != transmitActive ||
-            priorBluetoothStateEnabled != isBtOn(context)
+            bleTransmitterDevice.measuredPowerSetting != measuredPower || priorBluetoothStateEnabled != isBtOn(context)
         ) {
             bleTransmitterDevice.restartRequired = true
         }
@@ -174,6 +178,7 @@ class BluetoothSensorManager : SensorManager {
         bleTransmitterDevice.major = major
         bleTransmitterDevice.minor = minor
         bleTransmitterDevice.transmitPowerSetting = transmitPower
+        bleTransmitterDevice.measuredPowerSetting = measuredPower
         bleTransmitterDevice.advertiseModeSetting = advertiseMode
         bleTransmitterDevice.transmitRequested = transmitActive
     }
@@ -209,7 +214,8 @@ class BluetoothSensorManager : SensorManager {
             mapOf(
                 "id" to bleTransmitterDevice.uuid + "-" + bleTransmitterDevice.major + "-" + bleTransmitterDevice.minor,
                 "Transmitting power" to bleTransmitterDevice.transmitPowerSetting,
-                "Advertise mode" to bleTransmitterDevice.advertiseModeSetting
+                "Advertise mode" to bleTransmitterDevice.advertiseModeSetting,
+                "Measured power" to bleTransmitterDevice.measuredPowerSetting
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -32,7 +32,7 @@ class BluetoothSensorManager : SensorManager {
         private var priorBluetoothStateEnabled = false
 
         // private const val TAG = "BluetoothSM"
-        private var bleTransmitterDevice = IBeaconTransmitter("", "", "", transmitPowerSetting = "", measuredPowerSetting = 0,  advertiseModeSetting = "", transmitting = false, state = "", restartRequired = false)
+        private var bleTransmitterDevice = IBeaconTransmitter("", "", "", transmitPowerSetting = "", measuredPowerSetting = 0, advertiseModeSetting = "", transmitting = false, state = "", restartRequired = false)
         val bluetoothConnection = SensorManager.BasicSensor(
             "bluetooth_connection",
             "sensor",
@@ -159,7 +159,7 @@ class BluetoothSensorManager : SensorManager {
         val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, "string", UUID.randomUUID().toString())
         val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, "string", DEFAULT_BLE_MAJOR)
         val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, "string", DEFAULT_BLE_MINOR)
-        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number",  DEFAULT_MEASURED_POWER_AT_1M).toInt()
+        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number", DEFAULT_MEASURED_POWER_AT_1M).toInt()
         val transmitPower = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_POWER, "list", listOf("ultraLow", "low", "medium", "high"), DEFAULT_BLE_TRANSMIT_POWER)
         val advertiseMode = getSetting(context, bleTransmitter, SETTING_BLE_ADVERTISE_MODE, "list", listOf("lowPower", "balanced", "lowLatency"), DEFAULT_BLE_ADVERTISE_MODE)
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -299,7 +299,7 @@ like to connect to:</string>
   <string name="sensor_description_battery_health">The health of the battery</string>
   <string name="sensor_description_battery_level">The current battery level of the device</string>
   <string name="sensor_description_battery_state">The current charging state of the battery</string>
-  <string name="sensor_description_bluetooth_ble_emitter">Send BLE iBeacon with configured interval, used to track presence around house, e.g. together with roomassistant or esp32-mqtt-room projects.\nBy default this sensor is not turned on with the Enable all toggle, to avoid battery drain, there is a setting to enable this (\"Include when enabling all sensors\").\n\nWarning: this can affect battery life, particularly if the \"Transmitter power\" setting is set to High or \"Advertise Mode\" is set to Low latency.\nSettings allow for specifying:\n- \"UUID\" (standard UUID format), \"Major\" and \"Minor\" (should be 0 - 65535), to tailor identifiers and groups\n- \"Transmitter Power\" and \"Advertise Mode\" to help to preserve battery life (use lowest values if possible)\n\nNote:\nAdditionally a separate setting exists (\"Enable Transmitter\") to stop or start transmitting.</string>
+  <string name="sensor_description_bluetooth_ble_emitter">Send BLE iBeacon with configured interval, used to track presence around house, e.g. together with roomassistant, esp32-mqtt-room or espresence projects.\nBy default this sensor is not turned on with the Enable all toggle, to avoid battery drain, there is a setting to enable this (\"Include when enabling all sensors\").\n\nWarning: this can affect battery life, particularly if the \"Transmitter power\" setting is set to High or \"Advertise Mode\" is set to Low latency.\nSettings allow for specifying:\n- \"UUID\" (standard UUID format), \"Major\" and \"Minor\" (should be 0 - 65535), to tailor identifiers and groups\n- \"Transmitter Power\" and \"Advertise Mode\" to help to preserve battery life (use lowest values if possible)#n - \"Measured Power\" to specify power measured at 1m (initial default -59)\n\nNote:\nAdditionally a separate setting exists (\"Enable Transmitter\") to stop or start transmitting.</string>
   <string name="sensor_description_bluetooth_connection">Information about currently connected bluetooth devices</string>
   <string name="sensor_description_bluetooth_state">Whether or not bluetooth is enabled on the device</string>
   <string name="sensor_description_call_number">The cell number of the incoming or outgoing call</string>
@@ -565,6 +565,7 @@ like to connect to:</string>
   <string name="sensor_setting_location_ham_only_bt_dev_title">High accuracy mode only when connected to BT devices</string>
   <string name="sensor_setting_location_ham_only_enter_zone_title">High accuracy mode only when entering zone</string>
   <string name="sensor_setting_location_ham_trigger_range_title">High accuracy mode trigger range for zone (meters)</string>
+  <string name="sensor_setting_ble_measured_power_at_1m_title">Measured power</string>
   <string name="sensor_setting_ble_transmit_power_title">Transmitter power</string>
   <string name="sensor_setting_ble_transmit_power_high_label">High</string>
   <string name="sensor_setting_ble_transmit_power_low_label">Low</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Revert default setting to publish with measured power of -59, in attempt to resolve issues described by #1855.

Setting added to allow override if required.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![info](https://user-images.githubusercontent.com/596188/139755134-70e90449-3a16-4844-a13f-367658d397a1.PNG)

![sensor_detail](https://user-images.githubusercontent.com/596188/139755146-12d3403a-da1f-4898-93ab-655ab0e5b9c5.PNG)

![attribures](https://user-images.githubusercontent.com/596188/139755164-ecfe7358-3bc9-4983-9cb7-eaeec72f5e6e.PNG)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#604

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
As I'm not experiencing issues myself I'm not 100% sure this will solve these problems, but reinstating old behaviour as default seems like a good start.