### PR TITLE
Fix widget crash on orientation change and landscape layout fixes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -168,24 +168,28 @@
         </receiver>
 
         <activity android:name=".widgets.button.ButtonWidgetConfigureActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
         <activity android:name=".widgets.camera.CameraWidgetConfigureActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
         <activity android:name=".widgets.entity.EntityWidgetConfigureActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
         <activity android:name=".widgets.media_player_controls.MediaPlayerControlsWidgetConfigureActivity"
+            android:configChanges="orientation|screenSize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -36,7 +36,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:completionThreshold="0"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionNext|flagNoFullscreen"
                 android:inputType="text" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/widget_button_configure_dynamic_field.xml
+++ b/app/src/main/res/layout/widget_button_configure_dynamic_field.xml
@@ -19,7 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:completionThreshold="0"
-        android:imeOptions="actionNext"
+        android:imeOptions="actionNext|flagNoFullscreen"
         android:inputType="text" />
 </LinearLayout>
 

--- a/app/src/main/res/layout/widget_camera_configure.xml
+++ b/app/src/main/res/layout/widget_camera_configure.xml
@@ -34,7 +34,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:completionThreshold="0"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionNext|flagNoFullscreen"
                 android:inputType="text" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -34,7 +34,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:completionThreshold="0"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionNext|flagNoFullscreen"
                 android:inputType="text" />
         </LinearLayout>
 

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -35,7 +35,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:completionThreshold="0"
-                android:imeOptions="actionNext"
+                android:imeOptions="actionNext|flagNoFullscreen"
                 android:inputType="text" />
 
         </LinearLayout>
@@ -75,7 +75,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:completionThreshold="0"
-                    android:imeOptions="actionNext"
+                    android:imeOptions="actionNext|flagNoFullscreen"
                     android:inputType="text" />
 
             </LinearLayout>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Had a user report in discord that the app was crashing when the autocomplete text field was expanded and the device orientation changed.  

https://discord.com/channels/330944238910963714/562408603345092636/954056480284373063

This causes the following crash:

```
2022-03-17 09:58:00.274 17976-17976/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.homeassistant.companion.android, PID: 17976
    android.view.WindowManager$BadTokenException: Unable to add window -- token null is not valid; is your activity running?
        at android.view.ViewRootImpl.setView(ViewRootImpl.java:1153)
        at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:399)
        at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:133)
        at android.widget.PopupWindow.invokePopup(PopupWindow.java:1576)
        at android.widget.PopupWindow.showAsDropDown(PopupWindow.java:1423)
        at android.widget.ListPopupWindow.show(ListPopupWindow.java:722)
        at android.widget.AutoCompleteTextView.showDropDown(AutoCompleteTextView.java:1317)
        at com.google.android.material.textfield.MaterialAutoCompleteTextView.showDropDown(MaterialAutoCompleteTextView.java:138)
        at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.dropDownOnFocus$lambda-4(ButtonWidgetConfigureActivity.kt:109)
        at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.$r8$lambda$LEi5w1VAeKkYoKcafH8E9TBoe7s(Unknown Source:0)
        at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity$$ExternalSyntheticLambda8.onFocusChange(Unknown Source:0)
        at android.view.View.onFocusChanged(View.java:8109)
        at android.widget.TextView.onFocusChanged(TextView.java:11058)
        at android.widget.AutoCompleteTextView.onFocusChanged(AutoCompleteTextView.java:1173)
        at android.view.View.handleFocusGainInternal(View.java:7779)
        at android.view.View.requestFocusNoSearch(View.java:13540)
        at android.view.View.requestFocus(View.java:13514)
        at android.view.View.requestFocus(View.java:13481)
        at android.view.View.requestFocus(View.java:13423)
        at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2208)
        at android.app.Activity.onRestoreInstanceState(Activity.java:1723)
        at android.app.Activity.performRestoreInstanceState(Activity.java:1676)
        at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1376)
        at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3676)
        at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
        at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2210)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7839)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
```

To fix this we adjust the manifest to account for orientation changes on these activities.

Furthermore I noticed once in landscape the full screen editor shows up which defeats the purpose of the autocomplete text fields, so on these fields I opted to not go full screen to allow the autocomplete field to work as desired. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->