### PR TITLE
Show friendly name instead of entity ID when setting favorites from phone

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -24,6 +25,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.mikepenz.iconics.IconicsDrawable
 import io.homeassistant.companion.android.settings.wear.SettingsWearViewModel
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
@@ -87,35 +89,51 @@ fun LoadWearFavoritesSettings(
                 )
             }
             items(favoriteEntities.size, { favoriteEntities[it] }) { index ->
-                Row(
-                    modifier = Modifier
-                        .padding(12.dp)
-                        .clickable {
-                            settingsWearViewModel.onEntitySelected(
-                                false,
-                                favoriteEntities[index]
+                val favoriteEntityID = favoriteEntities[index].replace("[", "").replace("]", "")
+                var favoriteAttributes: Map<*, *>
+                var favoriteFriendlyName: String
+                for (entity in validEntities)
+                    if (entity.entityId == favoriteEntityID) {
+                        favoriteAttributes = entity.attributes as Map<*, *>
+                        favoriteFriendlyName = favoriteAttributes["friendly_name"].toString()
+                        Row(
+                            modifier = Modifier
+                                .padding(12.dp)
+                                .clickable {
+                                    settingsWearViewModel.onEntitySelected(
+                                        false,
+                                        favoriteEntities[index]
+                                    )
+                                }
+                                .draggedItem(
+                                    reorderState.offsetByKey(favoriteEntities[index]),
+                                    Orientation.Vertical
+                                )
+                                .detectReorderAfterLongPress(reorderState)
+                        ) {
+                            val iconBitmap =
+                                IconicsDrawable(LocalContext.current, "cmd-drag_vertical").toBitmap()
+                                    .asImageBitmap()
+                            Icon(iconBitmap, "", modifier = Modifier.padding(top = 13.dp))
+                            Checkbox(
+                                checked = favoriteEntities.contains(favoriteEntities[index]),
+                                onCheckedChange = {
+                                    settingsWearViewModel.onEntitySelected(it, favoriteEntities[index])
+                                },
+                                modifier = Modifier.padding(end = 5.dp)
                             )
+                            Column {
+                                Text(
+                                    text = favoriteFriendlyName,
+                                    modifier = Modifier.padding(top = 10.dp)
+                                )
+                                Text(
+                                    text = getDomainString(favoriteEntityID.split('.')[0]),
+                                    fontSize = 11.sp
+                                )
+                            }
                         }
-                        .draggedItem(
-                            reorderState.offsetByKey(favoriteEntities[index]),
-                            Orientation.Vertical
-                        )
-                        .detectReorderAfterLongPress(reorderState)
-                ) {
-                    val iconBitmap = IconicsDrawable(LocalContext.current, "cmd-drag_vertical").toBitmap().asImageBitmap()
-                    Icon(iconBitmap, "", modifier = Modifier.padding(top = 13.dp))
-                    Checkbox(
-                        checked = favoriteEntities.contains(favoriteEntities[index]),
-                        onCheckedChange = {
-                            settingsWearViewModel.onEntitySelected(it, favoriteEntities[index])
-                        },
-                        modifier = Modifier.padding(end = 5.dp)
-                    )
-                    Text(
-                        text = favoriteEntities[index].replace("[", "").replace("]", ""),
-                        modifier = Modifier.padding(top = 10.dp)
-                    )
-                }
+                    }
             }
             item {
                 Divider()
@@ -123,6 +141,7 @@ fun LoadWearFavoritesSettings(
             if (!validEntities.isNullOrEmpty()) {
                 items(validEntities.size) { index ->
                     val item = validEntities[index]
+                    val itemAttributes = item.attributes as Map<*, *>
                     if (!favoriteEntities.contains(item.entityId)) {
                         Row(
                             modifier = Modifier
@@ -138,14 +157,33 @@ fun LoadWearFavoritesSettings(
                                 },
                                 modifier = Modifier.padding(end = 5.dp)
                             )
-                            Text(
-                                text = item.entityId,
-                                modifier = Modifier.padding(top = 10.dp)
-                            )
+                            Column {
+                                Text(
+                                    text = itemAttributes["friendly_name"].toString(),
+                                    modifier = Modifier.padding(top = 10.dp)
+                                )
+                                Text(
+                                    text = getDomainString(item.entityId.split('.')[0]),
+                                    fontSize = 11.sp
+                                )
+                            }
                         }
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun getDomainString(domain: String): String {
+    return when (domain) {
+        "input_boolean" -> stringResource(commonR.string.domain_input_boolean)
+        "light" -> stringResource(commonR.string.domain_light)
+        "lock" -> stringResource(commonR.string.domain_lock)
+        "scene" -> stringResource(commonR.string.domain_scene)
+        "script" -> stringResource(commonR.string.domain_script)
+        "switch" -> stringResource(commonR.string.domain_switch)
+        else -> ""
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2048 

I opted to show the domain as a sub text still in case a user has more than 1 entity with the same name (like I do). As it wouldn't be easy to split by domain in the favorites section and to keep the UI consistent I opted to make it part of the row

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/147184235-16046a8d-388a-4d98-8f15-c74bef694206.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->