### PR TITLE
Add support for urlencoded intent extras

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import java.net.URL
+import java.net.URLDecoder
 import java.util.Locale
 import javax.inject.Inject
 import kotlin.collections.HashMap
@@ -515,16 +516,22 @@ class MessagingService : FirebaseMessagingService() {
                     if (!extras.isNullOrEmpty()) {
                         val items = extras.split(',')
                         for (item in items) {
-                            val pair = item.split(":")
+                            val chunks = item.split(":")
+                            var value = chunks[1]
+                            if (chunks.size > 2) {
+                                value = chunks.subList(1, chunks.lastIndex).joinToString(":")
+                                if (chunks.last() == "urlencoded")
+                                    value = URLDecoder.decode(value, "UTF-8")
+                            }
                             intent.putExtra(
-                                pair[0],
-                                if (pair[1].isDigitsOnly())
-                                    pair[1].toInt()
-                                else if ((pair[1].toLowerCase() == "true") ||
-                                    (pair[1].toLowerCase() == "false")
+                                chunks[0],
+                                if (value.isDigitsOnly())
+                                    value.toInt()
+                                else if ((value.lowercase() == "true") ||
+                                    (value.lowercase() == "false")
                                 )
-                                    pair[1].toBoolean()
-                                else pair[1]
+                                    value.toBoolean()
+                                else value
                             )
                         }
                     }

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -514,26 +514,7 @@ class MessagingService : FirebaseMessagingService() {
                     val extras = data["group"]
                     val className = data[INTENT_CLASS_NAME]
                     if (!extras.isNullOrEmpty()) {
-                        val items = extras.split(',')
-                        for (item in items) {
-                            val chunks = item.split(":")
-                            var value = chunks[1]
-                            if (chunks.size > 2) {
-                                value = chunks.subList(1, chunks.lastIndex).joinToString(":")
-                                if (chunks.last() == "urlencoded")
-                                    value = URLDecoder.decode(value, "UTF-8")
-                            }
-                            intent.putExtra(
-                                chunks[0],
-                                if (value.isDigitsOnly())
-                                    value.toInt()
-                                else if ((value.lowercase() == "true") ||
-                                    (value.lowercase() == "false")
-                                )
-                                    value.toBoolean()
-                                else value
-                            )
-                        }
+                        addExtrasToIntent(intent, extras)
                     }
                     intent.`package` = packageName
                     if (!packageName.isNullOrEmpty() && !className.isNullOrEmpty())
@@ -649,6 +630,32 @@ class MessagingService : FirebaseMessagingService() {
                 }
             }
             else -> Log.d(TAG, "No command received")
+        }
+    }
+
+    /**
+     * Add Extra values to Intent.
+     */
+    private fun addExtrasToIntent(intent: Intent, extras: String) {
+        val items = extras.split(',')
+        for (item in items) {
+            val chunks = item.split(":")
+            var value = chunks[1]
+            if (chunks.size > 2) {
+                value = chunks.subList(1, chunks.lastIndex).joinToString(":")
+                if (chunks.last() == "urlencoded")
+                    value = URLDecoder.decode(value, "UTF-8")
+            }
+            intent.putExtra(
+                chunks[0],
+                if (value.isDigitsOnly())
+                    value.toInt()
+                else if ((value.lowercase() == "true") ||
+                    (value.lowercase() == "false")
+                )
+                    value.toBoolean()
+                else value
+            )
         }
     }
 
@@ -1425,26 +1432,7 @@ class MessagingService : FirebaseMessagingService() {
                 intent.setClassName(packageName, className)
             val extras = data["group"]
             if (!extras.isNullOrEmpty()) {
-                val items = extras.split(',')
-                for (item in items) {
-                    val chunks = item.split(":")
-                    var value = chunks[1]
-                    if (chunks.size > 2) {
-                        value = chunks.subList(1, chunks.lastIndex).joinToString(":")
-                        if (chunks.last() == "urlencoded")
-                            value = URLDecoder.decode(value, "UTF-8")
-                    }
-                    intent.putExtra(
-                        chunks[0],
-                        if (value.isDigitsOnly())
-                            value.toInt()
-                        else if ((value.lowercase() == "true") ||
-                            (value.lowercase() == "false")
-                        )
-                            value.toBoolean()
-                        else value
-                    )
-                }
+                addExtrasToIntent(intent, extras)
             }
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             if (!packageName.isNullOrEmpty()) {

--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -1427,16 +1427,22 @@ class MessagingService : FirebaseMessagingService() {
             if (!extras.isNullOrEmpty()) {
                 val items = extras.split(',')
                 for (item in items) {
-                    val pair = item.split(":")
+                    val chunks = item.split(":")
+                    var value = chunks[1]
+                    if (chunks.size > 2) {
+                        value = chunks.subList(1, chunks.lastIndex).joinToString(":")
+                        if (chunks.last() == "urlencoded")
+                            value = URLDecoder.decode(value, "UTF-8")
+                    }
                     intent.putExtra(
-                        pair[0],
-                        if (pair[1].isDigitsOnly())
-                            pair[1].toInt()
-                        else if ((pair[1].toLowerCase() == "true") ||
-                            (pair[1].toLowerCase() == "false")
+                        chunks[0],
+                        if (value.isDigitsOnly())
+                            value.toInt()
+                        else if ((value.lowercase() == "true") ||
+                            (value.lowercase() == "false")
                         )
-                            pair[1].toBoolean()
-                        else pair[1]
+                            value.toBoolean()
+                        else value
                     )
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When specifying intent extras for notification command `command_broadcast_intent`, the format used to specify these extras prohibits the use of certain special characters (`,` and `:`). With this PR, we allow extras to be urlencoded to overcome this limitation.
To use this functionality, the extras format is extended by allowing the user to append `:urlencoded` to any extra. The format then becomes a comma-separated list of the following:
`<INTENT_NAME>:<INTENT_VALUE>[:urlencoded]`
If the `:urlencoded` suffix is present, `<INTENT_VALUE>` will be urldecoded before adding it to the intent.
Since the old processing code did not handle `:` in `<INTENT_VALUE>` correctly, existing functionality is not affected.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#626

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
fixes #1949 