### PR TITLE
Fix crash when we don't have new_state or old_state in websocket.

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -26,13 +26,13 @@ import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.json.JSONArray
 import java.util.regex.Pattern
 import javax.inject.Inject
 import javax.inject.Named
-import kotlin.Exception
 
 class IntegrationRepositoryImpl @Inject constructor(
     private val integrationService: IntegrationService,
@@ -464,16 +464,18 @@ class IntegrationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getEntityUpdates(): Flow<Entity<*>> {
-        return webSocketRepository.getStateChanges().map {
-            Entity(
-                it.newState.entityId,
-                it.newState.state,
-                it.newState.attributes,
-                it.newState.lastChanged,
-                it.newState.lastUpdated,
-                it.newState.context
-            )
-        }
+        return webSocketRepository.getStateChanges()
+            .filter { it.newState != null }
+            .map {
+                Entity(
+                    it.newState!!.entityId,
+                    it.newState.state,
+                    it.newState.attributes,
+                    it.newState.lastChanged,
+                    it.newState.lastUpdated,
+                    it.newState.context
+                )
+            }
     }
 
     private suspend fun canRegisterEntityCategoryStateClass(): Boolean {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/StateChangedEvent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/StateChangedEvent.kt
@@ -6,6 +6,6 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class StateChangedEvent(
     val entityId: String,
-    val oldState: Entity<*>,
-    val newState: Entity<*>
+    val oldState: Entity<*>?,
+    val newState: Entity<*>?
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes this:
```
2021-12-09 20:06:16.564 12564-19701/? E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-6
    Process: io.homeassistant.companion.android, PID: 12564
    java.lang.IllegalArgumentException: Instantiation of [simple type, class io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent] value failed for JSON property old_state due to missing (therefore NULL) value for creator parameter oldState which is a non-nullable type
        at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.homeassistant.companion.android.common.data.websocket.impl.entities.EventResponse["data"]->io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent["old_state"])
        at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4394)
        at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4335)
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.handleEvent(WebSocketRepositoryImpl.kt:241)
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.access$handleEvent(WebSocketRepositoryImpl.kt:47)
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$onMessage$1.invokeSuspend(WebSocketRepositoryImpl.kt:286)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
     Caused by: com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException: Instantiation of [simple type, class io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent] value failed for JSON property old_state due to missing (therefore NULL) value for creator parameter oldState which is a non-nullable type
        at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.homeassistant.companion.android.common.data.websocket.impl.entities.EventResponse["data"]->io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent["old_state"])
        at com.fasterxml.jackson.module.kotlin.KotlinValueInstantiator.createFromObjectWith(KotlinValueInstantiator.kt:116)
        at com.fasterxml.jackson.databind.deser.impl.PropertyBasedCreator.build(PropertyBasedCreator.java:202)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:443)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:351)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:184)
        at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:542)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeWithErrorWrapping(BeanDeserializer.java:563)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:438)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1405)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:351)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:184)
        at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4389)
        at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4335) 
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.handleEvent(WebSocketRepositoryImpl.kt:241) 
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.access$handleEvent(WebSocketRepositoryImpl.kt:47) 
        at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$onMessage$1.invokeSuspend(WebSocketRepositoryImpl.kt:286) 
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33) 
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106) 
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571) 
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750) 
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678) 
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665) 
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->