### PR TITLE
Fix websocket invalid auth race condition

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.convertValue
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
+import io.homeassistant.companion.android.common.data.authentication.AuthorizationException
 import io.homeassistant.companion.android.common.data.integration.ServiceData
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
 import io.homeassistant.companion.android.common.data.url.UrlRepository
@@ -288,6 +289,7 @@ class WebSocketRepositoryImpl @Inject constructor(
             return true == withTimeoutOrNull(30000) {
                 return@withTimeoutOrNull try {
                     connected.join()
+                    if (connected.isCancelled) throw AuthorizationException()
                     true
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to authenticate", e)
@@ -372,8 +374,12 @@ class WebSocketRepositoryImpl @Inject constructor(
     }
 
     private fun handleClosingSocket() {
-        connected = Job()
-        connection = null
+        ioScope.launch {
+            connectedMutex.withLock {
+                connected = Job()
+                connection = null
+            }
+        }
         // If we still have flows flowing
         if ((eventSubscriptionFlow.any() || notificationFlow != null) && ioScope.isActive) {
             ioScope.launch {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -451,6 +451,9 @@ class WebSocketRepositoryImpl @Inject constructor(
 
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         Log.e(TAG, "Websocket: onFailure", t)
+        if (connected.isActive) {
+            connected.completeExceptionally(t)
+        }
         handleClosingSocket()
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If the authentication that is provided to the websocket is invalid, Home Assistant will immediately close the websocket after sending the `auth_invalid` message. Because the `onClosing` function will reset the Job used for monitoring the authentication result, this can result in a race condition where the job is changed before the result is processed. As a result, the job won't complete and checking authentication will have to wait for the timeout to complete. Example log:

```
2022-02-10 21:55:44.561 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Websocket: onOpen
2022-02-10 21:55:44.564 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Websocket: onMessage (text)
2022-02-10 21:55:44.870 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number null received: {"type": "auth_required", "ha_version": "2022.2.5"}
2022-02-10 21:55:44.886 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Websocket: onMessage (text)
2022-02-10 21:55:44.887 10649-10689/io.homeassistant.companion.android.debug D/WebSocketRepository: Auth Requested
2022-02-10 21:55:44.888 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number null received: {"type": "auth_invalid", "message": "Invalid access token or password"}
2022-02-10 21:55:44.893 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: Websocket: onClosing code: 1000, reason: 
2022-02-10 21:55:44.894 10649-10682/io.homeassistant.companion.android.debug D/WebSocketRepository: handleClosingSocket
2022-02-10 21:55:44.896 10649-10689/io.homeassistant.companion.android.debug D/WebSocketRepository: handleAuthComplete: false
```

This PR will use the same mutex that is used for initial auth when closing the connection. This will ensure that any (auth) result is delivered before the connection is closed (if, somehow, no auth result is delivered, the mutex is still unlocked by a timeout).

Additionally, if the auth is invalid that should return false as expected. An `auth_invalid` message calls `completeExceptionally` which cancels the job but that is still `isCompleted` (see ["Job states"](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/-job/index.html)), so a check has been added to make sure it was completed without a cancellation.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->