### PR TITLE
Check the interactive state instead of display state for websocket connection

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -5,10 +5,9 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.hardware.display.DisplayManager
 import android.os.Build
+import android.os.PowerManager
 import android.util.Log
-import android.view.Display
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import androidx.work.Constraints
@@ -123,8 +122,8 @@ class WebsocketManager(
     }
 
     private fun shouldWeRun(): Boolean {
-        val dm = applicationContext.getSystemService(Context.DISPLAY_SERVICE) as DisplayManager
-        val displayOff = dm.displays.all { it.state == Display.STATE_OFF }
+        val powerManager = applicationContext.getSystemService<PowerManager>()!!
+        val displayOff = !powerManager.isInteractive
         val setting = settingsDao.get(0)?.websocketSetting ?: DEFAULT_WEBSOCKET_SETTING
         if (setting == WebsocketSetting.NEVER) {
             return false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We noticed in discord when the setting was set to Screen On the connection was lingering longer than we expected. So changing the call to use `isInteractive` from PowerManager as we know the screen on/off intents are linked to it.

https://developer.android.com/reference/android/os/PowerManager#isInteractive()

Now when I test with default settings the notification goes away after 30 seconds of the screen being off

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->