### PR TITLE
Fix statusbar brightness calculation

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1012,7 +1012,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         // Set foreground colors
         if (statusBarColor != 0) {
-            windowInsetsController.isAppearanceLightStatusBars = !isColorDark(navigationBarColor)
+            windowInsetsController.isAppearanceLightStatusBars = !isColorDark(statusBarColor)
         }
         if (navigationBarColor != 0) {
             windowInsetsController.isAppearanceLightNavigationBars = !isColorDark(navigationBarColor)


### PR DESCRIPTION
## Summary
I just landed the pr /pull/1994, which fixed the issue, that the brightness on the statusbar was not applied at all. But in doing so I introduced a new issue, by accidentally relying on the navigationBarColor when calculating the brightness for the statusbar.

This PR fixes this mistake. Sorry for that 😢

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->