### PR TITLE
Breaking change: Switch to android API to determine state of DND

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DNDSensorManager.kt
@@ -39,7 +39,8 @@ class DNDSensorManager : SensorManager {
     }
 
     override fun requestSensorUpdate(context: Context) {
-        updateDNDState(context)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            updateDNDState(context)
     }
 
     override fun hasSensor(context: Context): Boolean {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This PR is a breaking change as we are going to switch from the undocumented variable and use the actual android API so we can use the standard practice. This android API is only available on Android 6+ devices.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#678

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->