### PR TITLE
Catch the failure on devices without rotary input

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/util/RotaryEventDispatcher.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/RotaryEventDispatcher.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.util
 
 import android.os.Build
+import android.util.Log
 import android.view.MotionEvent
 import android.view.ViewConfiguration
 import androidx.compose.foundation.gestures.ScrollableState
@@ -17,6 +18,8 @@ import androidx.core.view.InputDeviceCompat
 import androidx.core.view.MotionEventCompat
 import kotlinx.coroutines.launch
 
+private const val TAG = "RotaryEvent"
+
 @ExperimentalComposeUiApi
 fun Modifier.scrollHandler(scrollState: ScrollableState): Modifier = composed {
     val context = LocalContext.current
@@ -26,7 +29,13 @@ fun Modifier.scrollHandler(scrollState: ScrollableState): Modifier = composed {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 ViewConfiguration.get(context).scaledVerticalScrollFactor
             } else {
-                ViewConfiguration::class.java.getDeclaredMethod("getScaledScrollFactor").toString().toFloat()
+                try {
+                    ViewConfiguration::class.java.getDeclaredMethod("getScaledScrollFactor")
+                        .toString().toFloat()
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unable to get scaled scroll factor", e)
+                    0f
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2090 by catching the exception and passing `0f` to avoid scrolling or a failure. I didn't seem to see a way to detect if a device has rotary input I assume this wont be an issue once google adds rotary input and we avoid our current work around


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->