### PR TITLE
Add a transport sensor

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -798,4 +798,6 @@
     <string name="delete_channel">Delete notification channel</string>
     <string name="notification_channel_deleted">Channel \"%1$s\" deleted</string>
     <string name="undo">Undo</string>
+    <string name="basic_sensor_name_network_type">Network Type</string>
+    <string name="sensor_description_network_type">The type of transport the current active network is using</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds a new sensor for the "Network Type" to show the transport type being used.  Possible states can be `bluetooth`, `cellular`, `ethernet`, `lowpan`, `vpn`, `wifi` or `wifi_aware`

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/157526774-4f3399da-dcc9-4251-9704-ebe0abc7e4fc.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#710

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Adding this as a sensor because it reports potentially good data if a user wants to know if they are on vpn or something, also because I had already done the work mistakenly so why throw it out 😛 https://github.com/home-assistant/android/issues/2350#issuecomment-1061272547