### PR TITLE
Allow the websocket to reconnect

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -5,6 +5,7 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DomainResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 
 interface WebSocketRepository {
@@ -14,5 +15,6 @@ interface WebSocketRepository {
     suspend fun getServices(): List<DomainResponse>
     suspend fun getPanels(): List<String>
     suspend fun callService(request: ServiceCallRequest)
+    @ExperimentalCoroutinesApi
     suspend fun getStateChanges(): Flow<StateChangedEvent>
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently if we loose our connection with the websocket we also loose our state changed registration.  This should force the websocket to reconnect.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->