### PR TITLE
Fix foreground color of status bar

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -139,6 +139,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private lateinit var exoPlayerView: PlayerView
     private lateinit var playerBinding: ExoPlayerViewBinding
     private lateinit var currentLang: String
+    private lateinit var windowInsetsController: WindowInsetsControllerCompat
 
     private var mFilePathCallback: ValueCallback<Array<Uri>>? = null
     private var isConnected = false
@@ -166,6 +167,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         binding = ActivityWebviewBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
 
         // Initially set status and navigation bar color to colorLaunchScreenBackground to match the launch screen until the web frontend is loaded
         val colorLaunchScreenBackground = ResourcesCompat.getColor(resources, R.color.colorLaunchScreenBackground, theme)
@@ -992,21 +995,27 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     override fun setStatusBarAndNavigationBarColor(statusBarColor: Int, navigationBarColor: Int) {
-        val windowInsetsController = WindowInsetsControllerCompat(window, window.decorView)
+        // window.statusBarColor and window.navigationBarColor must both be set before
+        // windowInsetsController sets the foreground colors.
 
+        // Set background colors
         if (statusBarColor != 0) {
             window.statusBarColor = statusBarColor
-            windowInsetsController.isAppearanceLightStatusBars = !isColorDark(statusBarColor)
         } else {
             Log.e(TAG, "Cannot set status bar color $statusBarColor. Skipping coloring...")
         }
-
         if (navigationBarColor != 0) {
             window.navigationBarColor = navigationBarColor
-
-            windowInsetsController.isAppearanceLightNavigationBars = !isColorDark(navigationBarColor)
         } else {
             Log.e(TAG, "Cannot set navigation bar color $navigationBarColor. Skipping coloring...")
+        }
+
+        // Set foreground colors
+        if (statusBarColor != 0) {
+            windowInsetsController.isAppearanceLightStatusBars = !isColorDark(navigationBarColor)
+        }
+        if (navigationBarColor != 0) {
+            windowInsetsController.isAppearanceLightNavigationBars = !isColorDark(navigationBarColor)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When the background of the status bar is bright, the status bar foreground should be dark.
But it is not. It stays light. This is caused, because whenever window.navigationBarColor is set, the foreground colors of the status and navigation bar are reset.

So to fix the bug I just changed the order of when which command is executed.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![Screenshot_2021-12-08-03-45-00-054_io homeassistant companion android](https://user-images.githubusercontent.com/10547444/145139333-3ea9fd57-25ec-445f-95be-25c343555b74.jpg)


</td>
<td>



![Screenshot_2021-12-08-03-44-47-849_io homeassistant companion android debug](https://user-images.githubusercontent.com/10547444/145139327-8188e98b-9924-4e0f-8f2c-bd594d8e2758.jpg)
</td>
</tr>
</table>

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->