### PR TITLE
fix headphone sensor: check audio OUTPUT devices, not INPUT

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -171,7 +171,7 @@ class AudioSensorManager : SensorManager {
 
         var isHeadphones = false
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_INPUTS)
+            val audioDevices = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS)
             for (deviceInfo in audioDevices) {
                 if (deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADPHONES || deviceInfo.type == AudioDeviceInfo.TYPE_WIRED_HEADSET || deviceInfo.type == AudioDeviceInfo.TYPE_USB_HEADSET)
                     isHeadphones = true


### PR DESCRIPTION
Fixes #2387
This probably worked fine with headsets, as those also provide audio input.


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix headphone sensor: #2387

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->