### PR TITLE
Change Firebase Error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -96,7 +96,7 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
                     AlertDialog.Builder(this@LaunchActivity)
                         .setTitle(commonR.string.firebase_error_title)
                         .setMessage(commonR.string.firebase_error_message)
-                        .setPositiveButton(commonR.string.skip) { _, _ ->
+                        .setPositiveButton(commonR.string.continue_connect) { _, _ ->
                             mainScope.launch {
                                 registerAndOpenWebview(
                                     url,

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -190,7 +190,7 @@
     <string name="filter_sensors">Filter sensors</string>
     <string name="filter_show_only_enabled_sensors">Only enabled sensors</string>
     <string name="finish">Finish</string>
-    <string name="firebase_error_message">By skipping/ignoring this error you will be unable to receive any push notifications.</string>
+    <string name="firebase_error_message">This means you will be unable to receive cloud notifications.\n\nLocal notifications will still be available via websocket settings in companion app settings</string>
     <string name="firebase_error_title">Firebase Error</string>
     <string name="fullscreen_def">Put application in full screen</string>
     <string name="fullscreen">Fullscreen</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Changes the firebase error message to mention the loss of cloud notifications since we have local WebSocket notifications now as well also changes the skip button to continue as skip sounded like it should've had another option with it

Don't know why the error page glitches the logo out like that

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/37350695/152476238-0cc18398-144e-47d3-a782-3c909dcbd147.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->