### PR TITLE
Show the location section during onboarding only if user is on the full flavor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -8,6 +8,7 @@ import android.view.KeyEvent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.welcome.WelcomeFragment
 
@@ -20,7 +21,7 @@ class OnboardingActivity : AppCompatActivity() {
         private const val EXTRA_DEFAULT_DEVICE_NAME = "extra_default_device_name"
         private const val EXTRA_LOCATION_TRACKING_POSSIBLE = "location_tracking_possible"
 
-        fun newInstance(context: Context, defaultDeviceName: String = Build.MODEL, locationTrackingPossible: Boolean = true): Intent {
+        fun newInstance(context: Context, defaultDeviceName: String = Build.MODEL, locationTrackingPossible: Boolean = BuildConfig.FLAVOR == "full"): Intent {
             return Intent(context, OnboardingActivity::class.java).apply {
                 putExtra(EXTRA_DEFAULT_DEVICE_NAME, defaultDeviceName)
                 putExtra(EXTRA_LOCATION_TRACKING_POSSIBLE, locationTrackingPossible)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

While testing the minimal builds I noticed that the location section was showing during onboarding when it should be hidden, turns out we were always sending `true` so now doing a flavor check

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->