### PR TITLE
Check for permissions and notify if they are missing when command_bluetooth is used

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
     <string name="message_some_installed">The Wear app is installed on some of your wear devices: (%1$s)\n\nClick the button below to install the app on the other devices.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
     <string name="mfa_title">Two-factor\nAuthentication</string>
     <string name="mfa_hint">Code</string>
-    <string name="missing_command_permission">Please open the Home Assistant app and send the command again in order to grant the proper permissions.</string>
+    <string name="missing_command_permission">Please open the Home Assistant app and send the command again in order to grant the proper permissions. You will be taken to a page to either grant the Home Assistant app the permission, or you will need to select Permissions from the details page and then grant the missing permission. For command_bluetooth the name of the permission is Nearby devices.</string>
     <string name="areas">Areas</string>
     <string name="more_entities">More entities</string>
     <string name="need_help">Need Help?</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the below sentry error by checking for permissions and if the user has not granted them we notify the user and explain how to grant them. As this command needs a different permission not linked to a particular activity and the commands are sent in the background we take the user to app details and have them grant the permission. String was also updated to reflect this. Only impacts users on Android 12 who attempt to use `command_bluetooth` without proper permissions, usualy a user will have already granted this permission assuming they had the sensor enabled.

```
java.lang.SecurityException: Need android.permission.BLUETOOTH_CONNECT permission for AttributionSource { uid = 10309, packageName = io.homeassistant.companion.android, attributionTag = null, token = android.os.BinderProxy@ba98dfd, next = null }: enable
    at android.os.Parcel.createExceptionOrNull(Parcel.java:2437)
    at android.os.Parcel.createException(Parcel.java:2421)
    at android.os.Parcel.readException(Parcel.java:2404)
    at android.os.Parcel.readException(Parcel.java:2346)
    at android.bluetooth.IBluetoothManager$Stub$Proxy.enable(IBluetoothManager.java:987)
    at android.bluetooth.BluetoothAdapter.enable(BluetoothAdapter.java:2200)
    at io.homeassistant.companion.android.notifications.MessagingManager.handleDeviceCommands(MessagingManager.kt:550)
    at io.homeassistant.companion.android.notifications.MessagingManager.handleMessage(MessagingManager.kt:277)
    at io.homeassistant.companion.android.notifications.FirebaseCloudMessagingService.onMessageReceived(FirebaseCloudMessagingService.kt:38)
    at com.google.firebase.messaging.FirebaseMessagingService.dispatchMessage(com.google.firebase:firebase-messaging@@23.0.0:12)
    at com.google.firebase.messaging.FirebaseMessagingService.passMessageIntentToSdk(com.google.firebase:firebase-messaging@@23.0.0:8)
    at com.google.firebase.messaging.FirebaseMessagingService.handleMessageIntent(com.google.firebase:firebase-messaging@@23.0.0:3)
    at com.google.firebase.messaging.FirebaseMessagingService.handleIntent(com.google.firebase:firebase-messaging@@23.0.0:3)
    at com.google.firebase.messaging.EnhancedIntentService.lambda$processIntent$0$com-google-firebase-messaging-EnhancedIntentService(com.google.firebase:firebase-messaging@@23.0.0:1)
    at com.google.firebase.messaging.EnhancedIntentService$$ExternalSyntheticLambda1.run
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
    at com.google.android.gms.common.util.concurrent.zza.run(com.google.android.gms:play-services-basement@@18.0.0:2)
    at java.lang.Thread.run(Thread.java:920)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->