### PR TITLE
Remove enable all sensors toggle to reduce battery complaints

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -22,7 +22,6 @@ class BluetoothSensorManager : SensorManager {
         private const val SETTING_BLE_TRANSMIT_POWER = "ble_transmit_power"
         private const val SETTING_BLE_ADVERTISE_MODE = "ble_advertise_mode"
         private const val SETTING_BLE_TRANSMIT_ENABLED = "ble_transmit_enabled"
-        private const val SETTING_BLE_ENABLE_TOGGLE_ALL = "ble_enable_toggle_all"
         private const val SETTING_BLE_MEASURED_POWER = "ble_measured_power_at_1m"
 
         private const val DEFAULT_BLE_TRANSMIT_POWER = "ultraLow"
@@ -162,15 +161,7 @@ class BluetoothSensorManager : SensorManager {
         )
     }
 
-    override fun enableToggleAll(context: Context, sensorId: String): Boolean {
-        if (sensorId == bleTransmitter.id) {
-            return getSetting(context, bleTransmitter, SETTING_BLE_ENABLE_TOGGLE_ALL, "toggle", "false").toBoolean()
-        }
-        return super.enableToggleAll(context, sensorId)
-    }
-
     private fun updateBLEDevice(context: Context) {
-        addSettingIfNotPresent(context, bleTransmitter, SETTING_BLE_ENABLE_TOGGLE_ALL, "toggle", "false")
         val transmitActive = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, "toggle", "true").toBoolean()
         val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, "string", UUID.randomUUID().toString())
         val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, "string", DEFAULT_BLE_MAJOR)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorsSettingsFragment.kt
@@ -1,32 +1,24 @@
 package io.homeassistant.companion.android.sensors
 
-import android.Manifest
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
-import android.provider.Settings
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.SearchView
-import androidx.core.app.NotificationManagerCompat
 import androidx.core.view.MenuItemCompat
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
 import androidx.preference.PreferenceFragmentCompat
 import androidx.preference.PreferenceGroup
-import androidx.preference.SwitchPreference
 import androidx.preference.forEach
 import androidx.preference.iterator
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
-import io.homeassistant.companion.android.database.sensor.Sensor
-import io.homeassistant.companion.android.util.DisabledLocationHandler
-import io.homeassistant.companion.android.util.LocationPermissionInfoHandler
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -40,15 +32,12 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
     private val refresh = object : Runnable {
         override fun run() {
             SensorWorker.start(requireContext())
-            totalDisabledSensors = 0
-            totalEnabledSensors = 0
             val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
             SensorReceiver.MANAGERS.forEach { managers ->
                 managers.getAvailableSensors(requireContext()).forEach { basicSensor ->
                     findPreference<Preference>(basicSensor.id)?.let {
                         val sensorEntity = sensorDao.get(basicSensor.id)
                         if (sensorEntity?.enabled == true) {
-                            totalEnabledSensors += 1
                             if (!sensorEntity.state.isNullOrBlank()) {
                                 if (basicSensor.unitOfMeasurement.isNullOrBlank()) it.summary = sensorEntity.state
                                 else it.summary = sensorEntity.state + " " + basicSensor.unitOfMeasurement
@@ -57,44 +46,16 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
                             }
                             // TODO: Add the icon from mdi:icon?
                         } else {
-                            totalDisabledSensors += 1
                             it.summary = getString(commonR.string.disabled)
                         }
                     }
                 }
             }
-
-            findPreference<PreferenceCategory>("enable_disable_category")?.let {
-                it.summary = getString(commonR.string.manage_all_sensors_summary, (totalDisabledSensors + totalEnabledSensors))
-            }
-
-            findPreference<SwitchPreference>("enable_disable_sensors")?.let {
-                if (totalDisabledSensors == 0) {
-                    it.title = getString(commonR.string.disable_all_sensors, totalEnabledSensors)
-                    it.summary = ""
-                    it.isChecked = permissionsAllGranted
-                    enableAllSensors = permissionsAllGranted
-                    activity?.invalidateOptionsMenu()
-                } else {
-                    if (totalEnabledSensors == 0)
-                        it.title = getString(commonR.string.enable_all_sensors)
-                    else
-                        it.title = getString(commonR.string.enable_remaining_sensors, totalDisabledSensors)
-                    it.summary = getString(commonR.string.enable_all_sensors_summary)
-                    it.isChecked = false
-                }
-            }
-
             handler.postDelayed(this, 10000)
         }
     }
 
     companion object {
-        private var totalEnabledSensors = 0
-        private var totalDisabledSensors = 0
-        private var permissionsAllGranted = true
-        private var settingsWithLocation = mutableListOf<String>()
-        private var enableAllSensors = false
         private var showOnlyEnabledSensors = false
         private const val TAG = "SensorSettings"
 
@@ -106,68 +67,6 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
 
         setPreferencesFromResource(R.xml.sensors, rootKey)
-
-        findPreference<SwitchPreference>("enable_disable_sensors")?.let {
-
-            it.setOnPreferenceChangeListener { _, newState ->
-
-                settingsWithLocation.clear()
-                var permArray: Array<String> = arrayOf()
-                val context = requireContext()
-                enableAllSensors = newState as Boolean
-
-                val locationEnabled = DisabledLocationHandler.isLocationEnabled(context)
-
-                SensorReceiver.MANAGERS.forEach { managers ->
-                    managers.getAvailableSensors(context).forEach { basicSensor ->
-                        val requiredPermissions = managers.requiredPermissions(basicSensor.id)
-
-                        val locationPermissionCoarse = DisabledLocationHandler.containsLocationPermission(requiredPermissions, false)
-                        val locationPermissionFine = DisabledLocationHandler.containsLocationPermission(requiredPermissions, true)
-                        val locationPermission = locationPermissionCoarse || locationPermissionFine
-
-                        var enableSensor = false
-                        // Only if one of the options is true, enable the sensor
-                        if (!enableAllSensors || // All Sensors switch is disabled
-                            !locationPermission || // No location permission used for sensor
-                            (locationEnabled && locationPermissionCoarse) || // Coarse location used for sensor and location is enabled in settings
-                            (locationEnabled && locationPermissionFine) // Fine location used for sensor and location is enabled in settings
-                        ) {
-                            enableSensor = enableAllSensors
-                        } else {
-                            settingsWithLocation.add(getString(basicSensor.name))
-                        }
-
-                        if (enableSensor && !managers.checkPermission(requireContext(), basicSensor.id))
-                            permArray += requiredPermissions.asList()
-                    }
-                }
-
-                if (permArray.isNotEmpty()) {
-
-                    if (enableAllSensors) {
-                        val locationPermissionCoarse = DisabledLocationHandler.containsLocationPermission(permArray, false)
-                        val locationPermissionFine = DisabledLocationHandler.containsLocationPermission(permArray, true)
-                        if (locationPermissionCoarse || locationPermissionFine) {
-                            LocationPermissionInfoHandler.showLocationPermInfoDialogIfNeeded(
-                                context, permArray,
-                                continueYesCallback = {
-                                    requestPermission(permArray)
-                                }
-                            )
-                        } else requestPermission(permArray)
-                    }
-                } else {
-
-                    if (showAdditionalDialogsIfNeeded()) {
-                        return@setOnPreferenceChangeListener false
-                    }
-                }
-
-                requireActivity().invalidateOptionsMenu()
-                return@setOnPreferenceChangeListener true
-            }
-        }
 
         SensorReceiver.MANAGERS.sortedBy { getString(it.name) }.filter { it.hasSensor(requireContext()) }.forEach { manager ->
             val prefCategory = PreferenceCategory(preferenceScreen.context)
@@ -213,9 +112,6 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
         super.onPrepareOptionsMenu(menu)
 
         menu.setGroupVisible(R.id.senor_detail_toolbar_group, true)
-
-        if (enableAllSensors)
-            menu.removeItem(R.id.action_filter)
 
         val searchViewItem = menu.findItem(R.id.action_search)
         val searchView: SearchView = MenuItemCompat.getActionView(searchViewItem) as SearchView
@@ -302,98 +198,5 @@ class SensorsSettingsFragment : PreferenceFragmentCompat() {
     override fun onPause() {
         super.onPause()
         handler.removeCallbacks(refresh)
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        if (requestCode == 0) {
-            enableDisableSensorBasedOnPermission()
-            showDisabledLocationWarningIfNeeded()
-        }
-    }
-
-    private fun requestPermission(permissions: Array<String>) {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-            requestPermissions(
-                permissions.toSet()
-                    .minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-                    .toTypedArray(),
-                0
-            )
-        } else {
-            requestPermissions(permissions, 0)
-        }
-    }
-
-    override fun onRequestPermissionsResult(
-        requestCode: Int,
-        permissions: Array<out String>,
-        grantResults: IntArray
-    ) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-
-        if (permissions.contains(Manifest.permission.ACCESS_FINE_LOCATION) &&
-            android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R
-        ) {
-            requestPermissions(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION), 0)
-            return
-        }
-
-        showAdditionalDialogsIfNeeded()
-
-        findPreference<SwitchPreference>("enable_disable_sensors")?.run {
-            permissionsAllGranted = grantResults.all { it == PackageManager.PERMISSION_GRANTED }
-            this.isChecked = permissionsAllGranted
-        }
-    }
-
-    private fun showAdditionalDialogsIfNeeded(): Boolean {
-        return if (!showNotificationListenerDialogIfNeeded()) {
-            enableDisableSensorBasedOnPermission()
-            showDisabledLocationWarningIfNeeded()
-        } else true
-    }
-
-    private fun showNotificationListenerDialogIfNeeded(): Boolean {
-        val context = requireContext()
-        return if (!NotificationManagerCompat.getEnabledListenerPackages(context).contains(context.packageName)) {
-            startActivityForResult(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS), 0)
-            true
-        } else false
-    }
-
-    private fun showDisabledLocationWarningIfNeeded(): Boolean {
-        return if (settingsWithLocation.isNotEmpty()) {
-            DisabledLocationHandler.showLocationDisabledWarnDialog(requireActivity(), settingsWithLocation.toTypedArray())
-            true
-        } else false
-    }
-
-    private fun enableDisableSensorBasedOnPermission() {
-        val sensorDao = AppDatabase.getInstance(requireContext()).sensorDao()
-
-        SensorReceiver.MANAGERS.forEach { managers ->
-            managers.getAvailableSensors(requireContext()).forEach { basicSensor ->
-                val sensorTurnsOnWithGroupToggle = managers.enableToggleAll(requireContext(), basicSensor.id)
-                if (!sensorTurnsOnWithGroupToggle) {
-                    return@forEach
-                }
-                var enableSensor = false
-                if (enableAllSensors && sensorTurnsOnWithGroupToggle) {
-                    enableSensor = managers.checkPermission(requireContext(), basicSensor.id)
-                }
-                var sensorEntity = sensorDao.get(basicSensor.id)
-                if (sensorEntity != null) {
-                    sensorEntity.enabled = enableSensor
-                    sensorEntity.lastSentState = ""
-                    sensorDao.update(sensorEntity)
-                } else {
-                    sensorEntity = Sensor(basicSensor.id, enableSensor, false, "")
-                    sensorDao.add(sensorEntity)
-                }
-            }
-        }
-        filterSensors()
     }
 }

--- a/app/src/main/res/xml/sensors.xml
+++ b/app/src/main/res/xml/sensors.xml
@@ -1,13 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-
-    <androidx.preference.PreferenceCategory
-        app:key="enable_disable_category"
-        app:title="@string/manage_all_sensors">
-        <androidx.preference.SwitchPreference
-            app:key="enable_disable_sensors"/>
-    </androidx.preference.PreferenceCategory>
-
-</androidx.preference.PreferenceScreen>
+<androidx.preference.PreferenceScreen />

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -74,10 +74,6 @@ interface SensorManager {
         return true
     }
 
-    fun enableToggleAll(context: Context, sensorId: String): Boolean {
-        return true
-    }
-
     fun addSettingIfNotPresent(
         context: Context,
         sensor: BasicSensor,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I know some of our advanced users will be disappointed by this change and I'm sorry 🙏 . The issue is that many new users come to the page and blindly enable all sensors which in most cases will result in a high amount of unnecessary updates causing extensive battery drain. A lot of users trust that by default the app will not drain their battery and this toggle gave a false perception of that. The main thing is users were not seeing sensor descriptions which tell them whats recommended like for example creating an allow list for a notification sensor.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
