### PR TITLE
Only skip some reports when high accuracy mode is off

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -575,7 +575,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                 "\nAccuracy: ${location.accuracy}" +
                 "\nBearing: ${location.bearing}"
         )
-        val highAccuracy = getHighAccuracyModeSetting()
+        val highAccuracy = getHighAccuracyMode()
         var accuracy = 0
         if (location.accuracy.toInt() >= 0) {
             accuracy = location.accuracy.toInt()

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -575,6 +575,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                 "\nAccuracy: ${location.accuracy}" +
                 "\nBearing: ${location.bearing}"
         )
+        val highAccuracy = getHighAccuracyModeSetting()
         var accuracy = 0
         if (location.accuracy.toInt() >= 0) {
             accuracy = location.accuracy.toInt()
@@ -591,7 +592,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         val now = System.currentTimeMillis()
 
         Log.d(TAG, "Begin evaluating if location update should be skipped")
-        if (now + 5000 < location.time) {
+        if (now + 5000 < location.time && !highAccuracy) {
             Log.d(TAG, "Skipping location update that came from the future. ${now + 5000} should always be greater than ${location.time}")
             return
         }
@@ -615,7 +616,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                     return
                 }
             } else {
-                if (now < lastLocationSend + 5000 && !geofenceUpdate) {
+                if (now < lastLocationSend + 5000 && !geofenceUpdate && !highAccuracy) {
                     Log.d(
                         TAG,
                         "New location update not possible within 5 seconds, not sending to HA"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2336 by only skipping some of the reports when high accuracy mode is off. When high accuracy mode is on we can assume the app will not get a report in the future nor do we need to worry about the 5 second delay as the `time` could be off slightly per the logs above.

I thought it might be better to check for high accuracy mode being on instead of simply increasing the time check which is set to 5 seconds.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->