### PR TITLE
Add an intent for the wifi state sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -101,7 +101,10 @@ open class HomeAssistantApplication : Application() {
         // This will trigger an update any time the wifi state has changed
         registerReceiver(
             sensorReceiver,
-            IntentFilter(WifiManager.NETWORK_STATE_CHANGED_ACTION)
+            IntentFilter().apply {
+                addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
+                addAction(WifiManager.WIFI_STATE_CHANGED_ACTION)
+            }
         )
 
         // This will cause the phone state sensor to be updated every time the OS broadcasts that a call triggered.

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.media.AudioManager
+import android.net.wifi.WifiManager
 import android.os.PowerManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
@@ -79,5 +80,6 @@ class SensorReceiver : SensorReceiverBase() {
         AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
         Intent.ACTION_MANAGED_PROFILE_UNAVAILABLE to DevicePolicyManager.isWorkProfile.id,
         Intent.ACTION_MANAGED_PROFILE_AVAILABLE to DevicePolicyManager.isWorkProfile.id,
+        WifiManager.WIFI_STATE_CHANGED_ACTION to NetworkSensorManager.wifiState.id,
     )
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was helping a user in the forums and for some reason their network state intent is not picking up and I came to find this intent which is related to the wifi state itself. Linking it to wifi state sensor as that is all this intent looks at. On my Pixel I dont see this intent but its possible other devices will pick it up, my pixel does pick up the network state change intent as expected when wifi is turned on/off.

https://developer.android.com/reference/android/net/wifi/WifiManager#WIFI_STATE_CHANGED_ACTION
https://community.home-assistant.io/t/force-updates-for-app-sensors/383846/23?u=dshokouhi

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->