### PR TITLE
Fix BLE command when enabling or disabling the transmitter

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -196,7 +196,7 @@ class MessagingManager @Inject constructor(
             MEDIA_FAST_FORWARD, MEDIA_NEXT, MEDIA_PAUSE, MEDIA_PLAY,
             MEDIA_PLAY_PAUSE, MEDIA_PREVIOUS, MEDIA_REWIND, MEDIA_STOP
         )
-        val BLE_COMMANDS = listOf(TURN_OFF, TURN_ON, BLE_SET_ADVERTISE_MODE, BLE_SET_TRANSMIT_POWER)
+        val BLE_COMMANDS = listOf(BLE_SET_ADVERTISE_MODE, BLE_SET_TRANSMIT_POWER)
         val BLE_TRANSMIT_COMMANDS =
             listOf(BLE_TRANSMIT_HIGH, BLE_TRANSMIT_LOW, BLE_TRANSMIT_MEDIUM, BLE_TRANSMIT_ULTRA_LOW)
         val BLE_ADVERTISE_COMMANDS =
@@ -313,10 +313,13 @@ class MessagingManager @Inject constructor(
                     }
                     COMMAND_BLE_TRANSMITTER -> {
                         if (
-                            (!jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] in BLE_COMMANDS) &&
+                            (!jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] in ENABLE_COMMANDS) ||
                             (
-                                !jsonData[BLE_ADVERTISE].isNullOrEmpty() && jsonData[BLE_ADVERTISE] in BLE_ADVERTISE_COMMANDS ||
-                                    !jsonData[BLE_TRANSMIT].isNullOrEmpty() && jsonData[BLE_TRANSMIT] in BLE_TRANSMIT_COMMANDS
+                                (!jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] in BLE_COMMANDS) &&
+                                    (
+                                        !jsonData[BLE_ADVERTISE].isNullOrEmpty() && jsonData[BLE_ADVERTISE] in BLE_ADVERTISE_COMMANDS ||
+                                            !jsonData[BLE_TRANSMIT].isNullOrEmpty() && jsonData[BLE_TRANSMIT] in BLE_TRANSMIT_COMMANDS
+                                        )
                                 )
                         )
                             handleDeviceCommands(jsonData)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This fixes the condition when a user is trying to just enable/disable the transmitter.  Reported via: https://community.home-assistant.io/t/enable-ble-transmitter-via-notification-command-dont-work-anymore/396224

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->