### PR TITLE
Use same group check as before when a group is used to avoid null error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -719,7 +719,7 @@ class MessagingManager @Inject constructor(
         notificationManagerCompat.apply {
             Log.d(TAG, "Show notification with tag \"$tag\" and id \"$messageId\"")
             notify(tag, messageId, notificationBuilder.build())
-            if (group != null) {
+            if (!group.isNullOrBlank()) {
                 Log.d(TAG, "Show group notification with tag \"$group\" and id \"$groupId\"")
                 notify(group, groupId, getGroupNotificationBuilder(channelId, group, data).build())
             } else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the below sentry error by preventing the case when `group` is blank. We just use the same condition as when we set the values so we know they are not null or blank.

https://github.com/home-assistant/android/blob/master/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt#L665

```
java.lang.StringIndexOutOfBoundsException: length=0; index=6
    at java.lang.String.substring(String.java:2027)
    at io.homeassistant.companion.android.notifications.MessagingManager.getGroupNotificationBuilder(MessagingManager.kt:827)
    at io.homeassistant.companion.android.notifications.MessagingManager.sendNotification(MessagingManager.kt:721)
    at io.homeassistant.companion.android.notifications.MessagingManager.access$sendNotification(MessagingManager.kt:72)
    at io.homeassistant.companion.android.notifications.MessagingManager$handleMessage$12.invokeSuspend(MessagingManager.kt:360)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at android.app.ActivityThread.main(ActivityThread.java:8582)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:563)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1133)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->