### PR TITLE
Force resize of video frames instead of compressing

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import java.io.ByteArrayOutputStream
 import java.net.URL
 import java.net.URLDecoder
 import java.util.Locale

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1270,11 +1270,11 @@ class MessagingManager @Inject constructor(
             return@withContext processingFrames.awaitAll().filterNotNull()
         }
 
-    private fun Bitmap.getCompressedFrame(): Bitmap? =
-        ByteArrayOutputStream().let { outputStream ->
-            this.compress(Bitmap.CompressFormat.JPEG, 50, outputStream)
-            outputStream.toByteArray().let { bytes -> BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }
-        }
+    private fun Bitmap.getCompressedFrame(): Bitmap? {
+        val newHeight = height / 4
+        val newWidth = width / 4
+        return Bitmap.createScaledBitmap(this, newWidth, newHeight, false)
+    }
 
     private fun handleActions(
         builder: NotificationCompat.Builder,


### PR DESCRIPTION
Unfortunately, I tried on my personal device and was still seeing this fail. Turns out that compressing wasn't enough and I need to manually scale down the bitmap to get it to work. This is a small addendum to #2353 

Sorry for the extra PR 😦 