### PR TITLE
Wear use state and device class for entity icons

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -84,7 +84,7 @@ private fun ChooseEntityChip(
 ) {
     val attributes = entityList[index].attributes as Map<*, *>
     val iconBitmap = getIcon(
-        attributes["icon"] as String?,
+        entityList[index] as Entity<Map<String, Any>>,
         entityList[index].entityId.split(".")[0],
         LocalContext.current
     )

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -34,7 +34,7 @@ fun EntityUi(
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
     val attributes = entity.attributes as Map<*, *>
-    val iconBitmap = getIcon(attributes["icon"] as String?, entity.entityId.split(".")[0], LocalContext.current)
+    val iconBitmap = getIcon(entity as Entity<Map<String, Any>>, entity.entityId.split(".")[0], LocalContext.current)
     val friendlyName = attributes["friendly_name"].toString()
 
     if (entity.entityId.split(".")[0] in HomePresenterImpl.toggleDomains) {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -89,7 +89,7 @@ private fun FavoriteToggleChip(
 ) {
     val attributes = entityList[index].attributes as Map<*, *>
     val iconBitmap = getIcon(
-        attributes["icon"] as String?,
+        entityList[index] as Entity<Map<String, Any>>,
         entityList[index].entityId.split(".")[0],
         LocalContext.current
     )

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -29,6 +29,7 @@ import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import com.google.common.util.concurrent.ListenableFuture
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.backgroundColor
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
@@ -36,6 +37,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.data.SimplifiedEntity
+import io.homeassistant.companion.android.util.getIcon
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -102,25 +104,13 @@ class ShortcutsTile : TileService() {
                 .setVersion(entities.toString())
                 .apply {
                     entities.map { entity ->
-                        // Find icon name
-                        val iconName: String = if (entity.icon.startsWith("mdi")) {
-                            entity.icon.split(":")[1]
-                        } else { // Default scene icon
-                            when (entity.entityId.split(".")[0]) {
-                                "button", "input_button" -> "gesture_tap_button"
-                                "cover" -> "window_closed"
-                                "fan" -> "fan"
-                                "input_boolean", "switch" -> "light_switch"
-                                "light" -> "lightbulb"
-                                "lock" -> "lock"
-                                "script" -> "script_text_outline"
-                                "scene" -> "palette_outline"
-                                else -> "cellphone"
-                            }
-                        }
-
-                        // Create Bitmap from icon name
-                        val iconBitmap = IconicsDrawable(this@ShortcutsTile, "cmd-$iconName").apply {
+                        // Find icon and create Bitmap
+                        val iconIIcon = getIcon(
+                            entity.icon,
+                            entity.entityId.split("")[0],
+                            this@ShortcutsTile
+                        ) ?: CommunityMaterial.Icon.cmd_cellphone
+                        val iconBitmap = IconicsDrawable(this@ShortcutsTile, iconIIcon).apply {
                             colorInt = Color.WHITE
                             sizeDp = iconSize.roundToInt()
                             backgroundColor = IconicsColor.colorRes(R.color.colorOverlay)

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -13,7 +13,7 @@ fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
     return if (icon?.startsWith("mdi") == true) {
         val mdiIcon = icon.split(":")[1]
         IconicsDrawable(context, "cmd-$mdiIcon").icon
-    } else {
+    } else { // Default domain icon
         when (domain) {
             "button", "input_button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
             "cover" -> CommunityMaterial.Icon3.cmd_window_closed

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -7,23 +7,118 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.common.data.integration.Entity
+import java.util.Calendar
 import io.homeassistant.companion.android.common.R as commonR
 
 fun getIcon(icon: String?, domain: String, context: Context): IIcon? {
+    val simpleEntity = Entity(
+        "",
+        "",
+        mapOf("icon" to icon),
+        Calendar.getInstance(),
+        Calendar.getInstance(),
+        null
+    )
+    return getIcon(simpleEntity as Entity<Map<String, Any>>, domain, context)
+}
+
+fun getIcon(entity: Entity<Map<String, Any>>?, domain: String, context: Context): IIcon? {
+    val icon = entity?.attributes?.get("icon") as? String
     return if (icon?.startsWith("mdi") == true) {
         val mdiIcon = icon.split(":")[1]
         IconicsDrawable(context, "cmd-$mdiIcon").icon
-    } else { // Default domain icon
+    } else {
+        /**
+         * Return a default icon for the domain that matches the icon used in the frontend, see
+         * https://github.com/home-assistant/frontend/blob/dev/src/common/entity/domain_icon.ts.
+         * Note: for SimplifiedEntity sometimes return a more general icon because we don't have state.
+         */
+        val compareState =
+            if (entity?.state?.isNotBlank() == true)
+                entity.state
+            else
+                entity?.attributes?.get("state") as String?
         when (domain) {
-            "button", "input_button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
-            "cover" -> CommunityMaterial.Icon3.cmd_window_closed
+            "button" -> when (entity?.attributes?.get("device_class")) {
+                "restart" -> CommunityMaterial.Icon3.cmd_restart
+                "update" -> CommunityMaterial.Icon3.cmd_package_up
+                else -> CommunityMaterial.Icon2.cmd_gesture_tap_button
+            }
+            "cover" -> coverIcon(compareState, entity)
             "fan" -> CommunityMaterial.Icon2.cmd_fan
-            "input_boolean", "switch" -> CommunityMaterial.Icon2.cmd_light_switch
+            "input_boolean" -> if (entity?.entityId?.isNotBlank() == true) {
+                if (compareState == "on")
+                    CommunityMaterial.Icon.cmd_check_circle_outline
+                else
+                    CommunityMaterial.Icon.cmd_close_circle_outline
+            } else { // For SimplifiedEntity without state, use a more generic icon
+                CommunityMaterial.Icon2.cmd_light_switch
+            }
+            "input_button" -> CommunityMaterial.Icon2.cmd_gesture_tap_button
             "light" -> CommunityMaterial.Icon2.cmd_lightbulb
-            "lock" -> CommunityMaterial.Icon2.cmd_lock
-            "script" -> CommunityMaterial.Icon3.cmd_script_text_outline
-            "scene" -> CommunityMaterial.Icon3.cmd_palette_outline
+            "lock" -> when (compareState) {
+                "unlocked" -> CommunityMaterial.Icon2.cmd_lock_open
+                "jammed" -> CommunityMaterial.Icon2.cmd_lock_alert
+                "locking", "unlocking" -> CommunityMaterial.Icon2.cmd_lock_clock
+                else -> CommunityMaterial.Icon2.cmd_lock
+            }
+            "script" -> CommunityMaterial.Icon3.cmd_script_text_outline // Different from frontend: outline version
+            "scene" -> CommunityMaterial.Icon3.cmd_palette_outline // Different from frontend: outline version
+            "switch" -> if (entity?.entityId?.isNotBlank() == true) {
+                when (entity.attributes["device_class"]) {
+                    "outlet" -> if (compareState == "on") CommunityMaterial.Icon3.cmd_power_plug else CommunityMaterial.Icon3.cmd_power_plug_off
+                    "switch" -> if (compareState == "on") CommunityMaterial.Icon3.cmd_toggle_switch else CommunityMaterial.Icon3.cmd_toggle_switch_off
+                    else -> CommunityMaterial.Icon2.cmd_flash
+                }
+            } else { // For SimplifiedEntity without state, use a more generic icon
+                CommunityMaterial.Icon2.cmd_light_switch
+            }
             else -> CommunityMaterial.Icon.cmd_cellphone
+        }
+    }
+}
+
+private fun coverIcon(state: String?, entity: Entity<Map<String, Any>>?): IIcon? {
+    val open = state !== "closed"
+
+    return when (entity?.attributes?.get("device_class")) {
+        "garage" -> when (state) {
+            "opening" -> CommunityMaterial.Icon.cmd_arrow_up_box
+            "closing" -> CommunityMaterial.Icon.cmd_arrow_down_box
+            "closed" -> CommunityMaterial.Icon2.cmd_garage
+            else -> CommunityMaterial.Icon2.cmd_garage_open
+        }
+        "gate" -> when (state) {
+            "opening", "closing" -> CommunityMaterial.Icon2.cmd_gate_arrow_right
+            "closed" -> CommunityMaterial.Icon2.cmd_gate
+            else -> CommunityMaterial.Icon2.cmd_gate_open
+        }
+        "door" -> if (open) CommunityMaterial.Icon.cmd_door_open else CommunityMaterial.Icon.cmd_door_closed
+        "damper" -> if (open) CommunityMaterial.Icon.cmd_circle else CommunityMaterial.Icon.cmd_circle_slice_8
+        "shutter" -> when (state) {
+            "opening" -> CommunityMaterial.Icon.cmd_arrow_up_box
+            "closing" -> CommunityMaterial.Icon.cmd_arrow_down_box
+            "closed" -> CommunityMaterial.Icon3.cmd_window_shutter
+            else -> CommunityMaterial.Icon3.cmd_window_shutter_open
+        }
+        "curtain" -> when (state) {
+            "opening" -> CommunityMaterial.Icon.cmd_arrow_split_vertical
+            "closing" -> CommunityMaterial.Icon.cmd_arrow_collapse_horizontal
+            "closed" -> CommunityMaterial.Icon.cmd_curtains_closed
+            else -> CommunityMaterial.Icon.cmd_curtains
+        }
+        "blind", "shade" -> when (state) {
+            "opening" -> CommunityMaterial.Icon.cmd_arrow_up_box
+            "closing" -> CommunityMaterial.Icon.cmd_arrow_down_box
+            "closed" -> CommunityMaterial.Icon.cmd_blinds
+            else -> CommunityMaterial.Icon.cmd_blinds_open
+        }
+        else -> when (state) {
+            "opening" -> CommunityMaterial.Icon.cmd_arrow_up_box
+            "closing" -> CommunityMaterial.Icon.cmd_arrow_down_box
+            "closed" -> CommunityMaterial.Icon3.cmd_window_closed
+            else -> CommunityMaterial.Icon3.cmd_window_open
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR improves the icons that are displayed in the Wear OS app by using information about the state and device class, if available, to better match the icons in frontend when no specific icon has been set by the user. When no state is available (= shortcuts tile) the icons mostly match what was already used.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
A few examples, I'm not going to show every possible combination.
|     |Before|After|
|-----|-----|-----|
|Covers: blind class closed + garage class open|![image](https://user-images.githubusercontent.com/8148535/154135256-f2c4757f-a2cf-4565-8f8f-dc55235f5aff.png)|![image](https://user-images.githubusercontent.com/8148535/154135225-efd17e83-242e-4647-8043-28b1294abc47.png)|
|Covers: blind class open + garage class open|![image](https://user-images.githubusercontent.com/8148535/154135391-33b2402d-68ba-4907-9238-a719c35745fd.png)|![image](https://user-images.githubusercontent.com/8148535/154135351-dbbad769-4d77-4881-8ebb-a6f265846ce5.png)|
|Input booleans: on/off|![image](https://user-images.githubusercontent.com/8148535/154135462-7d08fe49-6cf8-4296-b65f-b3fa74095b47.png)|![image](https://user-images.githubusercontent.com/8148535/154135816-3098dc12-ec31-4e98-bde3-3c167d215cd3.png)|
|Buttons: update/restart classes|![image](https://user-images.githubusercontent.com/8148535/154135678-c980ea81-b9eb-49f3-9d66-c0e2987c6879.png)|![image](https://user-images.githubusercontent.com/8148535/154136042-cfa2750a-b045-4bb0-8b17-42d6148794f4.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not necessary

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->