### PR TITLE
Support downloading files from WebViewActivity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1293,6 +1293,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 request.addRequestHeader("Authorization", presenter.getAuthorizationHeader())
             }
         }
+        try {
+            request.addRequestHeader("Cookie", CookieManager.getInstance().getCookie(url))
+        } catch (e: Exception) {
+            // Cannot get cookies, probably not relevant
+        }
 
         getSystemService<DownloadManager>()?.enqueue(request) ?: Log.d(TAG, "Unable to start download, cannot get DownloadManager")
     }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.webview
 
 import android.annotation.SuppressLint
+import android.app.DownloadManager
 import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
@@ -12,6 +13,7 @@ import android.net.Uri
 import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
+import android.os.Environment
 import android.os.Handler
 import android.os.Looper
 import android.os.VibrationEffect
@@ -31,6 +33,7 @@ import android.webkit.JavascriptInterface
 import android.webkit.JsResult
 import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
+import android.webkit.URLUtil
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
@@ -123,6 +126,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {
             webView.reload()
         }
+    private val requestStoragePermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                downloadFile(downloadFileUrl, downloadFileContentDisposition, downloadFileMimetype)
+            }
+        }
     private val writeNfcTag = registerForActivityResult(WriteNfcTag()) { messageId ->
         webView.externalBus(
             id = messageId,
@@ -184,6 +193,9 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private var moreInfoEntity = ""
     private val moreInfoMutex = Mutex()
     private var currentAutoplay: Boolean = false
+    private var downloadFileUrl = ""
+    private var downloadFileContentDisposition = ""
+    private var downloadFileMimetype = ""
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -362,6 +374,23 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                         }
                     }
                     return false
+                }
+            }
+
+            setDownloadListener { url, _, contentDisposition, mimetype, _ ->
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ||
+                    Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ||
+                    ActivityCompat.checkSelfPermission(
+                            context,
+                            android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        ) == PackageManager.PERMISSION_GRANTED
+                ) {
+                    downloadFile(url, contentDisposition, mimetype)
+                } else {
+                    downloadFileUrl = url
+                    downloadFileContentDisposition = contentDisposition
+                    downloadFileMimetype = mimetype
+                    requestStoragePermission.launch(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 }
             }
 
@@ -1245,6 +1274,25 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         Log.d(TAG, script)
 
         this.evaluateJavascript(script, callback)
+    }
+
+    private fun downloadFile(url: String, contentDisposition: String, mimetype: String) {
+        val request = DownloadManager.Request(Uri.parse(url))
+            .setMimeType(mimetype)
+            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            .setDestinationInExternalPublicDir(
+                Environment.DIRECTORY_DOWNLOADS,
+                URLUtil.guessFileName(url, contentDisposition, mimetype)
+            )
+        runBlocking {
+            if (url.startsWith(urlRepository.getUrl(true).toString()) ||
+                url.startsWith(urlRepository.getUrl(false).toString())
+            ) {
+                request.addRequestHeader("Authorization", presenter.getAuthorizationHeader())
+            }
+        }
+
+        getSystemService<DownloadManager>()?.enqueue(request)
     }
 
     override fun dispatchKeyEvent(event: KeyEvent?): Boolean {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -364,6 +364,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                 }
                                 return true
                             } else if (!webView.url.toString().contains(it.toString())) {
+                                Log.d(TAG, "Launching browser")
                                 val browserIntent = Intent(Intent.ACTION_VIEW, it)
                                 startActivity(browserIntent)
                                 return true
@@ -1277,6 +1278,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     private fun downloadFile(url: String, contentDisposition: String, mimetype: String) {
+        Log.d(TAG, "WebView requested download of $url")
         val request = DownloadManager.Request(Uri.parse(url))
             .setMimeType(mimetype)
             .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
@@ -1292,7 +1294,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
         }
 
-        getSystemService<DownloadManager>()?.enqueue(request)
+        getSystemService<DownloadManager>()?.enqueue(request) ?: Log.d(TAG, "Unable to start download, cannot get DownloadManager")
     }
 
     override fun dispatchKeyEvent(event: KeyEvent?): Boolean {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -28,5 +28,7 @@ interface WebViewPresenter {
 
     fun isSsidUsed(): Boolean
 
+    fun getAuthorizationHeader(): String
+
     suspend fun parseWebViewColor(webViewColor: String): Int
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -178,6 +178,12 @@ class WebViewPresenterImpl @Inject constructor(
         }
     }
 
+    override fun getAuthorizationHeader(): String {
+        return runBlocking {
+            authenticationUseCase.buildBearerToken()
+        }
+    }
+
     override suspend fun parseWebViewColor(webViewColor: String): Int = withContext(Dispatchers.IO) {
         var color = 0
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support for clicking on links which trigger a download of a file from the `WebViewActivity` to the Downloads folder. These links can be created both by the frontend (for example, downloading device diagnostics or supervisor back-ups) and third-party integrations or add-ons, the app will use the default callback from the webview for this.

Downloads are passed to the system's `DownloadManager`, so there is basically no logic for downloading/service in the app itself.

Fixes #2212, will probably fix #1341 but I'm unable to test with the community add-on that is mentioned in the issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
After tapping on a download, the system will display a download notification:
![Phone notifications showing an active download '20220202_Backup.tar' with an indeterminate progress bar](https://user-images.githubusercontent.com/8148535/152437075-40272d17-c4aa-4286-8071-62981307a357.png)

When it is finished, another notification is shown (alerting by default) which can be tapped to open the file:
![Phone notifications showing an alerting notification '20220202_Backup.tar - Download complete.'](https://user-images.githubusercontent.com/8148535/152437182-0dd41168-4efb-45e2-93b2-370dcee89495.png)

On Android 6, 7, 8 and 9, the user will need to grant permission to save the downloaded files:
![Alert dialog on top of the app with the text 'Allow Home Assistant to access photos, media, and files on your device?', with options for Don't ask again, Deny and Allow](https://user-images.githubusercontent.com/8148535/152437284-36e4df5c-7b9b-435d-bd23-1c2dce0e32ce.png)
The permission is requested when starting a download, if it is denied the app will do nothing (like the app does right now). Android <6 doesn't need a permission because of no permissions system, Android >= 10 doesn't need a permission because scoped storage allows downloading to the downloads folder by default.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Doesn't seem necessary

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->