### PR TITLE
Add the actual URL to the authentication calls for wear

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -32,7 +32,9 @@ class AuthenticationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun initiateLoginFlow(): LoginFlowInit {
+        val url = urlRepository.getUrl()?.toHttpUrlOrNull().toString()
         return authenticationService.initializeLogin(
+            url + "auth/login_flow",
             LoginFlowRequest(
                 AuthenticationService.CLIENT_ID,
                 AuthenticationService.AUTH_CALLBACK,
@@ -42,8 +44,9 @@ class AuthenticationRepositoryImpl @Inject constructor(
     }
 
     override suspend fun loginAuthentication(flowId: String, username: String, password: String): LoginFlowCreateEntry {
+        val url = urlRepository.getUrl()?.toHttpUrlOrNull().toString()
         return authenticationService.authenticate(
-            AuthenticationService.AUTHENTICATE_BASE_PATH + flowId,
+            url + AuthenticationService.AUTHENTICATE_BASE_PATH + flowId,
             LoginFlowAuthentication(
                 AuthenticationService.CLIENT_ID,
                 username,

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationService.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationService.kt
@@ -51,8 +51,8 @@ interface AuthenticationService {
         @Field("action") action: String
     )
 
-    @POST("auth/login_flow")
-    suspend fun initializeLogin(@Body body: LoginFlowRequest): LoginFlowInit
+    @POST
+    suspend fun initializeLogin(@Url url: String, @Body body: LoginFlowRequest): LoginFlowInit
 
     @POST
     suspend fun authenticate(@Url url: String, @Body body: LoginFlowAuthentication): LoginFlowCreateEntry


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was chatting with @jpelgrom in discord and we discovered that logging in on an actual android wear device showed the incorrect URL. In fact it was defaulting to localhost so it was never pulling in the URL. Tested below code by logging into wearable directly and also logging in via phone settings to wear

Should also fix #2114 the user was filtering by `homeassistant` however the error did not print anything to our app so it was easy to miss


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->