### PR TITLE
Breaking Change: Enforce an allow list for notification sensors to prevent battery issues

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -17,6 +17,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     companion object {
         private const val TAG = "NotificationManager"
         private const val SETTING_ALLOW_LIST = "notification_allow_list"
+        private const val SETTING_DISABLE_ALLOW_LIST = "notification_disable_allow_list"
 
         private var listenerConnected = false
         val lastNotification = SensorManager.BasicSensor(
@@ -102,8 +103,16 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             ""
         ).split(", ").filter { it.isNotBlank() }
 
+        val disableAllowListRequirement = getSetting(
+            applicationContext,
+            lastNotification,
+            SETTING_DISABLE_ALLOW_LIST,
+            "toggle",
+            "false"
+        ).toBoolean()
+
         if (sbn.packageName == application.packageName ||
-            (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages)
+            (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) || !disableAllowListRequirement
         ) {
             return
         }
@@ -147,8 +156,16 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             ""
         ).split(", ").filter { it.isNotBlank() }
 
+        val disableAllowListRequirement = getSetting(
+            applicationContext,
+            lastRemovedNotification,
+            SETTING_DISABLE_ALLOW_LIST,
+            "toggle",
+            "false"
+        ).toBoolean()
+
         if (sbn.packageName == application.packageName ||
-            (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages)
+            (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) || !disableAllowListRequirement
         ) {
             return
         }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -402,9 +402,9 @@
     <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
     <string name="sensor_description_keyguard_locked">Whether the keyguard is currently locked.</string>
     <string name="sensor_description_keyguard_secure">Whether the keyguard is secured by a PIN, pattern or password or a SIM card is currently locked.</string>
-    <string name="sensor_description_last_notification">The details of the last notification.</string>
+    <string name="sensor_description_last_notification">The details of the last notification. You must setup an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
     <string name="sensor_description_last_reboot">The date and time of the devices last reboot. The setting below will allow you to adjust the deadband in milliseconds, if you still find the value to jump incorrectly. The default value is 60000 (1 minute).</string>
-    <string name="sensor_description_last_removed_notification">The details of the last removed notification. This can be any notification either cleared by the user or removed by an application.</string>
+    <string name="sensor_description_last_removed_notification">The details of the last removed notification. This can be any notification either cleared by the user or removed by an application. You must setup an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
     <string name="sensor_description_last_update">The intent for the last update that was sent, periodic updates will show as \"SensorWorker\". Enabling the \"Add New Intent\" toggle will create 1 setting to allow you to register for a broadcast intent. The toggle will switch back to off once a new setting is created so you will need to turn it back on to save more intents. You can also clear out the setting value to remove the setting in the next update. You must restart the application after making changes to these settings to take effect.</string>
     <string name="sensor_description_light_sensor">The current level of illuminance</string>
     <string name="sensor_description_location_accurate">Allow Home Assistant to send a notification to request an accurate location along with the application periodically requesting an accurate location.  The Minimum Accuracy setting will allow you to decide how accurate the device location (in meters) has to be in order to send to Home Assistant.  The Minimum time between updates (in milliseconds) keeps the device from sending the accurate location too often. The Include in sensor update setting will make a location request with each sensor update.</string>
@@ -514,6 +514,7 @@
     <string name="sensor_setting_network_replace_mac_title">Replace MAC address %1$s with ...</string>
     <string name="sensor_setting_nextalarm_allow_list_title">Allow List</string>
     <string name="sensor_setting_notification_allow_list_title">Allow List</string>
+    <string name="sensor_setting_notification_disable_allow_list_title">Disable Allow List Requirement</string>
     <string name="sensor_settings">Sensor Settings</string>
     <string name="sensor_summary">Use this to manage what sensors are enabled/disabled.</string>
     <string name="sensor_title">Manage Sensors</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We have noticed a lot of users enabling all sensors and then wondering where the battery drain is coming from. Most of the time its from a notification sensor because given the circumstances they can be extremely chatty. Most users dont need all notification data. So we are introducing a breaking change where the sensor will not report all notification data unless the user explicitly requests it via a sensor setting that is off by default. This should greatly reduce battery complaints and other issues users can see.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/146845510-a25555d1-be13-4c4f-b312-a5caf12c3f98.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#640

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->