### PR TITLE
Set the last high accuracy mode variable when enabled/disabled via notification command

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -253,6 +253,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun startHighAccuracyService(intervalInSeconds: Int) {
+        lastHighAccuracyMode = true
         onSensorUpdated(
             latestContext,
             highAccuracyMode,
@@ -265,6 +266,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun stopHighAccuracyService() {
+        lastHighAccuracyMode = false
         onSensorUpdated(
             latestContext,
             highAccuracyMode,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2102 by setting the `lastHighAccuracyMode` variable when a notification command updates it. I noticed this because in the logs the service is on but for some reason we are still attempting to stop background updates and start the service which is already running.

```
01-02 10:35:40.941 26154 26154 D ForegrndServiceLauncher: Check if service HighAccuracyLocationService is running. Service running = true
01-02 10:35:42.889 26154  3997 D LocBroadcastReceiver: High accuracy mode enabled, because in zone [zone.home_expanded]
01-02 10:35:42.890 26154  3997 D LocBroadcastReceiver: High accuracy mode parameters changed. Enable high accuracy mode.
01-02 10:35:42.890 26154  3997 D LocBroadcastReceiver: Removing background location requests.
01-02 10:35:42.894 26154  3997 D HighAccLocService: Try starting high accuracy location service (Interval: 5s)...
01-02 10:35:42.894 26154  3997 W ForegrndServiceLauncher: Cannot start service HighAccuracyLocationService. Service is not running...
```

Seems to be an edge case where this condition should not be true but probably evaluates as `true` because the default for the variable is `false` and we never set it after updating the sensor and starting the service initially. We only set the variable at the end of this setup method which would explain the mismatch.

https://github.com/home-assistant/android/blob/cb482fa0da3c63c25741ea076a55c8e6e350ab10/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt#L210

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->