### PR TITLE
Fix forwarding HA instance to wear after phone settings introduction

### DIFF
--- a/app/src/full/res/values/wear.xml
+++ b/app/src/full/res/values/wear.xml
@@ -3,5 +3,7 @@
     <string-array name="android_wear_capabilities">
         <!-- IMPORTANT NOTE: Should be different than capability in Wear res/values/wear.xml. -->
         <item>verify_phone_app</item>
+        <item>request_authentication_token</item>
+        <item>request_home_assistant_instance</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/wear.xml
+++ b/app/src/main/res/values/wear.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools"
-    tools:keep="@array/android_wear_capabilities">
-    <string-array name="android_wear_capabilities">
-        <item>request_authentication_token</item>
-        <item>request_home_assistant_instance</item>
-    </string-array>
-</resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

After #1796 the onboarding listener was unable to forward an instance to wear as I was overriding `wear.xml` in the full version. So moving the capabilities to the full version so we are no longer overriding them.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->