### PR TITLE
Allow reconfiguring camera widgets

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsViewModel.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.viewModelScope
 import io.homeassistant.companion.android.HomeAssistantApplication
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.widget.ButtonWidgetEntity
+import io.homeassistant.companion.android.database.widget.CameraWidgetEntity
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetEntity
 import io.homeassistant.companion.android.database.widget.StaticWidgetEntity
 import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
@@ -34,6 +35,8 @@ class ManageWidgetsViewModel @Inject constructor(
 
     private val buttonWidgetDao = AppDatabase.getInstance(application).buttonWidgetDao()
     private fun buttonWidgetFlow(): Flow<List<ButtonWidgetEntity>>? = buttonWidgetDao.getAllFlow()
+    private val cameraWidgetDao = AppDatabase.getInstance(application).cameraWidgetDao()
+    private fun cameraWidgetFlow(): Flow<List<CameraWidgetEntity>>? = cameraWidgetDao.getAllFlow()
     private val staticWidgetDao = AppDatabase.getInstance(application).staticWidgetDao()
     private fun staticWidgetFlow(): Flow<List<StaticWidgetEntity>>? = staticWidgetDao.getAllFlow()
     private val mediaPlayerControlsWidgetDao = AppDatabase.getInstance(application).mediaPlayCtrlWidgetDao()
@@ -42,6 +45,8 @@ class ManageWidgetsViewModel @Inject constructor(
     private fun templateWidgetFlow(): Flow<List<TemplateWidgetEntity>>? = templateWidgetDao.getAllFlow()
 
     var buttonWidgetList = mutableStateListOf<ButtonWidgetEntity>()
+        private set
+    var cameraWidgetList = mutableStateListOf<CameraWidgetEntity>()
         private set
     var staticWidgetList = mutableStateListOf<StaticWidgetEntity>()
         private set
@@ -54,6 +59,7 @@ class ManageWidgetsViewModel @Inject constructor(
 
     init {
         buttonWidgetList()
+        cameraWidgetList()
         staticWidgetList()
         mediaWidgetList()
         templateWidgetList()
@@ -66,6 +72,16 @@ class ManageWidgetsViewModel @Inject constructor(
                 buttonWidgetList.clear()
                 it.forEach { widget ->
                     buttonWidgetList.add(widget)
+                }
+            }
+        }
+    }
+    private fun cameraWidgetList() {
+        viewModelScope.launch {
+            cameraWidgetFlow()?.collect {
+                cameraWidgetList.clear()
+                it.forEach { widget ->
+                    cameraWidgetList.add(widget)
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -106,7 +106,8 @@ fun ManageWidgetsView(
             modifier = Modifier.padding(start = 16.dp, end = 16.dp)
         ) {
             if (viewModel.buttonWidgetList.isNullOrEmpty() && viewModel.staticWidgetList.isNullOrEmpty() &&
-                viewModel.mediaWidgetList.isNullOrEmpty() && viewModel.templateWidgetList.isNullOrEmpty()
+                viewModel.mediaWidgetList.isNullOrEmpty() && viewModel.templateWidgetList.isNullOrEmpty() &&
+                viewModel.cameraWidgetList.isNullOrEmpty()
             ) {
                 item {
                     Column(
@@ -141,6 +142,15 @@ fun ManageWidgetsView(
                     val item = viewModel.buttonWidgetList[index]
                     val label = if (!item.label.isNullOrEmpty()) item.label else "${item.domain}.${item.service}"
                     WidgetRow(widgetLabel = label.toString(), widgetId = item.id, widgetType = "button")
+                }
+            }
+            if (!viewModel.cameraWidgetList.isNullOrEmpty()) {
+                item {
+                    Text(stringResource(id = R.string.camera_widgets))
+                }
+                items(viewModel.cameraWidgetList.size) { index ->
+                    val item = viewModel.cameraWidgetList[index]
+                    WidgetRow(widgetLabel = item.entityId, widgetId = item.id, widgetType = "camera")
                 }
             }
             if (!viewModel.staticWidgetList.isNullOrEmpty()) {
@@ -231,6 +241,7 @@ fun WidgetRow(
                 context,
                 when (widgetType) {
                     "button" -> ButtonWidgetConfigureActivity::class.java
+                    "camera" -> CameraWidgetConfigureActivity::class.java
                     "media" -> MediaPlayerControlsWidgetConfigureActivity::class.java
                     "state" -> EntityWidgetConfigureActivity::class.java
                     "template" -> TemplateWidgetConfigureActivity::class.java

--- a/app/src/main/res/layout/widget_camera_configure.xml
+++ b/app/src/main/res/layout/widget_camera_configure.xml
@@ -46,5 +46,14 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/delete_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:visibility="gone"
+            android:text="@string/delete_widget" />
+
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/xml/camera_widget_info.xml
+++ b/app/src/main/res/xml/camera_widget_info.xml
@@ -8,5 +8,6 @@
     android:resizeMode="vertical|horizontal"
     android:updatePeriodMillis="3600000"
     android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable"
     android:description="@string/camera_widget_desc"
     android:previewImage="@drawable/widget_example_camera" />

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface CameraWidgetDao {
@@ -23,4 +24,7 @@ interface CameraWidgetDao {
 
     @Query("SELECT * FROM camera_widgets")
     fun getAll(): Array<CameraWidgetEntity>?
+
+    @Query("SELECT * FROM camera_widgets")
+    fun getAllFlow(): Flow<List<CameraWidgetEntity>>?
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="button_forward">Next</string>
     <string name="button_widget_desc">Call any service</string>
     <string name="calendar">Calendar</string>
+    <string name="camera_widgets">Camera Widgets</string>
     <string name="camera_widget_desc">Displays the latest image from the camera</string>
     <string name="cancel">Cancel</string>
     <string name="changelog">View Full Change Log</string>
@@ -326,7 +327,7 @@
     <string name="nfc_write_tag_too_early">Please fill out the form first</string>
     <string name="no_notifications_summary">You have not received any notifications yet</string>
     <string name="no_notifications">No Notifications</string>
-    <string name="no_widgets_summary">When you add a configurable widget to your home screen, you will see it here</string>
+    <string name="no_widgets_summary">When you add a widget to your home screen, you will see it here</string>
     <string name="no_widgets">No Widgets Found</string>
     <string name="none">None</string>
     <string name="not_private">Your connection to this site is not private.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently, you can reconfigure all of the widgets except for the camera widget. This PR changes that and will allow users to also edit the camera widget. 

While it is a very simple widget, having just one widget not configurable is inconsistent, Android 12 will show options to edit the widget in the launcher which will make it faster to change the camera (edit instead of delete + scroll widgets list + add again), and this will 'fix' the widgets settings in the app being empty when only camera widgets have been added (which could be confusing).

Code based on editing an entity/state widget.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|------|
|Settings|![Widget settings in the app showing two camera widgets, light mode](https://user-images.githubusercontent.com/8148535/153267913-bb93fb18-a99e-4f78-bfdf-a991bf3bc380.png)|![Widget settings in the app showing two camera widgets, dark mode](https://user-images.githubusercontent.com/8148535/153267947-29738cbc-ba86-4fcf-9b2a-f89395e02f0f.png)|
|Editing|![A screen to edit the camera widget for 'camera.one', similar to a new widget screen but with buttons labeled 'Update widget' and 'Delete widget', light mode](https://user-images.githubusercontent.com/8148535/153268098-72cb9560-1e58-4e74-a41e-ed41b77aff5a.png)|![A screen to edit the camera widget for 'camera.one', similar to a new widget screen but with buttons labeled 'Update widget' and 'Delete widget', dark mode](https://user-images.githubusercontent.com/8148535/153268219-38ebfb6c-c900-4754-9d4f-b94f7cd6f929.png)|

Editing controls show up on Android 12 when dragging (top of the screen) and resizing (pencil in bottom right):
![A camera widget is being dragged, at the top of the screen there are options for 'Remove' and 'Widget settings'](https://user-images.githubusercontent.com/8148535/153268473-6e9621ac-188f-45f4-a51e-400db08d26a6.png) ![A camera widget is being resized, in the bottom right a button with a pencil icon is visible](https://user-images.githubusercontent.com/8148535/153268491-a18117d5-95f4-4f3d-926e-96f883599fa2.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->