### PR TITLE
Widgets: use received entity state changes for updating if possible

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -77,7 +77,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
                 if (getAllWidgetIds(context).isNotEmpty()) {
                     entityUpdates = integrationUseCase.getEntityUpdates()
                     entityUpdates!!.collect {
-                        updateAllWidgets(context)
+                        onEntityStateChanged(context, it)
                     }
                 }
             }
@@ -111,4 +111,5 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
     abstract suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews
     abstract fun getAllWidgetIds(context: Context): List<Int>
     abstract fun saveEntityConfiguration(context: Context, extras: Bundle?, appWidgetId: Int)
+    abstract fun onEntityStateChanged(context: Context, entity: Entity<*>)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -108,7 +108,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
         }
     }
 
-    abstract suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews
+    abstract suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>? = null): RemoteViews
     abstract fun getAllWidgetIds(context: Context): List<Int>
     abstract fun saveEntityConfiguration(context: Context, extras: Bundle?, appWidgetId: Int)
     abstract fun onEntityStateChanged(context: Context, entity: Entity<*>)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -32,7 +32,7 @@ class EntityWidget : BaseWidgetProvider() {
         internal const val EXTRA_ATTRIBUTE_SEPARATOR = "EXTRA_ATTRIBUTE_SEPARATOR"
     }
 
-    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
+    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>?): RemoteViews {
         val intent = Intent(context, EntityWidget::class.java).apply {
             action = UPDATE_VIEW
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
@@ -57,6 +57,7 @@ class EntityWidget : BaseWidgetProvider() {
                     resolveTextToShow(
                         context,
                         entityId,
+                        suggestedEntity,
                         attributeIds,
                         stateSeparator,
                         attributeSeparator,
@@ -89,6 +90,7 @@ class EntityWidget : BaseWidgetProvider() {
     private suspend fun resolveTextToShow(
         context: Context,
         entityId: String?,
+        suggestedEntity: Entity<Map<String, Any>>?,
         attributeIds: String?,
         stateSeparator: String,
         attributeSeparator: String,
@@ -97,7 +99,11 @@ class EntityWidget : BaseWidgetProvider() {
         val staticWidgetDao = AppDatabase.getInstance(context).staticWidgetDao()
         var entity: Entity<Map<String, Any>>? = null
         try {
-            entity = entityId?.let { integrationUseCase.getEntity(it) }
+            entity = if (suggestedEntity != null && suggestedEntity.entityId == entityId) {
+                suggestedEntity
+            } else {
+                entityId?.let { integrationUseCase.getEntity(it) }
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Unable to fetch entity", e)
             if (lastIntent == UPDATE_VIEW)
@@ -173,12 +179,13 @@ class EntityWidget : BaseWidgetProvider() {
     }
 
     override fun onEntityStateChanged(context: Context, entity: Entity<*>) {
-        getAllWidgetIds(context).forEach { appWidgetId ->
-            val intent = Intent(context, EntityWidget::class.java).apply {
-                action = UPDATE_VIEW
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        AppDatabase.getInstance(context).staticWidgetDao().getAll().orEmpty().forEach {
+            if (it.entityId == entity.entityId) {
+                mainScope.launch {
+                    val views = getWidgetRemoteViews(context, it.id, entity as Entity<Map<String, Any>>)
+                    AppWidgetManager.getInstance(context).updateAppWidget(it.id, views)
+                }
             }
-            context.sendBroadcast(intent)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -172,6 +172,16 @@ class EntityWidget : BaseWidgetProvider() {
         }
     }
 
+    override fun onEntityStateChanged(context: Context, entity: Entity<*>) {
+        getAllWidgetIds(context).forEach { appWidgetId ->
+            val intent = Intent(context, EntityWidget::class.java).apply {
+                action = UPDATE_VIEW
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            context.sendBroadcast(intent)
+        }
+    }
+
     override fun onDeleted(context: Context, appWidgetIds: IntArray) {
         val staticWidgetDao = AppDatabase.getInstance(context).staticWidgetDao()
         appWidgetIds.forEach { appWidgetId ->

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -421,6 +421,16 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         }
     }
 
+    override fun onEntityStateChanged(context: Context, entity: Entity<*>) {
+        getAllWidgetIds(context).forEach { appWidgetId ->
+            val intent = Intent(context, MediaPlayerControlsWidget::class.java).apply {
+                action = UPDATE_VIEW
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            context.sendBroadcast(intent)
+        }
+    }
+
     private fun callPreviousTrackService(appWidgetId: Int) {
         mainScope.launch {
             Log.d(TAG, "Retrieving media player entity for app widget $appWidgetId")

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -90,7 +90,7 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         }
     }
 
-    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
+    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>?): RemoteViews {
         val updateMediaIntent = Intent(context, MediaPlayerControlsWidget::class.java).apply {
             action = UPDATE_MEDIA_IMAGE
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
@@ -128,7 +128,7 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
                 var label: String? = widget.label
                 val showSkip: Boolean = widget.showSkip
                 val showSeek: Boolean = widget.showSeek
-                val entity = getEntity(context, widget.entityId)
+                val entity = getEntity(context, widget.entityId, suggestedEntity)
 
                 if (entity?.state.equals("playing")) {
                     setImageViewResource(
@@ -342,10 +342,14 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         return AppDatabase.getInstance(context).mediaPlayCtrlWidgetDao().getAll()?.map { it.id }.orEmpty()
     }
 
-    private suspend fun getEntity(context: Context, entityId: String): Entity<Map<String, Any>>? {
+    private suspend fun getEntity(context: Context, entityId: String, suggestedEntity: Entity<Map<String, Any>>?): Entity<Map<String, Any>>? {
         val entity: Entity<Map<String, Any>>
         try {
-            entity = integrationUseCase.getEntity(entityId)
+            entity = if (suggestedEntity != null && suggestedEntity.entityId == entityId) {
+                suggestedEntity
+            } else {
+                entityId.let { integrationUseCase.getEntity(it) }
+            }
         } catch (e: Exception) {
             Log.d(TAG, "Failed to fetch entity or entity does not exist")
             if (lastIntent == UPDATE_MEDIA_IMAGE)
@@ -422,12 +426,13 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
     }
 
     override fun onEntityStateChanged(context: Context, entity: Entity<*>) {
-        getAllWidgetIds(context).forEach { appWidgetId ->
-            val intent = Intent(context, MediaPlayerControlsWidget::class.java).apply {
-                action = UPDATE_VIEW
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        AppDatabase.getInstance(context).mediaPlayCtrlWidgetDao().getAll().orEmpty().forEach {
+            if (it.entityId == entity.entityId) {
+                mainScope.launch {
+                    val views = getWidgetRemoteViews(context, it.id, entity as Entity<Map<String, Any>>)
+                    AppWidgetManager.getInstance(context).updateAppWidget(it.id, views)
+                }
             }
-            context.sendBroadcast(intent)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -38,7 +38,7 @@ class TemplateWidget : BaseWidgetProvider() {
         return templateWidgetDao.getAll()?.map { it.id }.orEmpty()
     }
 
-    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
+    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>?): RemoteViews {
         // Every time AppWidgetManager.updateAppWidget(...) is called, the button listener
         // and label need to be re-assigned, or the next time the layout updates
         // (e.g home screen rotation) the widget will fall back on its default layout

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -11,6 +11,7 @@ import android.widget.RemoteViews
 import android.widget.Toast
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
@@ -101,6 +102,16 @@ class TemplateWidget : BaseWidgetProvider() {
                 )
             )
             onUpdate(context, AppWidgetManager.getInstance(context), intArrayOf(appWidgetId))
+        }
+    }
+
+    override fun onEntityStateChanged(context: Context, entity: Entity<*>) {
+        getAllWidgetIds(context).forEach { appWidgetId ->
+            val intent = Intent(context, TemplateWidget::class.java).apply {
+                action = UPDATE_VIEW
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            }
+            context.sendBroadcast(intent)
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently, any time an entity state change is received (via the websocket) all widgets data is refreshed and views are updated. While it works to keep the widgets 'live', it is very inefficient, especially if there are a lot of state changes and/or you have a lot of widgets.

This PR proposes a way to use the entity state changes the app already receives to update the widgets more efficiently, specifically:
- Only update the widgets that are affected by the state change*
- Re-use the received entity state instead of making a call to the REST API to get the entity state, if possible

\*Right now that is just the entity state and media player widgets. The template widget is rendered on the server which might be affected by state changes in ways we don't know anything about, so just keep refreshing that as before. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visible changes

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Doesn't seem necessary

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
