### PR TITLE
Fix gesture detection on WebViewActivity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
@@ -19,8 +19,8 @@ abstract class OnSwipeListener : View.OnTouchListener {
     var downEvent: MotionEvent? = null
     var numberOfPointers = 0
 
-    var minimumFlingVelocity: Int? = null
-    var maximumFlingVelocity: Int? = null
+    var minimumFlingVelocity = ViewConfiguration.getMinimumFlingVelocity()
+    var maximumFlingVelocity = ViewConfiguration.getMaximumFlingVelocity()
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {
         event?.let { motionEvent ->
@@ -53,35 +53,32 @@ abstract class OnSwipeListener : View.OnTouchListener {
                     // From the GestureDetector: check the dot product of current velocities.
                     // If the pointer that left was opposing another velocity vector, clear.
                     calculateVelocityForView(v)
-                    if (minimumFlingVelocity != null && maximumFlingVelocity != null) {
-                        velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity!!.toFloat())
-                        val upIndex = motionEvent.actionIndex
-                        val id1 = motionEvent.getPointerId(upIndex)
-                        val x1 = velocityTracker?.getXVelocity(id1) ?: 0f
-                        val y1 = velocityTracker?.getYVelocity(id1) ?: 0f
-                        for (i in 0 until motionEvent.pointerCount) {
-                            if (i == upIndex) continue
-                            val id2 = motionEvent.getPointerId(i)
-                            val x = x1 * (velocityTracker?.getXVelocity(id2) ?: 0f)
-                            val y = y1 * (velocityTracker?.getYVelocity(id2) ?: 0f)
-                            val dot = x + y
-                            if (dot < 0) {
-                                velocityTracker?.clear()
-                                break
-                            }
+                    velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity.toFloat())
+                    val upIndex = motionEvent.actionIndex
+                    val id1 = motionEvent.getPointerId(upIndex)
+                    val x1 = velocityTracker?.getXVelocity(id1) ?: 0f
+                    val y1 = velocityTracker?.getYVelocity(id1) ?: 0f
+                    for (i in 0 until motionEvent.pointerCount) {
+                        if (i == upIndex) continue
+                        val id2 = motionEvent.getPointerId(i)
+                        val x = x1 * (velocityTracker?.getXVelocity(id2) ?: 0f)
+                        val y = y1 * (velocityTracker?.getYVelocity(id2) ?: 0f)
+                        val dot = x + y
+                        if (dot < 0) {
+                            velocityTracker?.clear()
+                            break
                         }
                     }
                 }
                 MotionEvent.ACTION_UP -> {
                     var handled: Boolean? = null
                     calculateVelocityForView(v)
-                    velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity!!.toFloat())
+                    velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity.toFloat())
                     val velocityX = velocityTracker?.getXVelocity(motionEvent.getPointerId(0))
                     val velocityY = velocityTracker?.getYVelocity(motionEvent.getPointerId(0))
                     if (
                         velocityX != null && velocityY != null &&
-                        minimumFlingVelocity != null && maximumFlingVelocity != null &&
-                        ((abs(velocityY) > minimumFlingVelocity!!) || (abs(velocityX) > minimumFlingVelocity!!))
+                        ((abs(velocityY) > minimumFlingVelocity) || (abs(velocityX) > minimumFlingVelocity))
                     ) {
                         handled = onFling(
                             downEvent!!,
@@ -101,12 +98,9 @@ abstract class OnSwipeListener : View.OnTouchListener {
     }
 
     private fun calculateVelocityForView(view: View?) {
-        if (view != null) {
+        if (view?.context != null) {
             minimumFlingVelocity = ViewConfiguration.get(view.context).scaledMinimumFlingVelocity
             maximumFlingVelocity = ViewConfiguration.get(view.context).scaledMaximumFlingVelocity
-        } else {
-            minimumFlingVelocity = ViewConfiguration.getMinimumFlingVelocity()
-            maximumFlingVelocity = ViewConfiguration.getMaximumFlingVelocity()
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
@@ -1,0 +1,223 @@
+package io.homeassistant.companion.android.util
+
+import android.os.Handler
+import android.os.Looper
+import android.view.MotionEvent
+import android.view.VelocityTracker
+import android.view.View
+import android.view.ViewConfiguration
+import kotlin.math.abs
+import kotlin.math.atan2
+
+// Adapted from the system GestureDetector/GestureListener and https://stackoverflow.com/a/26387629
+// We need to keep track of (pointer) down, move, (pointer) up and cancel events to be able to detect flings
+// (or swipes) and send the direction + number of pointers for that fling to the app
+abstract class OnSwipeListener : View.OnTouchListener {
+    var handler = Handler(Looper.getMainLooper())
+
+    var velocityTracker: VelocityTracker? = null
+    var downEvent: MotionEvent? = null
+    var numberOfPointers = 0
+
+    var minimumFlingVelocity: Int? = null
+    var maximumFlingVelocity: Int? = null
+
+    override fun onTouch(v: View?, event: MotionEvent?): Boolean {
+        event?.let { motionEvent ->
+            if (velocityTracker == null) velocityTracker = VelocityTracker.obtain()
+            velocityTracker?.addMovement(event)
+
+            when (motionEvent.action and MotionEvent.ACTION_MASK) {
+                MotionEvent.ACTION_DOWN -> {
+                    downEvent?.recycle()
+                    downEvent = MotionEvent.obtain(motionEvent)
+                    numberOfPointers = 1
+                }
+                MotionEvent.ACTION_POINTER_DOWN -> {
+                    if (motionEvent.pointerCount > numberOfPointers) {
+                        handler.removeCallbacksAndMessages(null)
+                        numberOfPointers = motionEvent.pointerCount
+                    }
+                }
+                MotionEvent.ACTION_POINTER_UP -> {
+                    if ((motionEvent.pointerCount - 1) < numberOfPointers) {
+                        // Delay lowering the pointer count, to make sure that if all pointers are removed at once
+                        // we are still able to give the 'full' count but also don't give a count too high if the user
+                        // accidentally had another pointer on screen at the start
+                        handler.removeCallbacksAndMessages(null)
+                        handler.postDelayed({
+                            numberOfPointers = motionEvent.pointerCount - 1
+                        }, 600)
+                    }
+
+                    // From the GestureDetector: check the dot product of current velocities.
+                    // If the pointer that left was opposing another velocity vector, clear.
+                    calculateVelocityForView(v)
+                    if (minimumFlingVelocity != null && maximumFlingVelocity != null) {
+                        velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity!!.toFloat())
+                        val upIndex = motionEvent.actionIndex
+                        val id1 = motionEvent.getPointerId(upIndex)
+                        val x1 = velocityTracker?.getXVelocity(id1) ?: 0f
+                        val y1 = velocityTracker?.getYVelocity(id1) ?: 0f
+                        for (i in 0 until motionEvent.pointerCount) {
+                            if (i == upIndex) continue
+                            val id2 = motionEvent.getPointerId(i)
+                            val x = x1 * (velocityTracker?.getXVelocity(id2) ?: 0f)
+                            val y = y1 * (velocityTracker?.getYVelocity(id2) ?: 0f)
+                            val dot = x + y
+                            if (dot < 0) {
+                                velocityTracker?.clear()
+                                break
+                            }
+                        }
+                    }
+                }
+                MotionEvent.ACTION_UP -> {
+                    var handled: Boolean? = null
+                    calculateVelocityForView(v)
+                    velocityTracker?.computeCurrentVelocity(1000, maximumFlingVelocity!!.toFloat())
+                    val velocityX = velocityTracker?.getXVelocity(motionEvent.getPointerId(0))
+                    val velocityY = velocityTracker?.getYVelocity(motionEvent.getPointerId(0))
+                    if (
+                        velocityX != null && velocityY != null &&
+                        minimumFlingVelocity != null && maximumFlingVelocity != null &&
+                        ((abs(velocityY) > minimumFlingVelocity!!) || (abs(velocityX) > minimumFlingVelocity!!))
+                    ) {
+                        handled = onFling(
+                            downEvent!!,
+                            motionEvent,
+                            velocityX,
+                            velocityY,
+                            numberOfPointers
+                        )
+                    }
+                    cleanup()
+                    if (handled != null) return handled
+                }
+                MotionEvent.ACTION_CANCEL -> cleanup()
+            }
+        }
+        return onMotionEventHandled(v, event)
+    }
+
+    private fun calculateVelocityForView(view: View?) {
+        if (view != null) {
+            minimumFlingVelocity = ViewConfiguration.get(view.context).scaledMinimumFlingVelocity
+            maximumFlingVelocity = ViewConfiguration.get(view.context).scaledMaximumFlingVelocity
+        } else {
+            minimumFlingVelocity = ViewConfiguration.getMinimumFlingVelocity()
+            maximumFlingVelocity = ViewConfiguration.getMaximumFlingVelocity()
+        }
+    }
+
+    private fun cleanup() {
+        handler.removeCallbacksAndMessages(null)
+
+        velocityTracker?.recycle()
+        velocityTracker = null
+        downEvent?.recycle()
+        downEvent = null
+        numberOfPointers = 0
+    }
+
+    private fun onFling(
+        e1: MotionEvent,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float,
+        pointerCount: Int
+    ): Boolean {
+        // Grab two events located on the plane at e1=(x1, y1) and e2=(x2, y2)
+        // Let e1 be the initial event
+        // e2 can be located at 4 different positions, consider the following diagram
+        // (Assume that lines are separated by 90 degrees.)
+        //
+        //         \ up /
+        //          \  /
+        //    left   e1   right
+        //          /  \
+        //         /down\
+        //
+        val direction = getDirection(e1.x, e1.y, e2.x, e2.y)
+        return onSwipe(
+            e1,
+            e2,
+            abs(if (direction == SwipeDirection.UP || direction == SwipeDirection.DOWN) velocityY else velocityX),
+            direction,
+            pointerCount
+        )
+    }
+
+    abstract fun onSwipe(
+        e1: MotionEvent,
+        e2: MotionEvent,
+        velocity: Float,
+        direction: SwipeDirection,
+        pointerCount: Int
+    ): Boolean
+
+    abstract fun onMotionEventHandled(
+        v: View?,
+        event: MotionEvent?
+    ): Boolean
+
+    /**
+     * Given two points in the plane p1=(x1, x2) and p2=(y1, y1), this method
+     * returns the direction that an arrow pointing from p1 to p2 would have.
+     * @param x1 the x position of the first point
+     * @param y1 the y position of the first point
+     * @param x2 the x position of the second point
+     * @param y2 the y position of the second point
+     * @return the direction
+     */
+    private fun getDirection(x1: Float, y1: Float, x2: Float, y2: Float): SwipeDirection {
+        val angle = getAngle(x1, y1, x2, y2)
+        return SwipeDirection.fromAngle(angle)
+    }
+
+    /**
+     * Finds the angle between two points in the plane (x1,y1) and (x2, y2)
+     * The angle is measured with 0/360 being the X-axis to the right, angles
+     * increase counter clockwise.
+     *
+     * @param x1 the x position of the first point
+     * @param y1 the y position of the first point
+     * @param x2 the x position of the second point
+     * @param y2 the y position of the second point
+     * @return the angle between two points
+     */
+    private fun getAngle(x1: Float, y1: Float, x2: Float, y2: Float): Double {
+        val rad = atan2((y1 - y2).toDouble(), (x2 - x1).toDouble()) + Math.PI
+        return (rad * 180 / Math.PI + 180) % 360
+    }
+
+    enum class SwipeDirection {
+        UP, DOWN, LEFT, RIGHT;
+
+        companion object {
+            /**
+             * Returns a direction given an angle.
+             * Directions are defined as follows:
+             *
+             * Up: [45, 135]
+             * Right: [0,45] and [315, 360]
+             * Down: [225, 315]
+             * Left: [135, 225]
+             *
+             * @param angle an angle from 0 to 360 - e
+             * @return the direction of an angle
+             */
+            fun fromAngle(angle: Double): SwipeDirection {
+                return if (angle in (45f..135f)) {
+                    UP
+                } else if (angle in (0f..45f) || angle in (315f..360f)) {
+                    RIGHT
+                } else if (angle in (225f..315f)) {
+                    DOWN
+                } else {
+                    LEFT
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/OnSwipeListener.kt
@@ -80,11 +80,14 @@ abstract class OnSwipeListener : View.OnTouchListener {
                         velocityX != null && velocityY != null &&
                         ((abs(velocityY) > minimumFlingVelocity) || (abs(velocityX) > minimumFlingVelocity))
                     ) {
-                        handled = onFling(
+                        // = onFling in GestureDetector.OnGestureListener
+                        // Calculate the position of motionEvent relative to downEvent to find the fling direction
+                        val direction = getDirection(downEvent!!.x, downEvent!!.y, motionEvent.x, motionEvent.y)
+                        handled = onSwipe(
                             downEvent!!,
                             motionEvent,
-                            velocityX,
-                            velocityY,
+                            abs(if (direction == SwipeDirection.UP || direction == SwipeDirection.DOWN) velocityY else velocityX),
+                            direction,
                             numberOfPointers
                         )
                     }
@@ -112,34 +115,6 @@ abstract class OnSwipeListener : View.OnTouchListener {
         downEvent?.recycle()
         downEvent = null
         numberOfPointers = 0
-    }
-
-    private fun onFling(
-        e1: MotionEvent,
-        e2: MotionEvent,
-        velocityX: Float,
-        velocityY: Float,
-        pointerCount: Int
-    ): Boolean {
-        // Grab two events located on the plane at e1=(x1, y1) and e2=(x2, y2)
-        // Let e1 be the initial event
-        // e2 can be located at 4 different positions, consider the following diagram
-        // (Assume that lines are separated by 90 degrees.)
-        //
-        //         \ up /
-        //          \  /
-        //    left   e1   right
-        //          /  \
-        //         /down\
-        //
-        val direction = getDirection(e1.x, e1.y, e2.x, e2.y)
-        return onSwipe(
-            e1,
-            e2,
-            abs(if (direction == SwipeDirection.UP || direction == SwipeDirection.DOWN) velocityY else velocityX),
-            direction,
-            pointerCount
-        )
     }
 
     abstract fun onSwipe(

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -82,6 +82,7 @@ import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.language.LanguagesManager
 import io.homeassistant.companion.android.themes.ThemesManager
 import io.homeassistant.companion.android.util.ChangeLog
+import io.homeassistant.companion.android.util.OnSwipeListener
 import io.homeassistant.companion.android.util.isStarted
 import io.homeassistant.companion.android.websocket.WebsocketManager
 import kotlinx.coroutines.CoroutineScope
@@ -235,12 +236,27 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         webView = binding.webview
         webView.apply {
-            setOnTouchListener { _, motionEvent ->
-                if (motionEvent.pointerCount == 3 && motionEvent.action == MotionEvent.ACTION_POINTER_3_DOWN) {
-                    dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_E))
+            setOnTouchListener(object : OnSwipeListener() {
+                override fun onSwipe(
+                    e1: MotionEvent,
+                    e2: MotionEvent,
+                    velocity: Float,
+                    direction: SwipeDirection,
+                    pointerCount: Int
+                ): Boolean {
+                    if (pointerCount == 3 &&
+                        direction == SwipeDirection.DOWN &&
+                        velocity >= 250
+                    ) {
+                        dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_E))
+                    }
+                    return !unlocked
                 }
-                return@setOnTouchListener !unlocked
-            }
+
+                override fun onMotionEventHandled(v: View?, event: MotionEvent?): Boolean {
+                    return !unlocked
+                }
+            })
 
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -246,7 +246,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 ): Boolean {
                     if (pointerCount == 3 &&
                         direction == SwipeDirection.DOWN &&
-                        velocity >= 250
+                        velocity >= 150
                     ) {
                         dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_E))
                     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2392 

Unfortunately the default `GestureDetector.OnGestureListener` doesn't provide information about the number of pointers and the direction of a swipe, so a custom class has been created based on the default to fix these issues. At least adding more swipe gestures will be easier in the future :)

I've also checked the frontend for an event to fire to open the quick bar and this still doesn't appear to exist.

Swiping while opened doesn't switch between quick bar modes as mentioned in the documentation and there doesn't seem to be a reliable way to make this work, so I've also opened a PR to update the documentation to reflect what the gesture actually does.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
https://user-images.githubusercontent.com/8148535/159681345-0efb95d7-de16-4477-820d-1d14eb3723ce.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#719

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->