### PR TITLE
Initial support for websocket state changed events!

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.common.data.integration
 
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
+import kotlinx.coroutines.flow.Flow
 
 interface IntegrationRepository {
 
@@ -45,6 +46,7 @@ interface IntegrationRepository {
 
     suspend fun getEntities(): List<Entity<Any>>
     suspend fun getEntity(entityId: String): Entity<Map<String, Any>>
+    suspend fun getEntityUpdates(): Flow<Entity<*>>
 
     suspend fun callService(domain: String, service: String, serviceData: HashMap<String, Any>)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -25,6 +25,8 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -447,6 +449,19 @@ class IntegrationRepositoryImpl @Inject constructor(
             response.lastUpdated,
             response.context
         )
+    }
+
+    override suspend fun getEntityUpdates(): Flow<Entity<*>> {
+        return webSocketRepository.getStateChanges().map {
+            Entity(
+                it.newState.entityId,
+                it.newState.state,
+                it.newState.attributes,
+                it.newState.lastChanged,
+                it.newState.lastUpdated,
+                it.newState.context
+            )
+        }
     }
 
     private suspend fun canRegisterEntityCategoryStateClass(): Boolean {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -4,6 +4,8 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.ServiceCallRequest
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DomainResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent
+import kotlinx.coroutines.flow.Flow
 
 interface WebSocketRepository {
     suspend fun sendPing(): Boolean
@@ -12,4 +14,5 @@ interface WebSocketRepository {
     suspend fun getServices(): List<DomainResponse>
     suspend fun getPanels(): List<String>
     suspend fun callService(request: ServiceCallRequest)
+    suspend fun getStateChanges(): Flow<StateChangedEvent>
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EventResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EventResponse.kt
@@ -1,0 +1,10 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EventResponse(
+    val eventType: String,
+    val timeFired: String,
+    val data: StateChangedEvent
+)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/SocketResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/SocketResponse.kt
@@ -8,5 +8,6 @@ data class SocketResponse(
     val id: Long?,
     val type: String,
     val success: Boolean?,
-    val result: JsonNode?
+    val result: JsonNode?,
+    val event: JsonNode?
 )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/StateChangedEvent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/StateChangedEvent.kt
@@ -1,0 +1,11 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import io.homeassistant.companion.android.common.data.integration.Entity
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class StateChangedEvent(
+    val entityId: String,
+    val oldState: Entity<*>,
+    val newState: Entity<*>
+)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support for listening to state changed events.  We setup a flow that can be listened to and when the flow is no longer collection it will automatically unsubscribe from the events in the socket.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Screenshot_20211111-153412](https://user-images.githubusercontent.com/1051414/141365373-5fd74547-d1a8-4f26-9392-15281dad861e.jpg)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->