### PR TITLE
Allow changing high accuracy update interval via command

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -112,6 +112,7 @@ class MessagingManager @Inject constructor(
         const val REPLY = "REPLY"
         const val BLE_ADVERTISE = "ble_advertise"
         const val BLE_TRANSMIT = "ble_transmit"
+        const val HIGH_ACCURACY_UPDATE_INTERVAL = "high_accuracy_update_interval"
 
         // special action constants
         const val REQUEST_LOCATION_UPDATE = "request_location_update"
@@ -174,6 +175,9 @@ class MessagingManager @Inject constructor(
         const val BLE_TRANSMIT_LOW = "ble_transmit_low"
         const val BLE_TRANSMIT_MEDIUM = "ble_transmit_medium"
         const val BLE_TRANSMIT_HIGH = "ble_transmit_high"
+
+        // High accuracy commands
+        const val HIGH_ACCURACY_SET_UPDATE_INTERVAL = "high_accuracy_set_update_interval"
 
         // Command groups
         val DEVICE_COMMANDS = listOf(
@@ -344,7 +348,12 @@ class MessagingManager @Inject constructor(
                         }
                     }
                     COMMAND_HIGH_ACCURACY_MODE -> {
-                        if (!jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] in ENABLE_COMMANDS)
+                        if ((!jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] in ENABLE_COMMANDS) ||
+                            (
+                                !jsonData[TITLE].isNullOrEmpty() && jsonData[TITLE] == HIGH_ACCURACY_SET_UPDATE_INTERVAL &&
+                                    jsonData[HIGH_ACCURACY_UPDATE_INTERVAL]?.toIntOrNull() != null && jsonData[HIGH_ACCURACY_UPDATE_INTERVAL]?.toInt()!! > 5
+                                )
+                        )
                             handleDeviceCommands(jsonData)
                         else {
                             mainScope.launch {
@@ -352,6 +361,7 @@ class MessagingManager @Inject constructor(
                                     TAG,
                                     "Invalid high accuracy mode command received, posting notification to device"
                                 )
+                                sendNotification(jsonData)
                             }
                         }
                     }
@@ -641,11 +651,10 @@ class MessagingManager @Inject constructor(
                     )
             }
             COMMAND_HIGH_ACCURACY_MODE -> {
-                if (title == TURN_OFF) {
-                    LocationSensorManager.setHighAccuracyModeSetting(context, false)
-                }
-                if (title == TURN_ON) {
-                    LocationSensorManager.setHighAccuracyModeSetting(context, true)
+                when (title) {
+                    TURN_OFF -> LocationSensorManager.setHighAccuracyModeSetting(context, false)
+                    TURN_ON -> LocationSensorManager.setHighAccuracyModeSetting(context, true)
+                    HIGH_ACCURACY_SET_UPDATE_INTERVAL -> LocationSensorManager.setHighAccuracyModeIntervalSetting(context, data[HIGH_ACCURACY_UPDATE_INTERVAL]!!.toInt())
                 }
                 val intent = Intent(context, LocationSensorManager::class.java)
                 intent.action = LocationSensorManager.ACTION_FORCE_HIGH_ACCURACY

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -43,6 +43,7 @@ class LocationSensorManager : LocationSensorManagerBase(), SensorManager {
         internal const val TAG = "LocBroadcastReceiver"
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {}
+        fun setHighAccuracyModeIntervalSetting(context: Context, updateInterval: Int) {}
     }
 
     override fun onReceive(context: Context, intent: Intent) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2328 by introducing a new command for high accuracy mode commands to set the update interval. Once set the service will restart with the new interval. I also noticed failed commands for high accuracy mode was not posting the notification as it should so added that as well.

example:
```
service: notify.mobile_app_pixel_6_pro
data:
  message: command_high_accuracy_mode
  title: high_accuracy_set_update_interval
  data:
    high_accuracy_update_interval: 60
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#709

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM: https://github.com/home-assistant/mobile-apps-fcm-push/pull/68