### PR TITLE
Breaking change:Typo in power sensor attribute

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PowerSensorManager.kt
@@ -99,7 +99,7 @@ class PowerSensorManager : SensorManager {
             dozeState,
             icon,
             mapOf(
-                "ignoring_battery_optizimations" to powerManager.isIgnoringBatteryOptimizations(packageName)
+                "ignoring_battery_optimizations" to powerManager.isIgnoringBatteryOptimizations(packageName)
             )
         )
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Corrected the spelling used in the Power Sensor attribute name, changing from 
"ignoring_battery_optizimations" to "ignoring_battery_optimizations"

This is a breaking change, since any template that depends on the name
will need updating to correct to the typo corrected version.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
The existing docs document the correct name of this attribute, so do not need updating.
https://companion.home-assistant.io/docs/core/sensors/#doze-sensor

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->