### PR TITLE
FEAT: Ability to show video in notification as a gif

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1201,6 +1201,14 @@ class MessagingManager @Inject constructor(
                             )
                         }
 
+                        data[TITLE]?.let { rawTitle ->
+                            remoteViewFlipper.setTextViewText(R.id.title, rawTitle)
+                        }
+
+                        data[MESSAGE]?.let { rawMessage ->
+                            remoteViewFlipper.setTextViewText(R.id.info, rawMessage)
+                        }
+
                         builder.setCustomBigContentView(remoteViewFlipper)
                         builder.setStyle(NotificationCompat.DecoratedCustomViewStyle())
                     }

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -32,6 +32,7 @@ import android.speech.tts.UtteranceProgressListener
 import android.text.Spanned
 import android.util.Log
 import android.view.KeyEvent
+import android.widget.RemoteViews
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
@@ -1179,7 +1180,24 @@ class MessagingManager @Inject constructor(
         data[VIDEO_URL]?.let {
             val url = UrlHandler.handle(urlUseCase.getUrl(), it)
             getVideoFrames(url, !UrlHandler.isAbsoluteUrl(it))?.let { frames ->
+                RemoteViews(context.packageName, R.layout.view_image_flipper).let { remoteViewFlipper ->
+                    if (frames.isNotEmpty()) {
+                        frames.forEach { frame ->
+                            remoteViewFlipper.addView(
+                                R.id.frame_flipper,
+                                RemoteViews(context.packageName, R.layout.view_single_frame).apply {
+                                    setImageViewBitmap(
+                                        R.id.frame,
+                                        frame
+                                    )
+                                }
+                            )
+                        }
 
+                        builder.setCustomBigContentView(remoteViewFlipper)
+                        builder.setStyle(NotificationCompat.DecoratedCustomViewStyle())
+                    }
+                }
             }
         }
     }

--- a/app/src/main/res/layout/view_image_flipper.xml
+++ b/app/src/main/res/layout/view_image_flipper.xml
@@ -1,9 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/frame_flipper"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:autoStart="true"
-    android:flipInterval="200"
-    android:inAnimation="@null"
-    android:outAnimation="@null" />
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/title"
+        style="@style/TextAppearance.Compat.Notification.Title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical" />
+
+    <TextView
+        android:id="@+id/info"
+        style="@style/TextAppearance.Compat.Notification.Info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical" />
+
+    <ViewFlipper
+        android:id="@+id/frame_flipper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="4dp"
+        android:autoStart="true"
+        android:flipInterval="400"
+        android:inAnimation="@null"
+        android:outAnimation="@null" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_image_flipper.xml
+++ b/app/src/main/res/layout/view_image_flipper.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ViewFlipper xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/frame_flipper"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <ViewFlipper
-        android:id="@+id/frame_flipper"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:autoStart="true"
-        android:flipInterval="250"
-        android:inAnimation="@null"
-        android:outAnimation="@null" />
-
-</FrameLayout>
+    android:layout_height="match_parent"
+    android:autoStart="true"
+    android:flipInterval="200"
+    android:inAnimation="@null"
+    android:outAnimation="@null" />

--- a/app/src/main/res/layout/view_image_flipper.xml
+++ b/app/src/main/res/layout/view_image_flipper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ViewFlipper
+        android:id="@+id/frame_flipper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:autoStart="true"
+        android:flipInterval="250"
+        android:inAnimation="@null"
+        android:outAnimation="@null" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/view_single_frame.xml
+++ b/app/src/main/res/layout/view_single_frame.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/frame"
-    android:layout_width="300dp"
-    android:layout_height="match_parent"
+    android:layout_width="400dp"
+    android:layout_height="300dp"
     android:adjustViewBounds="true"
     android:scaleType="centerCrop" />

--- a/app/src/main/res/layout/view_single_frame.xml
+++ b/app/src/main/res/layout/view_single_frame.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ImageView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/frame"
-    android:layout_width="400dp"
-    android:layout_height="300dp"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_gravity="center"
     android:adjustViewBounds="true"
     android:scaleType="centerCrop" />

--- a/app/src/main/res/layout/view_single_frame.xml
+++ b/app/src/main/res/layout/view_single_frame.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/frame"
+    android:layout_width="300dp"
+    android:layout_height="match_parent"
+    android:adjustViewBounds="true"
+    android:scaleType="centerCrop" />


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
I have added the ability for a user to define `video` as part of an Android notification. This video will be downloaded and home assistant will attempt to parse frames from this video to show in a notification. The goal is to find 5 frames but it will work for any number of frames < 5 as well. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

https://user-images.githubusercontent.com/14866235/156859680-5c76f67d-4e27-4ec5-a6ee-c6c96937ce91.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#705