### PR TITLE
This should fix issue with random interruptions in work manager.

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -234,7 +234,7 @@ class WebSocketRepositoryImpl @Inject constructor(
                         notificationProducerScope = null
                         connection?.close(1001, "Done listening to notifications.")
                     }
-                }.shareIn(ioScope, SharingStarted.WhileSubscribed(DISCONNECT_DELAY))
+                }.shareIn(ioScope, SharingStarted.WhileSubscribed(DISCONNECT_DELAY, 0))
             }
 
             return notificationFlow


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This should fix issue with random interruptions in work manager.  If we just use KEEP instead of REPLACE then we could end up waiting 15 minutes for the work to requeue.  This should work around that and requeue the next time your screen comes on.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->