### PR TITLE
Add new option for persistent connection to only connect when on home wifi

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -51,6 +51,8 @@ open class HomeAssistantApplication : Application() {
                 addAction(Intent.ACTION_SCREEN_OFF)
                 addAction(Intent.ACTION_SCREEN_ON)
                 addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+                addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
+                addAction(WifiManager.WIFI_STATE_CHANGED_ACTION)
             }
         )
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
@@ -57,6 +57,11 @@ fun WebsocketSettingView(
             onClick = { onSettingChanged(WebsocketSetting.NEVER) }
         )
         RadioButtonRow(
+            text = stringResource(R.string.websocket_setting_home_wifi),
+            selected = websocketSetting == WebsocketSetting.HOME_WIFI,
+            onClick = { onSettingChanged(WebsocketSetting.HOME_WIFI) }
+        )
+        RadioButtonRow(
             text = stringResource(if (BuildConfig.FLAVOR == "full") R.string.websocket_setting_while_screen_on else R.string.websocket_setting_while_screen_on_minimal),
             selected = websocketSetting == WebsocketSetting.SCREEN_ON,
             onClick = { onSettingChanged(WebsocketSetting.SCREEN_ON) }

--- a/common/src/main/java/io/homeassistant/companion/android/database/settings/WebsocketSetting.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/settings/WebsocketSetting.kt
@@ -5,7 +5,8 @@ import androidx.room.TypeConverter
 enum class WebsocketSetting {
     NEVER,
     SCREEN_ON,
-    ALWAYS
+    ALWAYS,
+    HOME_WIFI
 }
 
 class LocalNotificationSettingConverter {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -781,5 +781,5 @@
     <string name="shortcut_pinned">Pinned Shortcuts</string>
     <string name="remote_debugging">WebView Remote Debugging</string>
     <string name="remote_debugging_summary">Allow remote debugging of WebView to troubleshoot Home Assistant frontend issues</string>
-    <string name="websocket_setting_home_wifi">On Home WiFi Only\n\nThe persistent connection will only be maintained when on Home WiFi.</string>
+    <string name="websocket_setting_home_wifi">On Home WiFi Only\n\nNotifications will be delivered by Google only when not on Home WiFi.</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -781,4 +781,5 @@
     <string name="shortcut_pinned">Pinned Shortcuts</string>
     <string name="remote_debugging">WebView Remote Debugging</string>
     <string name="remote_debugging_summary">Allow remote debugging of WebView to troubleshoot Home Assistant frontend issues</string>
+    <string name="websocket_setting_home_wifi">On Home WiFi Only\n\nThe persistent connection will only be maintained when on Home WiFi.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2279 by adding a new option that only maintains the connection when on the defined home wifi

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/155243604-bbfae688-7fe9-4bbc-a465-64456412ade1.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

Not needed as we do not describe any setting on this page.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->