### PR TITLE
Catch the exception when an invalid URL is used

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,6 +14,7 @@ import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.viewinterop.AndroidView
@@ -93,14 +95,21 @@ class AuthenticationFragment : Fragment() {
     }
 
     private fun buildAuthUrl(base: String): String {
-        return base.toHttpUrl()
-            .newBuilder()
-            .addPathSegments("auth/authorize")
-            .addEncodedQueryParameter("response_type", "code")
-            .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
-            .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
-            .build()
-            .toString()
+        return try {
+            base.toHttpUrl()
+                .newBuilder()
+                .addPathSegments("auth/authorize")
+                .addEncodedQueryParameter("response_type", "code")
+                .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
+                .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
+                .build()
+                .toString()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to build authentication URL", e)
+            Toast.makeText(context, commonR.string.error_connection_failed, Toast.LENGTH_LONG).show()
+            parentFragmentManager.popBackStack()
+            ""
+        }
     }
 
     private fun onRedirect(url: String): Boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed the following sentry error so decided to catch the error and keep the user on the same screen to prevent a crash:

```
java.lang.IllegalArgumentException: Expected URL scheme 'http' or 'https' but no colon was found
    at okhttp3.HttpUrl$Builder.parse$okhttp(HttpUrl.kt:1260)
    at okhttp3.HttpUrl$Companion.get(HttpUrl.kt:1633)
    at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment.buildAuthUrl(AuthenticationFragment.kt:96)
    at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment.access$buildAuthUrl(AuthenticationFragment.kt:34)
    at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment$onCreateView$1$1$1$1.invoke(AuthenticationFragment.kt:87)
    at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment$onCreateView$1$1$1$1.invoke(AuthenticationFragment.kt:57)
    at androidx.compose.ui.viewinterop.ViewFactoryHolder.setFactory(AndroidView.android.kt:156)
    at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$1.invoke(AndroidView.android.kt:99)
    at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$1.invoke(AndroidView.android.kt:96)
    at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$$inlined$ComposeNode$1.invoke(Composables.kt:225)
    at androidx.compose.runtime.ComposerImpl$createNode$2.invoke(Composer.kt:1365)
    at androidx.compose.runtime.ComposerImpl$createNode$2.invoke(Composer.kt:1363)
    at androidx.compose.runtime.ComposerImpl$recordInsert$2.invoke(Composer.kt:2768)
    at androidx.compose.runtime.ComposerImpl$recordInsert$2.invoke(Composer.kt:2765)
    at androidx.compose.runtime.CompositionImpl.applyChanges(Composition.kt:637)
    at androidx.compose.runtime.Recomposer.composeInitial$runtime_release(Recomposer.kt:763)
    at androidx.compose.runtime.CompositionImpl.setContent(Composition.kt:433)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:140)
    at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:131)
    at androidx.compose.ui.platform.AndroidComposeView.setOnViewTreeOwnersAvailable(AndroidComposeView.android.kt:876)
    at androidx.compose.ui.platform.WrappedComposition.setContent(Wrapper.android.kt:131)
    at androidx.compose.ui.platform.WrappedComposition.onStateChanged(Wrapper.android.kt:182)
    at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
    at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:265)
    at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:307)
    at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:148)
    at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
    at androidx.fragment.app.FragmentViewLifecycleOwner.handleLifecycleEvent(FragmentViewLifecycleOwner.java:88)
    at androidx.fragment.app.Fragment.restoreViewState(Fragment.java:653)
    at androidx.fragment.app.Fragment.restoreViewState(Fragment.java:3010)
    at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:3001)
    at androidx.fragment.app.FragmentStateManager.activityCreated(FragmentStateManager.java:580)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:285)
    at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2189)
    at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2100)
    at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
    at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:524)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loop(Looper.java:246)
    at android.app.ActivityThread.main(ActivityThread.java:8633)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:602)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1130)
```

during testing I noticed that logging into a URL with just `http://` crashes the app back to the welcome fragment so I assume this should fix both errors and hopefully the guide the user to a better URL :)

```
2021-12-23 14:38:50.941 27899-27899/io.homeassistant.companion.android.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.homeassistant.companion.android.debug, PID: 27899
    java.lang.IllegalArgumentException: Invalid URL host: ""
        at okhttp3.HttpUrl$Builder.parse$okhttp(HttpUrl.kt:1337)
        at okhttp3.HttpUrl$Companion.get(HttpUrl.kt:1633)
        at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment.buildAuthUrl(AuthenticationFragment.kt:96)
        at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment.access$buildAuthUrl(AuthenticationFragment.kt:34)
        at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment$onCreateView$1$1$1$1.invoke(AuthenticationFragment.kt:87)
        at io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment$onCreateView$1$1$1$1.invoke(AuthenticationFragment.kt:57)
        at androidx.compose.ui.viewinterop.ViewFactoryHolder.setFactory(AndroidView.android.kt:156)
        at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$1.invoke(AndroidView.android.kt:99)
        at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$1.invoke(AndroidView.android.kt:96)
        at androidx.compose.ui.viewinterop.AndroidView_androidKt$AndroidView$$inlined$ComposeNode$1.invoke(Composables.kt:225)
        at androidx.compose.runtime.ComposerImpl$createNode$2.invoke(Composer.kt:1365)
        at androidx.compose.runtime.ComposerImpl$createNode$2.invoke(Composer.kt:1363)
        at androidx.compose.runtime.ComposerImpl$recordInsert$2.invoke(Composer.kt:2768)
        at androidx.compose.runtime.ComposerImpl$recordInsert$2.invoke(Composer.kt:2765)
        at androidx.compose.runtime.CompositionImpl.applyChanges(Composition.kt:637)
        at androidx.compose.runtime.Recomposer.composeInitial$runtime_release(Recomposer.kt:763)
        at androidx.compose.runtime.CompositionImpl.setContent(Composition.kt:433)
        at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:140)
        at androidx.compose.ui.platform.WrappedComposition$setContent$1.invoke(Wrapper.android.kt:131)
        at androidx.compose.ui.platform.AndroidComposeView.setOnViewTreeOwnersAvailable(AndroidComposeView.android.kt:876)
        at androidx.compose.ui.platform.WrappedComposition.setContent(Wrapper.android.kt:131)
        at androidx.compose.ui.platform.WrappedComposition.onStateChanged(Wrapper.android.kt:182)
        at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.java:354)
        at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.java:265)
        at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.java:307)
        at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.java:148)
        at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.java:134)
        at androidx.fragment.app.FragmentViewLifecycleOwner.handleLifecycleEvent(FragmentViewLifecycleOwner.java:88)
        at androidx.fragment.app.Fragment.restoreViewState(Fragment.java:653)
        at androidx.fragment.app.Fragment.restoreViewState(Fragment.java:3010)
        at androidx.fragment.app.Fragment.performActivityCreated(Fragment.java:3001)
        at androidx.fragment.app.FragmentStateManager.activityCreated(FragmentStateManager.java:580)
        at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:285)
        at androidx.fragment.app.FragmentManager.executeOpsTogether(FragmentManager.java:2189)
        at androidx.fragment.app.FragmentManager.removeRedundantOperationsAndExecute(FragmentManager.java:2100)
        at androidx.fragment.app.FragmentManager.execPendingActions(FragmentManager.java:2002)
        at androidx.fragment.app.FragmentManager$5.run(FragmentManager.java:524)
        at android.os.Handler.handleCallback(Handler.java:938)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->