### PR TITLE
Add last used app sensor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
+        tools:ignore="ProtectedPermissions" />
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.sensors
 
 import android.Manifest
-import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.pm.PackageManager
@@ -9,7 +8,6 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.sensors.SensorManager
-import java.util.TreeMap
 import io.homeassistant.companion.android.common.R as commonR
 
 class LastAppSensorManager : SensorManager {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -1,0 +1,77 @@
+package io.homeassistant.companion.android.sensors
+
+import android.Manifest
+import android.app.usage.UsageStats
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import java.util.TreeMap
+import io.homeassistant.companion.android.common.R as commonR
+
+class LastAppSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "LastApp"
+
+        val last_used = SensorManager.BasicSensor(
+            "last_used_app",
+            "sensor",
+            commonR.string.basic_sensor_name_last_used_app,
+            commonR.string.sensor_description_last_used_app
+        )
+    }
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/core/sensors#last-used-app-sensor"
+    }
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = commonR.string.sensor_name_last_app
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(last_used)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+    }
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return arrayOf(Manifest.permission.PACKAGE_USAGE_STATS)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        updateLastApp(context)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
+    private fun updateLastApp(context: Context) {
+        if (!isEnabled(context, last_used.id))
+            return
+
+        val usageStats = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
+        val current = System.currentTimeMillis()
+        val appList = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current)
+        val sortedMap = TreeMap<Long, UsageStats>()
+        if (!appList.isNullOrEmpty() && appList.size > 0) {
+            for (item in appList) {
+                sortedMap[item.lastTimeUsed] = item
+            }
+        }
+
+        val icon = "mdi:android"
+
+        onSensorUpdated(
+            context,
+            last_used,
+            sortedMap[sortedMap.lastKey()]?.packageName ?: "none",
+            icon,
+            mapOf()
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -66,7 +66,7 @@ class LastAppSensorManager : SensorManager {
             }
         }
 
-        var lastApp = sortedMap[sortedMap.lastKey()]?.packageName ?: "none"
+        var lastApp = sortedMap.maxByOrNull { it.key }?.value?.packageName ?: "none"
         try {
             val pm = context.packageManager
             val appInfo = pm.getApplicationInfo(lastApp, PackageManager.GET_META_DATA)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -58,15 +58,7 @@ class LastAppSensorManager : SensorManager {
 
         val usageStats = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
         val current = System.currentTimeMillis()
-        val appList = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current)
-        val sortedMap = TreeMap<Long, UsageStats>()
-        if (!appList.isNullOrEmpty() && appList.size > 0) {
-            for (item in appList) {
-                sortedMap[item.lastTimeUsed] = item
-            }
-        }
-
-        var lastApp = sortedMap.maxByOrNull { it.key }?.value?.packageName ?: "none"
+        val lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
         try {
             val pm = context.packageManager
             val appInfo = pm.getApplicationInfo(lastApp, PackageManager.GET_META_DATA)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -56,7 +56,7 @@ class LastAppSensorManager : SensorManager {
 
         val usageStats = context.getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
         val current = System.currentTimeMillis()
-        val lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
+        var lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
         try {
             val pm = context.packageManager
             val appInfo = pm.getApplicationInfo(lastApp, PackageManager.GET_META_DATA)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -4,7 +4,9 @@ import android.Manifest
 import android.app.usage.UsageStats
 import android.app.usage.UsageStatsManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import java.util.TreeMap
@@ -64,12 +66,21 @@ class LastAppSensorManager : SensorManager {
             }
         }
 
+        var lastApp = sortedMap[sortedMap.lastKey()]?.packageName ?: "none"
+        try {
+            val pm = context.packageManager
+            val appInfo = pm.getApplicationInfo(lastApp, PackageManager.GET_META_DATA)
+            lastApp = pm.getApplicationLabel(appInfo).toString()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get package name for: $lastApp", e)
+        }
+
         val icon = "mdi:android"
 
         onSensorUpdated(
             context,
             last_used,
-            sortedMap[sortedMap.lastKey()]?.packageName ?: "none",
+            lastApp,
             icon,
             mapOf()
         )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -1,6 +1,8 @@
 package io.homeassistant.companion.android.sensors
 
 import android.Manifest
+import android.app.AppOpsManager
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -127,6 +129,13 @@ class SensorDetailFragment(
                                         requestPermissions(permissions)
                                     }
                                 )
+                            } else if (sensorManager is LastAppSensorManager) {
+                                val pm = context.packageManager
+                                val appInfo = pm.getApplicationInfo(context.packageName, 0)
+                                val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+                                val mode = appOpsManager.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, appInfo.uid, appInfo.packageName)
+                                if (mode != AppOpsManager.MODE_ALLOWED)
+                                    requestPermissions(permissions)
                             } else requestPermissions(permissions)
 
                             return@setOnPreferenceChangeListener false
@@ -483,6 +492,8 @@ class SensorDetailFragment(
         when {
             permissions.any { perm -> perm == Manifest.permission.BIND_NOTIFICATION_LISTENER_SERVICE } ->
                 startActivity(Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS))
+            permissions.any { perm -> perm == Manifest.permission.PACKAGE_USAGE_STATS } ->
+                startActivity(Intent(Settings.ACTION_USAGE_ACCESS_SETTINGS))
             android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R ->
                 requestPermissions(
                     permissions.toSet()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.sensors
 
 import android.Manifest
-import android.app.AppOpsManager
-import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -129,13 +127,8 @@ class SensorDetailFragment(
                                         requestPermissions(permissions)
                                     }
                                 )
-                            } else if (sensorManager is LastAppSensorManager) {
-                                val pm = context.packageManager
-                                val appInfo = pm.getApplicationInfo(context.packageName, 0)
-                                val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
-                                val mode = appOpsManager.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, appInfo.uid, appInfo.packageName)
-                                if (mode != AppOpsManager.MODE_ALLOWED)
-                                    requestPermissions(permissions)
+                            } else if (sensorManager is LastAppSensorManager && !sensorManager.checkUsageStatsPermission(context)) {
+                                requestPermissions(permissions)
                             } else requestPermissions(permissions)
 
                             return@setOnPreferenceChangeListener false

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -36,6 +36,7 @@ class SensorReceiver : SensorReceiverBase() {
             DNDSensorManager(),
             GeocodeSensorManager(),
             KeyguardSensorManager(),
+            LastAppSensorManager(),
             LastRebootSensorManager(),
             LastUpdateManager(),
             LightSensorManager(),

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -46,13 +46,17 @@ interface SensorManager {
             if (sensorId != "last_used_app")
                 context.checkPermission(it, myPid(), myUid()) == PackageManager.PERMISSION_GRANTED
             else {
-                val pm = context.packageManager
-                val appInfo = pm.getApplicationInfo(context.packageName, 0)
-                val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
-                val mode = appOpsManager.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, appInfo.uid, appInfo.packageName)
-                mode == AppOpsManager.MODE_ALLOWED
+                checkUsageStatsPermission(context)
             }
         }
+    }
+
+    fun checkUsageStatsPermission(context: Context): Boolean {
+        val pm = context.packageManager
+        val appInfo = pm.getApplicationInfo(context.packageName, 0)
+        val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+        val mode = appOpsManager.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, appInfo.uid, appInfo.packageName)
+        return mode == AppOpsManager.MODE_ALLOWED
     }
 
     fun isEnabled(context: Context, sensorId: String): Boolean {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.sensors
 
+import android.app.AppOpsManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Process.myPid
@@ -42,7 +43,15 @@ interface SensorManager {
 
     fun checkPermission(context: Context, sensorId: String): Boolean {
         return requiredPermissions(sensorId).all {
-            context.checkPermission(it, myPid(), myUid()) == PackageManager.PERMISSION_GRANTED
+            if (sensorId != "last_used_app")
+                context.checkPermission(it, myPid(), myUid()) == PackageManager.PERMISSION_GRANTED
+            else {
+                val pm = context.packageManager
+                val appInfo = pm.getApplicationInfo(context.packageName, 0)
+                val appOpsManager = context.getSystemService(Context.APP_OPS_SERVICE) as AppOpsManager
+                val mode = appOpsManager.checkOpNoThrow(AppOpsManager.OPSTR_GET_USAGE_STATS, appInfo.uid, appInfo.packageName)
+                mode == AppOpsManager.MODE_ALLOWED
+            }
         }
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -698,5 +698,8 @@
     <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
     <string name="failed_wear_config_request">Failed to send config request to wear device</string>
     <string name="companion_app">Companion App</string>
+    <string name="basic_sensor_name_last_used_app">Last Used App</string>
+    <string name="sensor_description_last_used_app">Package name of the last used application on the device</string>
+    <string name="sensor_name_last_app">Last Used App</string>
 
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -699,7 +699,7 @@
     <string name="failed_wear_config_request">Failed to send config request to wear device</string>
     <string name="companion_app">Companion App</string>
     <string name="basic_sensor_name_last_used_app">Last Used App</string>
-    <string name="sensor_description_last_used_app">Package name of the last used application on the device</string>
+    <string name="sensor_description_last_used_app">Application name or package name of the last used application on the device</string>
     <string name="sensor_name_last_app">Last Used App</string>
 
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds a new sensor that reports the last used app since the last update. Currently this sensor does not update immediately so will need to look into methods for faster updates. This sensor requires a special permission unlike the others we have so had to add additional checks for it.  We will try to determine the application label and if unable to determine a label we will send the package name.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/147420336-80c87311-db07-4e02-a5b4-a1c907ca3f35.png)

![image](https://user-images.githubusercontent.com/1634145/147419370-85f1d0e4-6c69-4449-a292-1f0b3f41cebf.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#647

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->