### PR TITLE
Fix handling of line feed control char

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/MessagingService.kt
@@ -1031,7 +1031,8 @@ class MessagingService : FirebaseMessagingService() {
     private fun prepareText(
         text: String
     ): Spanned {
-        var emojiParsedText = EmojiParser.parseToUnicode(text)
+        var brText = text.replace("\\n", "<br>")
+        var emojiParsedText = EmojiParser.parseToUnicode(brText)
         return HtmlCompat.fromHtml(emojiParsedText, HtmlCompat.FROM_HTML_MODE_LEGACY)
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When sending a message to an Iphone and an Android phone, it is currently necessary to distinguish between a newline control character. 

The Iphone uses `\n` and Android uses the html code `<br>`.

This is a problem when a message is sent via a Notify group consisting of an Iphone and Android. 

```
notify:
  - name: all_devices
    platform: group
    services:
      - service: mobile_app_android
      - service: mobile_app_iphone
```
```
service: notify.all_devices
data:
  message: test1\n\ntest2\n\ntest3
```


As a simple solution we just replace all `\n` with `<br>`. Then we can also use the control character `\n` for Android phones.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/12832850/149498076-2509af84-7f9c-42b9-a046-9a73ef6ade7c.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->