### PR TITLE
Fix default icon for shortcut tile

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -98,7 +98,7 @@ class ShortcutsTile : TileService() {
                         val iconName: String = if (entity.icon.startsWith("mdi")) {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
-                            when (entity.entityId.split(":")[1]) {
+                            when (entity.entityId.split(".")[0]) {
                                 "input_boolean", "switch" -> "light_switch"
                                 "light" -> "lightbulb"
                                 "script" -> "script_text_outline"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was playing around with tiles and noticed that none of the icons were loading because all my selected entities had default icons. Came to find the following error due to a minor issue :)

```
2021-11-21 17:17:08.862 27675-27675/? E/TileService: onResourcesRequest Future failed
    java.util.concurrent.ExecutionException: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
        at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:588)
        at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:547)
        at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:113)
        at kotlinx.coroutines.guava.JobListenableFuture.get(ListenableFuture.kt:427)
        at androidx.wear.tiles.TileService$TileProviderWrapper.lambda$onResourcesRequest$2(TileService.java:293)
        at androidx.wear.tiles.TileService$TileProviderWrapper$$ExternalSyntheticLambda0.run(Unknown Source:4)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6680)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
        at java.util.Collections$SingletonList.get(Collections.java:4863)
        at io.homeassistant.companion.android.tiles.ShortcutsTile$onResourcesRequest$1.invokeSuspend(ShortcutsTile.kt:101)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
2021-11-21 17:17:28.858 19474-19474/? E/HOME: [ProtoTilesManagerImpl]Error getting tile resources
    java.util.concurrent.ExecutionException: ktx: Timed out: ktt@60fb062[status=PENDING]
        at krp.s(AW783461766:3)
        at krp.get(AW783461766:2)
        at fiu.run(AW783461766:2)
        at caa.run(Unknown Source:2)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:458)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at bzl.run(AW783461766:7)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6680)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
     Caused by: ktx: Timed out: ktt@60fb062[status=PENDING]

```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->