### PR TITLE
Fix adding widgets with invalid config via app to home screen

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -286,7 +286,10 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
         binding.addFieldButton.setOnClickListener(onAddFieldListener)
         binding.addButton.setOnClickListener {
             if (requestLauncherSetup) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val widgetConfigService = binding.widgetTextConfigService.text.toString()
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                    (widgetConfigService in services || widgetConfigService.split(".", limit = 2).size == 2)
+                ) {
                     getSystemService<AppWidgetManager>()?.requestPinAppWidget(
                         ComponentName(this, ButtonWidget::class.java),
                         null,
@@ -297,7 +300,7 @@ class ButtonWidgetConfigureActivity : BaseActivity(), IconDialog.Callback {
                             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                         )
                     )
-                } else showAddWidgetError() // this shouldn't be possible
+                } else showAddWidgetError()
             } else {
                 onAddWidget()
             }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
@@ -57,7 +57,7 @@ class CameraWidgetConfigureActivity : BaseActivity() {
 
         binding.addButton.setOnClickListener {
             if (requestLauncherSetup) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && selectedEntity != null) {
                     getSystemService<AppWidgetManager>()?.requestPinAppWidget(
                         ComponentName(this, CameraWidget::class.java),
                         null,
@@ -68,7 +68,7 @@ class CameraWidgetConfigureActivity : BaseActivity() {
                             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                         )
                     )
-                } else showAddWidgetError() // this shouldn't be possible
+                } else showAddWidgetError()
             } else {
                 onAddWidget()
             }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -63,7 +63,7 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
 
         binding.addButton.setOnClickListener {
             if (requestLauncherSetup) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && selectedEntity != null) {
                     getSystemService<AppWidgetManager>()?.requestPinAppWidget(
                         ComponentName(this, MediaPlayerControlsWidget::class.java),
                         null,
@@ -74,7 +74,7 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
                             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
                         )
                     )
-                } else showAddWidgetError() // this shouldn't be possible
+                } else showAddWidgetError()
             } else {
                 onAddWidget()
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Found a small bug in the new option to add widgets to your home screen via the app: invalid configuration only causes an exception when trying to save the data. However, when adding them via the app, the app will try saving the data _after_ asking the launcher to add a widget, resulting in an error after adding a widget to the home screen and the widget on the home screen will never be updated.

This PR adjusts that process to check the variable/input that would typically cause the exception before asking the launcher to add a widget. Validation in general could be better, but at least now adding widgets from the app will match the behavior of adding widgets from the home screen.

(To test: add the updated widget without setting any values.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->