### PR TITLE
Support (input_)button entities in quick settings tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -121,7 +121,11 @@ abstract class TileExtensions : TileService() {
                     try {
                         integrationUseCase.callService(
                             tileData?.entityId?.split(".")!![0],
-                            if (tileData.entityId.split(".")[0] in toggleDomains) "toggle" else "turn_on",
+                            when (tileData.entityId.split(".")[0]) {
+                                "button", "input_button" -> "press"
+                                in toggleDomains -> "toggle"
+                                else -> "turn_on"
+                            },
                             hashMapOf("entity_id" to tileData.entityId)
                         )
                         Log.d(TAG, "Service call sent for tile ID: $tileId")

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -32,7 +32,7 @@ class ManageTilesFragment constructor(
     companion object {
         private const val TAG = "TileFragment"
         val validDomains = listOf(
-            "cover", "fan", "humidifier", "input_boolean", "light",
+            "button", "cover", "fan", "humidifier", "input_boolean", "input_button", "light",
             "media_player", "remote", "siren", "scene", "script", "switch"
         )
     }

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -17,6 +17,7 @@
         <change>Improve reliability of opening entity information from device controls</change>
         <change>Editing Wear OS Template Tile from phone settings</change>
         <change>Add support for button and input_button domains in device controls</change>
+        <change>Add support for button and input_button domains in quick settings tiles</change>
         <change>Add In Use sensor for Quest devices</change>
         <change>Minimal version fixes to remove Google dependencies</change>
         <change>Lots of miscellaneous bug fixes</change>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
There's still more places where `button` and `input_button` entities can be supported! This PR adds support for them in the quick settings tiles, and will resolve #2244.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Quick settings panel showing a tile labeled 'A button! Well, a virtual one'](https://user-images.githubusercontent.com/8148535/152657197-71e43311-0feb-4305-9f5f-d0ff21c90e5b.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#680

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->