### PR TITLE
Only attempt to authenticate websockets when connection is not null

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -213,14 +213,17 @@ class WebSocketRepositoryImpl @Inject constructor(
     }
 
     private suspend fun authenticate() {
-        connection!!.send(
-            mapper.writeValueAsString(
-                mapOf(
-                    "type" to "auth",
-                    "access_token" to authenticationRepository.retrieveAccessToken()
+        if (connection != null) {
+            connection!!.send(
+                mapper.writeValueAsString(
+                    mapOf(
+                        "type" to "auth",
+                        "access_token" to authenticationRepository.retrieveAccessToken()
+                    )
                 )
             )
-        )
+        } else
+            Log.e(TAG, "Attempted to authenticate when connection is null")
     }
 
     private fun handleAuthComplete(successful: Boolean) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry error by only attempting to authenticate when the connection variable is not null

```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.authenticate(WebSocketRepositoryImpl.kt:216)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.connect(WebSocketRepositoryImpl.kt:185)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.sendMessage(WebSocketRepositoryImpl.kt:199)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.getStateChanges(WebSocketRepositoryImpl.kt:135)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$getStateChanges$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7839)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->