### PR TITLE
Wear OS tile: Fix default icon and move to broadcast receiver

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -58,9 +58,12 @@
             <meta-data android:name="androidx.wear.tiles.PREVIEW"
                 android:resource="@drawable/favorite_entities_tile_example" />
         </service>
-        <activity android:name=".tiles.TileActionActivity"
-            android:exported="true"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <receiver android:name=".tiles.TileActionReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="io.homeassistant.companion.android.TILE_ACTION" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TilesComponent.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TilesComponent.kt
@@ -8,5 +8,5 @@ interface TilesComponent {
 
     fun inject(shortcutsTile: ShortcutsTile)
 
-    fun inject(tileActionActivity: TileActionActivity)
+    fun inject(tileActionReceiver: TileActionReceiver)
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Fix the default entity icon in the shortcuts tile (#1915).

Also change the TileActionActivity to a TileActionReceiver Broadcast receiver. This makes that clicking an entity in the tile never leads the user to the app.
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->