### PR TITLE
Fix template tile refresh interval

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -47,7 +47,7 @@ class TemplateTile : TileService() {
             Tile.Builder()
                 .setResourcesVersion("1")
                 .setFreshnessIntervalMillis(
-                    integrationUseCase.getTemplateTileRefreshInterval().toLong() * 60 * 1000
+                    integrationUseCase.getTemplateTileRefreshInterval().toLong() * 1000
                 )
                 .setTimeline(
                     Timeline.Builder().addTimelineEntry(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Fixes #2145 by removing `* 60` as the saved value is already in seconds, so there is no need to multiply (see [my comment on the issue](https://github.com/home-assistant/android/issues/2145#issuecomment-1013717094) for slightly more details). Tested and refreshing is working as intended on the emulator.
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->