### PR TITLE
Remove internet connectivity requirement for WebsocketManager

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -5,16 +5,15 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
 import android.os.Build
 import android.os.PowerManager
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
-import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ForegroundInfo
-import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -54,13 +53,8 @@ class WebsocketManager(
         private val DEFAULT_WEBSOCKET_SETTING = if (BuildConfig.FLAVOR == "full") WebsocketSetting.NEVER else WebsocketSetting.ALWAYS
 
         fun start(context: Context) {
-            val constraints = Constraints.Builder()
-                .setRequiredNetworkType(NetworkType.CONNECTED)
-                .build()
-
             val websocketNotifications =
                 PeriodicWorkRequestBuilder<WebsocketManager>(15, TimeUnit.MINUTES)
-                    .setConstraints(constraints)
                     .build()
 
             val workManager = WorkManager.getInstance(context)
@@ -124,13 +118,18 @@ class WebsocketManager(
         return@withContext Result.success()
     }
 
+    @Suppress("DEPRECATION")
     private suspend fun shouldWeRun(): Boolean {
+        // Check for connectivity but not internet access, based on WorkManager's NetworkConnectedController API <26
+        val connectivityManager = applicationContext.getSystemService<ConnectivityManager>()
+        val networkInfo = connectivityManager?.activeNetworkInfo
         val powerManager = applicationContext.getSystemService<PowerManager>()!!
         val displayOff = !powerManager.isInteractive
         val setting = settingsDao.get(0)?.websocketSetting ?: DEFAULT_WEBSOCKET_SETTING
         val isHome = urlRepository.isInternal()
         return when {
             (setting == WebsocketSetting.NEVER) -> false
+            (networkInfo != null && !networkInfo.isConnected) -> false
             (displayOff && setting == WebsocketSetting.SCREEN_ON) -> false
             (!isHome && setting == WebsocketSetting.HOME_WIFI) -> false
             else -> true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #2273 by replacing the `NetworkType.CONNECTED` constraint on the job for `WebsocketManager` with a check that does not take the validation status (= internet access) of the network into account. This change shouldn't have any negative consequences because validation will change network state for which the app is registered to receive broadcasts (in order to start websocket again).

Related: [WorkManager 2.7.1 code for constraint](https://android.googlesource.com/platform/frameworks/support.git/+/886e6487b3b009732a88af4bd242d4ae30f801ab/work/work-runtime/src/main/java/androidx/work/impl/constraints/controllers/NetworkConnectedController.java), [Google issue tracker request](https://issuetracker.google.com/issues/140056060)

## Screenshots
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I don't think this is necessary

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->