### PR TITLE
Prevent null values for BLE measured power, also allow negative values in case entire field is cleared out

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -28,7 +28,7 @@ class BluetoothSensorManager : SensorManager {
         private const val DEFAULT_BLE_ADVERTISE_MODE = "lowPower"
         private const val DEFAULT_BLE_MAJOR = "100"
         private const val DEFAULT_BLE_MINOR = "1"
-        const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
+        private const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
         private var priorBluetoothStateEnabled = false
 
         // private const val TAG = "BluetoothSM"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -22,13 +22,13 @@ class BluetoothSensorManager : SensorManager {
         private const val SETTING_BLE_TRANSMIT_POWER = "ble_transmit_power"
         private const val SETTING_BLE_ADVERTISE_MODE = "ble_advertise_mode"
         private const val SETTING_BLE_TRANSMIT_ENABLED = "ble_transmit_enabled"
-        private const val SETTING_BLE_MEASURED_POWER = "ble_measured_power_at_1m"
+        const val SETTING_BLE_MEASURED_POWER = "ble_measured_power_at_1m"
 
         private const val DEFAULT_BLE_TRANSMIT_POWER = "ultraLow"
         private const val DEFAULT_BLE_ADVERTISE_MODE = "lowPower"
         private const val DEFAULT_BLE_MAJOR = "100"
         private const val DEFAULT_BLE_MINOR = "1"
-        private const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
+        const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
         private var priorBluetoothStateEnabled = false
 
         // private const val TAG = "BluetoothSM"

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -166,7 +166,7 @@ class BluetoothSensorManager : SensorManager {
         val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, "string", UUID.randomUUID().toString())
         val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, "string", DEFAULT_BLE_MAJOR)
         val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, "string", DEFAULT_BLE_MINOR)
-        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number", DEFAULT_MEASURED_POWER_AT_1M).toInt()
+        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number", DEFAULT_MEASURED_POWER_AT_1M).toIntOrNull() ?: DEFAULT_MEASURED_POWER_AT_1M.toInt()
         val transmitPower = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_POWER, "list", listOf("ultraLow", "low", "medium", "high"), DEFAULT_BLE_TRANSMIT_POWER)
         val advertiseMode = getSetting(context, bleTransmitter, SETTING_BLE_ADVERTISE_MODE, "list", listOf("lowPower", "balanced", "lowLatency"), DEFAULT_BLE_ADVERTISE_MODE)
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -279,8 +279,13 @@ class SensorDetailFragment(
                         pref.isIconSpaceReserved = false
 
                         pref.setOnBindEditTextListener { fieldType ->
-                            if (setting.valueType == "number")
-                                fieldType.inputType = InputType.TYPE_CLASS_NUMBER
+                            if (setting.valueType == "number") {
+                                if (setting.name == BluetoothSensorManager.SETTING_BLE_MEASURED_POWER)
+                                    fieldType.inputType =
+                                        InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_SIGNED
+                                else
+                                    fieldType.inputType = InputType.TYPE_CLASS_NUMBER
+                            }
                         }
 
                         pref.setOnPreferenceChangeListener { _, newValue ->
@@ -288,7 +293,7 @@ class SensorDetailFragment(
                                 Setting(
                                     basicSensor.id,
                                     setting.name,
-                                    newValue as String,
+                                    if (setting.name == BluetoothSensorManager.SETTING_BLE_MEASURED_POWER && newValue == "") BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M else newValue as String,
                                     setting.valueType,
                                     setting.enabled
                                 )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorDetailFragment.kt
@@ -293,7 +293,7 @@ class SensorDetailFragment(
                                 Setting(
                                     basicSensor.id,
                                     setting.name,
-                                    if (setting.name == BluetoothSensorManager.SETTING_BLE_MEASURED_POWER && newValue == "") BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M else newValue as String,
+                                    newValue as String,
                                     setting.valueType,
                                     setting.enabled
                                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry error by defaulting to the correct value instead of crashing. I also noticed if a user clears out the field they can no longer add back a negative number so changed the field only for this setting as its the only one that expects a default value.

```
java.lang.NumberFormatException: For input string: ""
    at java.lang.Integer.parseInt(Integer.java:627)
    at java.lang.Integer.parseInt(Integer.java:650)
    at io.homeassistant.companion.android.sensors.BluetoothSensorManager.updateBLEDevice(BluetoothSensorManager.kt:169)
    at io.homeassistant.companion.android.sensors.BluetoothSensorManager.updateBLESensor(BluetoothSensorManager.kt:195)
    at io.homeassistant.companion.android.sensors.BluetoothSensorManager.requestSensorUpdate(BluetoothSensorManager.kt:109)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.refreshSensorData$lambda-17$lambda-16$lambda-12(SensorDetailFragment.kt:260)
    at io.homeassistant.companion.android.sensors.SensorDetailFragment.$r8$lambda$k1ldwhuKc_YUTyjQuSUk_5iHWwg
    at io.homeassistant.companion.android.sensors.SensorDetailFragment$$ExternalSyntheticLambda4.onPreferenceChange
    at androidx.preference.Preference.callChangeListener(Preference.java:1118)
    at androidx.preference.ListPreferenceDialogFragmentCompat.onDialogClosed(ListPreferenceDialogFragmentCompat.java:107)
    at androidx.preference.PreferenceDialogFragmentCompat.onDismiss(PreferenceDialogFragmentCompat.java:265)
    at androidx.fragment.app.DialogFragment$3.onDismiss(DialogFragment.java:132)
    at android.app.Dialog$ListenersHandler.handleMessage(Dialog.java:1424)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loop(Looper.java:257)
    at android.app.ActivityThread.main(ActivityThread.java:8307)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:612)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1006)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->