### PR TITLE
Breaking change: Always use package name for state of last used app

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -3,9 +3,7 @@ package io.homeassistant.companion.android.sensors
 import android.Manifest
 import android.app.usage.UsageStatsManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.BuildConfig
@@ -58,14 +56,7 @@ class LastAppSensorManager : SensorManager {
 
         val usageStats = context.getSystemService<UsageStatsManager>()!!
         val current = System.currentTimeMillis()
-        var lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
-        try {
-            val pm = context.packageManager
-            val appInfo = pm.getApplicationInfo(lastApp, PackageManager.GET_META_DATA)
-            lastApp = pm.getApplicationLabel(appInfo).toString()
-        } catch (e: Exception) {
-            Log.e(TAG, "Unable to get package name for: $lastApp", e)
-        }
+        val lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
 
         val icon = "mdi:android"
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Breaking change because the state will no longer reflect the app name but will instead be the package name so it is always guaranteed to be unique.

Fixes: #2126 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#679

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->