### PR TITLE
Support pressing (input_)buttons on Wear OS

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -173,6 +173,7 @@ fun LoadWearFavoritesSettings(
 @Composable
 private fun getDomainString(domain: String): String {
     return when (domain) {
+        "button" -> stringResource(commonR.string.domain_button)
         "cover" -> stringResource(commonR.string.domain_cover)
         "fan" -> stringResource(commonR.string.domain_fan)
         "input_boolean" -> stringResource(commonR.string.domain_input_boolean)

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -177,6 +177,7 @@ private fun getDomainString(domain: String): String {
         "cover" -> stringResource(commonR.string.domain_cover)
         "fan" -> stringResource(commonR.string.domain_fan)
         "input_boolean" -> stringResource(commonR.string.domain_input_boolean)
+        "input_button" -> stringResource(commonR.string.domain_input_button)
         "light" -> stringResource(commonR.string.domain_light)
         "lock" -> stringResource(commonR.string.domain_lock)
         "scene" -> stringResource(commonR.string.domain_scene)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -203,6 +203,7 @@
     <string name="home_assistant_not_discover">Unable to find your\nHome Assistant instance</string>
     <string name="icon">Icon</string>
     <string name="input_booleans">Input Booleans</string>
+    <string name="input_buttons">Input Buttons</string>
     <string name="input_url_hint">https://example.duckdns.org:8123</string>
     <string name="input_url">Home Assistant URL</string>
     <string name="install_app">Install App on Wear Device</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
     <string name="biometric_set_title">Confirm to continue</string>
     <string name="biometric_title">Home Assistant is locked</string>
     <string name="broadcast_intent_error">Unable to send broadcast intent, please check the command format</string>
+    <string name="buttons">Buttons</string>
     <string name="button_forward">Next</string>
     <string name="button_widget_desc">Call any service</string>
     <string name="calendar">Calendar</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -36,6 +36,7 @@ class HomePresenterImpl @Inject constructor(
             "media_player", "remote", "siren", "switch"
         )
         val domainsWithNames = mapOf(
+            "button" to commonR.string.buttons,
             "cover" to commonR.string.covers,
             "fan" to commonR.string.fans,
             "input_boolean" to commonR.string.input_booleans,
@@ -81,6 +82,7 @@ class HomePresenterImpl @Inject constructor(
     override suspend fun onEntityClicked(entityId: String, state: String) {
         val domain = entityId.split(".")[0]
         val serviceName = when (domain) {
+            "button" -> "press"
             "lock" -> {
                 // Defaults to locking, to be save
                 if (state == "locked")

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -40,6 +40,7 @@ class HomePresenterImpl @Inject constructor(
             "cover" to commonR.string.covers,
             "fan" to commonR.string.fans,
             "input_boolean" to commonR.string.input_booleans,
+            "input_button" to commonR.string.input_buttons,
             "light" to commonR.string.lights,
             "lock" to commonR.string.locks,
             "switch" to commonR.string.switches,
@@ -82,7 +83,7 @@ class HomePresenterImpl @Inject constructor(
     override suspend fun onEntityClicked(entityId: String, state: String) {
         val domain = entityId.split(".")[0]
         val serviceName = when (domain) {
-            "button" -> "press"
+            "button", "input_button" -> "press"
             "lock" -> {
                 // Defaults to locking, to be save
                 if (state == "locked")

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -107,7 +107,7 @@ class ShortcutsTile : TileService() {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
                             when (entity.entityId.split(".")[0]) {
-                                "button" -> "gesture_tap_button"
+                                "button", "input_button" -> "gesture_tap_button"
                                 "cover" -> "window_closed"
                                 "fan" -> "fan"
                                 "input_boolean", "switch" -> "light_switch"

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -107,6 +107,7 @@ class ShortcutsTile : TileService() {
                             entity.icon.split(":")[1]
                         } else { // Default scene icon
                             when (entity.entityId.split(".")[0]) {
+                                "button" -> "gesture_tap_button"
                                 "cover" -> "window_closed"
                                 "fan" -> "fan"
                                 "input_boolean", "switch" -> "light_switch"

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
@@ -38,6 +38,7 @@ class TileActionReceiver : BroadcastReceiver() {
 
                 val domain = entityId.split(".")[0]
                 val serviceName = when (domain) {
+                    "button" -> "press"
                     "lock" -> {
                         val lockEntity = integrationUseCase.getEntity(entityId)
                         if (lockEntity?.state == "locked")

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
@@ -38,7 +38,7 @@ class TileActionReceiver : BroadcastReceiver() {
 
                 val domain = entityId.split(".")[0]
                 val serviceName = when (domain) {
-                    "button" -> "press"
+                    "button", "input_button" -> "press"
                     "lock" -> {
                         val lockEntity = integrationUseCase.getEntity(entityId)
                         if (lockEntity?.state == "locked")

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -15,7 +15,7 @@ fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
         IconicsDrawable(context, "cmd-$mdiIcon").icon
     } else {
         when (domain) {
-            "button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
+            "button", "input_button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
             "cover" -> CommunityMaterial.Icon3.cmd_window_closed
             "fan" -> CommunityMaterial.Icon2.cmd_fan
             "input_boolean", "switch" -> CommunityMaterial.Icon2.cmd_light_switch

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -15,6 +15,7 @@ fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
         IconicsDrawable(context, "cmd-$mdiIcon").icon
     } else {
         when (domain) {
+            "button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
             "cover" -> CommunityMaterial.Icon3.cmd_window_closed
             "fan" -> CommunityMaterial.Icon2.cmd_fan
             "input_boolean", "switch" -> CommunityMaterial.Icon2.cmd_light_switch


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support for `button` and `input_button` entities to the Wear OS app.

Implements #2192 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Wear OS home screen showing 'Buttons' category to tap on](https://user-images.githubusercontent.com/8148535/152243572-44c9b4ca-76d7-409e-bc89-25e294b848d4.png)
![Wear OS home screen showing 'Input Buttons' category to tap on](https://user-images.githubusercontent.com/8148535/152243630-e8903953-0b31-4c5d-87ed-0a2dd0598cf8.png)
![Screen with a title 'Input Buttons', and one chip for a button that says 'Launch 🚀'](https://user-images.githubusercontent.com/8148535/152243671-aa92e457-fb16-4b32-ae2a-c00685a693e9.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#
Coming soon

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->