### PR TITLE
Don't crash on sensor update on on/off/setting change

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -141,7 +141,11 @@ class SensorDetailViewModel @Inject constructor(
         }
 
         updateSensorEntity(isEnabled)
-        if (isEnabled) sensorManager?.requestSensorUpdate(app)
+        if (isEnabled) try {
+            sensorManager?.requestSensorUpdate(app)
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception while updating sensor $sensorId", e)
+        }
     }
 
     fun onSettingWithDialogPressed(setting: SensorSetting) {
@@ -181,7 +185,11 @@ class SensorDetailViewModel @Inject constructor(
 
     fun setSetting(setting: SensorSetting) {
         sensorDao.add(setting)
-        sensorManager?.requestSensorUpdate(app)
+        try {
+            sensorManager?.requestSensorUpdate(app)
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception while updating sensor $sensorId", e)
+        }
         refreshSensorData()
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -144,7 +144,7 @@ class SensorDetailViewModel @Inject constructor(
         if (isEnabled) try {
             sensorManager?.requestSensorUpdate(app)
         } catch (e: Exception) {
-            Log.e(TAG, "Exception while updating sensor $sensorId", e)
+            Log.e(TAG, "Exception while requesting update for sensor $sensorId", e)
         }
     }
 
@@ -188,7 +188,7 @@ class SensorDetailViewModel @Inject constructor(
         try {
             sensorManager?.requestSensorUpdate(app)
         } catch (e: Exception) {
-            Log.e(TAG, "Exception while updating sensor $sensorId", e)
+            Log.e(TAG, "Exception while requesting update for sensor $sensorId", e)
         }
         refreshSensorData()
     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -261,8 +261,11 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
                 .first { basicSensor -> basicSensor.id == sensorId }
             updateSensorEntity(sensorsDao, basicSensor, isEnabled)
 
-            if (isEnabled)
+            if (isEnabled) try {
                 sensorManager.requestSensorUpdate(app)
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception while requesting update for sensor $sensorId", e)
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR includes a more generic fix for #2386 to make sure that the UI _never_ crashes on a sensor update initiated by toggling a sensor on/off or changing a sensor setting, the app should instead fail silently because it might not be related to the user's action.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->