### PR TITLE
Hide delete icon on more app created channels

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -18,6 +18,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
+import io.homeassistant.companion.android.common.util.highAccuracyChannel
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.util.ForegroundServiceLauncher
 import kotlin.math.abs
@@ -110,10 +111,8 @@ class HighAccuracyLocationService : Service() {
         }
 
         private fun createNotificationBuilder(context: Context) {
-            var channelID = "High accuracy location"
-
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val channel = NotificationChannel(channelID, context.getString(commonR.string.high_accuracy_mode_channel_name), NotificationManager.IMPORTANCE_DEFAULT)
+                val channel = NotificationChannel(highAccuracyChannel, context.getString(commonR.string.high_accuracy_mode_channel_name), NotificationManager.IMPORTANCE_DEFAULT)
                 notificationManagerCompat.createNotificationChannel(channel)
             }
 
@@ -124,7 +123,7 @@ class HighAccuracyLocationService : Service() {
 
             val disablePendingIntent = PendingIntent.getBroadcast(context, 0, disableIntent, PendingIntent.FLAG_MUTABLE)
 
-            notificationBuilder = NotificationCompat.Builder(context, channelID)
+            notificationBuilder = NotificationCompat.Builder(context, highAccuracyChannel)
                 .setSmallIcon(commonR.drawable.ic_stat_ic_notification)
                 .setColor(Color.GRAY)
                 .setOngoing(true)

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -52,6 +52,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.util.cancel
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
+import io.homeassistant.companion.android.common.util.generalChannel
 import io.homeassistant.companion.android.common.util.getActiveNotification
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.notification.NotificationItem
@@ -1399,7 +1400,7 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ): String {
         // Define some values for a default channel
-        var channelID = "general"
+        var channelID = generalChannel
         var channelName = "General"
 
         if (data.containsKey("channel")) {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/notification/views/NotificationChannelView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/notification/views/NotificationChannelView.kt
@@ -26,9 +26,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.common.R
-import io.homeassistant.companion.android.common.sensors.SensorWorkerBase
+import io.homeassistant.companion.android.common.util.appCreatedChannels
 import io.homeassistant.companion.android.settings.notification.NotificationViewModel
-import io.homeassistant.companion.android.websocket.WebsocketManager
 import kotlinx.coroutines.launch
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -73,7 +72,7 @@ fun NotificationChannelView(
                                 .clickable { notificationViewModel.editChannelDetails(channel.id) }
                                 .padding(12.dp)
                         )
-                        if (channel.id != SensorWorkerBase.channelId && channel.id != WebsocketManager.CHANNEL_ID) {
+                        if (channel.id !in appCreatedChannels) {
                             Icon(
                                 Icons.Filled.Delete,
                                 stringResource(id = R.string.delete_channel),

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorUpdateFrequencyView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorUpdateFrequencyView.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.common.R
-import io.homeassistant.companion.android.common.sensors.SensorWorkerBase
+import io.homeassistant.companion.android.common.util.sensorWorkerChannel
 import io.homeassistant.companion.android.database.settings.SensorUpdateFrequencySetting
 import io.homeassistant.companion.android.util.compose.InfoNotification
 import io.homeassistant.companion.android.util.compose.RadioButtonRow
@@ -56,7 +56,7 @@ fun SensorUpdateFrequencyView(
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             InfoNotification(
                 infoString = R.string.sensor_update_notification,
-                channelId = SensorWorkerBase.channelId,
+                channelId = sensorWorkerChannel,
                 buttonString = R.string.sensor_worker_notification_channel
             )
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
@@ -19,10 +19,10 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.util.websocketChannel
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
 import io.homeassistant.companion.android.util.compose.InfoNotification
 import io.homeassistant.companion.android.util.compose.RadioButtonRow
-import io.homeassistant.companion.android.websocket.WebsocketManager
 
 @Composable
 fun WebsocketSettingView(
@@ -67,7 +67,7 @@ fun WebsocketSettingView(
         if (websocketSetting != WebsocketSetting.NEVER && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION) {
             InfoNotification(
                 infoString = R.string.websocket_persistent_notification,
-                channelId = WebsocketManager.CHANNEL_ID,
+                channelId = websocketChannel,
                 buttonString = R.string.websocket_notification_channel
             )
         }

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -27,6 +27,7 @@ import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
+import io.homeassistant.companion.android.common.util.websocketChannel
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
 import io.homeassistant.companion.android.notifications.MessagingManager
@@ -49,7 +50,6 @@ class WebsocketManager(
     companion object {
         private const val TAG = "WebSockManager"
         private const val SOURCE = "Websocket"
-        const val CHANNEL_ID = "Websocket"
         private const val NOTIFICATION_ID = 65423
         private val DEFAULT_WEBSOCKET_SETTING = if (BuildConfig.FLAVOR == "full") WebsocketSetting.NEVER else WebsocketSetting.ALWAYS
 
@@ -169,10 +169,10 @@ class WebsocketManager(
     private suspend fun createNotification() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             var notificationChannel =
-                notificationManager.getNotificationChannel(CHANNEL_ID)
+                notificationManager.getNotificationChannel(websocketChannel)
             if (notificationChannel == null) {
                 notificationChannel = NotificationChannel(
-                    CHANNEL_ID,
+                    websocketChannel,
                     applicationContext.getString(R.string.websocket_setting_name),
                     NotificationManager.IMPORTANCE_LOW
                 )
@@ -200,13 +200,13 @@ class WebsocketManager(
             settingIntent,
             PendingIntent.FLAG_IMMUTABLE
         )
-        val notification = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+        val notification = NotificationCompat.Builder(applicationContext, websocketChannel)
             .setSmallIcon(R.drawable.ic_stat_ic_notification)
             .setContentTitle(applicationContext.getString(R.string.websocket_listening))
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
-            .setGroup(CHANNEL_ID)
+            .setGroup(websocketChannel)
             .addAction(
                 io.homeassistant.companion.android.R.drawable.ic_websocket,
                 applicationContext.getString(R.string.settings),

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
@@ -11,6 +11,7 @@ import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.util.sensorWorkerChannel
 import io.homeassistant.companion.android.database.AppDatabase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -26,7 +27,6 @@ abstract class SensorWorkerBase(
 
     companion object {
         const val TAG = "SensorWorker"
-        const val channelId = "Sensor Worker"
         const val NOTIFICATION_ID = 42
     }
 
@@ -38,7 +38,7 @@ abstract class SensorWorkerBase(
         if (enabledSensorCount > 0) {
             Log.d(TAG, "Updating all Sensors.")
             createNotificationChannel()
-            val notification = NotificationCompat.Builder(applicationContext, channelId)
+            val notification = NotificationCompat.Builder(applicationContext, sensorWorkerChannel)
                 .setSmallIcon(commonR.drawable.ic_stat_ic_notification)
                 .setContentTitle(appContext.getString(commonR.string.updating_sensors))
                 .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -59,10 +59,10 @@ abstract class SensorWorkerBase(
     protected fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             var notificationChannel =
-                notificationManager.getNotificationChannel(channelId)
+                notificationManager.getNotificationChannel(sensorWorkerChannel)
             if (notificationChannel == null) {
                 notificationChannel = NotificationChannel(
-                    channelId, TAG, NotificationManager.IMPORTANCE_LOW
+                    sensorWorkerChannel, TAG, NotificationManager.IMPORTANCE_LOW
                 )
                 notificationManager.createNotificationChannel(notificationChannel)
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
@@ -1,0 +1,17 @@
+package io.homeassistant.companion.android.common.util
+
+const val sensorWorkerChannel = "Sensor Worker"
+const val websocketChannel = "Websocket"
+const val highAccuracyChannel = "High accuracy location"
+const val databaseChannel = "App Database"
+const val locationDisabledChannel = "Location disabled"
+const val generalChannel = "general"
+
+val appCreatedChannels = listOf(
+    sensorWorkerChannel,
+    websocketChannel,
+    highAccuracyChannel,
+    databaseChannel,
+    locationDisabledChannel,
+    generalChannel
+)

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/DisabledLocationHandler.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/DisabledLocationHandler.kt
@@ -81,10 +81,9 @@ object DisabledLocationHandler {
         if ((!withDisableOption || callback == null) && showAsNotification) {
             val notificationManager = NotificationManagerCompat.from(context)
             if (notificationManager.getActiveNotification(DISABLED_LOCATION_WARN_ID, DISABLED_LOCATION_WARN_ID.hashCode()) == null) {
-                var channelID = "Location disabled"
 
                 if (VERSION.SDK_INT >= VERSION_CODES.O) {
-                    val channel = NotificationChannel(channelID, context.applicationContext.getString(commonR.string.location_warn_channel), NotificationManager.IMPORTANCE_DEFAULT)
+                    val channel = NotificationChannel(locationDisabledChannel, context.applicationContext.getString(commonR.string.location_warn_channel), NotificationManager.IMPORTANCE_DEFAULT)
                     notificationManager.createNotificationChannel(channel)
                 }
 
@@ -93,7 +92,7 @@ object DisabledLocationHandler {
                     intent, PendingIntent.FLAG_IMMUTABLE
                 )
 
-                val notificationBuilder = NotificationCompat.Builder(context, channelID)
+                val notificationBuilder = NotificationCompat.Builder(context, locationDisabledChannel)
                     .setSmallIcon(commonR.drawable.ic_stat_ic_notification)
                     .setColor(Color.RED)
                     .setOngoing(true)

--- a/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -20,6 +20,7 @@ import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.util.databaseChannel
 import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.authentication.AuthenticationDao
 import io.homeassistant.companion.android.database.notification.NotificationDao
@@ -90,7 +91,6 @@ abstract class AppDatabase : RoomDatabase() {
     companion object {
         private const val DATABASE_NAME = "HomeAssistantDB"
         internal const val TAG = "AppDatabase"
-        private const val channelId = "App Database"
         private const val NOTIFICATION_ID = 45
         private lateinit var appContext: Context
         lateinit var integrationRepository: IntegrationRepository
@@ -497,10 +497,10 @@ abstract class AppDatabase : RoomDatabase() {
                 val notificationManager = appContext.getSystemService<NotificationManager>()!!
 
                 var notificationChannel =
-                    notificationManager.getNotificationChannel(channelId)
+                    notificationManager.getNotificationChannel(databaseChannel)
                 if (notificationChannel == null) {
                     notificationChannel = NotificationChannel(
-                        channelId, TAG, NotificationManager.IMPORTANCE_HIGH
+                        databaseChannel, TAG, NotificationManager.IMPORTANCE_HIGH
                     )
                     notificationManager.createNotificationChannel(notificationChannel)
                 }
@@ -509,7 +509,7 @@ abstract class AppDatabase : RoomDatabase() {
 
         private fun notifyMigrationFailed() {
             createNotificationChannel()
-            val notification = NotificationCompat.Builder(appContext, channelId)
+            val notification = NotificationCompat.Builder(appContext, databaseChannel)
                 .setSmallIcon(commonR.drawable.ic_stat_ic_notification)
                 .setContentTitle(appContext.getString(commonR.string.database_migration_failed))
                 .setPriority(NotificationCompat.PRIORITY_HIGH)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I realized that we didn't hide all app created channels, we only hid the ones most users will see. So I opted to move all app created channels to its own file so we can maintain them in a single location. I also opted to add the `General` channel to the exclusion list because that is the default channel if not specified so it should be treated like an app created channel.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->