### PR TITLE
Check if there are any widgets before connecting to websocket

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -75,9 +74,11 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
                     return@launch
                 }
                 updateAllWidgets(context)
-                entityUpdates = integrationUseCase.getEntityUpdates()
-                entityUpdates!!.collect {
-                    updateAllWidgets(context)
+                if (getAllWidgetIds(context).isNotEmpty()) {
+                    entityUpdates = integrationUseCase.getEntityUpdates()
+                    entityUpdates!!.collect {
+                        updateAllWidgets(context)
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2075.
Using the `getAllWidgetIds` function will only check the table for the specific type of widget, so if any new widgets are added in the future this won't need updating.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
-