### PR TITLE
Update widget settings empty state, add "Add widget" button

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -2,19 +2,43 @@ package io.homeassistant.companion.android.settings.widgets.views
 
 import android.appwidget.AppWidgetManager
 import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
+import androidx.compose.material.ExtendedFloatingActionButton
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity
+import io.homeassistant.companion.android.widgets.camera.CameraWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.entity.EntityWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigureActivity
@@ -23,52 +47,145 @@ import io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigu
 fun ManageWidgetsView(
     viewModel: ManageWidgetsViewModel
 ) {
-    LazyColumn(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp)
-    ) {
-        if (viewModel.buttonWidgetList.isNullOrEmpty() && viewModel.staticWidgetList.isNullOrEmpty() &&
-            viewModel.mediaWidgetList.isNullOrEmpty() && viewModel.templateWidgetList.isNullOrEmpty()
+    var expandedAddWidget by remember { mutableStateOf(false) }
+    Scaffold(floatingActionButton = {
+        if (viewModel.supportsAddingWidgets.value) {
+            ExtendedFloatingActionButton(
+                backgroundColor = MaterialTheme.colors.primary,
+                contentColor = MaterialTheme.colors.onPrimary,
+                icon = { Icon(Icons.Filled.Add, contentDescription = null) },
+                text = { Text(stringResource(R.string.add_widget)) },
+                onClick = { expandedAddWidget = true }
+            )
+        }
+    }) {
+        if (expandedAddWidget) {
+            Dialog(onDismissRequest = { expandedAddWidget = false }) {
+                val availableWidgets = mapOf(
+                    stringResource(R.string.widget_button_image_description) to Pair("button", CommunityMaterial.Icon2.cmd_gesture_tap),
+                    stringResource(R.string.widget_camera_description) to Pair("camera", CommunityMaterial.Icon.cmd_camera),
+                    stringResource(R.string.widget_static_image_description) to Pair("entity", CommunityMaterial.Icon3.cmd_shape),
+                    stringResource(R.string.widget_media_player_description) to Pair("media", CommunityMaterial.Icon3.cmd_play_box_multiple),
+                    stringResource(R.string.template_widget) to Pair("template", CommunityMaterial.Icon.cmd_code_braces)
+                ).toSortedMap(compareBy { it })
+                Box(modifier = Modifier.background(MaterialTheme.colors.surface, RoundedCornerShape(4.dp))) {
+                    LazyColumn {
+                        item {
+                            Text(
+                                text = stringResource(R.string.add_widget),
+                                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+                                style = MaterialTheme.typography.h6
+                            )
+                        }
+                        availableWidgets.forEach {
+                            item {
+                                PopupWidgetRow(widgetLabel = it.key, widgetIcon = it.value.second, widgetType = it.value.first) {
+                                    expandedAddWidget = false
+                                }
+                            }
+                        }
+                        item {
+                            Row(
+                                horizontalArrangement = Arrangement.End,
+                                modifier = Modifier.fillMaxWidth().padding(end = 8.dp, bottom = 8.dp)
+                            ) {
+                                TextButton(onClick = { expandedAddWidget = false }) {
+                                    Text(stringResource(R.string.cancel))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        LazyColumn(
+            modifier = Modifier.padding(start = 16.dp, end = 16.dp)
         ) {
-            item { Text(stringResource(id = R.string.no_widgets)) }
+            if (viewModel.buttonWidgetList.isNullOrEmpty() && viewModel.staticWidgetList.isNullOrEmpty() &&
+                viewModel.mediaWidgetList.isNullOrEmpty() && viewModel.templateWidgetList.isNullOrEmpty()
+            ) {
+                item { Text(stringResource(id = R.string.no_widgets)) }
+            }
+            if (!viewModel.buttonWidgetList.isNullOrEmpty()) {
+                item {
+                    Text(stringResource(id = R.string.button_widgets))
+                }
+                items(viewModel.buttonWidgetList.size) { index ->
+                    val item = viewModel.buttonWidgetList[index]
+                    val label = if (!item.label.isNullOrEmpty()) item.label else "${item.domain}.${item.service}"
+                    WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "button")
+                }
+            }
+            if (!viewModel.staticWidgetList.isNullOrEmpty()) {
+                item {
+                    Text(stringResource(id = R.string.entity_state_widgets))
+                }
+                items(viewModel.staticWidgetList.size) { index ->
+                    val item = viewModel.staticWidgetList[index]
+                    val label = if (!item.label.isNullOrEmpty()) item.label else "${item.entityId} ${item.stateSeparator} ${item.attributeIds}"
+                    WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "state")
+                }
+            }
+            if (!viewModel.mediaWidgetList.isNullOrEmpty()) {
+                item {
+                    Text(stringResource(id = R.string.media_player_widgets))
+                }
+                items(viewModel.mediaWidgetList.size) { index ->
+                    val item = viewModel.mediaWidgetList[index]
+                    val label = if (!item.label.isNullOrEmpty()) item.label else item.entityId
+                    WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "media")
+                }
+            }
+            if (!viewModel.templateWidgetList.isNullOrEmpty()) {
+                item {
+                    Text(stringResource(id = R.string.template_widgets))
+                }
+                items(viewModel.templateWidgetList.size) { index ->
+                    val item = viewModel.templateWidgetList[index]
+                    WidgetRow(widgetLabel = item.template, widgetId = item.id, widgetType = "template")
+                }
+            }
         }
-        if (!viewModel.buttonWidgetList.isNullOrEmpty()) {
-            item {
-                Text(stringResource(id = R.string.button_widgets))
+    }
+}
+
+@Composable
+fun PopupWidgetRow(
+    widgetLabel: String,
+    widgetIcon: IIcon,
+    widgetType: String,
+    onClickCallback: () -> Unit
+) {
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier.fillMaxWidth().clickable {
+            val intent = Intent(
+                context,
+                when (widgetType) {
+                    "button" -> ButtonWidgetConfigureActivity::class.java
+                    "camera" -> CameraWidgetConfigureActivity::class.java
+                    "media" -> MediaPlayerControlsWidgetConfigureActivity::class.java
+                    "state" -> EntityWidgetConfigureActivity::class.java
+                    "template" -> TemplateWidgetConfigureActivity::class.java
+                    else -> ButtonWidgetConfigureActivity::class.java // We will never reach this
+                }
+            ).apply {
+                putExtra(ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, true)
             }
-            items(viewModel.buttonWidgetList.size) { index ->
-                val item = viewModel.buttonWidgetList[index]
-                val label = if (!item.label.isNullOrEmpty()) item.label else "${item.domain}.${item.service}"
-                WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "button")
-            }
+            context.startActivity(intent)
+            onClickCallback()
         }
-        if (!viewModel.staticWidgetList.isNullOrEmpty()) {
-            item {
-                Text(stringResource(id = R.string.entity_state_widgets))
-            }
-            items(viewModel.staticWidgetList.size) { index ->
-                val item = viewModel.staticWidgetList[index]
-                val label = if (!item.label.isNullOrEmpty()) item.label else "${item.entityId} ${item.stateSeparator} ${item.attributeIds}"
-                WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "state")
-            }
-        }
-        if (!viewModel.mediaWidgetList.isNullOrEmpty()) {
-            item {
-                Text(stringResource(id = R.string.media_player_widgets))
-            }
-            items(viewModel.mediaWidgetList.size) { index ->
-                val item = viewModel.mediaWidgetList[index]
-                val label = if (!item.label.isNullOrEmpty()) item.label else item.entityId
-                WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "media")
-            }
-        }
-        if (!viewModel.templateWidgetList.isNullOrEmpty()) {
-            item {
-                Text(stringResource(id = R.string.template_widgets))
-            }
-            items(viewModel.templateWidgetList.size) { index ->
-                val item = viewModel.templateWidgetList[index]
-                WidgetRow(widgetLabel = item.template, widgetId = item.id, widgetType = "template")
-            }
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                asset = widgetIcon,
+                colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
+                contentDescription = widgetLabel
+            )
+            Text(text = widgetLabel, modifier = Modifier.padding(start = 16.dp))
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
@@ -20,6 +22,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Widgets
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -30,6 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.mikepenz.iconics.compose.Image
@@ -104,7 +108,30 @@ fun ManageWidgetsView(
             if (viewModel.buttonWidgetList.isNullOrEmpty() && viewModel.staticWidgetList.isNullOrEmpty() &&
                 viewModel.mediaWidgetList.isNullOrEmpty() && viewModel.templateWidgetList.isNullOrEmpty()
             ) {
-                item { Text(stringResource(id = R.string.no_widgets)) }
+                item {
+                    Column(
+                        verticalArrangement = Arrangement.Center,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        modifier = Modifier.fillMaxWidth().padding(top = 64.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Widgets,
+                            contentDescription = null,
+                            modifier = Modifier.size(48.dp)
+                        )
+                        Text(
+                            text = stringResource(id = R.string.no_widgets),
+                            style = MaterialTheme.typography.h6,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(0.7f).padding(top = 8.dp)
+                        )
+                        Text(
+                            text = stringResource(id = R.string.no_widgets_summary),
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth(0.7f)
+                        )
+                    }
+                }
             }
             if (!viewModel.buttonWidgetList.isNullOrEmpty()) {
                 item {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -64,7 +64,7 @@ fun ManageWidgetsView(
                 val availableWidgets = mapOf(
                     stringResource(R.string.widget_button_image_description) to Pair("button", CommunityMaterial.Icon2.cmd_gesture_tap),
                     stringResource(R.string.widget_camera_description) to Pair("camera", CommunityMaterial.Icon.cmd_camera),
-                    stringResource(R.string.widget_static_image_description) to Pair("entity", CommunityMaterial.Icon3.cmd_shape),
+                    stringResource(R.string.widget_static_image_description) to Pair("state", CommunityMaterial.Icon3.cmd_shape),
                     stringResource(R.string.widget_media_player_description) to Pair("media", CommunityMaterial.Icon3.cmd_play_box_multiple),
                     stringResource(R.string.template_widget) to Pair("template", CommunityMaterial.Icon.cmd_code_braces)
                 ).toSortedMap(compareBy { it })
@@ -171,6 +171,7 @@ fun PopupWidgetRow(
                 }
             ).apply {
                 putExtra(ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, true)
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
             context.startActivity(intent)
             onClickCallback()

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.widgets.button
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
@@ -16,6 +17,7 @@ import android.widget.AutoCompleteTextView
 import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.getSystemService
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.graphics.drawable.toBitmap
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -35,6 +37,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.integration.Service
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetButtonConfigureBinding
+import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.common.ServiceFieldBinder
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetDynamicFieldAdapter
@@ -51,6 +54,7 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
     companion object {
         private const val TAG: String = "ButtonWidgetConfigAct"
         private const val ICON_DIALOG_TAG = "icon-dialog"
+        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     @Inject
@@ -68,72 +72,11 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private var requestLauncherSetup = false
 
     private var onDeleteWidget = View.OnClickListener {
         val context = this@ButtonWidgetConfigureActivity
         deleteConfirmation(context)
-    }
-
-    private var onAddWidget = View.OnClickListener {
-        try {
-            val context = this@ButtonWidgetConfigureActivity
-
-            // Set up a broadcast intent and pass the service call data as extras
-            val intent = Intent()
-            intent.action = ButtonWidget.RECEIVE_DATA
-            intent.component = ComponentName(context, ButtonWidget::class.java)
-
-            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-
-            // Analyze and send service and domain
-            val serviceText = binding.widgetTextConfigService.text.toString()
-            val domain = services[serviceText]?.domain ?: serviceText.split(".", limit = 2)[0]
-            val service = services[serviceText]?.service ?: serviceText.split(".", limit = 2)[1]
-            intent.putExtra(
-                ButtonWidget.EXTRA_DOMAIN,
-                domain
-            )
-            intent.putExtra(
-                ButtonWidget.EXTRA_SERVICE,
-                service
-            )
-
-            // Fetch and send label and icon
-            intent.putExtra(
-                ButtonWidget.EXTRA_LABEL,
-                binding.label.text.toString()
-            )
-            intent.putExtra(
-                ButtonWidget.EXTRA_ICON,
-                binding.widgetConfigIconSelector.tag as Int
-            )
-
-            // Analyze and send service data
-            val serviceDataMap = HashMap<String, Any>()
-            dynamicFields.forEach {
-                if (it.value != null) {
-                    serviceDataMap[it.field] = it.value!!
-                }
-            }
-
-            intent.putExtra(
-                ButtonWidget.EXTRA_SERVICE_DATA,
-                jacksonObjectMapper().writeValueAsString(serviceDataMap)
-            )
-
-            context.sendBroadcast(intent)
-
-            // Make sure we pass back the original appWidgetId
-            setResult(
-                RESULT_OK,
-                Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            )
-            finish()
-        } catch (e: Exception) {
-            Log.e(TAG, "Issue configuring widget", e)
-            Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG)
-                .show()
-        }
     }
 
     private val onAddFieldListener = View.OnClickListener {
@@ -239,10 +182,13 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
             appWidgetId = extras.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
             )
+            requestLauncherSetup = extras.getBoolean(
+                ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, false
+            )
         }
 
         // If this activity was started with an intent without an app widget ID, finish with an error.
-        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID && !requestLauncherSetup) {
             finish()
             return
         }
@@ -338,7 +284,24 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
         binding.widgetTextConfigService.addTextChangedListener(serviceTextWatcher)
 
         binding.addFieldButton.setOnClickListener(onAddFieldListener)
-        binding.addButton.setOnClickListener(onAddWidget)
+        binding.addButton.setOnClickListener {
+            if (requestLauncherSetup) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    getSystemService<AppWidgetManager>()?.requestPinAppWidget(
+                        ComponentName(this, ButtonWidget::class.java),
+                        null,
+                        PendingIntent.getActivity(
+                            this,
+                            System.currentTimeMillis().toInt(),
+                            Intent(this, ButtonWidgetConfigureActivity::class.java).putExtra(PIN_WIDGET_CALLBACK, true).setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                        )
+                    )
+                } else showAddWidgetError() // this shouldn't be possible
+            } else {
+                onAddWidget()
+            }
+        }
 
         dynamicFieldAdapter = WidgetDynamicFieldAdapter(services, entities, dynamicFields)
         binding.widgetConfigFieldsLayout.adapter = dynamicFieldAdapter
@@ -366,6 +329,16 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
         super.onDestroy()
     }
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (intent != null && intent.extras != null && intent.hasExtra(PIN_WIDGET_CALLBACK)) {
+            appWidgetId = intent.extras!!.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
+            )
+            onAddWidget()
+        }
+    }
+
     override val iconDialogIconPack: IconPack?
         get() = iconPack
 
@@ -383,6 +356,75 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
                 binding.widgetConfigIconSelector.setImageBitmap(icon.toBitmap())
             }
         }
+    }
+
+    private fun onAddWidget() {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            showAddWidgetError()
+            return
+        }
+        try {
+            val context = this@ButtonWidgetConfigureActivity
+
+            // Set up a broadcast intent and pass the service call data as extras
+            val intent = Intent()
+            intent.action = ButtonWidget.RECEIVE_DATA
+            intent.component = ComponentName(context, ButtonWidget::class.java)
+
+            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+
+            // Analyze and send service and domain
+            val serviceText = binding.widgetTextConfigService.text.toString()
+            val domain = services[serviceText]?.domain ?: serviceText.split(".", limit = 2)[0]
+            val service = services[serviceText]?.service ?: serviceText.split(".", limit = 2)[1]
+            intent.putExtra(
+                ButtonWidget.EXTRA_DOMAIN,
+                domain
+            )
+            intent.putExtra(
+                ButtonWidget.EXTRA_SERVICE,
+                service
+            )
+
+            // Fetch and send label and icon
+            intent.putExtra(
+                ButtonWidget.EXTRA_LABEL,
+                binding.label.text.toString()
+            )
+            intent.putExtra(
+                ButtonWidget.EXTRA_ICON,
+                binding.widgetConfigIconSelector.tag as Int
+            )
+
+            // Analyze and send service data
+            val serviceDataMap = HashMap<String, Any>()
+            dynamicFields.forEach {
+                if (it.value != null) {
+                    serviceDataMap[it.field] = it.value!!
+                }
+            }
+
+            intent.putExtra(
+                ButtonWidget.EXTRA_SERVICE_DATA,
+                jacksonObjectMapper().writeValueAsString(serviceDataMap)
+            )
+
+            context.sendBroadcast(intent)
+
+            // Make sure we pass back the original appWidgetId
+            setResult(
+                RESULT_OK,
+                Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            )
+            finish()
+        } catch (e: Exception) {
+            Log.e(TAG, "Issue configuring widget", e)
+            showAddWidgetError()
+        }
+    }
+
+    private fun showAddWidgetError() {
+        Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG).show()
     }
 
     private fun deleteConfirmation(context: Context) {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
@@ -1,9 +1,11 @@
 package io.homeassistant.companion.android.widgets.entity
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -13,14 +15,15 @@ import android.widget.AutoCompleteTextView
 import android.widget.LinearLayout.VISIBLE
 import android.widget.MultiAutoCompleteTextView.CommaTokenizer
 import android.widget.Toast
+import androidx.core.content.getSystemService
 import androidx.core.view.isVisible
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
-import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetStaticConfigureBinding
+import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import kotlinx.coroutines.CoroutineScope
@@ -37,6 +40,7 @@ class EntityWidgetConfigureActivity : BaseActivity() {
 
     companion object {
         private const val TAG: String = "StaticWidgetConfigAct"
+        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.entity.EntityWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     @Inject
@@ -53,6 +57,7 @@ class EntityWidgetConfigureActivity : BaseActivity() {
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private var requestLauncherSetup = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -64,7 +69,24 @@ class EntityWidgetConfigureActivity : BaseActivity() {
         binding = WidgetStaticConfigureBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.addButton.setOnClickListener(addWidgetButtonClickListener)
+        binding.addButton.setOnClickListener {
+            if (requestLauncherSetup) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    getSystemService<AppWidgetManager>()?.requestPinAppWidget(
+                        ComponentName(this, EntityWidget::class.java),
+                        null,
+                        PendingIntent.getActivity(
+                            this,
+                            System.currentTimeMillis().toInt(),
+                            Intent(this, EntityWidgetConfigureActivity::class.java).putExtra(PIN_WIDGET_CALLBACK, true).setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                        )
+                    )
+                } else showAddWidgetError() // this shouldn't be possible
+            } else {
+                onAddWidget()
+            }
+        }
 
         // Find the widget id from the intent.
         val intent = intent
@@ -73,10 +95,13 @@ class EntityWidgetConfigureActivity : BaseActivity() {
             appWidgetId = extras.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
             )
+            requestLauncherSetup = extras.getBoolean(
+                ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, false
+            )
         }
 
         // If this activity was started with an intent without an app widget ID, finish with an error.
-        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID && !requestLauncherSetup) {
             finish()
             return
         }
@@ -182,9 +207,12 @@ class EntityWidgetConfigureActivity : BaseActivity() {
         }
     }
 
-    private var addWidgetButtonClickListener = View.OnClickListener {
+    private fun onAddWidget() {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            showAddWidgetError()
+            return
+        }
         try {
-
             val context = this@EntityWidgetConfigureActivity
 
             // Set up a broadcast intent and pass the service call data as extras
@@ -244,14 +272,27 @@ class EntityWidgetConfigureActivity : BaseActivity() {
             finish()
         } catch (e: Exception) {
             Log.e(TAG, "Issue configuring widget", e)
-            Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG)
-                .show()
+            showAddWidgetError()
         }
+    }
+
+    private fun showAddWidgetError() {
+        Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG).show()
     }
 
     override fun onDestroy() {
         mainScope.cancel()
         super.onDestroy()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (intent != null && intent.extras != null && intent.hasExtra(PIN_WIDGET_CALLBACK)) {
+            appWidgetId = intent.extras!!.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
+            )
+            onAddWidget()
+        }
     }
 
     private var onDeleteWidget = View.OnClickListener {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -1,21 +1,25 @@
 package io.homeassistant.companion.android.widgets.media_player_controls
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import android.widget.AutoCompleteTextView
 import android.widget.Toast
+import androidx.core.content.getSystemService
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetMediaControlsConfigureBinding
+import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,9 +35,11 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
 
     companion object {
         private const val TAG: String = "MediaWidgetConfigAct"
+        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.media_player_controls.MediaPlayerControlsWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private var requestLauncherSetup = false
 
     @Inject
     lateinit var integrationUseCase: IntegrationRepository
@@ -55,7 +61,24 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
         binding = WidgetMediaControlsConfigureBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.addButton.setOnClickListener(addWidgetButtonClickListener)
+        binding.addButton.setOnClickListener {
+            if (requestLauncherSetup) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    getSystemService<AppWidgetManager>()?.requestPinAppWidget(
+                        ComponentName(this, MediaPlayerControlsWidget::class.java),
+                        null,
+                        PendingIntent.getActivity(
+                            this,
+                            System.currentTimeMillis().toInt(),
+                            Intent(this, MediaPlayerControlsWidgetConfigureActivity::class.java).putExtra(PIN_WIDGET_CALLBACK, true).setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                        )
+                    )
+                } else showAddWidgetError() // this shouldn't be possible
+            } else {
+                onAddWidget()
+            }
+        }
 
         // Find the widget id from the intent.
         val intent = intent
@@ -64,10 +87,13 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
             appWidgetId = extras.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
             )
+            requestLauncherSetup = extras.getBoolean(
+                ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, false
+            )
         }
 
         // If this activity was started with an intent without an app widget ID, finish with an error.
-        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID && !requestLauncherSetup) {
             finish()
             return
         }
@@ -138,9 +164,12 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
             selectedEntity = parent.getItemAtPosition(position) as Entity<Any>?
         }
 
-    private var addWidgetButtonClickListener = View.OnClickListener {
+    private fun onAddWidget() {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            showAddWidgetError()
+            return
+        }
         try {
-
             val context = this@MediaPlayerControlsWidgetConfigureActivity
 
             // Set up a broadcast intent and pass the service call data as extras
@@ -177,14 +206,27 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
             finish()
         } catch (e: Exception) {
             Log.e(TAG, "Issue configuring widget", e)
-            Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG)
-                .show()
+            showAddWidgetError()
         }
+    }
+
+    private fun showAddWidgetError() {
+        Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG).show()
     }
 
     override fun onDestroy() {
         mainScope.cancel()
         super.onDestroy()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (intent != null && intent.extras != null && intent.hasExtra(PIN_WIDGET_CALLBACK)) {
+            appWidgetId = intent.extras!!.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
+            )
+            onAddWidget()
+        }
     }
 
     private var onDeleteWidget = View.OnClickListener {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -1,19 +1,24 @@
 package io.homeassistant.companion.android.widgets.template
 
+import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.text.Html.fromHtml
 import android.view.View
 import android.view.View.VISIBLE
+import android.widget.Toast
+import androidx.core.content.getSystemService
 import androidx.core.widget.doAfterTextChanged
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetTemplateConfigureBinding
+import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -27,6 +32,7 @@ import io.homeassistant.companion.android.common.R as commonR
 class TemplateWidgetConfigureActivity : BaseActivity() {
     companion object {
         private const val TAG: String = "TemplateWidgetConfigAct"
+        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     @Inject
@@ -38,6 +44,7 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private var requestLauncherSetup = false
 
     public override fun onCreate(icicle: Bundle?) {
         super.onCreate(icicle)
@@ -56,10 +63,13 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
             appWidgetId = extras.getInt(
                 AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
             )
+            requestLauncherSetup = extras.getBoolean(
+                ManageWidgetsViewModel.CONFIGURE_REQUEST_LAUNCHER, false
+            )
         }
 
         // If this activity was started with an intent without an app widget ID, finish with an error.
-        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID && !requestLauncherSetup) {
             finish()
             return
         }
@@ -92,25 +102,63 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
         }
 
         binding.addButton.setOnClickListener {
-            val createIntent = Intent().apply {
-                action = BaseWidgetProvider.RECEIVE_DATA
-                component = ComponentName(applicationContext, TemplateWidget::class.java)
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-                putExtra(TemplateWidget.EXTRA_TEMPLATE, binding.templateText.text.toString())
+            if (requestLauncherSetup) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    getSystemService<AppWidgetManager>()?.requestPinAppWidget(
+                        ComponentName(this, TemplateWidget::class.java),
+                        null,
+                        PendingIntent.getActivity(
+                            this,
+                            System.currentTimeMillis().toInt(),
+                            Intent(this, TemplateWidgetConfigureActivity::class.java).putExtra(PIN_WIDGET_CALLBACK, true).setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP),
+                            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+                        )
+                    )
+                } else showAddWidgetError() // this shouldn't be possible
+            } else {
+                onAddWidget()
             }
-            applicationContext.sendBroadcast(createIntent)
-
-            setResult(
-                RESULT_OK,
-                Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            )
-            finish()
         }
+    }
+
+    private fun onAddWidget() {
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            showAddWidgetError()
+            return
+        }
+
+        val createIntent = Intent().apply {
+            action = BaseWidgetProvider.RECEIVE_DATA
+            component = ComponentName(applicationContext, TemplateWidget::class.java)
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+            putExtra(TemplateWidget.EXTRA_TEMPLATE, binding.templateText.text.toString())
+        }
+        applicationContext.sendBroadcast(createIntent)
+
+        setResult(
+            RESULT_OK,
+            Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+        )
+        finish()
+    }
+
+    private fun showAddWidgetError() {
+        Toast.makeText(applicationContext, commonR.string.widget_creation_error, Toast.LENGTH_LONG).show()
     }
 
     override fun onDestroy() {
         mainScope.cancel()
         super.onDestroy()
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        if (intent != null && intent.extras != null && intent.hasExtra(PIN_WIDGET_CALLBACK)) {
+            appWidgetId = intent.extras!!.getInt(
+                AppWidgetManager.EXTRA_APPWIDGET_ID, AppWidgetManager.INVALID_APPWIDGET_ID
+            )
+            onAddWidget()
+        }
     }
 
     private fun renderTemplateText(template: String) {

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -4,7 +4,7 @@
     <release version="Beta">
         <change>&lt;b&gt;Breaking Change:&lt;/b&gt; Local Push notifications directly from your Home Assistant instance. The app will need to maintain a consistent websocket connection by using a persistent notification. You are free to minimize the notification channel to hide the icon.</change>
         <change>Add change log dialog to show when the app is updated. Can also be accessed in settings.</change>
-        <change>Minor design changes to Manage Widgets page</change>
+        <change>Add option to add a new widget and other design changes on the Manage Widgets page</change>
         <change>Add notification channel settings so they are easier to find</change>
         <change>Add icons to settings</change>
         <change>Improve reliability of opening entity information from device controls</change>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -322,7 +322,7 @@
     <string name="nfc_write_tag_too_early">Please fill out the form first</string>
     <string name="no_notifications_summary">You have not received any notifications yet</string>
     <string name="no_notifications">No Notifications</string>
-    <string name="no_widgets_summary">You have not added any widgets, please add one from the home screen to populate this list.</string>
+    <string name="no_widgets_summary">When you add a configurable widget to your home screen, you will see it here</string>
     <string name="no_widgets">No Widgets Found</string>
     <string name="none">None</string>
     <string name="not_private">Your connection to this site is not private.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
With the new Compose-based UI for managing widgets, the empty state arguably became worse, showing only the text "No Widgets Found" with almost no formatting and no information on how you can solve it.

This PR updates the empty state for the widget settings to restore the summary text (edited to reflect that camera widgets won't show up) and make the layout look nicer (following Material guidelines).
For devices running Android 8+ with a compatible launcher, this PR will also add a button to the widget settings screen to add a new widget to the home screen, to make it easier to 'solve the problem' of no added widgets or for when users simply decide to add a widget while browsing the list of existing widgets.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
As a reminder, the current empty state of the "Manage Widgets" screen on the latest beta version:
|Light|Dark|
|----|----|
|![Manage Widgets screen with "No Widgets Found" text in the top left corner, without any padding, light mode](https://user-images.githubusercontent.com/8148535/151066924-31d3fc93-e7a7-4bbc-b365-99e4caf90822.png)|![Manage Widgets screen with "No Widgets Found" text in the top left corner, without any padding, dark mode](https://user-images.githubusercontent.com/8148535/151066945-20cdac76-13db-418e-8109-4afa1c233ce7.png)|

This PR updates the empty state to:
|Light|Dark|
|----|----|
|![Manage Widgets screen with centered column with: a widgets icon, larger "No Widgets Found" text and a short text that explains that configurable widgets will be shown in this screen, light mode](https://user-images.githubusercontent.com/8148535/151067140-0185ad90-4947-47e4-9977-78c24c8f426c.png)|![Manage Widgets screen with centered column with: a widgets icon, larger "No Widgets Found" text and a short text that explains that configurable widgets will be shown in this screen, dark mode](https://user-images.githubusercontent.com/8148535/151067149-ed284c16-0320-4ba7-807b-e8a449b8639d.png)|

As you can see, there is now a 'Add widget' button (if the device is on Android 8+ and the launcher supports it). Tapping on 'Add widget' will show a dialog with all widgets. I've tried to use a similar style to the default `AlertDialog` and also the dialog in the Home Assistant frontend for creating something new like an automation helper (input_* entity):
|Light|Dark|
|----|----|
|![A dialog showing camera widget, entity state, media player widget, service button, and template widget, each with an icon, light mode](https://user-images.githubusercontent.com/8148535/151067498-e58aed88-4bdb-47bf-a86c-42b0ae7294f8.png)|![A dialog showing camera widget, entity state, media player widget, service button, and template widget, each with an icon, dark mode](https://user-images.githubusercontent.com/8148535/151067541-a811d8e4-e949-4104-a66d-14f6610ac8aa.png)|

After selecting a widget, it will show the configuration activity like when it is dragged to the home screen from the home screen's widget menu. However, when you tap on the button to add the widget, the launcher will show a dialog to add it:
|Light|Dark|
|----|----|
|![A popup with the title "Pixel Launcher" at the bottom of the screen that shows a preview of the widget that is about to be added to the home screen, light mode](https://user-images.githubusercontent.com/8148535/151068036-b628aa48-29b7-435d-989b-99dfa27e491e.png)|![A popup with the title "Pixel Launcher" at the bottom of the screen that shows a preview of the widget that is about to be added to the home screen, dark mode](https://user-images.githubusercontent.com/8148535/151068012-14cc50cc-41a6-4579-b16b-19725839c538.png)|

After adding the widget, the app will return to the widget settings where the new widget is now shown in the list:
|Light|Dark|
|----|----|
|![Manage Widgets screen showing a title "Entity State widgets", with a button for the widget that was just added, light mode](https://user-images.githubusercontent.com/8148535/151068289-c8713dbb-48b0-4d93-8da9-1a9b2c54fffa.png)|![Manage Widgets screen showing a title "Entity State widgets", with a button for the widget that was just added, dark mode](https://user-images.githubusercontent.com/8148535/151068323-ef4801d9-83cb-4040-8ed6-176284dfcf03.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
The current documentation offers default instructions that work for everyone who can use widgets, the "Add widget" button might not be available depending on the device used so I think it is best to keep the documentation as it is right now.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
In the widget configuration classes there is quite a lot of duplicate code, and this PR adds even more code + moves some existing code around. I think it would be a good idea to refactor these classes to reduce duplication, but that would've made this PR too big.