### PR TITLE
Fix refreshing settings after requesting background access

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -14,6 +14,7 @@ import android.os.PowerManager
 import android.provider.Settings
 import android.text.InputType
 import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.biometric.BiometricManager
@@ -66,6 +67,10 @@ class SettingsFragment constructor(
 
     private lateinit var authenticator: Authenticator
     private var setLock = false
+
+    private val requestBackgroundAccessResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        updateBackgroundAccessPref()
+    }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         presenter.init(this)
@@ -451,13 +456,13 @@ class SettingsFragment constructor(
 
     @SuppressLint("BatteryLife")
     private fun requestBackgroundAccess() {
-        val intent: Intent
         if (!isIgnoringBatteryOptimizations()) {
-            intent = Intent(
-                Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-                Uri.parse("package:${activity?.packageName}")
+            requestBackgroundAccessResult.launch(
+                Intent(
+                    Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
+                    Uri.parse("package:${activity?.packageName}")
+                )
             )
-            startActivityForResult(intent, 0)
         }
     }
 
@@ -512,7 +517,6 @@ class SettingsFragment constructor(
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        updateBackgroundAccessPref()
 
         val isGreaterR = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The intent to request that battery optimizations are ignored for the app returns an activity result, not a permissions result. Changed to the correct callback to fix refreshing the setting after accepting/denying.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed, bug fix.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->