### PR TITLE
Don't crash app on tiles/widgets/device controls if entity doesn't load

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -163,6 +163,7 @@ dependencies {
     implementation("androidx.navigation:navigation-ui-ktx:2.3.5")
     implementation("com.google.android.material:material:1.4.0")
 
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.1")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.picasso:picasso:2.8")

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.util.Calendar
 import java.util.concurrent.Flow
 import java.util.function.Consumer
 import javax.inject.Inject
@@ -40,11 +42,12 @@ class HaControlsProviderService : ControlsProviderService() {
 
     private val domainToHaControl = mapOf(
         "automation" to DefaultSwitchControl,
-        "camera" to null,
         "button" to DefaultButtonControl,
+        "camera" to null,
         "climate" to ClimateControl,
         "cover" to CoverControl,
         "fan" to FanControl,
+        "ha_failed" to HaFailedControl,
         "input_boolean" to DefaultSwitchControl,
         "input_button" to DefaultButtonControl,
         "input_number" to DefaultSliderControl,
@@ -121,7 +124,15 @@ class HaControlsProviderService : ControlsProviderService() {
                                     Log.e(TAG, "Unable to get $it from Home Assistant, null response.")
                                 }
                             } catch (e: Exception) {
-                                Log.e(TAG, "Unable to get $it from Home Assistant, exception.", e)
+                                entities["ha_failed.$it"] = Entity(
+                                    entityId = it,
+                                    state = if (e is HttpException && e.code() == 404) "notfound" else "exception",
+                                    attributes = mapOf<String, String>(),
+                                    lastChanged = Calendar.getInstance(),
+                                    lastUpdated = Calendar.getInstance(),
+                                    context = null
+                                )
+                                Log.e(TAG, "Unable to get $it from Home Assistant, caught exception.", e)
                             }
                         }
                         sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -113,11 +113,15 @@ class HaControlsProviderService : ControlsProviderService() {
                         var entityRegistry = webSocketRepository.getEntityRegistry()
                         val entities = mutableMapOf<String, Entity<Map<String, Any>>>()
                         controlIds.forEach {
-                            val entity = integrationRepository.getEntity(it)
-                            if (entity != null) {
-                                entities[it] = entity
-                            } else {
-                                Log.e(TAG, "Unable to get $it from Home Assistant.")
+                            try {
+                                val entity = integrationRepository.getEntity(it)
+                                if (entity != null) {
+                                    entities[it] = entity
+                                } else {
+                                    Log.e(TAG, "Unable to get $it from Home Assistant, null response.")
+                                }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Unable to get $it from Home Assistant, exception.", e)
                             }
                         }
                         sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
@@ -1,0 +1,46 @@
+package io.homeassistant.companion.android.controls
+
+import android.content.Context
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.StatelessTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+
+@RequiresApi(Build.VERSION_CODES.R)
+class HaFailedControl {
+    companion object : HaControl {
+        override fun provideControlFeatures(
+            context: Context,
+            control: Control.StatefulBuilder,
+            entity: Entity<Map<String, Any>>,
+            area: AreaRegistryResponse?
+        ): Control.StatefulBuilder {
+            control.setStatus(if (entity.state == "notfound") Control.STATUS_NOT_FOUND else Control.STATUS_ERROR)
+            control.setStatusText("")
+            control.setControlTemplate(
+                StatelessTemplate(
+                    entity.entityId
+                )
+            )
+            return control
+        }
+
+        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+            DeviceTypes.TYPE_UNKNOWN
+
+        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+            entity.entityId.split(".")[0].capitalize()
+
+        override fun performAction(
+            integrationRepository: IntegrationRepository,
+            action: ControlAction
+        ): Boolean {
+            return false
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -74,8 +74,13 @@ abstract class TileExtensions : TileService() {
                         tile.subtitle = tileData.subtitle
                     }
                     if (tileData.entityId.split('.')[0] in toggleDomains) {
-                        val state = runBlocking { integrationUseCase.getEntity(tileData.entityId) }
-                        tile.state = if (state?.state == "on" || state?.state == "open") Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+                        try {
+                            val state = runBlocking { integrationUseCase.getEntity(tileData.entityId) }
+                            tile.state = if (state?.state == "on" || state?.state == "open") Tile.STATE_ACTIVE else Tile.STATE_INACTIVE
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Unable to set state for tile", e)
+                            tile.state = Tile.STATE_UNAVAILABLE
+                        }
                     } else
                         tile.state = Tile.STATE_INACTIVE
                     val iconId = tileData.iconId

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -173,15 +173,15 @@ class CameraWidget : AppWidgetProvider() {
     }
 
     private suspend fun retrieveCameraImageUrl(context: Context, entityId: String): String? {
-        val entity = integrationUseCase.getEntity(entityId)
-        if (entity == null) {
+        return try {
+            val entity = integrationUseCase.getEntity(entityId)
+            entity?.attributes?.get("entity_picture")?.toString()
+        } catch (e: Exception) {
             Log.e(TAG, "Failed to fetch entity or entity does not exist")
             if (lastIntent == UPDATE_IMAGE)
                 Toast.makeText(context, commonR.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
-            return null
+            null
         }
-
-        return entity.attributes["entity_picture"]?.toString()
     }
 
     override fun onReceive(context: Context, intent: Intent) {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -177,7 +177,7 @@ class CameraWidget : AppWidgetProvider() {
             val entity = integrationUseCase.getEntity(entityId)
             entity?.attributes?.get("entity_picture")?.toString()
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to fetch entity or entity does not exist")
+            Log.e(TAG, "Failed to fetch entity or entity does not exist", e)
             if (lastIntent == UPDATE_IMAGE)
                 Toast.makeText(context, commonR.string.widget_entity_fetch_error, Toast.LENGTH_LONG).show()
             null


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2169

Did a quick check to see where else the app loads the entity and added a try/catch to the quick settings tiles state and camera widget as well.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
All of these failure states are generated by the system, this is on a Google Pixel 4a running Android 12.

Device controls will now show 'Not Found' if the exception is a HTTP 404 response, tapping on it shows more details, and it will show a simple tile in case of any other exception (tapping does nothing). Other controls can still be loaded and used:
|HttpException: 404|Tap on 'Not Found' tile|Other exceptions|
|-------|-------|-------|
|![404-notfound](https://user-images.githubusercontent.com/8148535/150613024-b81c0912-c16f-439f-926e-5f1871e02f14.png)|![404-notfound-tap](https://user-images.githubusercontent.com/8148535/150613039-ab1432c4-91dc-45c0-abc4-9ab9f6450dec.png)|![404-other](https://user-images.githubusercontent.com/8148535/150613281-a01811f5-a30f-4ac1-9235-3846448e8db2.png)|

Quick settings tile will become unavailable / 'greyed out':
![404-tile](https://user-images.githubusercontent.com/8148535/150607843-5453bba1-ff88-4f56-be3e-a6cd5acabfe0.png)

I don't have a camera to add to the widget to show the failure toast, but it should be the same as an entity widget failing.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I don't think we need to add this to the documentation, if it stops working and the user notices it they will now be able to spot which one it is and fix it themselves.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->