### PR TITLE
Less duplicate code for classes implementing HaControl

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.controls
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.service.controls.Control
 import android.service.controls.DeviceTypes
@@ -13,33 +11,18 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
 class ClimateControl {
     companion object : HaControl {
-
-        override fun createControl(
+        override fun provideControlFeatures(
             context: Context,
+            control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
-        ): Control {
-            val control = Control.StatefulBuilder(
-                entity.entityId,
-                PendingIntent.getActivity(
-                    context,
-                    0,
-                    WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
-            control.setSubtitle(area?.name ?: "")
-            control.setDeviceType(DeviceTypes.TYPE_AC_HEATER)
-            control.setZone(area?.name ?: context.getString(commonR.string.domain_climate))
-            control.setStatus(Control.STATUS_OK)
+        ): Control.StatefulBuilder {
             control.setStatusText(
                 when (entity.state) {
                     "auto" -> context.getString(commonR.string.state_auto)
@@ -74,8 +57,14 @@ class ClimateControl {
                 )
 
             )
-            return control.build()
+            return control
         }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            DeviceTypes.TYPE_AC_HEATER
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            context.getString(commonR.string.domain_climate)
 
         override fun performAction(
             integrationRepository: IntegrationRepository,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.controls
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.service.controls.Control
 import android.service.controls.DeviceTypes
@@ -13,32 +11,19 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
 class DefaultSliderControl {
     companion object : HaControl {
-        override fun createControl(
+        override fun provideControlFeatures(
             context: Context,
+            control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
-        ): Control {
-            val control = Control.StatefulBuilder(
-                entity.entityId,
-                PendingIntent.getActivity(
-                    context,
-                    0,
-                    WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
-            control.setSubtitle(area?.name ?: "")
-            control.setDeviceType(DeviceTypes.TYPE_UNKNOWN)
-            control.setZone(area?.name ?: context.getString(commonR.string.domain_input_number))
-            control.setStatus(Control.STATUS_OK)
+        ): Control.StatefulBuilder {
+            control.setStatusText("")
             control.setControlTemplate(
                 RangeTemplate(
                     entity.entityId,
@@ -49,8 +34,14 @@ class DefaultSliderControl {
                     null
                 )
             )
-            return control.build()
+            return control
         }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            DeviceTypes.TYPE_UNKNOWN
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            context.getString(commonR.string.domain_input_number)
 
         override fun performAction(
             integrationRepository: IntegrationRepository,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.controls
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.service.controls.Control
 import android.service.controls.DeviceTypes
@@ -14,53 +12,18 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
 class DefaultSwitchControl {
     companion object : HaControl {
-        override fun createControl(
+        override fun provideControlFeatures(
             context: Context,
+            control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
-        ): Control {
-            val control = Control.StatefulBuilder(
-                entity.entityId,
-                PendingIntent.getActivity(
-                    context,
-                    0,
-                    WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
-            control.setSubtitle(area?.name ?: "")
-            control.setDeviceType(
-                when (entity.entityId.split(".")[0]) {
-                    "switch" -> DeviceTypes.TYPE_SWITCH
-                    else -> DeviceTypes.TYPE_GENERIC_ON_OFF
-                }
-            )
-            control.setZone(
-                area?.name
-                    ?: when (entity.entityId.split(".")[0]) {
-                        "automation" -> context.getString(commonR.string.domain_automation)
-                        "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
-                        "switch" -> context.getString(commonR.string.domain_switch)
-                        else -> entity.entityId.split(".")[0].capitalize()
-                    }
-            )
-            control.setStatus(Control.STATUS_OK)
-            control.setStatusText(
-                when (entity.state) {
-                    "off" -> context.getString(commonR.string.state_off)
-                    "on" -> context.getString(commonR.string.state_on)
-                    "unavailable" -> context.getString(commonR.string.state_unavailable)
-                    else -> context.getString(commonR.string.state_unknown)
-                }
-            )
+        ): Control.StatefulBuilder {
             control.setControlTemplate(
                 ToggleTemplate(
                     entity.entityId,
@@ -70,8 +33,22 @@ class DefaultSwitchControl {
                     )
                 )
             )
-            return control.build()
+            return control
         }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            when (entity.entityId.split(".")[0]) {
+                "switch" -> DeviceTypes.TYPE_SWITCH
+                else -> DeviceTypes.TYPE_GENERIC_ON_OFF
+            }
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            when (entity.entityId.split(".")[0]) {
+                "automation" -> context.getString(commonR.string.domain_automation)
+                "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
+                "switch" -> context.getString(commonR.string.domain_switch)
+                else -> entity.entityId.split(".")[0].capitalize()
+            }
 
         override fun performAction(
             integrationRepository: IntegrationRepository,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -1,15 +1,58 @@
 package io.homeassistant.companion.android.controls
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
+import android.os.Build
 import android.service.controls.Control
 import android.service.controls.actions.ControlAction
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.webview.WebViewActivity
 
+@RequiresApi(Build.VERSION_CODES.R)
 interface HaControl {
 
-    fun createControl(context: Context, entity: Entity<Map<String, Any>>, area: AreaRegistryResponse?): Control
+    fun createControl(context: Context, entity: Entity<Map<String, Any>>, area: AreaRegistryResponse?): Control {
+        val control = Control.StatefulBuilder(
+            entity.entityId,
+            PendingIntent.getActivity(
+                context,
+                0,
+                WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        )
+        control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
+        control.setSubtitle(area?.name ?: "")
+        control.setDeviceType(getDeviceType(entity))
+        control.setZone(area?.name ?: getDomainString(context, entity))
+        control.setStatus(Control.STATUS_OK)
+        control.setStatusText(
+            when (entity.state) {
+                "off" -> context.getString(R.string.state_off)
+                "on" -> context.getString(R.string.state_on)
+                "unavailable" -> context.getString(R.string.state_unavailable)
+                else -> context.getString(R.string.state_unknown)
+            }
+        )
+
+        return provideControlFeatures(context, control, entity, area).build()
+    }
+
+    fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder
+
+    fun getDeviceType(entity: Entity<Map<String, Any>>): Int
+
+    fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String
 
     fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.controls
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.service.controls.Control
 import android.service.controls.DeviceTypes
@@ -14,34 +12,18 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
 class LockControl {
     companion object : HaControl {
-        override fun createControl(
+        override fun provideControlFeatures(
             context: Context,
+            control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
-        ): Control {
-            val control = Control.StatefulBuilder(
-                entity.entityId,
-                PendingIntent.getActivity(
-                    context,
-                    0,
-                    WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
-            control.setSubtitle(area?.name ?: "")
-            control.setDeviceType(
-                DeviceTypes.TYPE_LOCK
-            )
-            control.setZone(area?.name ?: context.getString(commonR.string.domain_lock))
-            control.setStatus(Control.STATUS_OK)
+        ): Control.StatefulBuilder {
             control.setStatusText(
                 when (entity.state) {
                     "jammed" -> context.getString(commonR.string.state_jammed)
@@ -62,8 +44,14 @@ class LockControl {
                     )
                 )
             )
-            return control.build()
+            return control
         }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            DeviceTypes.TYPE_LOCK
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            context.getString(commonR.string.domain_lock)
 
         override fun performAction(
             integrationRepository: IntegrationRepository,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/SceneControl.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.controls
 
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.os.Build
 import android.service.controls.Control
 import android.service.controls.DeviceTypes
@@ -12,47 +10,36 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
 class SceneControl {
     companion object : HaControl {
-
-        override fun createControl(
+        override fun provideControlFeatures(
             context: Context,
+            control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
-        ): Control {
-            val control = Control.StatefulBuilder(
-                entity.entityId,
-                PendingIntent.getActivity(
-                    context,
-                    0,
-                    WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
-                )
-            )
-            control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)
-            control.setSubtitle(area?.name ?: "")
-            control.setDeviceType(DeviceTypes.TYPE_ROUTINE)
-            control.setZone(
-                area?.name
-                    ?: when (entity.entityId.split(".")[0]) {
-                        "scene" -> context.getString(commonR.string.domain_scene)
-                        "script" -> context.getString(commonR.string.domain_script)
-                        else -> entity.entityId.split(".")[0].capitalize()
-                    }
-            )
-            control.setStatus(Control.STATUS_OK)
+        ): Control.StatefulBuilder {
+            control.setStatusText("")
             control.setControlTemplate(
                 StatelessTemplate(
                     entity.entityId
                 )
             )
-            return control.build()
+            return control
         }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            DeviceTypes.TYPE_ROUTINE
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            when (entity.entityId.split(".")[0]) {
+                "scene" -> context.getString(commonR.string.domain_scene)
+                "script" -> context.getString(commonR.string.domain_script)
+                else -> entity.entityId.split(".")[0].capitalize()
+            }
 
         override fun performAction(
             integrationRepository: IntegrationRepository,


### PR DESCRIPTION
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While working on adding area information to the device controls, I noticed a lot of code duplicated across all classes implementing `HaControl` (to which I also added area related code which is exactly the same for each class).
This PR is a small refactor that moves setup and some options that are the same for all/most controls to a default function in the interface. This should make it easier to understand and maintain the control classes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visible changes

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->