### PR TITLE
Allow opening notification history from URI action

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -57,6 +57,7 @@ import io.homeassistant.companion.android.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.sensors.NotificationSensorManager
 import io.homeassistant.companion.android.sensors.SensorWorker
+import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.util.UrlHandler
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.CoroutineScope
@@ -84,6 +85,8 @@ class MessagingManager @Inject constructor(
         const val TAG = "MessagingService"
 
         const val APP_PREFIX = "app://"
+        const val SETTINGS_PREFIX = "settings://"
+        const val NOTIFICATION_HISTORY = "notification_history"
 
         const val TITLE = "title"
         const val MESSAGE = "message"
@@ -1195,6 +1198,12 @@ class MessagingManager @Inject constructor(
             uri.startsWith(APP_PREFIX) -> {
                 context.packageManager.getLaunchIntentForPackage(uri.substringAfter(APP_PREFIX))
             }
+            uri.startsWith(SETTINGS_PREFIX) -> {
+                if (uri.substringAfter(SETTINGS_PREFIX) == NOTIFICATION_HISTORY)
+                    SettingsActivity.newInstance(context)
+                else
+                    WebViewActivity.newInstance(context)
+            }
             UrlHandler.isAbsoluteUrl(uri) -> {
                 Intent(Intent.ACTION_VIEW).apply {
                     this.data = Uri.parse(uri)
@@ -1205,6 +1214,8 @@ class MessagingManager @Inject constructor(
             }
         } ?: WebViewActivity.newInstance(context)
 
+        if (uri.startsWith(SETTINGS_PREFIX) && uri.substringAfter(SETTINGS_PREFIX) == NOTIFICATION_HISTORY)
+            intent.putExtra("fragment", NOTIFICATION_HISTORY)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.components.ActivityComponent
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.settings.notification.NotificationHistoryFragment
 import io.homeassistant.companion.android.settings.websocket.WebsocketSettingFragment
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -56,6 +57,7 @@ class SettingsActivity : BaseActivity() {
                 else {
                     when (settingsNavigation) {
                         "websocket" -> WebsocketSettingFragment::class.java
+                        "notification_history" -> NotificationHistoryFragment::class.java
                         else -> SettingsFragment::class.java
                     }
                 },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2303 

```
service: notify.mobile_app_pixel_6_pro
data:
  message: test action
  data:
    actions:
    - action: URI
      title: history
      uri: settings://notification_history
```

or

```
service: notify.mobile_app_pixel_6_pro
data:
  message: test
  data:
    clickAction: settings://notification_history
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#693

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->