### PR TITLE
Fix minimal including Play Services dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,8 +163,6 @@ dependencies {
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
     implementation("com.google.android.material:material:1.4.0")
 
-    implementation("androidx.wear:wear-remote-interactions:1.0.0")
-
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.picasso:picasso:2.8")
@@ -176,6 +174,7 @@ dependencies {
     "fullImplementation"("io.sentry:sentry-android:5.5.3")
     "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.0")
     "fullImplementation"("com.google.android.gms:play-services-wearable:17.1.0")
+    "fullImplementation"("androidx.wear:wear-remote-interactions:1.0.0")
 
     implementation("androidx.biometric:biometric:1.1.0")
     implementation("androidx.webkit:webkit:1.4.0")
@@ -183,7 +182,15 @@ dependencies {
     implementation("com.google.android.exoplayer:exoplayer-core:2.15.1")
     implementation("com.google.android.exoplayer:exoplayer-hls:2.15.1")
     implementation("com.google.android.exoplayer:exoplayer-ui:2.15.1")
-    implementation("com.google.android.exoplayer:extension-cronet:2.15.1")
+    "fullImplementation"("com.google.android.exoplayer:extension-cronet:2.15.1")
+    "minimalImplementation"("com.google.android.exoplayer:extension-cronet:2.15.1") {
+        exclude(group = "com.google.android.gms", module = "play-services-cronet")
+    }
+    "questImplementation"("com.google.android.exoplayer:extension-cronet:2.15.1") {
+        exclude(group = "com.google.android.gms", module = "play-services-cronet")
+    }
+    "minimalImplementation"("org.chromium.net:cronet-embedded:95.4638.50")
+    "questImplementation"("org.chromium.net:cronet-embedded:95.4638.50")
 
     implementation("androidx.compose.animation:animation:1.0.5")
     implementation("androidx.compose.compiler:compiler:1.0.5")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Yet another attempt to fix #2153.
According to Gradle, two dependencies were still adding Google libraries to the app (see [this comment](https://github.com/home-assistant/android/issues/2153#issuecomment-1016813714)). This PR addresses that by:
- embedding ExoPlayer Cronet for minimal builds + excluding the Play Services dependency from the default (see [this comment](https://github.com/home-assistant/android/issues/2153#issuecomment-1016933008) for details)*
- moving the Wear OS remote interactions to full, already only used in the full app

Checked the merged manifest and classes in the generated APK and no `com.google.android.gms` to be found!

\* Note that this will increase the app download size for minimal and quest by ~8MB. Because this doesn't require code changes and should ensure the same behavior for all versions I think it is worth the increased size.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->