### PR TITLE
Only complete onboarding if intent data is not null

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.launch
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -92,37 +93,40 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
 
     private fun onOnboardingComplete(result: ActivityResult) {
         mainScope.launch {
-            val intent = result.data!!
-            val url = intent.getStringExtra("URL").toString()
-            val authCode = intent.getStringExtra("AuthCode").toString()
-            val deviceName = intent.getStringExtra("DeviceName").toString()
-            val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
-            val messagingToken = getMessagingToken()
-            if (messagingToken.isNullOrBlank()) {
-                AlertDialog.Builder(this@LaunchActivity)
-                    .setTitle(commonR.string.firebase_error_title)
-                    .setMessage(commonR.string.firebase_error_message)
-                    .setPositiveButton(commonR.string.skip) { _, _ ->
-                        mainScope.launch {
-                            registerAndOpenWebview(
-                                url,
-                                authCode,
-                                deviceName,
-                                messagingToken,
-                                deviceTrackingEnabled
-                            )
+            if (result.data != null) {
+                val intent = result.data!!
+                val url = intent.getStringExtra("URL").toString()
+                val authCode = intent.getStringExtra("AuthCode").toString()
+                val deviceName = intent.getStringExtra("DeviceName").toString()
+                val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
+                val messagingToken = getMessagingToken()
+                if (messagingToken.isNullOrBlank()) {
+                    AlertDialog.Builder(this@LaunchActivity)
+                        .setTitle(commonR.string.firebase_error_title)
+                        .setMessage(commonR.string.firebase_error_message)
+                        .setPositiveButton(commonR.string.skip) { _, _ ->
+                            mainScope.launch {
+                                registerAndOpenWebview(
+                                    url,
+                                    authCode,
+                                    deviceName,
+                                    messagingToken,
+                                    deviceTrackingEnabled
+                                )
+                            }
                         }
-                    }
-                    .show()
-            } else {
-                registerAndOpenWebview(
-                    url,
-                    authCode,
-                    deviceName,
-                    messagingToken,
-                    deviceTrackingEnabled
-                )
-            }
+                        .show()
+                } else {
+                    registerAndOpenWebview(
+                        url,
+                        authCode,
+                        deviceName,
+                        messagingToken,
+                        deviceTrackingEnabled
+                    )
+                }
+            } else
+                Log.e(TAG, "onOnboardingComplete: Activity result returned null intent data")
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes following sentry error, same one as we have seen in Wear OS onboarding in #2007 

```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.launch.LaunchActivity$onOnboardingComplete$1.invokeSuspend(LaunchActivity.kt:95)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:233)
    at android.app.ActivityThread.main(ActivityThread.java:8052)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:656)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:967)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->