### PR TITLE
Breaking change: hide non-primary entities on Wear home screen

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
@@ -3,5 +3,6 @@ package io.homeassistant.companion.android.common.data.websocket.impl.entities
 data class EntityRegistryResponse(
     val areaId: String?,
     val deviceId: String?,
+    val entityCategory: String?,
     val entityId: String
 )

--- a/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
@@ -26,4 +26,11 @@ object RegistriesDataHandler {
         }
         return null
     }
+
+    fun getCategoryForEntity(
+        entityId: String,
+        entityRegistry: List<EntityRegistryResponse>?
+    ): String? {
+        return entityRegistry?.firstOrNull { it.entityId == entityId }?.entityCategory
+    }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -193,6 +193,9 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     fun getAreaForEntity(entityId: String): AreaRegistryResponse? =
         RegistriesDataHandler.getAreaForEntity(entityId, areaRegistry, deviceRegistry, entityRegistry)
 
+    fun getCategoryForEntity(entityId: String): String? =
+        RegistriesDataHandler.getCategoryForEntity(entityId, entityRegistry)
+
     private fun getFavorites() {
         viewModelScope.launch {
             favorites()?.collect {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Right now the Wear OS app is usable, but the current approach can still create long lists on a small screen if you have a lot of entities and/or when we start supporting more domains in the future. Thinking about what you'd use the app for and how we matched the autogenerated Lovelace dashboard in showing areas first and then domains for usability, I believe we should hide configuration and diagnostic (non-primary) entities on the home screen from the main areas and domains lists, which [the autogenerated dashboard also started doing in 2021.11](https://www.home-assistant.io/blog/2021/11/03/release-202111/#entity-categorization).

This PR filters the entities shown in 'Areas' and 'More entities' on the home screen to only show primary entities. All types of entities, primary and non-primary, will remain available using the 'All entities' button and anywhere else in the app, so you can still use it on the shortcut tile and even add it as a favorite to the app's home screen.

Because this might hide entities users are currently seeing on the app's home screen, this is a **breaking change**.

**Something I would like input on**: should there be an option in the app to show non-primary entities on the home screen (current behavior)? Lovelace doesn't offer such an option but you can create your own dashboard with everything you want, whereas you can't really change the app's home screen aside from favorites. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
This will depend on the instance, but as an example, in the current app I have two configuration switches exposed by a motion sensor:
![image](https://user-images.githubusercontent.com/8148535/151720763-617f36a0-c1ca-42b7-9766-f3618857f79f.png) ![image](https://user-images.githubusercontent.com/8148535/151720770-5610ed55-5fd9-4fa1-ac3d-1adc882a8391.png)

As seen in HA's frontend:
![image](https://user-images.githubusercontent.com/8148535/151721394-122c66a4-09c6-4bf3-b386-04070e172c2a.png)

After this change, the switches domain will be removed for me because I don't have any primary area-less switches:
![image](https://user-images.githubusercontent.com/8148535/151720820-12750812-f929-42b0-b61e-61609684e128.png)

The switches are still available in 'All entities':
![image](https://user-images.githubusercontent.com/8148535/151720824-9f84ddc1-524a-4cd8-97a1-1a1eb189ec5f.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#673

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->