### PR TITLE
Check that connection is not null before attempting to send a message

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -305,13 +305,15 @@ class WebSocketRepositoryImpl @Inject constructor(
                 suspendCancellableCoroutine { cont ->
                     // Lock on the connection so that we fully send before allowing another send.
                     // This should prevent out of order errors.
-                    synchronized(connection!!) {
-                        val requestId = id.getAndIncrement()
-                        val outbound = request.plus("id" to requestId)
-                        Log.d(TAG, "Sending message $requestId: $outbound")
-                        responseCallbackJobs[requestId] = cont
-                        connection!!.send(mapper.writeValueAsString(outbound))
-                        Log.d(TAG, "Message number $requestId sent")
+                    if (connection != null) {
+                        synchronized(connection!!) {
+                            val requestId = id.getAndIncrement()
+                            val outbound = request.plus("id" to requestId)
+                            Log.d(TAG, "Sending message $requestId: $outbound")
+                            responseCallbackJobs[requestId] = cont
+                            connection!!.send(mapper.writeValueAsString(outbound))
+                            Log.d(TAG, "Message number $requestId sent")
+                        }
                     }
                 }
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -305,13 +305,13 @@ class WebSocketRepositoryImpl @Inject constructor(
                 suspendCancellableCoroutine { cont ->
                     // Lock on the connection so that we fully send before allowing another send.
                     // This should prevent out of order errors.
-                    if (connection != null) {
-                        synchronized(connection!!) {
+                    connection?.let {
+                        synchronized(it) {
                             val requestId = id.getAndIncrement()
                             val outbound = request.plus("id" to requestId)
                             Log.d(TAG, "Sending message $requestId: $outbound")
                             responseCallbackJobs[requestId] = cont
-                            connection!!.send(mapper.writeValueAsString(outbound))
+                            connection?.send(mapper.writeValueAsString(outbound))
                             Log.d(TAG, "Message number $requestId sent")
                         }
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry errors by performing a null check before attempting to send the message:

```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invokeSuspend(WebSocketRepositoryImpl.kt:313)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invoke
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invoke
    at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:100)
    at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:146)
    at kotlinx.coroutines.TimeoutKt.withTimeoutOrNull(Timeout.kt:103)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.sendMessage(WebSocketRepositoryImpl.kt:304)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.access$sendMessage(WebSocketRepositoryImpl.kt:56)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$handleClosingSocket$2.invokeSuspend(WebSocketRepositoryImpl.kt:400)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```
slightly different errors
```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invokeSuspend(WebSocketRepositoryImpl.kt:308)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invoke
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$sendMessage$2.invoke
    at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturnIgnoreTimeout(Undispatched.kt:100)
    at kotlinx.coroutines.TimeoutKt.setupTimeout(Timeout.kt:146)
    at kotlinx.coroutines.TimeoutKt.withTimeoutOrNull(Timeout.kt:103)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.sendMessage(WebSocketRepositoryImpl.kt:304)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.subscribeToEventsForType(WebSocketRepositoryImpl.kt:182)
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl.getAreaRegistryUpdates(WebSocketRepositoryImpl.kt:170)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherFor$1$1$request$1.invokeSuspend(HaControlsProviderService.kt:108)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:33)
    at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:39)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->