### PR TITLE
Fix some sentry wear bugs and add some logs with a toast

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
@@ -77,6 +77,14 @@ class SettingsWearViewModel @Inject constructor(
                     }
                 }
             }
+            .addOnFailureListener { e ->
+                Log.e(TAG, "Failed to send config request to wear", e)
+                Toast.makeText(
+                    application,
+                    application.getString(commonR.string.failed_wear_config_request),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
         viewModelScope.launch {
             integrationUseCase.getEntities().forEach {
                 entities[it.entityId] = it

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.settings.wear.views
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -47,14 +48,14 @@ class SettingsWearMainView : AppCompatActivity() {
         setContent {
             LoadSettingsHomeView(
                 settingsWearViewModel,
-                if (!currentNodes.isNullOrEmpty()) currentNodes.first().displayName else "unknown",
+                currentNodes.firstOrNull()?.displayName ?: "unknown",
                 this::loginWearOs
             )
         }
     }
 
     private fun loginWearOs() {
-        registerActivityResult.launch(OnboardingActivity.newInstance(this, currentNodes.first().displayName, false))
+        registerActivityResult.launch(OnboardingActivity.newInstance(this, currentNodes.firstOrNull()?.displayName ?: "unknown", false))
     }
 
     private fun onOnboardingComplete(result: ActivityResult) {
@@ -65,6 +66,7 @@ class SettingsWearMainView : AppCompatActivity() {
             val deviceName = intent.getStringExtra("DeviceName").toString()
             val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
             settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled)
-        }
+        } else
+            Log.e(TAG, "onOnboardingComplete: Activity result returned null intent data")
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
@@ -47,7 +47,7 @@ class SettingsWearMainView : AppCompatActivity() {
         setContent {
             LoadSettingsHomeView(
                 settingsWearViewModel,
-                currentNodes.first().displayName,
+                if (!currentNodes.isNullOrEmpty()) currentNodes.first().displayName else "unknown",
                 this::loginWearOs
             )
         }
@@ -58,11 +58,13 @@ class SettingsWearMainView : AppCompatActivity() {
     }
 
     private fun onOnboardingComplete(result: ActivityResult) {
-        val intent = result.data!!
-        val url = intent.getStringExtra("URL").toString()
-        val authCode = intent.getStringExtra("AuthCode").toString()
-        val deviceName = intent.getStringExtra("DeviceName").toString()
-        val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
-        settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled)
+        if (result.data != null) {
+            val intent = result.data!!
+            val url = intent.getStringExtra("URL").toString()
+            val authCode = intent.getStringExtra("AuthCode").toString()
+            val deviceName = intent.getStringExtra("DeviceName").toString()
+            val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
+            settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled)
+        }
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -695,5 +695,6 @@
     <string name="widget_text_size_label">Widget text size:</string>
     <string name="widgets">Widgets</string>
     <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
+    <string name="failed_wear_config_request">Failed to send config request to wear device</string>
 
 </resources>

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingPresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingPresenterImpl.kt
@@ -51,6 +51,7 @@ class OnboardingPresenterImpl @Inject constructor(
                 }
             }
         }
+        dataEvents.release()
     }
 
     override fun getInstance(map: DataMap): HomeAssistantInstance {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was helping to troubleshoot in #1866 and noticed that one of the data item buffers was not releasing properly so added a `release()` call to sort that out.

```
12-12 22:18:44.119   606   621 E DataBuffer: Internal data leak within a DataBuffer object detected!  Be sure to explicitly call release() on all DataBuffer extending objects when you are done with them. (internal object: com.google.android.gms.common.data.DataHolder@4510387)
```

There was this sentry error where for some reason we did not get a display name?  So now defaulting to "unknown" in those cases although I don't think we should be hitting this on the screen.

```
java.util.NoSuchElementException: Collection is empty.
    at kotlin.collections.CollectionsKt___CollectionsKt.first(_Collections.kt:200)
    at io.homeassistant.companion.android.settings.wear.views.SettingsWearMainView$onCreate$1.invoke(SettingsWearMainView.kt:50)
    at io.homeassistant.companion.android.settings.wear.views.SettingsWearMainView$onCreate$1.invoke(SettingsWearMainView.kt:47)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:107)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:34)
    at androidx.compose.ui.platform.ComposeView.Content(ComposeView.android.kt:410)
    at androidx.compose.ui.platform.AbstractComposeView$ensureCompositionCreated$1.invoke(ComposeView.android.kt:252)
    at androidx.compose.ui.platform.AbstractComposeView$ensureCompositionCreated$1.invoke(ComposeView.android.kt:251)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:107)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:34)
    at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:228)
    at androidx.compose.ui.platform.CompositionLocalsKt.ProvideCommonCompositionLocals(CompositionLocals.kt:166)
    at androidx.compose.ui.platform.AndroidCompositionLocals_androidKt$ProvideAndroidCompositionLocals$3.invoke(AndroidCompositionLocals.android.kt:123)
    at androidx.compose.ui.platform.AndroidCompositionLocals_androidKt$ProvideAndroidCompositionLocals$3.invoke(AndroidCompositionLocals.android.kt:122)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:107)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:34)
    at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:228)
    at androidx.compose.ui.platform.AndroidCompositionLocals_androidKt.ProvideAndroidCompositionLocals(AndroidCompositionLocals.android.kt:114)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1$1$3.invoke(Wrapper.android.kt:157)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1$1$3.invoke(Wrapper.android.kt:156)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:107)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:34)
    at androidx.compose.runtime.CompositionLocalKt.CompositionLocalProvider(CompositionLocal.kt:228)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1$1.invoke(Wrapper.android.kt:156)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1$1.invoke(Wrapper.android.kt:140)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:107)
    at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke(ComposableLambda.jvm.kt:34)
    at androidx.compose.runtime.ComposerKt.invokeComposable(Composer.kt:3337)
    at androidx.compose.runtime.ComposerImpl$doCompose$2$5.invoke(Composer.kt:2582)
    at androidx.compose.runtime.ComposerImpl$doCompose$2$5.invoke(Composer.kt:2571)
    at androidx.compose.runtime.SnapshotStateKt__DerivedStateKt.observeDerivedStateRecalculations(DerivedState.kt:234)
    at androidx.compose.runtime.SnapshotStateKt.observeDerivedStateRecalculations
    at androidx.compose.runtime.ComposerImpl.doCompose(Composer.kt:2571)
    at androidx.compose.runtime.ComposerImpl.composeContent$runtime_release(Composer.kt:2522)
    at androidx.compose.runtime.CompositionImpl.composeContent(Composition.kt:478)
    at androidx.compose.runtime.Recomposer.composeInitial$runtime_release(Recomposer.kt:748)
    at androidx.compose.runtime.CompositionImpl.setContent(Composition.kt:433)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:140)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:131)
    at androidx.compose.ui.platform.AndroidComposeView.setOnViewTreeOwnersAvailable(AndroidComposeView.android.kt:876)
    at androidx.compose.ui.platform.WrappedComposition.setContent(Wrapper.android.kt:131)
    at androidx.compose.ui.platform.WrappedComposition.onStateChanged(Wrapper.android.kt:182)
    at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
    at androidx.lifecycle.LifecycleRegistry.addObserver(LifecycleRegistry.java:196)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:138)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:131)
    at androidx.compose.ui.platform.AndroidComposeView.onAttachedToWindow(AndroidComposeView.android.kt:963)
    at android.view.View.dispatchAttachedToWindow(View.java:20604)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3522)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewGroup.dispatchAttachedToWindow(ViewGroup.java:3529)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:2531)
    at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2065)
    at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:8497)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1076)
    at android.view.Choreographer.doCallbacks(Choreographer.java:897)
    at android.view.Choreographer.doFrame(Choreographer.java:826)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1061)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:236)
    at android.app.ActivityThread.main(ActivityThread.java:8061)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

I also noticed that one of our data client calls did not add an on failure listener so added that so we can get the failure logs, also showing a toast here so the user knows that it failed.

Also fixes the below sentry error when the intent is `null` for some reason :)

```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.settings.wear.views.SettingsWearMainView.onOnboardingComplete(SettingsWearMainView.kt:61)
    at io.homeassistant.companion.android.settings.wear.views.SettingsWearMainView.$r8$lambda$1AOe5bBE3OjCYjNWHL0I3XcSusQ
    at io.homeassistant.companion.android.settings.wear.views.SettingsWearMainView$$ExternalSyntheticLambda0.onActivityResult
    at androidx.activity.result.ActivityResultRegistry$1.onStateChanged(ActivityResultRegistry.java:148)
    at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
    at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:265)
    at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:307)
    at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:148)
    at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
    at androidx.lifecycle.ReportFragment.dispatch(ReportFragment.java:68)
    at androidx.lifecycle.ReportFragment$LifecycleCallbacks.onActivityPostStarted(ReportFragment.java:187)
    at android.app.Activity.dispatchActivityPostStarted(Activity.java:1274)
    at android.app.Activity.performStart(Activity.java:8026)
    at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3677)
    at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
    at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2267)
    at android.os.Handler.dispatchMessage(Handler.java:107)
    at android.os.Looper.loop(Looper.java:237)
    at android.app.ActivityThread.main(ActivityThread.java:8167)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:496)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1100)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->