### PR TITLE
Add areas to entity list on Wear

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/AreaRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/AreaRegistryResponse.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.common.data.websocket.impl.entities
 
 data class AreaRegistryResponse(
-    val areaId: String?,
+    val areaId: String,
     val name: String,
     val picture: String?
 )

--- a/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
@@ -1,0 +1,29 @@
+package io.homeassistant.companion.android.util
+
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+
+object RegistriesDataHandler {
+    fun getAreaForEntity(
+        entityId: String,
+        areaRegistry: List<AreaRegistryResponse>?,
+        deviceRegistry: List<DeviceRegistryResponse>?,
+        entityRegistry: List<EntityRegistryResponse>?
+    ): AreaRegistryResponse? {
+        val rEntity = entityRegistry?.firstOrNull { it.entityId == entityId }
+        if (rEntity != null) {
+            // By default, an entity should be considered to be in the same area as the associated device (if any)
+            // This can be overridden for an individual entity, so check the entity registry first
+            if (rEntity.areaId != null) {
+                return areaRegistry?.firstOrNull { it.areaId == rEntity.areaId }
+            } else if (rEntity.deviceId != null) {
+                val rDevice = deviceRegistry?.firstOrNull { it.id == rEntity.deviceId }
+                if (rDevice != null) {
+                    return areaRegistry?.firstOrNull { it.areaId == rDevice.areaId }
+                }
+            }
+        }
+        return null
+    }
+}

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -274,6 +274,7 @@
     <string name="message_missing_all">The Wear app is missing on your watch, click the button below to install the app.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
     <string name="message_some_installed">The Wear app is installed on some of your wear devices: (%1$s)\n\nClick the button below to install the app on the other devices.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
     <string name="missing_command_permission">Please open the Home Assistant app and send the command again in order to grant the proper permissions.</string>
+    <string name="areas">Areas</string>
     <string name="more_entities">More entities</string>
     <string name="need_help">Need Help?</string>
     <string name="nfc_btn_create_duplicate">Create duplicate</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -1,6 +1,9 @@
 package io.homeassistant.companion.android.home
 
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -17,6 +20,11 @@ interface HomePresenter {
 
     suspend fun getEntities(): List<Entity<*>>?
     suspend fun getEntityUpdates(): Flow<Entity<*>>?
+
+    suspend fun getAreaRegistry(): List<AreaRegistryResponse>?
+    suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>?
+    suspend fun getEntityRegistry(): List<EntityRegistryResponse>?
+
     suspend fun getTileShortcuts(): List<SimplifiedEntity>
     suspend fun setTileShortcuts(entities: List<SimplifiedEntity>)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -2,8 +2,11 @@ package io.homeassistant.companion.android.home
 
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryUpdatedEvent
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import kotlinx.coroutines.flow.Flow
 
@@ -24,6 +27,9 @@ interface HomePresenter {
     suspend fun getAreaRegistry(): List<AreaRegistryResponse>?
     suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>?
     suspend fun getEntityRegistry(): List<EntityRegistryResponse>?
+    suspend fun getAreaRegistryUpdates(): Flow<AreaRegistryUpdatedEvent>?
+    suspend fun getDeviceRegistryUpdates(): Flow<DeviceRegistryUpdatedEvent>?
+    suspend fun getEntityRegistryUpdates(): Flow<EntityRegistryUpdatedEvent>?
 
     suspend fun getTileShortcuts(): List<SimplifiedEntity>
     suspend fun setTileShortcuts(entities: List<SimplifiedEntity>)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -9,12 +9,14 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryUpdatedEvent
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -118,19 +120,28 @@ class HomePresenterImpl @Inject constructor(
         return integrationUseCase.isRegistered()
     }
 
-    @ExperimentalCoroutinesApi
     override suspend fun getAreaRegistry(): List<AreaRegistryResponse>? {
         return webSocketUseCase.getAreaRegistry()
     }
 
-    @ExperimentalCoroutinesApi
     override suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>? {
         return webSocketUseCase.getDeviceRegistry()
     }
 
-    @ExperimentalCoroutinesApi
     override suspend fun getEntityRegistry(): List<EntityRegistryResponse>? {
         return webSocketUseCase.getEntityRegistry()
+    }
+
+    override suspend fun getAreaRegistryUpdates(): Flow<AreaRegistryUpdatedEvent>? {
+        return webSocketUseCase.getAreaRegistryUpdates()
+    }
+
+    override suspend fun getDeviceRegistryUpdates(): Flow<DeviceRegistryUpdatedEvent>? {
+        return webSocketUseCase.getDeviceRegistryUpdates()
+    }
+
+    override suspend fun getEntityRegistryUpdates(): Flow<EntityRegistryUpdatedEvent>? {
+        return webSocketUseCase.getEntityRegistryUpdates()
     }
 
     override suspend fun getTileShortcuts(): List<SimplifiedEntity> {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -12,8 +12,13 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ar
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.data.SimplifiedEntity
-import kotlinx.coroutines.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @ExperimentalCoroutinesApi

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@ExperimentalCoroutinesApi
 class HomePresenterImpl @Inject constructor(
     private val authenticationUseCase: AuthenticationRepository,
     private val integrationUseCase: IntegrationRepository,
@@ -119,14 +118,17 @@ class HomePresenterImpl @Inject constructor(
         return integrationUseCase.isRegistered()
     }
 
+    @ExperimentalCoroutinesApi
     override suspend fun getAreaRegistry(): List<AreaRegistryResponse>? {
         return webSocketUseCase.getAreaRegistry()
     }
 
+    @ExperimentalCoroutinesApi
     override suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>? {
         return webSocketUseCase.getDeviceRegistry()
     }
 
+    @ExperimentalCoroutinesApi
     override suspend fun getEntityRegistry(): List<EntityRegistryResponse>? {
         return webSocketUseCase.getEntityRegistry()
     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -36,12 +36,12 @@ class HomePresenterImpl @Inject constructor(
             "media_player", "remote", "siren", "switch"
         )
         val domainsWithNames = mapOf(
-            "input_boolean" to commonR.string.domain_input_boolean,
-            "light" to commonR.string.domain_light,
-            "lock" to commonR.string.domain_lock,
-            "switch" to commonR.string.domain_switch,
-            "script" to commonR.string.domain_script,
-            "scene" to commonR.string.domain_scene
+            "input_boolean" to commonR.string.input_booleans,
+            "light" to commonR.string.lights,
+            "lock" to commonR.string.locks,
+            "switch" to commonR.string.switches,
+            "script" to commonR.string.scripts,
+            "scene" to commonR.string.scenes
         )
         val supportedDomains = domainsWithNames.keys.toList()
         const val TAG = "HomePresenter"

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import io.homeassistant.companion.android.common.R as commonR
 
 class HomePresenterImpl @Inject constructor(
     private val authenticationUseCase: AuthenticationRepository,
@@ -34,9 +35,15 @@ class HomePresenterImpl @Inject constructor(
             "cover", "fan", "humidifier", "input_boolean", "light", "lock",
             "media_player", "remote", "siren", "switch"
         )
-        val supportedDomains = listOf(
-            "input_boolean", "light", "lock", "switch", "script", "scene"
+        val domainsWithNames = mapOf(
+            "input_boolean" to commonR.string.domain_input_boolean,
+            "light" to commonR.string.domain_light,
+            "lock" to commonR.string.domain_lock,
+            "switch" to commonR.string.domain_switch,
+            "script" to commonR.string.domain_script,
+            "scene" to commonR.string.domain_scene
         )
+        val supportedDomains = domainsWithNames.keys.toList()
         const val TAG = "HomePresenter"
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -7,18 +7,20 @@ import io.homeassistant.companion.android.common.data.authentication.SessionStat
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.data.SimplifiedEntity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+@ExperimentalCoroutinesApi
 class HomePresenterImpl @Inject constructor(
     private val authenticationUseCase: AuthenticationRepository,
-    private val integrationUseCase: IntegrationRepository
+    private val integrationUseCase: IntegrationRepository,
+    private val webSocketUseCase: WebSocketRepository
 ) : HomePresenter {
 
     companion object {
@@ -110,6 +112,18 @@ class HomePresenterImpl @Inject constructor(
 
     override suspend fun isConnected(): Boolean {
         return integrationUseCase.isRegistered()
+    }
+
+    override suspend fun getAreaRegistry(): List<AreaRegistryResponse>? {
+        return webSocketUseCase.getAreaRegistry()
+    }
+
+    override suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>? {
+        return webSocketUseCase.getDeviceRegistry()
+    }
+
+    override suspend fun getEntityRegistry(): List<EntityRegistryResponse>? {
+        return webSocketUseCase.getEntityRegistry()
     }
 
     override suspend fun getTileShortcuts(): List<SimplifiedEntity> {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -100,9 +100,33 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
             }
             updateEntityDomains()
 
-            homePresenter.getEntityUpdates()?.collect {
-                if (supportedDomains().contains(it.entityId.split(".")[0])) {
-                    entities[it.entityId] = it
+            viewModelScope.launch {
+                homePresenter.getEntityUpdates()?.collect {
+                    if (supportedDomains().contains(it.entityId.split(".")[0])) {
+                        entities[it.entityId] = it
+                        updateEntityDomains()
+                    }
+                }
+            }
+            viewModelScope.launch {
+                homePresenter.getAreaRegistryUpdates()?.collect {
+                    areaRegistry = homePresenter.getAreaRegistry()
+                    areas.clear()
+                    areaRegistry?.let {
+                        areas.addAll(it)
+                    }
+                    updateEntityDomains()
+                }
+            }
+            viewModelScope.launch {
+                homePresenter.getDeviceRegistryUpdates()?.collect {
+                    deviceRegistry = homePresenter.getDeviceRegistry()
+                    updateEntityDomains()
+                }
+            }
+            viewModelScope.launch {
+                homePresenter.getEntityRegistryUpdates()?.collect {
+                    entityRegistry = homePresenter.getEntityRegistry()
                     updateEntityDomains()
                 }
             }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -12,11 +13,11 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.wear.Favorites
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -40,27 +41,16 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     // entities
     var entities = mutableStateMapOf<String, Entity<*>>()
         private set
-    var entitiesNotInAreas = mutableStateMapOf<String, Entity<*>>()
-        private set
     var favoriteEntityIds = mutableStateListOf<String>()
         private set
     var shortcutEntities = mutableStateListOf<SimplifiedEntity>()
         private set
     var areas = mutableListOf<AreaRegistryResponse>()
         private set
-    var areaEntities = mutableStateMapOf<String, List<Entity<*>>>()
+
+    var entitiesByArea = mutableStateMapOf<String, SnapshotStateList<Entity<*>>>()
         private set
-    var scenes = mutableStateListOf<Entity<*>>()
-        private set
-    var scripts = mutableStateListOf<Entity<*>>()
-        private set
-    var lights = mutableStateListOf<Entity<*>>()
-        private set
-    var locks = mutableStateListOf<Entity<*>>()
-        private set
-    var inputBooleans = mutableStateListOf<Entity<*>>()
-        private set
-    var switches = mutableStateListOf<Entity<*>>()
+    var entitiesByDomain = mutableStateMapOf<String, SnapshotStateList<Entity<*>>>()
         private set
 
     // Content of EntityListView
@@ -74,6 +64,19 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
 
     private fun favorites(): Flow<List<Favorites>>? = favoritesDao.getAllFlow()
 
+    // TODO we shouldn't directly access an implementation
+    fun supportedDomains(): List<String> = HomePresenterImpl.supportedDomains
+
+    // TODO this should probably be provided from the same place as the supported domains list
+    val nameForDomain = mapOf(
+        "input_boolean" to app.applicationContext.getString(commonR.string.domain_input_boolean),
+        "light" to app.applicationContext.getString(commonR.string.domain_light),
+        "lock" to app.applicationContext.getString(commonR.string.domain_lock),
+        "switch" to app.applicationContext.getString(commonR.string.domain_switch),
+        "script" to app.applicationContext.getString(commonR.string.domain_script),
+        "scene" to app.applicationContext.getString(commonR.string.domain_scene)
+    )
+
     private fun loadEntities() {
         viewModelScope.launch {
             if (!homePresenter.isConnected()) {
@@ -83,63 +86,62 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
             isHapticEnabled.value = homePresenter.getWearHapticFeedback()
             isToastEnabled.value = homePresenter.getWearToastConfirmation()
 
-            areaRegistry = homePresenter.getAreaRegistry()
+            homePresenter.getAreaRegistry()?.let {
+                areaRegistry = it
+                areas.addAll(it)
+            }
             deviceRegistry = homePresenter.getDeviceRegistry()
             entityRegistry = homePresenter.getEntityRegistry()
             homePresenter.getEntities()?.forEach {
-                entities[it.entityId] = it
+                if (supportedDomains().contains(it.entityId.split(".")[0])) {
+                    entities[it.entityId] = it
+                }
             }
             updateEntityDomains()
 
             homePresenter.getEntityUpdates()?.collect {
-                entities[it.entityId] = it
-                updateEntityDomains()
+                if (supportedDomains().contains(it.entityId.split(".")[0])) {
+                    entities[it.entityId] = it
+                    updateEntityDomains()
+                }
             }
         }
     }
 
     fun updateEntityDomains() {
         val entitiesList = entities.values.toList().sortedBy { it.entityId }
-        val areaForEntity = mutableMapOf<String, AreaRegistryResponse?>()
-        entitiesList.forEach {
-            areaForEntity[it.entityId] = getAreaForEntity(it.entityId)
-        }
+        val areasList = areaRegistry.orEmpty().sortedBy { it.name }
+        val domainsList = entitiesList.map { it.entityId.split(".")[0] }.distinct()
 
-        val areasList = mutableListOf<AreaRegistryResponse>()
-        val areaEntitiesList = mutableMapOf<String, MutableList<Entity<*>>>()
-        entitiesNotInAreas.clear()
-        entitiesList.forEach { entity ->
-            areaForEntity[entity.entityId]?.let {
-                if (!areasList.contains(it)) {
-                    areasList.add(it)
-                }
-                if (areaEntitiesList[it.name] == null) {
-                    areaEntitiesList[it.name] = mutableListOf(entity)
-                } else {
-                    areaEntitiesList[it.name]!!.add(entity)
-                }
+        // Create a list with all areas + their entities
+        areasList.forEach { area ->
+            val entitiesInArea = mutableStateListOf<Entity<*>>()
+            entitiesInArea.addAll(entitiesList.filter { getAreaForEntity(it.entityId)?.areaId == area.areaId })
+            entitiesByArea[area.areaId]?.let {
+                it.clear()
+                it.addAll(entitiesInArea)
             } ?: run {
-                entitiesNotInAreas[entity.entityId] = entity
+                entitiesByArea[area.areaId] = entitiesInArea
             }
         }
-        areas.clear()
-        areas.addAll(areasList.sortedBy { it.name })
-        areaEntities.clear()
-        areaEntitiesList.forEach {
-            areaEntities[it.key] = it.value
+        // Quick check: are there any areas in the list that no longer exist?
+        entitiesByArea.forEach {
+            if (!areasList.any { item -> item.areaId == it.key }) {
+                entitiesByArea.remove(it.key)
+            }
         }
-        scenes.clear()
-        scenes.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "scene" })
-        scripts.clear()
-        scripts.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "script" })
-        lights.clear()
-        lights.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "light" })
-        locks.clear()
-        locks.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "lock" })
-        inputBooleans.clear()
-        inputBooleans.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "input_boolean" })
-        switches.clear()
-        switches.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "switch" })
+
+        // Create a list with all discovered domains + their entities
+        domainsList.forEach { domain ->
+            val entitiesInDomain = mutableStateListOf<Entity<*>>()
+            entitiesInDomain.addAll(entitiesList.filter { it.entityId.split(".")[0] == domain })
+            entitiesByDomain[domain]?.let {
+                it.clear()
+                it.addAll(entitiesInDomain)
+            } ?: run {
+                entitiesByDomain[domain] = entitiesInDomain
+            }
+        }
     }
 
     fun toggleEntity(entityId: String, state: String) {
@@ -148,7 +150,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         }
     }
 
-    private fun getAreaForEntity(entityId: String): AreaRegistryResponse? {
+    fun getAreaForEntity(entityId: String): AreaRegistryResponse? {
         val rEntity = entityRegistry?.firstOrNull { it.entityId == entityId }
         if (rEntity != null) {
             // By default, an entity should be considered to be in the same area as the associated device (if any)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -19,7 +19,6 @@ import io.homeassistant.companion.android.database.wear.Favorites
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import io.homeassistant.companion.android.common.R as commonR
 
 @HiltViewModel
 class MainViewModel @Inject constructor(application: Application) : AndroidViewModel(application) {
@@ -65,18 +64,10 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
 
     private fun favorites(): Flow<List<Favorites>>? = favoritesDao.getAllFlow()
 
-    // TODO we shouldn't directly access an implementation
     fun supportedDomains(): List<String> = HomePresenterImpl.supportedDomains
 
-    // TODO this should probably be provided from the same place as the supported domains list
-    val nameForDomain = mapOf(
-        "input_boolean" to app.applicationContext.getString(commonR.string.domain_input_boolean),
-        "light" to app.applicationContext.getString(commonR.string.domain_light),
-        "lock" to app.applicationContext.getString(commonR.string.domain_lock),
-        "switch" to app.applicationContext.getString(commonR.string.domain_switch),
-        "script" to app.applicationContext.getString(commonR.string.domain_script),
-        "scene" to app.applicationContext.getString(commonR.string.domain_scene)
-    )
+    fun stringForDomain(domain: String): String? =
+        HomePresenterImpl.domainsWithNames[domain]?.let { app.applicationContext.getString(it) }
 
     private fun loadEntities() {
         viewModelScope.launch {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -9,6 +9,9 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.HomeAssistantApplication
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.wear.Favorites
@@ -23,6 +26,9 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     private lateinit var homePresenter: HomePresenter
     val app = getApplication<HomeAssistantApplication>()
     private val favoritesDao = AppDatabase.getInstance(app.applicationContext).favoritesDao()
+    private var areaRegistry: List<AreaRegistryResponse>? = null
+    private var deviceRegistry: List<DeviceRegistryResponse>? = null
+    private var entityRegistry: List<EntityRegistryResponse>? = null
 
     // TODO: This is bad, do this instead: https://stackoverflow.com/questions/46283981/android-viewmodel-additional-arguments
     fun init(homePresenter: HomePresenter) {
@@ -34,9 +40,15 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     // entities
     var entities = mutableStateMapOf<String, Entity<*>>()
         private set
+    var entitiesNotInAreas = mutableStateMapOf<String, Entity<*>>()
+        private set
     var favoriteEntityIds = mutableStateListOf<String>()
         private set
     var shortcutEntities = mutableStateListOf<SimplifiedEntity>()
+        private set
+    var areas = mutableListOf<AreaRegistryResponse>()
+        private set
+    var areaEntities = mutableStateMapOf<String, List<Entity<*>>>()
         private set
     var scenes = mutableStateListOf<Entity<*>>()
         private set
@@ -52,7 +64,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         private set
 
     // Content of EntityListView
-    var entityLists = mutableStateMapOf<Int, List<Entity<*>>>()
+    var entityLists = mutableStateMapOf<String, List<Entity<*>>>()
 
     // settings
     var isHapticEnabled = mutableStateOf(false)
@@ -70,10 +82,15 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
             shortcutEntities.addAll(homePresenter.getTileShortcuts())
             isHapticEnabled.value = homePresenter.getWearHapticFeedback()
             isToastEnabled.value = homePresenter.getWearToastConfirmation()
+
+            areaRegistry = homePresenter.getAreaRegistry()
+            deviceRegistry = homePresenter.getDeviceRegistry()
+            entityRegistry = homePresenter.getEntityRegistry()
             homePresenter.getEntities()?.forEach {
                 entities[it.entityId] = it
             }
             updateEntityDomains()
+
             homePresenter.getEntityUpdates()?.collect {
                 entities[it.entityId] = it
                 updateEntityDomains()
@@ -83,24 +100,69 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
 
     fun updateEntityDomains() {
         val entitiesList = entities.values.toList().sortedBy { it.entityId }
+        val areaForEntity = mutableMapOf<String, AreaRegistryResponse?>()
+        entitiesList.forEach {
+            areaForEntity[it.entityId] = getAreaForEntity(it.entityId)
+        }
+
+        val areasList = mutableListOf<AreaRegistryResponse>()
+        val areaEntitiesList = mutableMapOf<String, MutableList<Entity<*>>>()
+        entitiesNotInAreas.clear()
+        entitiesList.forEach { entity ->
+            areaForEntity[entity.entityId]?.let {
+                if(!areasList.contains(it)) {
+                    areasList.add(it)
+                }
+                if(areaEntitiesList[it.name] == null) {
+                    areaEntitiesList[it.name] = mutableListOf(entity)
+                } else {
+                    areaEntitiesList[it.name]!!.add(entity)
+                }
+            } ?: run {
+                entitiesNotInAreas[entity.entityId] = entity
+            }
+        }
+        areas.clear()
+        areas.addAll(areasList.sortedBy { it.name })
+        areaEntities.clear()
+        areaEntitiesList.forEach {
+            areaEntities[it.key] = it.value
+        }
         scenes.clear()
-        scenes.addAll(entitiesList.filter { it.entityId.split(".")[0] == "scene" })
+        scenes.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "scene" })
         scripts.clear()
-        scripts.addAll(entitiesList.filter { it.entityId.split(".")[0] == "script" })
+        scripts.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "script" })
         lights.clear()
-        lights.addAll(entitiesList.filter { it.entityId.split(".")[0] == "light" })
+        lights.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "light" })
         locks.clear()
-        locks.addAll(entitiesList.filter { it.entityId.split(".")[0] == "lock" })
+        locks.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "lock" })
         inputBooleans.clear()
-        inputBooleans.addAll(entitiesList.filter { it.entityId.split(".")[0] == "input_boolean" })
+        inputBooleans.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "input_boolean" })
         switches.clear()
-        switches.addAll(entitiesList.filter { it.entityId.split(".")[0] == "switch" })
+        switches.addAll(entitiesList.filter { areaForEntity[it.entityId] == null && it.entityId.split(".")[0] == "switch" })
     }
 
     fun toggleEntity(entityId: String, state: String) {
         viewModelScope.launch {
             homePresenter.onEntityClicked(entityId, state)
         }
+    }
+
+    private fun getAreaForEntity(entityId: String): AreaRegistryResponse? {
+        val rEntity = entityRegistry?.firstOrNull { it.entityId == entityId }
+        if (rEntity != null) {
+            // By default, an entity should be considered to be in the same area as the associated device (if any)
+            // This can be overridden for an individual entity, so check the entity registry first
+            if (rEntity.areaId != null) {
+                return areaRegistry?.firstOrNull { it.areaId == rEntity.areaId }
+            } else if (rEntity.deviceId != null) {
+                val rDevice = deviceRegistry?.firstOrNull { it.id == rEntity.deviceId }
+                if (rDevice != null) {
+                    return areaRegistry?.firstOrNull { it.areaId == rDevice.areaId }
+                }
+            }
+        }
+        return null
     }
 
     private fun getFavorites() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -110,10 +110,10 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         entitiesNotInAreas.clear()
         entitiesList.forEach { entity ->
             areaForEntity[entity.entityId]?.let {
-                if(!areasList.contains(it)) {
+                if (!areasList.contains(it)) {
                     areasList.add(it)
                 }
-                if(areaEntitiesList[it.name] == null) {
+                if (areaEntitiesList[it.name] == null) {
                     areaEntitiesList[it.name] = mutableListOf(entity)
                 } else {
                     areaEntitiesList[it.name]!!.add(entity)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -13,13 +13,13 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
-import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.wear.Favorites
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import io.homeassistant.companion.android.common.R as commonR
 
 @HiltViewModel
 class MainViewModel @Inject constructor(application: Application) : AndroidViewModel(application) {
@@ -55,6 +55,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
 
     // Content of EntityListView
     var entityLists = mutableStateMapOf<String, List<Entity<*>>>()
+    var entityListFilter: (Entity<*>) -> Boolean = { true }
 
     // settings
     var isHapticEnabled = mutableStateOf(false)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -51,9 +51,14 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         private set
     var entitiesByDomain = mutableStateMapOf<String, SnapshotStateList<Entity<*>>>()
         private set
+    var entitiesByAreaOrder = mutableStateListOf<String>()
+        private set
+    var entitiesByDomainOrder = mutableStateListOf<String>()
+        private set
 
     // Content of EntityListView
     var entityLists = mutableStateMapOf<String, List<Entity<*>>>()
+    var entityListsOrder = mutableStateListOf<String>()
     var entityListFilter: (Entity<*>) -> Boolean = { true }
 
     // settings
@@ -140,6 +145,8 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
                 entitiesByArea[area.areaId] = entitiesInArea
             }
         }
+        entitiesByAreaOrder.clear()
+        entitiesByAreaOrder.addAll(areasList.map { it.areaId })
         // Quick check: are there any areas in the list that no longer exist?
         entitiesByArea.forEach {
             if (!areasList.any { item -> item.areaId == it.key }) {
@@ -158,6 +165,8 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
                 entitiesByDomain[domain] = entitiesInDomain
             }
         }
+        entitiesByDomainOrder.clear()
+        entitiesByDomainOrder.addAll(domainsList)
     }
 
     fun toggleEntity(entityId: String, state: String) {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -6,10 +6,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -43,12 +41,14 @@ fun ChooseEntityView(
     onNoneClicked: () -> Unit,
     onEntitySelected: (entity: SimplifiedEntity) -> Unit
 ) {
-    var expandedInputBooleans: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedLights: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedLocks: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedScenes: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedScripts: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedSwitches: Boolean by rememberSaveable { mutableStateOf(true) }
+    // Remember expanded state of each header
+    val expandedStates = remember {
+        mutableStateMapOf<String, Boolean>().apply {
+            mainViewModel.supportedDomains().forEach {
+                put(it, true)
+            }
+        }
+    }
 
     val scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState()
     LocalView.current.requestFocus()
@@ -84,111 +84,23 @@ fun ChooseEntityView(
                     )
                 )
             }
-            if (mainViewModel.entitiesByDomain["input_boolean"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.input_booleans,
-                        expanded = expandedInputBooleans,
-                        onExpandChanged = { expandedInputBooleans = it }
-                    )
-                }
-                if (expandedInputBooleans) {
-                    items(mainViewModel.entitiesByDomain["input_boolean"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["input_boolean"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
+            for ((domain, entities) in mainViewModel.entitiesByDomain) {
+                if (entities.isNotEmpty()) {
+                    item {
+                        ListHeader(
+                            string = mainViewModel.nameForDomain[domain]!!,
+                            expanded = expandedStates[domain]!!,
+                            onExpandChanged = { expandedStates[domain] = it }
                         )
                     }
-                }
-            }
-            if (mainViewModel.entitiesByDomain["lock"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.locks,
-                        expanded = expandedLocks,
-                        onExpandChanged = { expandedLocks = it }
-                    )
-                }
-                if (expandedLocks) {
-                    items(mainViewModel.entitiesByDomain["lock"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["lock"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
-                        )
-                    }
-                }
-            }
-            if (mainViewModel.entitiesByDomain["light"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.lights,
-                        expanded = expandedLights,
-                        onExpandChanged = { expandedLights = it }
-                    )
-                }
-                if (expandedLights) {
-                    items(mainViewModel.entitiesByDomain["light"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["light"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
-                        )
-                    }
-                }
-            }
-            if (mainViewModel.entitiesByDomain["scene"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.scenes,
-                        expanded = expandedScenes,
-                        onExpandChanged = { expandedScenes = it }
-                    )
-                }
-                if (expandedScenes) {
-                    items(mainViewModel.entitiesByDomain["scene"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["scene"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
-                        )
-                    }
-                }
-            }
-            if (mainViewModel.entitiesByDomain["script"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.scripts,
-                        expanded = expandedScripts,
-                        onExpandChanged = { expandedScripts = it }
-                    )
-                }
-                if (expandedScripts) {
-                    items(mainViewModel.entitiesByDomain["script"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["script"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
-                        )
-                    }
-                }
-            }
-            if (mainViewModel.entitiesByDomain["switch"].orEmpty().isNotEmpty()) {
-                item {
-                    ListHeader(
-                        stringId = commonR.string.switches,
-                        expanded = expandedSwitches,
-                        onExpandChanged = { expandedSwitches = it }
-                    )
-                }
-                if (expandedSwitches) {
-                    items(mainViewModel.entitiesByDomain["switch"].orEmpty().size) { index ->
-                        ChooseEntityChip(
-                            entityList = mainViewModel.entitiesByDomain["switch"].orEmpty(),
-                            index = index,
-                            onEntitySelected = onEntitySelected
-                        )
+                    if (expandedStates[domain] == true) {
+                        items(mainViewModel.entitiesByDomain[domain].orEmpty().size) { index ->
+                            ChooseEntityChip(
+                                entityList = mainViewModel.entitiesByDomain[domain]!!,
+                                index = index,
+                                onEntitySelected = onEntitySelected
+                            )
+                        }
                     }
                 }
             }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -84,7 +84,8 @@ fun ChooseEntityView(
                     )
                 )
             }
-            for ((domain, entities) in mainViewModel.entitiesByDomain) {
+            for (domain in mainViewModel.entitiesByDomainOrder) {
+                val entities = mainViewModel.entitiesByDomain[domain].orEmpty()
                 if (entities.isNotEmpty()) {
                     item {
                         ListHeader(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -84,7 +84,7 @@ fun ChooseEntityView(
                     )
                 )
             }
-            if (mainViewModel.inputBooleans.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["input_boolean"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.input_booleans,
@@ -93,16 +93,16 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedInputBooleans) {
-                    items(mainViewModel.inputBooleans.size) { index ->
+                    items(mainViewModel.entitiesByDomain["input_boolean"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.inputBooleans,
+                            entityList = mainViewModel.entitiesByDomain["input_boolean"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )
                     }
                 }
             }
-            if (mainViewModel.locks.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["lock"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.locks,
@@ -111,16 +111,16 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedLocks) {
-                    items(mainViewModel.locks.size) { index ->
+                    items(mainViewModel.entitiesByDomain["lock"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.locks,
+                            entityList = mainViewModel.entitiesByDomain["lock"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )
                     }
                 }
             }
-            if (mainViewModel.lights.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["light"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.lights,
@@ -129,16 +129,16 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedLights) {
-                    items(mainViewModel.lights.size) { index ->
+                    items(mainViewModel.entitiesByDomain["light"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.lights,
+                            entityList = mainViewModel.entitiesByDomain["light"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )
                     }
                 }
             }
-            if (mainViewModel.scenes.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["scene"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.scenes,
@@ -147,16 +147,16 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedScenes) {
-                    items(mainViewModel.scenes.size) { index ->
+                    items(mainViewModel.entitiesByDomain["scene"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.scenes,
+                            entityList = mainViewModel.entitiesByDomain["scene"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )
                     }
                 }
             }
-            if (mainViewModel.scripts.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["script"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.scripts,
@@ -165,16 +165,16 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedScripts) {
-                    items(mainViewModel.scripts.size) { index ->
+                    items(mainViewModel.entitiesByDomain["script"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.scripts,
+                            entityList = mainViewModel.entitiesByDomain["script"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )
                     }
                 }
             }
-            if (mainViewModel.switches.isNotEmpty()) {
+            if (mainViewModel.entitiesByDomain["switch"].orEmpty().isNotEmpty()) {
                 item {
                     ListHeader(
                         stringId = commonR.string.switches,
@@ -183,9 +183,9 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedSwitches) {
-                    items(mainViewModel.switches.size) { index ->
+                    items(mainViewModel.entitiesByDomain["switch"].orEmpty().size) { index ->
                         ChooseEntityChip(
-                            entityList = mainViewModel.switches,
+                            entityList = mainViewModel.entitiesByDomain["switch"].orEmpty(),
                             index = index,
                             onEntitySelected = onEntitySelected
                         )

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -88,7 +88,7 @@ fun ChooseEntityView(
                 if (entities.isNotEmpty()) {
                     item {
                         ListHeader(
-                            string = mainViewModel.nameForDomain[domain]!!,
+                            string = mainViewModel.stringForDomain(domain)!!,
                             expanded = expandedStates[domain]!!,
                             onExpandChanged = { expandedStates[domain] = it }
                         )

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.common.R as commonR
 @Composable
 fun EntityViewList(
     entityLists: Map<String, List<Entity<*>>>,
+    entityListsOrder: List<String>,
     entityListFilter: (Entity<*>) -> Boolean,
     onEntityClicked: (String, String) -> Unit,
     isHapticEnabled: Boolean,
@@ -65,7 +66,8 @@ fun EntityViewList(
             horizontalAlignment = Alignment.CenterHorizontally,
             state = scalingLazyListState
         ) {
-            for ((header, entities) in entityLists) {
+            for (header in entityListsOrder) {
+                val entities = entityLists[header].orEmpty()
                 if (entities.isNotEmpty()) {
                     item {
                         if (entityLists.size > 1) {
@@ -119,6 +121,7 @@ fun EntityViewList(
 private fun PreviewEntityListView() {
     EntityViewList(
         entityLists = mapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
+        entityListsOrder = listOf(stringResource(commonR.string.lights)),
         entityListFilter = { true },
         onEntityClicked = { _, _ -> },
         isHapticEnabled = false,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.common.R as commonR
 @Composable
 fun EntityViewList(
     entityLists: Map<String, List<Entity<*>>>,
+    entityListFilter: (Entity<*>) -> Boolean,
     onEntityClicked: (String, String) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean
@@ -78,16 +79,17 @@ fun EntityViewList(
                         }
                     }
                     if (expandedStates[header.hashCode()]!!) {
-                        items(entities.size) { index ->
+                        val filtered = entities.filter { entityListFilter(it) }
+                        items(filtered.size) { index ->
                             EntityUi(
-                                entities[index],
+                                filtered[index],
                                 onEntityClicked,
                                 isHapticEnabled,
                                 isToastEnabled
                             )
                         }
 
-                        if (entities.isNullOrEmpty()) {
+                        if (filtered.isNullOrEmpty()) {
                             item {
                                 Column {
                                     Chip(
@@ -117,6 +119,7 @@ fun EntityViewList(
 private fun PreviewEntityListView() {
     EntityViewList(
         entityLists = mapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
+        entityListFilter = { true },
         onEntityClicked = { _, _ -> },
         isHapticEnabled = false,
         isToastEnabled = false

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -32,7 +32,7 @@ import io.homeassistant.companion.android.common.R as commonR
 @ExperimentalComposeUiApi
 @Composable
 fun EntityViewList(
-    entityLists: Map<Int, List<Entity<*>>>,
+    entityLists: Map<String, List<Entity<*>>>,
     onEntityClicked: (String, String) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean
@@ -41,7 +41,7 @@ fun EntityViewList(
     val expandedStates = remember {
         mutableStateMapOf<Int, Boolean>().apply {
             entityLists.forEach {
-                put(it.key, true)
+                put(it.key.hashCode(), true)
             }
         }
     }
@@ -64,20 +64,20 @@ fun EntityViewList(
             horizontalAlignment = Alignment.CenterHorizontally,
             state = scalingLazyListState
         ) {
-            for ((headerId, entities) in entityLists) {
+            for ((header, entities) in entityLists) {
                 if (entities.isNotEmpty()) {
                     item {
                         if (entityLists.size > 1) {
                             ListHeader(
-                                stringId = headerId,
-                                expanded = expandedStates[headerId]!!,
-                                onExpandChanged = { expandedStates[headerId] = it }
+                                string = header,
+                                expanded = expandedStates[header.hashCode()]!!,
+                                onExpandChanged = { expandedStates[header.hashCode()] = it }
                             )
                         } else {
-                            ListHeader(headerId)
+                            ListHeader(header)
                         }
                     }
-                    if (expandedStates[headerId]!!) {
+                    if (expandedStates[header.hashCode()]!!) {
                         items(entities.size) { index ->
                             EntityUi(
                                 entities[index],
@@ -116,7 +116,7 @@ fun EntityViewList(
 @Composable
 private fun PreviewEntityListView() {
     EntityViewList(
-        entityLists = mapOf(commonR.string.lights to listOf(previewEntity1, previewEntity2)),
+        entityLists = mapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
         onEntityClicked = { _, _ -> },
         isHapticEnabled = false,
         isToastEnabled = false

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -86,9 +86,10 @@ fun LoadHomePage(
                         mainViewModel.favoriteEntityIds,
                         { id, state -> mainViewModel.toggleEntity(id, state) },
                         { swipeDismissableNavController.navigate(SCREEN_SETTINGS) },
-                        {
+                        { lists, filter ->
                             mainViewModel.entityLists.clear()
-                            mainViewModel.entityLists.putAll(it)
+                            mainViewModel.entityLists.putAll(lists)
+                            mainViewModel.entityListFilter = filter
                             swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                         },
                         mainViewModel.isHapticEnabled.value,
@@ -99,6 +100,7 @@ fun LoadHomePage(
                 composable(SCREEN_ENTITY_LIST) {
                     EntityViewList(
                         entityLists = mainViewModel.entityLists,
+                        entityListFilter = mainViewModel.entityListFilter,
                         onEntityClicked =
                         { entityId, state ->
                             mainViewModel.toggleEntity(entityId, state)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -86,9 +86,11 @@ fun LoadHomePage(
                         mainViewModel.favoriteEntityIds,
                         { id, state -> mainViewModel.toggleEntity(id, state) },
                         { swipeDismissableNavController.navigate(SCREEN_SETTINGS) },
-                        { lists, filter ->
+                        { lists, order, filter ->
                             mainViewModel.entityLists.clear()
                             mainViewModel.entityLists.putAll(lists)
+                            mainViewModel.entityListsOrder.clear()
+                            mainViewModel.entityListsOrder.addAll(order)
                             mainViewModel.entityListFilter = filter
                             swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                         },
@@ -100,6 +102,7 @@ fun LoadHomePage(
                 composable(SCREEN_ENTITY_LIST) {
                     EntityViewList(
                         entityLists = mainViewModel.entityLists,
+                        entityListsOrder = mainViewModel.entityListsOrder,
                         entityListFilter = mainViewModel.entityListFilter,
                         onEntityClicked =
                         { entityId, state ->

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ListHeader.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ListHeader.kt
@@ -16,13 +16,22 @@ fun ListHeader(
     expanded: Boolean,
     onExpandChanged: (Boolean) -> Unit
 ) {
+    ListHeader(stringResource(stringId), expanded, onExpandChanged)
+}
+
+@Composable
+fun ListHeader(
+    string: String,
+    expanded: Boolean,
+    onExpandChanged: (Boolean) -> Unit
+) {
     ListHeader(
         modifier = Modifier
             .clickable { onExpandChanged(!expanded) }
     ) {
         Row {
             Text(
-                text = stringResource(id = stringId) + if (expanded) "\u2001-" else "\u2001+"
+                text = string + if (expanded) "\u2001-" else "\u2001+"
             )
         }
     }
@@ -30,10 +39,15 @@ fun ListHeader(
 
 @Composable
 fun ListHeader(id: Int, modifier: Modifier = Modifier) {
+    ListHeader(stringResource(id), modifier)
+}
+
+@Composable
+fun ListHeader(string: String, modifier: Modifier = Modifier) {
     ListHeader {
         Row {
             Text(
-                text = stringResource(id = id),
+                text = string,
                 modifier = modifier
             )
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -161,11 +161,11 @@ fun MainView(
                     }
                 }
 
-                if(mainViewModel.areas.isNotEmpty()) {
+                if (mainViewModel.areas.isNotEmpty()) {
                     item {
                         ListHeader(id = commonR.string.areas)
                     }
-                    for(area in mainViewModel.areas) {
+                    for (area in mainViewModel.areas) {
                         item {
                             Chip(
                                 modifier = Modifier.fillMaxWidth(),
@@ -185,7 +185,7 @@ fun MainView(
                     }
                 }
 
-                if(mainViewModel.entitiesNotInAreas.isNotEmpty()) {
+                if (mainViewModel.entitiesNotInAreas.isNotEmpty()) {
                     item {
                         ListHeader(id = commonR.string.more_entities)
                     }
@@ -319,7 +319,7 @@ fun MainView(
                 }
 
                 // All entities regardless of area
-                if(mainViewModel.entities.isNotEmpty()) {
+                if (mainViewModel.entities.isNotEmpty()) {
                     item {
                         Chip(
                             modifier = Modifier

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -54,7 +54,7 @@ fun MainView(
     favoriteEntityIds: List<String>,
     onEntityClicked: (String, String) -> Unit,
     onSettingsClicked: () -> Unit,
-    onTestClicked: (entityLists: Map<String, List<Entity<*>>>) -> Unit,
+    onTestClicked: (entityLists: Map<String, List<Entity<*>>>, filter: (Entity<*>) -> (Boolean)) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
     deleteFavorite: (String) -> Unit
@@ -180,7 +180,7 @@ fun MainView(
                                             mapOf(
                                                 area.name to mainViewModel.entitiesByArea[id]!!
                                             )
-                                        )
+                                        ) { true }
                                     },
                                     colors = ChipDefaults.primaryChipColors()
                                 )
@@ -210,9 +210,9 @@ fun MainView(
                                 onClick = {
                                     onTestClicked(
                                         mapOf(
-                                            mainViewModel.nameForDomain[domain]!! to mainViewModel.entitiesByDomain[domain]!!.filter { mainViewModel.getAreaForEntity(it.entityId) == null }
+                                            mainViewModel.nameForDomain[domain]!! to mainViewModel.entitiesByDomain[domain]!!
                                         )
-                                    )
+                                    ) { mainViewModel.getAreaForEntity(it.entityId) == null }
                                 },
                                 colors = ChipDefaults.primaryChipColors()
                             )
@@ -240,7 +240,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mainViewModel.entitiesByDomain.mapKeys { mainViewModel.nameForDomain[it.key]!! }
-                                )
+                                ) { true }
                             },
                             colors = ChipDefaults.secondaryChipColors()
                         )

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -205,12 +205,12 @@ fun MainView(
                                     getIcon("", domain, context)?.let { Image(asset = it) }
                                 },
                                 label = {
-                                    Text(text = mainViewModel.nameForDomain[domain]!!)
+                                    Text(text = mainViewModel.stringForDomain(domain)!!)
                                 },
                                 onClick = {
                                     onTestClicked(
                                         mapOf(
-                                            mainViewModel.nameForDomain[domain]!! to mainViewModel.entitiesByDomain[domain]!!
+                                            mainViewModel.stringForDomain(domain)!! to mainViewModel.entitiesByDomain[domain]!!
                                         )
                                     ) { mainViewModel.getAreaForEntity(it.entityId) == null }
                                 },
@@ -240,7 +240,7 @@ fun MainView(
                             },
                             onClick = {
                                 onTestClicked(
-                                    mainViewModel.entitiesByDomain.mapKeys { mainViewModel.nameForDomain[it.key]!! }
+                                    mainViewModel.entitiesByDomain.mapKeys { mainViewModel.stringForDomain(it.key)!! }
                                 ) { true }
                             },
                             colors = ChipDefaults.secondaryChipColors()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -53,7 +53,7 @@ fun MainView(
     favoriteEntityIds: List<String>,
     onEntityClicked: (String, String) -> Unit,
     onSettingsClicked: () -> Unit,
-    onTestClicked: (entityLists: Map<Int, List<Entity<*>>>) -> Unit,
+    onTestClicked: (entityLists: Map<String, List<Entity<*>>>) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
     deleteFavorite: (String) -> Unit
@@ -159,39 +159,37 @@ fun MainView(
                             )
                         }
                     }
-                } else {
+                }
+
+                if(mainViewModel.areas.isNotEmpty()) {
                     item {
-                        ListHeader(id = commonR.string.more_entities)
+                        ListHeader(id = commonR.string.areas)
                     }
-                    item {
-                        Chip(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            icon = {
-                                Image(
-                                    asset = CommunityMaterial.Icon.cmd_animation
-                                )
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.all_entities))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        commonR.string.scenes to mainViewModel.scenes,
-                                        commonR.string.input_booleans to mainViewModel.inputBooleans,
-                                        commonR.string.lights to mainViewModel.lights,
-                                        commonR.string.locks to mainViewModel.locks,
-                                        commonR.string.scripts to mainViewModel.scripts,
-                                        commonR.string.switches to mainViewModel.switches
+                    for(area in mainViewModel.areas) {
+                        item {
+                            Chip(
+                                modifier = Modifier.fillMaxWidth(),
+                                label = {
+                                    Text(text = area.name)
+                                },
+                                onClick = {
+                                    onTestClicked(
+                                        mapOf(
+                                            area.name to mainViewModel.areaEntities[area.name]!!
+                                        )
                                     )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
+                                },
+                                colors = ChipDefaults.primaryChipColors()
+                            )
+                        }
                     }
                 }
 
+                if(mainViewModel.entitiesNotInAreas.isNotEmpty()) {
+                    item {
+                        ListHeader(id = commonR.string.more_entities)
+                    }
+                }
                 // Buttons for each existing category
                 if (mainViewModel.inputBooleans.isNotEmpty()) {
                     item {
@@ -206,7 +204,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.input_booleans to mainViewModel.inputBooleans
+                                        context.getString(commonR.string.input_booleans) to mainViewModel.inputBooleans
                                     )
                                 )
                             },
@@ -227,7 +225,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.lights to mainViewModel.lights
+                                        context.getString(commonR.string.lights) to mainViewModel.lights
                                     )
                                 )
                             },
@@ -248,7 +246,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.locks to mainViewModel.locks
+                                        context.getString(commonR.string.locks) to mainViewModel.locks
                                     )
                                 )
                             },
@@ -269,7 +267,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.scenes to mainViewModel.scenes
+                                        context.getString(commonR.string.scenes) to mainViewModel.scenes
                                     )
                                 )
                             },
@@ -290,7 +288,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.scripts to mainViewModel.scripts
+                                        context.getString(commonR.string.scripts) to mainViewModel.scripts
                                     )
                                 )
                             },
@@ -311,7 +309,7 @@ fun MainView(
                             onClick = {
                                 onTestClicked(
                                     mapOf(
-                                        commonR.string.switches to mainViewModel.switches
+                                        context.getString(commonR.string.switches) to mainViewModel.switches
                                     )
                                 )
                             },
@@ -320,12 +318,43 @@ fun MainView(
                     }
                 }
 
+                // All entities regardless of area
+                if(mainViewModel.entities.isNotEmpty()) {
+                    item {
+                        Chip(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 32.dp),
+                            icon = {
+                                Image(
+                                    asset = CommunityMaterial.Icon.cmd_animation
+                                )
+                            },
+                            label = {
+                                Text(text = stringResource(commonR.string.all_entities))
+                            },
+                            onClick = {
+                                onTestClicked(
+                                    mapOf(
+                                        context.getString(commonR.string.scenes) to mainViewModel.scenes,
+                                        context.getString(commonR.string.input_booleans) to mainViewModel.inputBooleans,
+                                        context.getString(commonR.string.lights) to mainViewModel.lights,
+                                        context.getString(commonR.string.locks) to mainViewModel.locks,
+                                        context.getString(commonR.string.scripts) to mainViewModel.scripts,
+                                        context.getString(commonR.string.switches) to mainViewModel.switches
+                                    )
+                                )
+                            },
+                            colors = ChipDefaults.secondaryChipColors()
+                        )
+                    }
+                }
+
                 // Settings
                 item {
                     Chip(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 32.dp),
+                            .fillMaxWidth(),
                         icon = {
                             Image(
                                 asset = CommunityMaterial.Icon.cmd_cog,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -231,7 +231,8 @@ fun MainView(
                                 .fillMaxWidth(),
                             icon = {
                                 Image(
-                                    asset = CommunityMaterial.Icon.cmd_animation
+                                    asset = CommunityMaterial.Icon.cmd_animation,
+                                    colorFilter = ColorFilter.tint(Color.White)
                                 )
                             },
                             label = {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -4,9 +4,10 @@ import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -161,21 +162,55 @@ fun MainView(
                     }
                 }
 
-                if (mainViewModel.areas.isNotEmpty()) {
+                if (mainViewModel.entitiesByArea.values.any { it.isNotEmpty() }) {
                     item {
                         ListHeader(id = commonR.string.areas)
                     }
-                    for (area in mainViewModel.areas) {
+                    for ((id, entities) in mainViewModel.entitiesByArea) {
+                        if (entities.isNotEmpty()) {
+                            val area = mainViewModel.areas.first { it.areaId == id }
+                            item {
+                                Chip(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    label = {
+                                        Text(text = area.name)
+                                    },
+                                    onClick = {
+                                        onTestClicked(
+                                            mapOf(
+                                                area.name to mainViewModel.entitiesByArea[id]!!
+                                            )
+                                        )
+                                    },
+                                    colors = ChipDefaults.primaryChipColors()
+                                )
+                            }
+                        }
+                    }
+                }
+
+                if (mainViewModel.entities.values.any { mainViewModel.getAreaForEntity(it.entityId) == null }) {
+                    item {
+                        ListHeader(id = commonR.string.more_entities)
+                    }
+                }
+                // Buttons for each existing category
+                for ((domain, entities) in mainViewModel.entitiesByDomain) {
+                    val domainEntitiesNotInArea = entities.filter { mainViewModel.getAreaForEntity(it.entityId) == null }
+                    if (domainEntitiesNotInArea.isNotEmpty()) {
                         item {
                             Chip(
                                 modifier = Modifier.fillMaxWidth(),
+                                icon = {
+                                    getIcon("", domain, context)?.let { Image(asset = it) }
+                                },
                                 label = {
-                                    Text(text = area.name)
+                                    Text(text = mainViewModel.nameForDomain[domain]!!)
                                 },
                                 onClick = {
                                     onTestClicked(
                                         mapOf(
-                                            area.name to mainViewModel.areaEntities[area.name]!!
+                                            mainViewModel.nameForDomain[domain]!! to mainViewModel.entitiesByDomain[domain]!!.filter { mainViewModel.getAreaForEntity(it.entityId) == null }
                                         )
                                     )
                                 },
@@ -185,146 +220,15 @@ fun MainView(
                     }
                 }
 
-                if (mainViewModel.entitiesNotInAreas.isNotEmpty()) {
-                    item {
-                        ListHeader(id = commonR.string.more_entities)
-                    }
+                item {
+                    Spacer(modifier = Modifier.height(32.dp))
                 }
-                // Buttons for each existing category
-                if (mainViewModel.inputBooleans.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "input_boolean", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.input_booleans))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.input_booleans) to mainViewModel.inputBooleans
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-                if (mainViewModel.lights.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "light", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.lights))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.lights) to mainViewModel.lights
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-                if (mainViewModel.locks.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "lock", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.locks))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.locks) to mainViewModel.locks
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-                if (mainViewModel.scenes.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "scene", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.scenes))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.scenes) to mainViewModel.scenes
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-                if (mainViewModel.scripts.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "script", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.scripts))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.scripts) to mainViewModel.scripts
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-                if (mainViewModel.switches.isNotEmpty()) {
-                    item {
-                        Chip(
-                            modifier = Modifier.fillMaxWidth(),
-                            icon = {
-                                getIcon("", "switch", context)?.let { Image(asset = it) }
-                            },
-                            label = {
-                                Text(text = stringResource(commonR.string.switches))
-                            },
-                            onClick = {
-                                onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.switches) to mainViewModel.switches
-                                    )
-                                )
-                            },
-                            colors = ChipDefaults.primaryChipColors()
-                        )
-                    }
-                }
-
                 // All entities regardless of area
                 if (mainViewModel.entities.isNotEmpty()) {
                     item {
                         Chip(
                             modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 32.dp),
+                                .fillMaxWidth(),
                             icon = {
                                 Image(
                                     asset = CommunityMaterial.Icon.cmd_animation
@@ -335,14 +239,7 @@ fun MainView(
                             },
                             onClick = {
                                 onTestClicked(
-                                    mapOf(
-                                        context.getString(commonR.string.scenes) to mainViewModel.scenes,
-                                        context.getString(commonR.string.input_booleans) to mainViewModel.inputBooleans,
-                                        context.getString(commonR.string.lights) to mainViewModel.lights,
-                                        context.getString(commonR.string.locks) to mainViewModel.locks,
-                                        context.getString(commonR.string.scripts) to mainViewModel.scripts,
-                                        context.getString(commonR.string.switches) to mainViewModel.switches
-                                    )
+                                    mainViewModel.entitiesByDomain.mapKeys { mainViewModel.nameForDomain[it.key]!! }
                                 )
                             },
                             colors = ChipDefaults.secondaryChipColors()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -54,7 +54,7 @@ fun MainView(
     favoriteEntityIds: List<String>,
     onEntityClicked: (String, String) -> Unit,
     onSettingsClicked: () -> Unit,
-    onTestClicked: (entityLists: Map<String, List<Entity<*>>>, filter: (Entity<*>) -> (Boolean)) -> Unit,
+    onTestClicked: (entityLists: Map<String, List<Entity<*>>>, listOrder: List<String>, filter: (Entity<*>) -> (Boolean)) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
     deleteFavorite: (String) -> Unit
@@ -166,7 +166,8 @@ fun MainView(
                     item {
                         ListHeader(id = commonR.string.areas)
                     }
-                    for ((id, entities) in mainViewModel.entitiesByArea) {
+                    for (id in mainViewModel.entitiesByAreaOrder) {
+                        val entities = mainViewModel.entitiesByArea[id]!!
                         if (entities.isNotEmpty()) {
                             val area = mainViewModel.areas.first { it.areaId == id }
                             item {
@@ -177,9 +178,8 @@ fun MainView(
                                     },
                                     onClick = {
                                         onTestClicked(
-                                            mapOf(
-                                                area.name to mainViewModel.entitiesByArea[id]!!
-                                            )
+                                            mapOf(area.name to mainViewModel.entitiesByArea[id]!!),
+                                            listOf(area.name)
                                         ) { true }
                                     },
                                     colors = ChipDefaults.primaryChipColors()
@@ -195,8 +195,8 @@ fun MainView(
                     }
                 }
                 // Buttons for each existing category
-                for ((domain, entities) in mainViewModel.entitiesByDomain) {
-                    val domainEntitiesNotInArea = entities.filter { mainViewModel.getAreaForEntity(it.entityId) == null }
+                for (domain in mainViewModel.entitiesByDomainOrder) {
+                    val domainEntitiesNotInArea = mainViewModel.entitiesByDomain[domain]!!.filter { mainViewModel.getAreaForEntity(it.entityId) == null }
                     if (domainEntitiesNotInArea.isNotEmpty()) {
                         item {
                             Chip(
@@ -211,7 +211,8 @@ fun MainView(
                                     onTestClicked(
                                         mapOf(
                                             mainViewModel.stringForDomain(domain)!! to mainViewModel.entitiesByDomain[domain]!!
-                                        )
+                                        ),
+                                        listOf(mainViewModel.stringForDomain(domain)!!)
                                     ) { mainViewModel.getAreaForEntity(it.entityId) == null }
                                 },
                                 colors = ChipDefaults.primaryChipColors()
@@ -240,7 +241,8 @@ fun MainView(
                             },
                             onClick = {
                                 onTestClicked(
-                                    mainViewModel.entitiesByDomain.mapKeys { mainViewModel.stringForDomain(it.key)!! }
+                                    mainViewModel.entitiesByDomain.mapKeys { mainViewModel.stringForDomain(it.key)!! },
+                                    mainViewModel.entitiesByDomain.keys.map { mainViewModel.stringForDomain(it)!! }.sorted()
                                 ) { true }
                             },
                             colors = ChipDefaults.secondaryChipColors()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -79,7 +79,8 @@ fun SetFavoritesView(
                 item {
                     ListHeader(id = commonR.string.set_favorite)
                 }
-                for ((domain, entities) in mainViewModel.entitiesByDomain) {
+                for (domain in mainViewModel.entitiesByDomainOrder) {
+                    val entities = mainViewModel.entitiesByDomain[domain].orEmpty()
                     if (entities.isNotEmpty()) {
                         item {
                             ListHeader(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -45,12 +43,14 @@ fun SetFavoritesView(
     favoriteEntityIds: List<String>,
     onFavoriteSelected: (entityId: String, entityPosition: Int, isSelected: Boolean) -> Unit
 ) {
-    var expandedInputBooleans: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedLights: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedLocks: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedScenes: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedScripts: Boolean by rememberSaveable { mutableStateOf(true) }
-    var expandedSwitches: Boolean by rememberSaveable { mutableStateOf(true) }
+    // Remember expanded state of each header
+    val expandedStates = remember {
+        mutableStateMapOf<String, Boolean>().apply {
+            mainViewModel.supportedDomains().forEach {
+                put(it, true)
+            }
+        }
+    }
 
     val scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState()
     LocalView.current.requestFocus()
@@ -79,122 +79,24 @@ fun SetFavoritesView(
                 item {
                     ListHeader(id = commonR.string.set_favorite)
                 }
-                if (mainViewModel.entitiesByDomain["input_boolean"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.input_booleans,
-                            expanded = expandedInputBooleans,
-                            onExpandChanged = { expandedInputBooleans = it }
-                        )
-                    }
-                    if (expandedInputBooleans) {
-                        items(mainViewModel.entitiesByDomain["input_boolean"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["input_boolean"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
+                for ((domain, entities) in mainViewModel.entitiesByDomain) {
+                    if (entities.isNotEmpty()) {
+                        item {
+                            ListHeader(
+                                string = mainViewModel.nameForDomain[domain]!!,
+                                expanded = expandedStates[domain]!!,
+                                onExpandChanged = { expandedStates[domain] = it }
                             )
                         }
-                    }
-                }
-
-                if (mainViewModel.entitiesByDomain["light"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.lights,
-                            expanded = expandedLights,
-                            onExpandChanged = { expandedLights = it }
-                        )
-                    }
-                    if (expandedLights) {
-                        items(mainViewModel.entitiesByDomain["light"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["light"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
-                            )
-                        }
-                    }
-                }
-
-                if (mainViewModel.entitiesByDomain["lock"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.locks,
-                            expanded = expandedLocks,
-                            onExpandChanged = { expandedLocks = it }
-                        )
-                    }
-                    if (expandedLocks) {
-                        items(mainViewModel.entitiesByDomain["lock"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["lock"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
-                            )
-                        }
-                    }
-                }
-
-                if (mainViewModel.entitiesByDomain["scene"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.scenes,
-                            expanded = expandedScenes,
-                            onExpandChanged = { expandedScenes = it }
-                        )
-                    }
-                    if (expandedScenes) {
-                        items(mainViewModel.entitiesByDomain["scene"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["scene"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
-                            )
-                        }
-                    }
-                }
-
-                if (mainViewModel.entitiesByDomain["script"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.scripts,
-                            expanded = expandedScripts,
-                            onExpandChanged = { expandedScripts = it }
-                        )
-                    }
-                    if (expandedScripts) {
-                        items(mainViewModel.entitiesByDomain["script"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["script"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
-                            )
-                        }
-                    }
-                }
-
-                if (mainViewModel.entitiesByDomain["switch"].orEmpty().isNotEmpty()) {
-                    item {
-                        ListHeader(
-                            stringId = commonR.string.switches,
-                            expanded = expandedSwitches,
-                            onExpandChanged = { expandedSwitches = it }
-                        )
-                    }
-                    if (expandedSwitches) {
-                        items(mainViewModel.entitiesByDomain["switch"].orEmpty().size) { index ->
-                            FavoriteToggleChip(
-                                entityList = mainViewModel.entitiesByDomain["switch"].orEmpty(),
-                                index = index,
-                                favoriteEntityIds = favoriteEntityIds,
-                                onFavoriteSelected = onFavoriteSelected
-                            )
+                        if (expandedStates[domain] == true) {
+                            items(mainViewModel.entitiesByDomain[domain].orEmpty().size) { index ->
+                                FavoriteToggleChip(
+                                    entityList = mainViewModel.entitiesByDomain[domain]!!,
+                                    index = index,
+                                    favoriteEntityIds = favoriteEntityIds,
+                                    onFavoriteSelected = onFavoriteSelected
+                                )
+                            }
                         }
                     }
                 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -79,7 +79,7 @@ fun SetFavoritesView(
                 item {
                     ListHeader(id = commonR.string.set_favorite)
                 }
-                if (mainViewModel.inputBooleans.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["input_boolean"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.input_booleans,
@@ -88,9 +88,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedInputBooleans) {
-                        items(mainViewModel.inputBooleans.size) { index ->
+                        items(mainViewModel.entitiesByDomain["input_boolean"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.inputBooleans,
+                                entityList = mainViewModel.entitiesByDomain["input_boolean"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected
@@ -99,7 +99,7 @@ fun SetFavoritesView(
                     }
                 }
 
-                if (mainViewModel.lights.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["light"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.lights,
@@ -108,9 +108,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedLights) {
-                        items(mainViewModel.lights.size) { index ->
+                        items(mainViewModel.entitiesByDomain["light"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.lights,
+                                entityList = mainViewModel.entitiesByDomain["light"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected
@@ -119,7 +119,7 @@ fun SetFavoritesView(
                     }
                 }
 
-                if (mainViewModel.locks.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["lock"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.locks,
@@ -128,9 +128,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedLocks) {
-                        items(mainViewModel.locks.size) { index ->
+                        items(mainViewModel.entitiesByDomain["lock"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.locks,
+                                entityList = mainViewModel.entitiesByDomain["lock"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected
@@ -139,7 +139,7 @@ fun SetFavoritesView(
                     }
                 }
 
-                if (mainViewModel.scenes.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["scene"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.scenes,
@@ -148,9 +148,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedScenes) {
-                        items(mainViewModel.scenes.size) { index ->
+                        items(mainViewModel.entitiesByDomain["scene"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.scenes,
+                                entityList = mainViewModel.entitiesByDomain["scene"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected
@@ -159,7 +159,7 @@ fun SetFavoritesView(
                     }
                 }
 
-                if (mainViewModel.scripts.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["script"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.scripts,
@@ -168,9 +168,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedScripts) {
-                        items(mainViewModel.scripts.size) { index ->
+                        items(mainViewModel.entitiesByDomain["script"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.scripts,
+                                entityList = mainViewModel.entitiesByDomain["script"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected
@@ -179,7 +179,7 @@ fun SetFavoritesView(
                     }
                 }
 
-                if (mainViewModel.switches.isNotEmpty()) {
+                if (mainViewModel.entitiesByDomain["switch"].orEmpty().isNotEmpty()) {
                     item {
                         ListHeader(
                             stringId = commonR.string.switches,
@@ -188,9 +188,9 @@ fun SetFavoritesView(
                         )
                     }
                     if (expandedSwitches) {
-                        items(mainViewModel.switches.size) { index ->
+                        items(mainViewModel.entitiesByDomain["switch"].orEmpty().size) { index ->
                             FavoriteToggleChip(
-                                entityList = mainViewModel.switches,
+                                entityList = mainViewModel.entitiesByDomain["switch"].orEmpty(),
                                 index = index,
                                 favoriteEntityIds = favoriteEntityIds,
                                 onFavoriteSelected = onFavoriteSelected

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -83,7 +83,7 @@ fun SetFavoritesView(
                     if (entities.isNotEmpty()) {
                         item {
                             ListHeader(
-                                string = mainViewModel.nameForDomain[domain]!!,
+                                string = mainViewModel.stringForDomain(domain)!!,
                                 expanded = expandedStates[domain]!!,
                                 onExpandChanged = { expandedStates[domain] = it }
                             )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Based on the work in #1970, this PR uses area information for entities to improve the main list shown on Wear OS. Should fix #1795.
I haven't worked on Wear OS or with Compose before, so happy to get any feedback from more frequent Wear OS contributors 🙂

Still to do:

- [x] Fix 'All entities' chip
- [x] Fix setting favorites + tiles from the watch settings
- [x] Sort area and domain chips/headers alphabetically, the current implementation with a map has no stable order
- [x] Listen for registry update events and refresh the list
- [x] Further tests for when all entities are in areas / no entities are in areas

Further possible improvements: 

- [x] ~Find a nicer way to create the lists while still allowing Compose to detect the changes (not considering favorites and shortcuts, we need to be able to make combinations of areas with entities in them, entities by area, and entities by domain)~ Edit: I've now implemented this by creating main entities and areas lists, and nested lists grouping entities by area and domain. Any further filtering is done in Compose which should be quick and allow it to stay live.
- [x] ~The code for determining the area of an entity is now used in both the Wear entity list and (phone) device controls, this should probably be moved somewhere else so it can be shared~ Created a utility object in the common code of the app for this. The function would typically be placed in a ViewModel or repository but there is no shared VM and the WebSocketRepository doesn't follow a repository pattern and do caching/transforming.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Favorites is still at the top, directly below that the user will see their areas with entities:
![ha-wear-1](https://user-images.githubusercontent.com/8148535/148588064-0506ea9b-2a5b-4277-9386-865de68fade0.png)

Tapping on an area shows a list of all entities in the area:
![ha-wear-2](https://user-images.githubusercontent.com/8148535/148588080-1832fdcd-4195-49e2-8976-3f9d8fb44a79.png)
(the first item is an input boolean, the second a light, ...)

Back on the main screen, below the areas the app shows chips for domains with entities not in any area (so 'More entities' refers to more than in the areas):
![ha-wear-3](https://user-images.githubusercontent.com/8148535/148588097-404537ba-55ac-4e35-9134-800b6c6960b8.png)

And finally at the bottom of the list is the chip for 'All entities', which shows all entities regardless of area status, and the settings:
![ha-wear-4](https://user-images.githubusercontent.com/8148535/148588202-28b14e8b-60da-4702-88f2-29ee2b1b34d2.png)

If the user has no areas with supported entities in them, nothing is shown and below favorites the app shows domains like it currently does:
![ha-wear-5](https://user-images.githubusercontent.com/8148535/148588229-87877ad9-bcd7-4609-b6c8-fb99421e8d76.png)

If the user has placed all the supported entities in an area, the app won't show any domains and just end with the all entities and settings chips.
![ha-wear-6](https://user-images.githubusercontent.com/8148535/148588251-b897bfde-5271-4a0e-90e4-73f96c7aeb31.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#653

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->