### PR TITLE
Allow toggling covers and fans on Wear OS

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
@@ -42,6 +42,7 @@ class SettingsWearViewModel @Inject constructor(
 
         private const val KEY_UPDATE_TIME = "UpdateTime"
         private const val KEY_IS_AUTHENTICATED = "isAuthenticated"
+        private const val KEY_SUPPORTED_DOMAINS = "supportedDomains"
         private const val KEY_FAVORITES = "favorites"
         private const val KEY_TEMPLATE_TILE = "templateTile"
         private const val KEY_TEMPLATE_TILE_REFRESH_INTERVAL = "templateTileRefreshInterval"
@@ -54,6 +55,8 @@ class SettingsWearViewModel @Inject constructor(
     var isAuthenticated = mutableStateOf(false)
         private set
     var entities = mutableStateMapOf<String, Entity<*>>()
+        private set
+    var supportedDomains = mutableStateListOf<String>()
         private set
     var favoriteEntityIds = mutableStateListOf<String>()
         private set
@@ -214,6 +217,10 @@ class SettingsWearViewModel @Inject constructor(
 
     private fun onLoadConfigFromWear(data: DataMap) {
         isAuthenticated.value = data.getBoolean(KEY_IS_AUTHENTICATED, false)
+        val supportedDomainsList: List<String> =
+            objectMapper.readValue(data.getString(KEY_SUPPORTED_DOMAINS, "[\"input_boolean\", \"light\", \"lock\", \"switch\", \"script\", \"scene\"]"))
+        supportedDomains.clear()
+        supportedDomains.addAll(supportedDomainsList)
         val favoriteEntityIdList: List<String> =
             objectMapper.readValue(data.getString(KEY_FAVORITES, "[]"))
         favoriteEntityIds.clear()

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -35,9 +35,6 @@ import org.burnoutcrew.reorderable.reorderable
 import io.homeassistant.companion.android.common.R as commonR
 
 const val WEAR_DOCS_LINK = "https://companion.home-assistant.io/docs/wear-os/"
-val supportedDomains = listOf(
-    "input_boolean", "light", "lock", "switch", "script", "scene"
-)
 
 @Composable
 fun LoadWearFavoritesSettings(
@@ -46,7 +43,7 @@ fun LoadWearFavoritesSettings(
     val context = LocalContext.current
     val reorderState = rememberReorderState()
 
-    val validEntities = settingsWearViewModel.entities.filter { it.key.split(".")[0] in supportedDomains }.values.sortedBy { it.entityId }.toList()
+    val validEntities = settingsWearViewModel.entities.filter { it.key.split(".")[0] in settingsWearViewModel.supportedDomains }.values.sortedBy { it.entityId }.toList()
     val favoriteEntities = settingsWearViewModel.favoriteEntityIds
     Scaffold(
         topBar = {
@@ -176,6 +173,8 @@ fun LoadWearFavoritesSettings(
 @Composable
 private fun getDomainString(domain: String): String {
     return when (domain) {
+        "cover" -> stringResource(commonR.string.domain_cover)
+        "fan" -> stringResource(commonR.string.domain_fan)
         "input_boolean" -> stringResource(commonR.string.domain_input_boolean)
         "light" -> stringResource(commonR.string.domain_light)
         "lock" -> stringResource(commonR.string.domain_lock)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -116,6 +116,7 @@
     <string name="connect">Connect</string>
     <string name="connected_to_home_assistant">Connected to Home Assistant</string>
     <string name="continue_connect">Continue</string>
+    <string name="covers">Covers</string>
     <string name="crash_reporting_summary">Help the developers fix bugs and crashes by leaving this enabled. If the application crashes this will automatically generate and send a report. If you notice a crash also create an issue on Github!</string>
     <string name="crash_reporting">Crash Reporting</string>
     <string name="create_template">Create Template</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -179,6 +179,7 @@
     <string name="failed_registration">Could not register</string>
     <string name="failed_scan">Scanning for Home Assistant failed.</string>
     <string name="failure_send_favorites_wear">Failed to send favorites selection to Wear OS</string>
+    <string name="fans">Fans</string>
     <string name="favorite_settings">Favorite Settings</string>
     <string name="favorite">Set Favorite Entities</string>
     <string name="favorites">Favorites</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -36,6 +36,7 @@ class HomePresenterImpl @Inject constructor(
             "media_player", "remote", "siren", "switch"
         )
         val domainsWithNames = mapOf(
+            "fan" to commonR.string.fans,
             "input_boolean" to commonR.string.input_booleans,
             "light" to commonR.string.lights,
             "lock" to commonR.string.locks,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -36,6 +36,7 @@ class HomePresenterImpl @Inject constructor(
             "media_player", "remote", "siren", "switch"
         )
         val domainsWithNames = mapOf(
+            "cover" to commonR.string.covers,
             "fan" to commonR.string.fans,
             "input_boolean" to commonR.string.input_booleans,
             "light" to commonR.string.lights,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -38,8 +38,9 @@ fun EntityUi(
     val friendlyName = attributes["friendly_name"].toString()
 
     if (entity.entityId.split(".")[0] in HomePresenterImpl.toggleDomains) {
+        val isChecked = entity.state in listOf("on", "locked", "open", "opening")
         ToggleChip(
-            checked = entity.state == "on" || entity.state == "locked",
+            checked = isChecked,
             onCheckedChange = {
                 onEntityClicked(entity.entityId, entity.state)
                 onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, friendlyName, haptic)
@@ -60,7 +61,7 @@ fun EntityUi(
                 )
             },
             enabled = entity.state != "unavailable",
-            toggleIcon = { ToggleChipDefaults.SwitchIcon(entity.state == "on") }
+            toggleIcon = { ToggleChipDefaults.SwitchIcon(isChecked) }
         )
     } else {
         Chip(

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -22,6 +22,7 @@ import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.wear.Favorites
 import io.homeassistant.companion.android.home.HomeActivity
+import io.homeassistant.companion.android.home.HomePresenterImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -49,6 +50,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
 
         private const val KEY_UPDATE_TIME = "UpdateTime"
         private const val KEY_IS_AUTHENTICATED = "isAuthenticated"
+        private const val KEY_SUPPORTED_DOMAINS = "supportedDomains"
         private const val KEY_FAVORITES = "favorites"
         private const val KEY_TEMPLATE_TILE = "templateTile"
         private const val KEY_TEMPLATE_TILE_REFRESH_INTERVAL = "templateTileRefreshInterval"
@@ -67,6 +69,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
         val putDataRequest = PutDataMapRequest.create("/config").run {
             dataMap.putLong(KEY_UPDATE_TIME, System.nanoTime())
             dataMap.putBoolean(KEY_IS_AUTHENTICATED, integrationUseCase.isRegistered())
+            dataMap.putString(KEY_SUPPORTED_DOMAINS, objectMapper.writeValueAsString(HomePresenterImpl.supportedDomains))
             dataMap.putString(KEY_FAVORITES, objectMapper.writeValueAsString(currentFavorites.map { it.id }))
             dataMap.putString(KEY_TEMPLATE_TILE, integrationUseCase.getTemplateTileContent())
             dataMap.putInt(KEY_TEMPLATE_TILE_REFRESH_INTERVAL, integrationUseCase.getTemplateTileRefreshInterval())

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -107,6 +107,7 @@ class ShortcutsTile : TileService() {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
                             when (entity.entityId.split(".")[0]) {
+                                "cover" -> "window-closed"
                                 "fan" -> "fan"
                                 "input_boolean", "switch" -> "light_switch"
                                 "light" -> "lightbulb"

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -107,6 +107,7 @@ class ShortcutsTile : TileService() {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
                             when (entity.entityId.split(".")[0]) {
+                                "fan" -> "fan"
                                 "input_boolean", "switch" -> "light_switch"
                                 "light" -> "lightbulb"
                                 "lock" -> "lock"

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -107,7 +107,7 @@ class ShortcutsTile : TileService() {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
                             when (entity.entityId.split(".")[0]) {
-                                "cover" -> "window-closed"
+                                "cover" -> "window_closed"
                                 "fan" -> "fan"
                                 "input_boolean", "switch" -> "light_switch"
                                 "light" -> "lightbulb"

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -15,6 +15,7 @@ fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
         IconicsDrawable(context, "cmd-$mdiIcon").icon
     } else {
         when (domain) {
+            "fan" -> CommunityMaterial.Icon2.cmd_fan
             "input_boolean", "switch" -> CommunityMaterial.Icon2.cmd_light_switch
             "light" -> CommunityMaterial.Icon2.cmd_lightbulb
             "lock" -> CommunityMaterial.Icon2.cmd_lock

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -15,6 +15,7 @@ fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
         IconicsDrawable(context, "cmd-$mdiIcon").icon
     } else {
         when (domain) {
+            "cover" -> CommunityMaterial.Icon3.cmd_window_closed
             "fan" -> CommunityMaterial.Icon2.cmd_fan
             "input_boolean", "switch" -> CommunityMaterial.Icon2.cmd_light_switch
             "light" -> CommunityMaterial.Icon2.cmd_lightbulb


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support to the Wear OS app to toggle other entities I could easily test: entities in the `cover` and `fan` domain. It also fixes the chip for locks being highlighted as on or off, but the toggle itself always being off.

Fixes #2211

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
**Wear OS**

Something changed in Android Studio 2021.1 and now my emulator screenshots are all fuzzy, sorry about that.

![Wear OS home screen showing 'Covers' and 'Fans' domains options in the list](https://user-images.githubusercontent.com/8148535/151709417-80b309af-cda2-4f11-ac2b-76bbacc6325c.png)

Open/closed for covers is 'converted' to on/off, matching device controls on phones.
!['Covers' screen showing one cover named "Template cover" with status on](https://user-images.githubusercontent.com/8148535/151709437-cf63729d-8ad4-409c-99a2-7610bc40f51f.png)

!['Fans' screen showing two fans, with one turned on and another turned off](https://user-images.githubusercontent.com/8148535/151709440-868370ac-a1e5-40d0-8712-0839b694a037.png)

**Phone settings**
|Light|Dark|
|----|----|
|![Companion app on phone showing the Wear OS favorite settings, with new entities cover/fan at the top of the list, light mode](https://user-images.githubusercontent.com/8148535/151711022-93b9dced-9eef-4db4-9d16-b77f7fde9e52.png)|![Companion app on phone showing the Wear OS favorite settings, with new entities cover/fan at the top of the list, dark mode](https://user-images.githubusercontent.com/8148535/151711028-a438157a-1b3e-4733-bf65-1985275c32f7.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#672

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->