### PR TITLE
Group device controls by area first, if set, when adding them

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -38,7 +38,7 @@ class ClimateControl {
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_AC_HEATER)
-            control.setZone(context.getString(commonR.string.domain_climate))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_climate))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -56,7 +56,7 @@ class CoverControl {
                     else -> DeviceTypes.TYPE_GENERIC_OPEN_CLOSE
                 }
             )
-            control.setZone(context.getString(commonR.string.domain_cover))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_cover))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -37,7 +37,7 @@ class DefaultSliderControl {
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_UNKNOWN)
-            control.setZone(context.getString(commonR.string.domain_input_number))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_input_number))
             control.setStatus(Control.STATUS_OK)
             control.setControlTemplate(
                 RangeTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -44,12 +44,13 @@ class DefaultSwitchControl {
                 }
             )
             control.setZone(
-                when (entity.entityId.split(".")[0]) {
-                    "automation" -> context.getString(commonR.string.domain_automation)
-                    "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
-                    "switch" -> context.getString(commonR.string.domain_switch)
-                    else -> entity.entityId.split(".")[0].capitalize()
-                }
+                area?.name
+                    ?: when (entity.entityId.split(".")[0]) {
+                        "automation" -> context.getString(commonR.string.domain_automation)
+                        "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
+                        "switch" -> context.getString(commonR.string.domain_switch)
+                        else -> entity.entityId.split(".")[0].capitalize()
+                    }
             )
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -42,7 +42,7 @@ class FanControl {
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_FAN)
-            control.setZone(context.getString(commonR.string.domain_fan))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_fan))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -64,14 +64,20 @@ class HaControlsProviderService : ControlsProviderService() {
                     val deviceRegistry = webSocketRepository.getDeviceRegistry()
                     val entityRegistry = webSocketRepository.getEntityRegistry()
 
-                    integrationRepository
-                        .getEntities()
+                    val entities = integrationRepository.getEntities()
+                    val areaForEntity = mutableMapOf<String, AreaRegistryResponse?>()
+                    entities?.forEach {
+                        areaForEntity[it.entityId] = getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry)
+                    }
+
+                    entities
+                        ?.sortedWith(compareBy(nullsLast()) { areaForEntity[it.entityId]?.name })
                         ?.mapNotNull {
                             val domain = it.entityId.split(".")[0]
                             domainToHaControl[domain]?.createControl(
                                 applicationContext,
                                 it as Entity<Map<String, Any>>,
-                                getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry)
+                                areaForEntity[it.entityId]
                             )
                         }
                         ?.forEach {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -49,7 +49,7 @@ class LightControl {
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_LIGHT)
-            control.setZone(context.getString(commonR.string.domain_light))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_light))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -40,7 +40,7 @@ class LockControl {
             control.setDeviceType(
                 DeviceTypes.TYPE_LOCK
             )
-            control.setZone(context.getString(commonR.string.domain_lock))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_lock))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
@@ -38,11 +38,12 @@ class SceneControl {
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_ROUTINE)
             control.setZone(
-                when (entity.entityId.split(".")[0]) {
-                    "scene" -> context.getString(commonR.string.domain_scene)
-                    "script" -> context.getString(commonR.string.domain_script)
-                    else -> entity.entityId.split(".")[0].capitalize()
-                }
+                area?.name
+                    ?: when (entity.entityId.split(".")[0]) {
+                        "scene" -> context.getString(commonR.string.domain_scene)
+                        "script" -> context.getString(commonR.string.domain_script)
+                        else -> entity.entityId.split(".")[0].capitalize()
+                    }
             )
             control.setStatus(Control.STATUS_OK)
             control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -42,7 +42,7 @@ class VacuumControl {
             control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
             control.setSubtitle(area?.name ?: "")
             control.setDeviceType(DeviceTypes.TYPE_VACUUM)
-            control.setZone(context.getString(commonR.string.domain_vacuum))
+            control.setZone(area?.name ?: context.getString(commonR.string.domain_vacuum))
             control.setStatus(Control.STATUS_OK)
             control.setStatusText(
                 if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
(Submitted as a result of a discussion in the Discord mobile apps dev channel)
When adding device controls order them by area first, if set, and only then by domain. This matches the autogenerated Lovelace dashboard and probably offers the best user experience.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The UI is provided by the system, this is on a Google Pixel 4a running Android 12. This screenshot is not complete because it is a very long list for me but the result should be obvious: 'Beneden' and 'Boven' are areas I have set and after that it shows devices not in any area by domain (such as Automation and Fan in the screenshot).
![ha-controls-areas-grouped](https://user-images.githubusercontent.com/8148535/147795147-10285a0f-dabe-445c-a414-d8db84ab993d.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Probably not needed?

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->