### PR TITLE
Allow enabling chrome remote debugging in settings

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -52,6 +52,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "crash_reporting" -> prefsRepository.isCrashReporting()
                 "prioritize_internal" -> urlUseCase.isPrioritizeInternal()
                 "autoplay_video" -> integrationUseCase.isAutoPlayVideoEnabled()
+                "webview_debug" -> integrationUseCase.isWebViewDebugEnabled()
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
             }
         }
@@ -67,6 +68,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "crash_reporting" -> prefsRepository.setCrashReporting(value)
                 "prioritize_internal" -> urlUseCase.setPrioritizeInternal(value)
                 "autoplay_video" -> integrationUseCase.setAutoPlayVideo(value)
+                "webview_debug" -> integrationUseCase.setWebViewDebugEnabled(value)
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -210,10 +210,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         val colorLaunchScreenBackground = ResourcesCompat.getColor(resources, commonR.color.colorLaunchScreenBackground, theme)
         setStatusBarAndNavigationBarColor(colorLaunchScreenBackground, colorLaunchScreenBackground)
 
-        if (BuildConfig.DEBUG) {
-            WebView.setWebContentsDebuggingEnabled(true)
-        }
-
         binding.blurView.setupWith(binding.root)
             .setBlurAlgorithm(RenderScriptBlur(this))
             .setBlurRadius(5f)
@@ -660,6 +656,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
 
         enablePinchToZoom()
+
+        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
 
         if (presenter.isKeepScreenOnEnabled())
             window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -17,6 +17,7 @@ interface WebViewPresenter {
     fun isKeepScreenOnEnabled(): Boolean
 
     fun isPinchToZoomEnabled(): Boolean
+    fun isWebViewDebugEnabled(): Boolean
 
     fun isLockEnabled(): Boolean
     fun isAutoPlayVideoEnabled(): Boolean

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -144,6 +144,12 @@ class WebViewPresenterImpl @Inject constructor(
         }
     }
 
+    override fun isWebViewDebugEnabled(): Boolean {
+        return runBlocking {
+            integrationUseCase.isWebViewDebugEnabled()
+        }
+    }
+
     override fun isLockEnabled(): Boolean {
         return runBlocking {
             authenticationUseCase.isLockEnabled()

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -90,6 +90,11 @@
             android:icon="@drawable/ic_baseline_video_settings_24"
             android:title="@string/autoplay_video"
             android:summary="@string/autoplay_video_summary" />
+        <SwitchPreference
+            android:key="webview_debug"
+            android:icon="@drawable/ic_android_debug_bridge"
+            android:title="@string/remote_debugging"
+            android:summary="@string/remote_debugging_summary" />
         <Preference
             android:key="nfc_tags"
             android:icon="@drawable/ic_nfc"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -31,6 +31,9 @@ interface IntegrationRepository {
     suspend fun setAutoPlayVideo(enabled: Boolean)
     suspend fun isAutoPlayVideoEnabled(): Boolean
 
+    suspend fun setWebViewDebugEnabled(enabled: Boolean)
+    suspend fun isWebViewDebugEnabled(): Boolean
+
     suspend fun sessionTimeOut(value: Int)
     suspend fun getSessionTimeOut(): Int
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -70,6 +70,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
         private const val PREF_KEEP_SCREEN_ON_ENABLED = "keep_screen_on_enabled"
         private const val PREF_PINCH_TO_ZOOM_ENABLED = "pinch_to_zoom_enabled"
+        private const val PREF_WEBVIEW_DEBUG_ENABLED = "webview_debug_enabled"
         private const val PREF_SESSION_TIMEOUT = "session_timeout"
         private const val PREF_SESSION_EXPIRE = "session_expire"
         private const val PREF_SEC_WARNING_NEXT = "sec_warning_last"
@@ -345,6 +346,14 @@ class IntegrationRepositoryImpl @Inject constructor(
 
     override suspend fun isPinchToZoomEnabled(): Boolean {
         return localStorage.getBoolean(PREF_PINCH_TO_ZOOM_ENABLED)
+    }
+
+    override suspend fun setWebViewDebugEnabled(enabled: Boolean) {
+        localStorage.putBoolean(PREF_WEBVIEW_DEBUG_ENABLED, enabled)
+    }
+
+    override suspend fun isWebViewDebugEnabled(): Boolean {
+        return localStorage.getBoolean(PREF_WEBVIEW_DEBUG_ENABLED)
     }
 
     override suspend fun isAutoPlayVideoEnabled(): Boolean {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -769,6 +769,6 @@
     <string name="tile_icon">Select a icon for the tile</string>
     <string name="tile_select">Select a tile to edit</string>
     <string name="shortcut_pinned">Pinned Shortcuts</string>
-    <string name="remote_debugging">Remote Debugging</string>
-    <string name="remote_debugging_summary">Allow remote debugging to troubleshoot Home Assistant frontend issues</string>
+    <string name="remote_debugging">WebView Remote Debugging</string>
+    <string name="remote_debugging_summary">Allow remote debugging of WebView to troubleshoot Home Assistant frontend issues</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -769,4 +769,6 @@
     <string name="tile_icon">Select a icon for the tile</string>
     <string name="tile_select">Select a tile to edit</string>
     <string name="shortcut_pinned">Pinned Shortcuts</string>
+    <string name="remote_debugging">Remote Debugging</string>
+    <string name="remote_debugging_summary">Allow remote debugging to troubleshoot Home Assistant frontend issues</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes #2162 by adding a remote debugging switch (default off) to settings. On a debug build we will still have debugging enabled no matter what but on other builds we will let the user decide. This will allow users to troubleshoot issues without needing to install a debug build.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/154781624-d830c9d5-f527-4fc9-a358-62ab60889e03.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#692

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->