### PR TITLE
Add fan speed to Wear OS detail panel

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -14,6 +14,7 @@ import android.service.controls.templates.ToggleTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.supportsFanSpeed
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -21,14 +22,13 @@ import io.homeassistant.companion.android.common.R as commonR
 @RequiresApi(Build.VERSION_CODES.R)
 class FanControl {
     companion object : HaControl {
-        private const val SUPPORT_SET_SPEED = 1
         override fun provideControlFeatures(
             context: Context,
             control: Control.StatefulBuilder,
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
         ): Control.StatefulBuilder {
-            if ((entity.attributes["supported_features"] as Int) and SUPPORT_SET_SPEED == SUPPORT_SET_SPEED) {
+            if (entity.supportsFanSpeed()) {
                 val minValue = 0f
                 val maxValue = 100f
                 var currentValue =

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -14,7 +14,7 @@ import android.service.controls.templates.ToggleTemplate
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
-import io.homeassistant.companion.android.common.data.integration.supportsFanSpeed
+import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -28,7 +28,7 @@ class FanControl {
             entity: Entity<Map<String, Any>>,
             area: AreaRegistryResponse?
         ): Control.StatefulBuilder {
-            if (entity.supportsFanSpeed()) {
+            if (entity.supportsFanSetSpeed()) {
                 val minValue = 0f
                 val maxValue = 100f
                 var currentValue =

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -15,6 +15,7 @@ data class Entity<T>(
 object EntityExt {
     const val TAG = "EntityExt"
 
+    const val FAN_SUPPORT_SET_SPEED = 1
     const val LIGHT_MODE_COLOR_TEMP = "color_temp"
     val LIGHT_MODE_NO_BRIGHTNESS_SUPPORT = listOf("unknown", "onoff")
     const val LIGHT_SUPPORT_BRIGHTNESS_DEPR = 1
@@ -23,6 +24,16 @@ object EntityExt {
 
 val <T> Entity<T>.domain: String
     get() = this.entityId.split(".")[0]
+
+fun <T> Entity<T>.supportsFanSpeed(): Boolean {
+    return try {
+        if (domain != "fan") return false
+        ((attributes as Map<*, *>)["supported_features"] as Int) and EntityExt.FAN_SUPPORT_SET_SPEED == EntityExt.FAN_SUPPORT_SET_SPEED
+    } catch (e: Exception) {
+        Log.e(EntityExt.TAG, "Unable to get supportsFanSpeed", e)
+        false
+    }
+}
 
 fun <T> Entity<T>.supportsLightBrightness(): Boolean {
     return try {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -25,12 +25,12 @@ object EntityExt {
 val <T> Entity<T>.domain: String
     get() = this.entityId.split(".")[0]
 
-fun <T> Entity<T>.supportsFanSpeed(): Boolean {
+fun <T> Entity<T>.supportsFanSetSpeed(): Boolean {
     return try {
         if (domain != "fan") return false
         ((attributes as Map<*, *>)["supported_features"] as Int) and EntityExt.FAN_SUPPORT_SET_SPEED == EntityExt.FAN_SUPPORT_SET_SPEED
     } catch (e: Exception) {
-        Log.e(EntityExt.TAG, "Unable to get supportsFanSpeed", e)
+        Log.e(EntityExt.TAG, "Unable to get supportsFanSetSpeed", e)
         false
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -89,7 +89,7 @@
     <string name="biometric_message">Unlock using your biometric or screenlock credential</string>
     <string name="biometric_set_title">Confirm to continue</string>
     <string name="biometric_title">Home Assistant is locked</string>
-    <string name="brightness">Brightness: %1$d</string>
+    <string name="brightness">Brightness: %1$d%%</string>
     <string name="broadcast_intent_error">Unable to send broadcast intent, please check the command format</string>
     <string name="buttons">Buttons</string>
     <string name="button_forward">Next</string>
@@ -604,6 +604,7 @@
     <string name="show_share_logs">Show and Share Logs</string>
     <string name="sign_in_on_phone">Sign in on phone</string>
     <string name="skip">Skip</string>
+    <string name="speed">Speed: %1$d%%</string>
     <string name="state_auto">Auto</string>
     <string name="state_cleaning">Cleaning</string>
     <string name="state_closed">Closed</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -17,6 +17,7 @@ interface HomePresenter {
 
     fun onViewReady()
     suspend fun onEntityClicked(entityId: String, state: String)
+    suspend fun onFanSpeedChanged(entityId: String, speed: Float)
     suspend fun onBrightnessChanged(entityId: String, brightness: Float)
     suspend fun onColorTempChanged(entityId: String, colorTemp: Float)
     fun onLogoutClicked()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -102,6 +102,17 @@ class HomePresenterImpl @Inject constructor(
         )
     }
 
+    override suspend fun onFanSpeedChanged(entityId: String, speed: Float) {
+        integrationUseCase.callService(
+            entityId.split(".")[0],
+            "set_percentage",
+            hashMapOf(
+                "entity_id" to entityId,
+                "percentage" to speed.toInt()
+            )
+        )
+    }
+
     override suspend fun onBrightnessChanged(entityId: String, brightness: Float) {
         integrationUseCase.callService(
             entityId.split(".")[0],

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -239,6 +239,11 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
             homePresenter.onEntityClicked(entityId, state)
         }
     }
+    fun setFanSpeed(entityId: String, speed: Float) {
+        viewModelScope.launch {
+            homePresenter.onFanSpeedChanged(entityId, speed)
+        }
+    }
     fun setBrightness(entityId: String, brightness: Float) {
         viewModelScope.launch {
             homePresenter.onBrightnessChanged(entityId, brightness)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -25,7 +25,7 @@ import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.common.data.integration.domain
-import io.homeassistant.companion.android.common.data.integration.supportsFanSpeed
+import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
 import io.homeassistant.companion.android.common.data.integration.supportsLightColorTemperature
 import io.homeassistant.companion.android.home.HomePresenterImpl
@@ -69,7 +69,7 @@ fun DetailsPanelView(
             }
 
             if (entity.domain == "fan") {
-                if (entity.supportsFanSpeed()) {
+                if (entity.supportsFanSetSpeed()) {
                     item {
                         FanSpeedSlider(attributes, onFanSpeedChanged)
                     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -25,6 +25,7 @@ import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.integration.supportsFanSpeed
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
 import io.homeassistant.companion.android.common.data.integration.supportsLightColorTemperature
 import io.homeassistant.companion.android.home.HomePresenterImpl
@@ -37,6 +38,7 @@ import java.text.DateFormat
 fun DetailsPanelView(
     entity: Entity<*>,
     onEntityToggled: (String, String) -> Unit,
+    onFanSpeedChanged: (Float) -> Unit,
     onBrightnessChanged: (Float) -> Unit,
     onColorTempChanged: (Float) -> Unit
 ) {
@@ -66,6 +68,13 @@ fun DetailsPanelView(
                 }
             }
 
+            if (entity.domain == "fan") {
+                if (entity.supportsFanSpeed()) {
+                    item {
+                        FanSpeedSlider(attributes, onFanSpeedChanged)
+                    }
+                }
+            }
             if (entity.domain == "light") {
                 if (entity.supportsLightBrightness()) {
                     item {
@@ -118,6 +127,45 @@ fun DetailsPanelView(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun FanSpeedSlider(attributes: Map<*, *>, onFanSpeedChanged: (Float) -> Unit) {
+    val minValue = 0f
+    val maxValue = 100f
+    var currentValue = (attributes["percentage"] as? Number)?.toFloat() ?: 0f
+    if (currentValue < minValue)
+        currentValue = minValue
+    if (currentValue > maxValue)
+        currentValue = maxValue
+
+    Column {
+        Text(
+            stringResource(R.string.speed, currentValue.toInt()),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp)
+        )
+        InlineSlider(
+            value = currentValue,
+            onValueChange = onFanSpeedChanged,
+            steps = 9,
+            valueRange = minValue..maxValue,
+            decreaseIcon = {
+                Image(
+                    asset = CommunityMaterial.Icon2.cmd_fan_minus,
+                    colorFilter = ColorFilter.tint(Color.White)
+                )
+            },
+            increaseIcon = {
+                Image(
+                    asset = CommunityMaterial.Icon2.cmd_fan_plus,
+                    colorFilter = ColorFilter.tint(Color.White)
+                )
+            },
+            modifier = Modifier.padding(bottom = 8.dp, top = 2.dp)
+        )
     }
 }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -112,6 +112,12 @@ fun LoadHomePage(
                             onEntityToggled = { entityId, state ->
                                 mainViewModel.toggleEntity(entityId, state)
                             },
+                            onFanSpeedChanged = { speed ->
+                                mainViewModel.setFanSpeed(
+                                    entity.entityId,
+                                    speed
+                                )
+                            },
                             onBrightnessChanged = { brightness ->
                                 mainViewModel.setBrightness(
                                     entity.entityId,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Now that there is a details screen for Wear OS, this PR adds support for controlling a `fan` entity's speed.

On the `InlineSlider`, `steps` has been set to 9 to allow controlling in steps of 10%, I think that is a good balance between quickly changing the value and specific control for fans.

(Also updates the label for the light brightness slider because that is also in %.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Wear OS app showing the details screen for a fan. At the top of the screen, the entity name "itho_fan" is shown with a toggle. Below that, there is a slider with "Speed: 20%" and two buttons to lower and raise the speed.](https://user-images.githubusercontent.com/8148535/156454992-bfda5c2c-3d47-47cf-8de6-50a86407657d.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#702

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->