### PR TITLE
Catch exception when we fail to get entity updates

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -58,7 +59,12 @@ class HomePresenterImpl @Inject constructor(
     }
 
     override suspend fun getEntityUpdates(): Flow<Entity<*>> {
-        return integrationUseCase.getEntityUpdates()
+        return try {
+            integrationUseCase.getEntityUpdates()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get entity updates", e)
+            emptyFlow()
+        }
     }
 
     override suspend fun onEntityClicked(entityId: String) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #1916 by catching the exception the same as we do for `getEntities`

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->