### PR TITLE
Improve reliability of opening entity 'more info' panel via intent

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -87,6 +87,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
 import org.chromium.net.CronetEngine
 import org.json.JSONObject
@@ -162,6 +163,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private var exoMute: Boolean = true
     private var failedConnection = "external"
     private var moreInfoEntity = ""
+    private var moreInfoMutex = Mutex()
     private var currentAutoplay: Boolean = false
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -234,13 +236,17 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 override fun onPageFinished(view: WebView?, url: String?) {
                     if (moreInfoEntity != "" && view?.progress == 100 && isConnected) {
                         ioScope.launch {
-                            delay(2000L)
-                            Log.d(TAG, "More info entity: $moreInfoEntity")
-                            webView.evaluateJavascript(
-                                "document.querySelector(\"home-assistant\").dispatchEvent(new CustomEvent(\"hass-more-info\", { detail: { entityId: \"$moreInfoEntity\" }}))",
-                                null
-                            )
-                            moreInfoEntity = ""
+                            val owner = "onPageFinished:$moreInfoEntity"
+                            if (moreInfoMutex.tryLock(owner)) {
+                                delay(2000L)
+                                Log.d(TAG, "More info entity: $moreInfoEntity")
+                                webView.evaluateJavascript(
+                                    "document.querySelector(\"home-assistant\").dispatchEvent(new CustomEvent(\"hass-more-info\", { detail: { entityId: \"$moreInfoEntity\" }}))"
+                                ) {
+                                    moreInfoMutex.unlock(owner)
+                                    moreInfoEntity = ""
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -163,7 +163,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private var exoMute: Boolean = true
     private var failedConnection = "external"
     private var moreInfoEntity = ""
-    private var moreInfoMutex = Mutex()
+    private val moreInfoMutex = Mutex()
     private var currentAutoplay: Boolean = false
 
     @SuppressLint("SetJavaScriptEnabled")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When long pressing on a device control to view the entity details, the more info panel sometimes didn't show up in the frontend or only flashed on screen for <1 second. I'd say it works 5/6 times, but it still fails frequently enough that it annoys me so I decided to investigate. 

I only noticed this for device controls but it should also apply to linking to an entity from a notification and quick settings tiles.

<details>
<summary>Details</summary>

Being able to reproduce this probably depends on your the speed of the network, device and HA instance. I just long pressed on a device control and waited to see if it would open the more info panel, on average it failed 1/6 times.

I started by adding a callback to the `webView.evaluateJavascript` call to see if there was a significant delay. In the logs I then noticed:

```
2022-01-20 23:33:16.913 32581-32581/io.homeassistant.companion.android.debug D/WebviewActivity: More info entity: fan.nrg_itho_09b8_fan
2022-01-20 23:33:16.971 32581-32581/io.homeassistant.companion.android.debug D/WebviewActivity: More info entity: 
2022-01-20 23:33:17.044 32581-32581/io.homeassistant.companion.android.debug D/WebviewActivity: More info entity returned: true
2022-01-20 23:33:17.069 32581-32581/io.homeassistant.companion.android.debug D/WebviewActivity: More info entity returned: true
```

It fired the event twice, and even before the first one had returned. The second event however doesn't include the entity ID any more, which means that the frontend will open the details and then immediately close them.

I moved resetting the entity ID to the callback, and added some additional logging to the function to see when it starts the delay and resumes, and now it fired the event even more:

```
2022-01-20 23:52:26.652 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onWindowFocusChanged: set more info entity to fan.nrg_itho_09b8_fan
(...)
2022-01-20 23:52:27.088 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Start delay for more info
(...)
2022-01-20 23:52:29.089 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: End delay, show more info for: fan.nrg_itho_09b8_fan
2022-01-20 23:52:29.089 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Sent more info event to JS
2022-01-20 23:52:29.099 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Start delay for more info
2022-01-20 23:52:29.099 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Start delay for more info
2022-01-20 23:52:29.184 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: More info entity returned: true
(...)
2022-01-20 23:52:31.100 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: End delay, show more info for: 
2022-01-20 23:52:31.101 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Sent more info event to JS
2022-01-20 23:52:31.101 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: End delay, show more info for: 
2022-01-20 23:52:31.101 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: Sent more info event to JS
2022-01-20 23:52:31.134 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: More info entity returned: true
2022-01-20 23:52:31.211 5227-5227/io.homeassistant.companion.android.debug D/WebviewActivity: onPageFinished: More info entity returned: true
```

---

</details>

What I found: because the `onPageFinished` function can be called multiple times and the coroutine (waiting for 2s) isn't blocking, you can end up with the event being fired multiple times, and if the entity ID has been reset by the first call, the app will fire an event with an empty id which will close the more info panel. This chance is increased by the fact that the app doesn't wait until the WebView has acknowledged the event, and it will reset it before it has finished firing the first event.

To fix this, this PR introduces a Mutex with a lock to make sure that the code isn't running multiple times, and waits with resetting the entity ID until the callback for the event is received ([`dispatchEvent` will always return something](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/dispatchEvent)).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->