### PR TITLE
Bring back rotary input support for home screen using workaround

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/util/RotaryEventDispatcher.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/RotaryEventDispatcher.kt
@@ -1,0 +1,62 @@
+package io.homeassistant.companion.android.util
+
+import android.view.MotionEvent
+import android.view.ViewConfiguration
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.InputDeviceCompat
+import androidx.core.view.MotionEventCompat
+import androidx.core.view.ViewConfigurationCompat
+import kotlinx.coroutines.launch
+
+val LocalRotaryEventDispatcher = staticCompositionLocalOf<RotaryEventDispatcher> {
+    noLocalProvidedFor("LocalRotaryEventDispatcher")
+}
+
+class RotaryEventDispatcher(
+    var scrollState: ScrollableState? = null
+) {
+    suspend fun onRotate(delta: Float): Float? =
+        scrollState?.scrollBy(delta)
+}
+
+@Composable
+fun RotaryEventHandlerSetup(rotaryEventDispatcher: RotaryEventDispatcher) {
+    val view = LocalView.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    view.requestFocus()
+    view.setOnGenericMotionListener { _, event ->
+        if (event?.action != MotionEvent.ACTION_SCROLL || !event.isFromSource(InputDeviceCompat.SOURCE_ROTARY_ENCODER)) {
+            return@setOnGenericMotionListener false
+        }
+
+        val delta = -event.getAxisValue(MotionEventCompat.AXIS_SCROLL) * ViewConfigurationCompat.getScaledVerticalScrollFactor(
+            ViewConfiguration.get(context), context
+        )
+
+        scope.launch {
+            rotaryEventDispatcher.onRotate(delta)
+        }
+        true
+    }
+}
+
+@Composable
+fun RotaryEventState(scrollState: ScrollableState?) {
+    val dispater = LocalRotaryEventDispatcher.current
+    SideEffect {
+        dispater.scrollState = scrollState
+    }
+}
+
+private fun noLocalProvidedFor(noOp: String): Nothing {
+    error("composition local $noOp not present")
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Implements the current workaround per recommendation from Google while they work on bringing back `View.RequestFocus()` to compose.

Should make the usability better for users as the list of entities can be quite large :)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
https://issuetracker.google.com/issues/204506310