### PR TITLE
Exit app when back is pressed on Screen_Landing

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.home.views
 
+import android.app.Activity
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Column

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -68,8 +68,10 @@ fun LoadHomePage(
         } else {
             val swipeDismissableNavController = rememberSwipeDismissableNavController()
             BackHandler {
-                // Check if current page is landing so we don't back into a null page
-                if (swipeDismissableNavController.currentDestination?.route != SCREEN_LANDING) {
+                val activity = (context as? Activity)
+                if (swipeDismissableNavController.currentDestination?.route == SCREEN_LANDING) {
+                    activity?.finish()
+                } else {
                     swipeDismissableNavController.popBackStack()
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR exits the app on Screen_Landing when the back button is pressed on wear instead of stopping on Screen_Landing

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A

Documentation: home-assistant/companion.home-assistant#

## Any other notes
N/A
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->