### PR TITLE
Fix getStateChanges call always returning empty flow

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -174,10 +174,12 @@ class WebSocketRepositoryImpl @Inject constructor(
                     }.shareIn(ioScope, SharingStarted.WhileSubscribed())
                 }
             }
+
+            return stateChangedFlow!!
         } catch (e: Exception) {
             Log.e(TAG, "Unable to get flow of entities", e)
+            return emptyFlow()
         }
-        return emptyFlow()
     }
 
     /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The commit made for [this comment in PR #2066](https://github.com/home-assistant/android/pull/2066#discussion_r774740738) introduced a new bug: a call to `getStateChanges()` now always returns an empty flow, meaning subscribing to the websocket does nothing (and widgets / device controls no longer update until you force a reload).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed (bugfix)

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This code is also in the currently released stable version of the app, 2012.12.2, should I (also) have made an issue?