### PR TITLE
Bump and fix Android Gradle Plugin from 7.0.4 to 7.1.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -118,8 +118,8 @@ android {
     }
 
     lint {
-        isAbortOnError = false
-        disable("MissingTranslation")
+        abortOnError = false
+        disable += "MissingTranslation"
     }
 
     kapt {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31")
         classpath("com.google.gms:google-services:4.3.10")
         classpath("com.google.firebase:firebase-appdistribution-gradle:3.0.0")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -38,8 +38,8 @@ android {
     }
 
     lint {
-        isAbortOnError = false
-        disable("MissingTranslation")
+        abortOnError = false
+        disable += "MissingTranslation"
     }
 
     kapt {

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -67,7 +67,7 @@ android {
     }
 
     lint {
-        disable("MissingTranslation")
+        disable += "MissingTranslation"
     }
 
     kapt {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
AGP 7.1.0's Lint DSL has renamed `isAbortOnError` to `abortOnError` (although according to the [documentation](https://developer.android.com/reference/tools/gradle-api/7.0/com/android/build/api/dsl/Lint) this was already in 7.0?) and has removed the functions to edit the `disable` set. This PR updates the lint configuration to fix the build.

Closes #2202 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->