### PR TITLE
Add Back button support to Wear

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.home.views
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
@@ -68,6 +69,9 @@ fun LoadHomePage(
             }
         } else {
             val swipeDismissableNavController = rememberSwipeDismissableNavController()
+            BackHandler {
+                swipeDismissableNavController.popBackStack()
+            }
             CompositionLocalProvider(
                 LocalRotaryEventDispatcher provides rotaryEventDispatcher
             ) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds Back button support to the Wear app. Previously when pressing the back button it would exit the app.
 https://issuetracker.google.com/issues/210205624

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
https://user-images.githubusercontent.com/37350695/146850049-a2bc3644-8a47-4f68-94b4-3ada35464b03.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->