### PR TITLE
Fix back button crash on Screen_Landing

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -70,7 +70,10 @@ fun LoadHomePage(
         } else {
             val swipeDismissableNavController = rememberSwipeDismissableNavController()
             BackHandler {
-                swipeDismissableNavController.popBackStack()
+                // Check if current page is landing so we don't back into a null page
+                if (swipeDismissableNavController.currentDestination?.route != SCREEN_LANDING) {
+                    swipeDismissableNavController.popBackStack()
+                }
             }
             CompositionLocalProvider(
                 LocalRotaryEventDispatcher provides rotaryEventDispatcher


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After PR #2039 I found that pressing the back button caused the app to crash on the landing page this PR checks if the current page is Screen_Landing thus not running the popBackStack()
One warning is that this does prevent users from exiting the app by pressing the back button

## Screenshots
N/A
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
N/A
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
N/A
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->