### PR TITLE
Use default trigger range if field is left blank for high accuracy mode

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -726,7 +726,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             DEFAULT_TRIGGER_RANGE_METERS.toString()
         )
 
-        var highAccuracyTriggerRangeInt = highAccuracyTriggerRange.toInt()
+        var highAccuracyTriggerRangeInt = highAccuracyTriggerRange.toIntOrNull() ?: DEFAULT_TRIGGER_RANGE_METERS
         if (highAccuracyTriggerRangeInt < 0) {
             highAccuracyTriggerRangeInt = DEFAULT_TRIGGER_RANGE_METERS
 
@@ -734,7 +734,7 @@ class LocationSensorManager : BroadcastReceiver(), SensorManager {
             sensorDao.add(Setting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE, highAccuracyTriggerRangeInt.toString(), "number"))
         }
 
-        return highAccuracyTriggerRangeInt.toInt()
+        return highAccuracyTriggerRangeInt
     }
 
     private fun getHighAccuracyModeZones(expandedZones: Boolean): List<String> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following stack trace provided by a user on Discord which occurs when the high accuracy trigger range is left blank. If the field is left blank we now use the default value.

```
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: Issue setting up location tracking
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: java.lang.NumberFormatException: For input string: ""
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at java.lang.Integer.parseInt(Integer.java:627)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at java.lang.Integer.parseInt(Integer.java:650)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at io.homeassistant.companion.android.sensors.LocationSensorManager.getHighAccuracyModeTriggerRange(LocationSensorManager.kt:714)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at io.homeassistant.companion.android.sensors.LocationSensorManager.getHighAccuracyMode(LocationSensorManager.kt:316)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at io.homeassistant.companion.android.sensors.LocationSensorManager.setupBackgroundLocation(LocationSensorManager.kt:202)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at io.homeassistant.companion.android.sensors.LocationSensorManager.access$setupBackgroundLocation(LocationSensorManager.kt:41)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at io.homeassistant.companion.android.sensors.LocationSensorManager$setupLocationTracking$1.invokeSuspend(LocationSensorManager.kt:187)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
11-12 16:25:01.759  4937 23166 E LocBroadcastReceiver: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
https://discord.com/channels/330944238910963714/562408603345092636/908866741965307904