### PR TITLE
Tweak device control for climate entities

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -63,13 +63,20 @@ class ClimateControl {
             if (currentValue > maxValue)
                 currentValue = maxValue
 
+            val temperatureUnit = entity.attributes["temperature_unit"] ?: ""
+            val temperatureStepSize = (entity.attributes["target_temperature_step"] as? Number)?.toFloat()
+                ?: when (temperatureUnit) {
+                    "°C" -> 0.5f
+                    else -> 1f
+                }
+            val temperatureFormatSize = if (temperatureStepSize < 1f) "1" else "0"
             val rangeTemplate = RangeTemplate(
                 entity.entityId,
                 minValue,
                 maxValue,
                 currentValue,
-                1f,
-                "%.0f"
+                temperatureStepSize,
+                "%.${temperatureFormatSize}f $temperatureUnit"
             )
             if (entityShouldBePresentedAsThermostat(entity)) {
                 var modesFlag = 0

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -11,7 +11,7 @@
         <change>Add icons to settings</change>
         <change>Improve reliability of opening entity information from device controls</change>
         <change>Editing Wear OS Template Tile from phone settings</change>
-        <change>Add support for button and input_button domains in device controls</change>
+        <change>Add support for button and input_button domains, tweak climate domain in device controls</change>
         <change>Add mount state sensor for Quest Devices</change>
         <change>Minimal version fixes to remove Google dependencies</change>
         <change>Lots of miscellaneous bug fixes</change>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Suggesting a few tweaks to improve the device control used for `climate` entities:

1. Use temperature unit related attributes, and use this to better match the controls offered by the frontend (number formatting / step size). This also fixes the situation where the current control always sets temperature values in multiples of 0.5 degrees even though the resulting value might not be supported, and always rounds what is displayed to a full number. If the unit isn't known, don't show anything* and use the settings with the least precision.
2. If the entity supports setting temperature and the [`hvac_modes`](https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes) only include values that match what is [available in the `TemperatureControlTemplate`](https://developer.android.com/reference/kotlin/android/service/controls/templates/TemperatureControlTemplate?hl=en) (so: off, heat, cool and/or heat-cool), wrap that around the existing `RangeTemplate` and change the device type to a thermostat. This will allow the system to better reflect the current status/mode: on my Pixel 4a with Android 12 the tile colors changed depending on the mode and it might also be possible to change the mode (but I couldn't find out how to trigger that action).

\* The frontend falls back to the Home Assistant config and uses the default unit, but that would require a websocket message to get the config, which I wanted to avoid.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The UI is provided by the system, this is on a Google Pixel 4a running Android 12.

1: Now showing "°C" and because of that a value with one decimal for this entity:
![Control tile with a grey background, blue status text showing 'Heat 19.0 °C', for 'Verwarming' (radiator) in the room 'Beneden' (downstairs)](https://user-images.githubusercontent.com/8148535/152655357-7affd577-4705-40ce-98cc-3a2c2fa9cea2.png)
1: This entity has a temperature setting step of 0.5 which you actually will be able to see now:
![Control tile with a grey background, blue status text where the temperature is being changed by dragging across the tile, now showing '17.5 °C'](https://user-images.githubusercontent.com/8148535/152655361-4436fa1e-8954-4e86-b76a-345e3e550e40.png)

2: I'm seeing updated colors for the tile depending on the heating mode. Off (grey status text, empty icon, range hidden) / heat (all red) / cool (all blue) / heat-cool (grey background with blue status text):
![Control tile with a grey background and grey status text showing 'Off 19.0 °C' for a climate entity](https://user-images.githubusercontent.com/8148535/152655562-8abe30c1-ef03-4a90-b98a-48f31b5376f3.png)
![Control tile with a red background and red status text showing 'Heat 19.0 °C' for a climate entity](https://user-images.githubusercontent.com/8148535/152655558-88f1a8f1-4182-409a-b126-f2b45ffbafc7.png)
![Control tile with a blue background and blue status text showing 'Cool 19.0 °C' for a climate entity](https://user-images.githubusercontent.com/8148535/152655576-825ab031-810b-41a9-b42c-111f2ae527d8.png)
![Control tile with a grey background and blue status text showing 'Heat Cool 19.0 °C' for a climate entity](https://user-images.githubusercontent.com/8148535/152655580-d11b13f6-82a3-4fdc-9855-18f49693390d.png)
2: There is also a `ModeAction` for this tile according to the documentation, but I'm not sure how to trigger it. The API request was tested.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->