### PR TITLE
Add extensions to Entity for domain, lights features

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.mikepenz.iconics.IconicsDrawable
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.settings.wear.SettingsWearViewModel
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
 import org.burnoutcrew.reorderable.draggedItem
@@ -158,7 +159,7 @@ fun LoadWearFavoritesSettings(
                                     modifier = Modifier.padding(top = 10.dp)
                                 )
                                 Text(
-                                    text = getDomainString(item.entityId.split('.')[0]),
+                                    text = getDomainString(item.domain),
                                     fontSize = 11.sp
                                 )
                             }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
@@ -9,6 +9,7 @@ import android.service.controls.templates.StatelessTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -32,18 +33,18 @@ class DefaultButtonControl {
         }
 
         override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            when (entity.entityId.split(".")[0]) {
+            when (entity.domain) {
                 "scene", "script" -> DeviceTypes.TYPE_ROUTINE
                 else -> DeviceTypes.TYPE_UNKNOWN
             }
 
         override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            when (entity.entityId.split(".")[0]) {
+            when (entity.domain) {
                 "button" -> context.getString(commonR.string.domain_button)
                 "input_button" -> context.getString(commonR.string.domain_input_button)
                 "scene" -> context.getString(commonR.string.domain_scene)
                 "script" -> context.getString(commonR.string.domain_script)
-                else -> entity.entityId.split(".")[0].capitalize()
+                else -> entity.domain.capitalize()
             }
 
         override fun performAction(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -11,6 +11,7 @@ import android.service.controls.templates.ToggleTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -37,17 +38,17 @@ class DefaultSwitchControl {
         }
 
         override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            when (entity.entityId.split(".")[0]) {
+            when (entity.domain) {
                 "switch" -> DeviceTypes.TYPE_SWITCH
                 else -> DeviceTypes.TYPE_GENERIC_ON_OFF
             }
 
         override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            when (entity.entityId.split(".")[0]) {
+            when (entity.domain) {
                 "automation" -> context.getString(commonR.string.domain_automation)
                 "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
                 "switch" -> context.getString(commonR.string.domain_switch)
-                else -> entity.entityId.split(".")[0].capitalize()
+                else -> entity.domain.capitalize()
             }
 
         override fun performAction(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -9,6 +9,7 @@ import androidx.annotation.RequiresApi
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
@@ -78,8 +79,7 @@ class HaControlsProviderService : ControlsProviderService() {
                     entities
                         ?.sortedWith(compareBy(nullsLast()) { areaForEntity[it.entityId]?.name })
                         ?.mapNotNull {
-                            val domain = it.entityId.split(".")[0]
-                            domainToHaControl[domain]?.createControl(
+                            domainToHaControl[it.domain]?.createControl(
                                 applicationContext,
                                 it as Entity<Map<String, Any>>,
                                 areaForEntity[it.entityId]
@@ -141,8 +141,7 @@ class HaControlsProviderService : ControlsProviderService() {
                         webSocketScope.launch {
                             entityFlow?.collect {
                                 if (controlIds.contains(it.entityId)) {
-                                    val domain = it.entityId.split(".")[0]
-                                    val control = domainToHaControl[domain]?.createControl(
+                                    val control = domainToHaControl[it.domain]?.createControl(
                                         applicationContext,
                                         it as Entity<Map<String, Any>>,
                                         RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry)
@@ -214,8 +213,7 @@ class HaControlsProviderService : ControlsProviderService() {
         entityRegistry: List<EntityRegistryResponse>?
     ) {
         entities.forEach {
-            val domain = it.key.split(".")[0]
-            val control = domainToHaControl[domain]?.createControl(
+            val control = domainToHaControl[it.value.domain]?.createControl(
                 applicationContext,
                 it.value,
                 RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
@@ -9,6 +9,7 @@ import android.service.controls.templates.StatelessTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -34,7 +35,7 @@ class HaFailedControl {
             DeviceTypes.TYPE_UNKNOWN
 
         override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            entity.entityId.split(".")[0].capitalize()
+            entity.domain.capitalize()
 
         override fun performAction(
             integrationRepository: IntegrationRepository,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -17,6 +17,7 @@ import io.homeassistant.companion.android.HomeAssistantApplication
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.qs.TileEntity
 import kotlinx.coroutines.flow.Flow
@@ -55,8 +56,7 @@ class ManageTilesViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             integrationUseCase.getEntities()?.forEach {
-                val split = it.entityId.split(".")
-                if (split[0] in ManageTilesFragment.validDomains)
+                if (it.domain in ManageTilesFragment.validDomains)
                     entities[it.entityId] = it
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetCameraConfigureBinding
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
@@ -128,11 +129,8 @@ class CameraWidgetConfigureActivity : BaseActivity() {
                 // Fetch entities
                 val fetchedEntities = integrationUseCase.getEntities()
                 fetchedEntities?.forEach {
-                    val entityId = it.entityId
-                    val domain = entityId.split(".")[0]
-
-                    if (domain == "camera") {
-                        entities[entityId] = it
+                    if (it.domain == "camera") {
+                        entities[it.entityId] = it
                     }
                 }
                 entityAdapter.addAll(entities.values)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -17,6 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.databinding.WidgetMediaControlsConfigureBinding
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
@@ -133,11 +134,8 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
                 // Fetch entities
                 val fetchedEntities = integrationUseCase.getEntities()
                 fetchedEntities?.forEach {
-                    val entityId = it.entityId
-                    val domain = entityId.split(".")[0]
-
-                    if (domain == "media_player") {
-                        entities[entityId] = it
+                    if (it.domain == "media_player") {
+                        entities[it.entityId] = it
                     }
                 }
                 entityAdapter.addAll(entities.values)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.data.integration
 
+import android.util.Log
 import java.util.Calendar
 
 data class Entity<T>(
@@ -10,3 +11,46 @@ data class Entity<T>(
     val lastUpdated: Calendar,
     val context: Map<String, Any>?
 )
+
+object EntityExt {
+    const val TAG = "EntityExt"
+
+    const val LIGHT_MODE_COLOR_TEMP = "color_temp"
+    val LIGHT_MODE_NO_BRIGHTNESS_SUPPORT = listOf("unknown", "onoff")
+    const val LIGHT_SUPPORT_BRIGHTNESS_DEPR = 1
+    const val LIGHT_SUPPORT_COLOR_TEMP_DEPR = 2
+}
+
+val <T> Entity<T>.domain: String
+    get() = this.entityId.split(".")[0]
+
+fun <T> Entity<T>.supportsLightBrightness(): Boolean {
+    return try {
+        if (domain != "light") return false
+
+        // On HA Core 2021.5 and later brightness detection has changed
+        // to simplify things in the app lets use both methods for now
+        val supportedColorModes = (attributes as Map<*, *>)["supported_color_modes"] as? List<String>
+        val supportsBrightness =
+            if (supportedColorModes == null) false else (supportedColorModes - EntityExt.LIGHT_MODE_NO_BRIGHTNESS_SUPPORT).isNotEmpty()
+        val supportedFeatures = attributes["supported_features"] as Int
+        supportsBrightness || (supportedFeatures and EntityExt.LIGHT_SUPPORT_BRIGHTNESS_DEPR == EntityExt.LIGHT_SUPPORT_BRIGHTNESS_DEPR)
+    } catch (e: Exception) {
+        Log.e(EntityExt.TAG, "Unable to get supportsLightBrightness", e)
+        false
+    }
+}
+
+fun <T> Entity<T>.supportsLightColorTemperature(): Boolean {
+    return try {
+        if (domain != "light") return false
+
+        val supportedColorModes = (attributes as Map<*, *>)["supported_color_modes"] as? List<String>
+        val supportsColorTemp = supportedColorModes?.contains(EntityExt.LIGHT_MODE_COLOR_TEMP) ?: false
+        val supportedFeatures = attributes["supported_features"] as Int
+        supportsColorTemp || (supportedFeatures and EntityExt.LIGHT_SUPPORT_COLOR_TEMP_DEPR == EntityExt.LIGHT_SUPPORT_COLOR_TEMP_DEPR)
+    } catch (e: Exception) {
+        Log.e(EntityExt.TAG, "Unable to get supportsLightColorTemperature", e)
+        false
+    }
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.HomeAssistantApplication
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.WebSocketState
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
@@ -132,7 +133,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
                 deviceRegistry = homePresenter.getDeviceRegistry()
                 entityRegistry = homePresenter.getEntityRegistry()
                 homePresenter.getEntities()?.forEach {
-                    if (supportedDomains().contains(it.entityId.split(".")[0])) {
+                    if (supportedDomains().contains(it.domain)) {
                         entities[it.entityId] = it
                     }
                 }
@@ -153,7 +154,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
                 // Listen for updates
                 viewModelScope.launch {
                     homePresenter.getEntityUpdates()?.collect {
-                        if (supportedDomains().contains(it.entityId.split(".")[0])) {
+                        if (supportedDomains().contains(it.domain)) {
                             entities[it.entityId] = it
                             updateEntityDomains()
                         }
@@ -191,7 +192,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     fun updateEntityDomains() {
         val entitiesList = entities.values.toList().sortedBy { it.entityId }
         val areasList = areaRegistry.orEmpty().sortedBy { it.name }
-        val domainsList = entitiesList.map { it.entityId.split(".")[0] }.distinct()
+        val domainsList = entitiesList.map { it.domain }.distinct()
 
         // Create a list with all areas + their entities
         areasList.forEach { area ->
@@ -221,7 +222,7 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         // Create a list with all discovered domains + their entities
         domainsList.forEach { domain ->
             val entitiesInDomain = mutableStateListOf<Entity<*>>()
-            entitiesInDomain.addAll(entitiesList.filter { it.entityId.split(".")[0] == domain })
+            entitiesInDomain.addAll(entitiesList.filter { it.domain == domain })
             entitiesByDomain[domain]?.let {
                 it.clear()
                 it.addAll(entitiesInDomain)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -17,6 +17,7 @@ import androidx.wear.compose.material.Text
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
@@ -85,7 +86,7 @@ private fun ChooseEntityChip(
     val attributes = entityList[index].attributes as Map<*, *>
     val iconBitmap = getIcon(
         entityList[index] as Entity<Map<String, Any>>,
-        entityList[index].entityId.split(".")[0],
+        entityList[index].domain,
         LocalContext.current
     )
     Chip(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -19,6 +19,7 @@ import androidx.wear.compose.material.ToggleChipDefaults
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.home.HomePresenterImpl
 import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.getIcon
@@ -37,10 +38,10 @@ fun EntityUi(
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
     val attributes = entity.attributes as Map<*, *>
-    val iconBitmap = getIcon(entity as Entity<Map<String, Any>>, entity.entityId.split(".")[0], LocalContext.current)
+    val iconBitmap = getIcon(entity as Entity<Map<String, Any>>, entity.domain, LocalContext.current)
     val friendlyName = attributes["friendly_name"].toString()
 
-    if (entity.entityId.split(".")[0] in HomePresenterImpl.toggleDomains) {
+    if (entity.domain in HomePresenterImpl.toggleDomains) {
         val isChecked = entity.state in listOf("on", "locked", "open", "opening")
         ToggleChip(
             checked = isChecked,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -19,6 +19,7 @@ import androidx.wear.compose.material.rememberScalingLazyListState
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.wearColorPalette
@@ -90,7 +91,7 @@ private fun FavoriteToggleChip(
     val attributes = entityList[index].attributes as Map<*, *>
     val iconBitmap = getIcon(
         entityList[index] as Entity<Map<String, Any>>,
-        entityList[index].entityId.split(".")[0],
+        entityList[index].domain,
         LocalContext.current
     )
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Wear OS details panel introduced a new location in the code base where entity properties are used to determine feature support, in addition to phone/'full Android' device controls. To prevent duplicate code or code getting out of sync, especially when more features are supported on Wear OS in the future, and perhaps in more places (widgets?), I propose using extensions to keep the code in one place and make code elsewhere easier to read.

I've added the code to the existing file used for the `Entity` data class, but maybe another location is better (in the `util` package, or a new `common.data.util` package)?

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->