### PR TITLE
Remove automatic darkening of system bars

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.webview
 import android.graphics.Color
 import android.net.Uri
 import android.util.Log
-import androidx.core.graphics.ColorUtils
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -210,9 +210,6 @@ class WebViewPresenterImpl @Inject constructor(
             }
         }
 
-        // Darken the found color a bit
-        statusbarNavBarColor = ColorUtils.blendARGB(statusbarNavBarColor, Color.BLACK, 0.1f)
-
         return@withContext statusbarNavBarColor
     }
 


### PR DESCRIPTION
In modern material design the system bars should not be darker then the rest of the app.
Fixes #1501 which should not be closed.

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Google material design changed over the years and they did not always update all the specifications accordingly.
But gladly with Material 3 / Material You, which's specification just got published, they updated everything.

The status bar color should now always be the same color as the AppBar and the navigation bar color should be the same as either the bottom bar or the background. 

Spec: https://m3.material.io/styles/color/the-color-system/tokens

## Screenshots
![image](https://user-images.githubusercontent.com/10547444/140648082-c155abe6-6589-415c-a3eb-621da4cd596c.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->