### PR TITLE
Load a temporary favorite chip for each entity ID until we get entities

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -23,8 +23,8 @@ class MainViewModel : ViewModel() {
 
     fun loadEntities() {
         viewModelScope.launch {
-            entities.addAll(homePresenter.getEntities())
             favoriteEntityIds.addAll(homePresenter.getWearHomeFavorites())
+            entities.addAll(homePresenter.getEntities())
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
-import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.ExperimentalWearMaterialApi
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.ScalingLazyColumn

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.home.views
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -11,11 +12,15 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ExperimentalWearMaterialApi
+import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.ScalingLazyColumn
@@ -23,6 +28,8 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.rememberScalingLazyListState
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.util.RotaryEventDispatcher
@@ -90,11 +97,37 @@ fun MainView(
                 }
                 if (expandedFavorites) {
                     items(favoriteEntityIds.size) { index ->
-                        EntityUi(
-                            // This is here to not break existing favorites.....
-                            entityMap[favoriteEntityIds[index].split(",")[0]]!!,
-                            onEntityClicked
-                        )
+                        val favoriteEntityID = favoriteEntityIds[index].split(",")[0]
+                        if (entities.isNullOrEmpty()) {
+                            // Use a normal chip when we don't have the state of the entity
+                            Chip(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = 0.dp),
+                                icon = {
+                                    Image(
+                                        asset = CommunityMaterial.Icon.cmd_cellphone
+                                    )
+                                },
+                                label = {
+                                    Text(
+                                        text = favoriteEntityID,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                },
+                                onClick = { onEntityClicked(favoriteEntityID) },
+                                colors = ChipDefaults.primaryChipColors(
+                                    backgroundColor = colorResource(id = R.color.colorAccent),
+                                    contentColor = Color.Black
+                                )
+                            )
+                        } else {
+                            EntityUi(
+                                entityMap[favoriteEntityID]!!,
+                                onEntityClicked
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This restores loading a favorite chip during the loading screen for faster execution, for now we will only show an Entity ID. Once we get Room setup we can go back to loading more details in the chip. This allows for a user to execute a chip as soon as the loading screen is up.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->