### PR TITLE
Remove unused properties from device/entity registry response

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/DeviceRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/DeviceRegistryResponse.kt
@@ -2,17 +2,5 @@ package io.homeassistant.companion.android.common.data.websocket.impl.entities
 
 data class DeviceRegistryResponse(
     val areaId: String?,
-    val configurationUrl: String?,
-    val configEntries: List<String>,
-    val connections: List<List<String>>,
-    val disabledBy: String?,
-    val entryType: String?,
-    val id: String,
-    val identifiers: List<List<String>>,
-    val manufacturer: String?,
-    val model: String?,
-    val nameByUser: String?,
-    val name: String?,
-    val swVersion: String?,
-    val viaDeviceId: String?
+    val id: String
 )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
@@ -2,12 +2,6 @@ package io.homeassistant.companion.android.common.data.websocket.impl.entities
 
 data class EntityRegistryResponse(
     val areaId: String?,
-    val configEntryId: String?,
     val deviceId: String?,
-    val disabledBy: String?,
-    val entityCategory: String?,
-    val entityId: String,
-    val icon: String?,
-    val name: String?,
-    val platform: String
+    val entityId: String
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
So it turns out that responses from the device registry might have different responses from what is [documented](https://developers.home-assistant.io/docs/device_registry_index/) and [type hinted in the core source](https://github.com/home-assistant/core/blob/dev/homeassistant/helpers/device_registry.py#L73), ["[core doesn't] enforce the types"](https://discord.com/channels/330944238910963714/330990195199442944/929416761294614548) and as a result the app might fail deserializing the response because the types don't match. I'm assuming the same applies to the entity registry as the data in there is also added by integrations.
For users, this can crash the app and there are already some issues reporting problems with the device controls which load the device/entity registries.

Because the app doesn't actually use most of the properties and will ignore unknown properties, the PR removes everything that is not being used right now to prevent the app from crashing on something that isn't relevant. The remaining properties are all set or generated by core so hopefully no surprises there.
The only other alternative I see is changing the response to be a `Map<String, Any?>` or changing the type for everything into a generic `T`, which will keep the data accessible, but that doesn't really solve the problem of not knowing the type for a specific property.

Should fix #2123 and #2124 and [another user's problem on Discord](https://discord.com/channels/330944238910963714/562408603345092636/928929359597801493) (all have the app failing deserializing a device registry response with data in a different type)
Might fix #2125 (if the app crashes while loading the data, the system will keep showing cached tiles with a 'Loading' state for quite some time, logs or the Add device controls page can confirm if the app has crashed)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->