### PR TITLE
Add notification channel settings so users can quickly find how to manage them

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -205,6 +205,13 @@ class SettingsFragment constructor(
             }
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            findPreference<Preference>("notification_channels")?.let {
+                it.isVisible = true
+                it.intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).putExtra(Settings.EXTRA_APP_PACKAGE, context?.packageName)
+            }
+        }
+
         findPreference<Preference>("notification_history")?.let {
             it.isVisible = true
             it.setOnPreferenceClickListener {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
@@ -1,25 +1,33 @@
 package io.homeassistant.companion.android.settings.websocket.views
 
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.material.Button
+import androidx.compose.material.Divider
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import io.homeassistant.companion.android.websocket.WebsocketManager
 
 @Composable
 fun WebsocketSettingView(
     websocketSetting: WebsocketSetting,
     onSettingChanged: (WebsocketSetting) -> Unit
 ) {
+    val context = LocalContext.current
     Column(modifier = Modifier.padding(20.dp)) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Text(stringResource(R.string.websocket_setting_description))
@@ -39,6 +47,28 @@ fun WebsocketSettingView(
             selected = websocketSetting == WebsocketSetting.ALWAYS,
             onClick = { onSettingChanged(WebsocketSetting.ALWAYS) }
         )
+        if (websocketSetting != WebsocketSetting.NEVER && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Divider()
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(20.dp)
+            ) {
+                Text(text = stringResource(id = R.string.websocket_persistent_notification))
+            }
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Button(
+                    modifier = Modifier.padding(start = 20.dp),
+                    onClick = {
+                        val intent = Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS)
+                        intent.putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                        intent.putExtra(Settings.EXTRA_CHANNEL_ID, WebsocketManager.CHANNEL_ID)
+                        context.startActivity(intent)
+                    }
+                ) {
+                    Text(text = stringResource(id = R.string.websocket_notification_channel))
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -48,7 +48,7 @@ class WebsocketManager(
     companion object {
         private const val TAG = "WebSockManager"
         private const val SOURCE = "Websocket"
-        private const val CHANNEL_ID = "Websocket"
+        const val CHANNEL_ID = "Websocket"
         private const val NOTIFICATION_ID = 65423
         private val DEFAULT_WEBSOCKET_SETTING = if (BuildConfig.FLAVOR == "full") WebsocketSetting.SCREEN_ON else WebsocketSetting.ALWAYS
 

--- a/app/src/main/res/drawable/ic_notification_channel.xml
+++ b/app/src/main/res/drawable/ic_notification_channel.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="@color/colorAccent" android:pathData="M23 7V13H21V7M21 15H23V17H21M12 2A2 2 0 0 0 10 4A2 2 0 0 0 10 4.29C7.12 5.14 5 7.82 5 11V17L3 19V20H21V19L19 17V11C19 7.82 16.88 5.14 14 4.29A2 2 0 0 0 14 4A2 2 0 0 0 12 2M10 21A2 2 0 0 0 12 23A2 2 0 0 0 14 21Z" />
+</vector>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -118,6 +118,12 @@
         android:key="notifications"
         app:isPreferenceVisible="false">
         <Preference
+            android:key="notification_channels"
+            android:title="@string/notification_channels"
+            android:summary="@string/notification_channels_summary"
+            app:isPreferenceVisible="false"
+            android:icon="@drawable/ic_notification_channel" />
+        <Preference
             android:key="notification_history"
             app:isPreferenceVisible="false"
             android:title="@string/notification_history"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -742,8 +742,12 @@
     <string name="sensor_name_last_app">Last Used App</string>
     <string name="websocket_setting_name">Websocket Settings</string>
     <string name="websocket_setting_summary">Manage when we are in direct communication with your server via websockets.</string>
-    <string name="websocket_setting_description">Please select when you would like the application to attempt to directly communicate with your Home Assistant instance for all communication.  This will include push notifications, if you are on a minimal build this needs to be always to consistently get push notifications.</string>
+    <string name="websocket_setting_description">Please select when you would like the application to attempt to directly communicate with your Home Assistant instance for all communication. This will include push notifications, if you are on a minimal build this needs to be always to consistently get push notifications.</string>
     <string name="websocket_setting_never">Never</string>
     <string name="websocket_setting_while_screen_on">While Screen On</string>
     <string name="websocket_setting_always">Always</string>
+    <string name="websocket_persistent_notification">In order to maintain the websocket connection the app will need to create a persistent notification. You may use the button below to manage the appearance of this notification. It is recommended to minimize the notification to hide it.</string>
+    <string name="websocket_notification_channel">Manage Websocket Notification Channel</string>
+    <string name="notification_channels">Notification Channels</string>
+    <string name="notification_channels_summary">Manage all notification channels configured on the device. Channels control the behavior of its notifications including visibility and sound.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I have seen quite a few users not knowing about notification channels or even how to find them. Now that the app creates its own persistent notification based on settings its probably a good time to help direct users to the proper location.

Under notifications there is a new Notification Channels setting that will take the user to all channels created by the app (including ones by the user).

I have also updated the websocket setting page to help direct users to managing this channel as well.

For sensor worker I didn't find a good place for it so for now users can get to it via the notification channel option. It will be there for them. For sensor worker it will probably make sense to add this once we move to compose on those screens and make a new UI.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/150696154-a0a08ee3-5fd2-4339-afd3-080092dfa6a5.png)

![image](https://user-images.githubusercontent.com/1634145/150696159-6ce2ed4d-d3e1-46a1-835d-aef97797a854.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->