### PR TITLE
Check cover state in QS tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -83,7 +83,7 @@ abstract class TileExtensions : TileService() {
                     }
                     if (tileData.entityId.split('.')[0] in toggleDomains) {
                         val state = runBlocking { integrationUseCase.getEntity(tileData.entityId) }
-                        tile.state = if (state.state == "on") Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+                        tile.state = if (state.state == "on" || state.state == "open") Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
                     } else
                         tile.state = Tile.STATE_INACTIVE
                     if (tileData.iconId != null) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1911 by including the state of a `open` cover
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

Tried to apply similar logic for `entityFlow` here but didn't have much luck so wasn't able to add live updates