### PR TITLE
Remove startup activity animation

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -23,6 +23,7 @@ class LaunchActivity : BaseActivity(), LaunchView {
 
         startActivity(WebViewActivity.newInstance(this, intent.data?.path))
         finish()
+        overridePendingTransition(0, 0) // Disable activity start/stop animation
     }
 
     override fun displayOnBoarding(sessionConnected: Boolean) {
@@ -31,6 +32,7 @@ class LaunchActivity : BaseActivity(), LaunchView {
 
         startActivity(intent)
         finish()
+        overridePendingTransition(0, 0) // Disable activity start/stop animation
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Currently when starting the home assistant app, first the launch screen is shown and then a transition to the webview activity is triggered.
The issue is, that this transition is animated, which should not be the case as a launch screen is supposed to just appear and reveal the app behind itself.

This PR disables the transition animation on startup.

## Screenshots

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://user-images.githubusercontent.com/10547444/142456015-5363b5ba-b37d-4e0a-b346-5634809a07f2.mp4

</td>
<td>

https://user-images.githubusercontent.com/10547444/142456724-4c1c53f2-0736-4fc0-b383-a1a8cb49062c.mp4


</td>
</tr>
</table>


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->