### PR TITLE
Add missing volume streams to sensor and command

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -159,6 +159,7 @@ class MessagingManager @Inject constructor(
         const val RING_STREAM = "ring_stream"
         const val SYSTEM_STREAM = "system_stream"
         const val CALL_STREAM = "call_stream"
+        const val DTMF_STREAM = "dtmf_stream"
 
         // Enable/Disable Commands
         const val TURN_ON = "turn_on"
@@ -206,8 +207,10 @@ class MessagingManager @Inject constructor(
         )
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
-        val CHANNEL_VOLUME_STREAM =
-            listOf(ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM, CALL_STREAM, SYSTEM_STREAM)
+        val CHANNEL_VOLUME_STREAM = listOf(
+            ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM, CALL_STREAM,
+            SYSTEM_STREAM, DTMF_STREAM
+        )
         val ENABLE_COMMANDS = listOf(TURN_OFF, TURN_ON)
         val MEDIA_COMMANDS = listOf(
             MEDIA_FAST_FORWARD, MEDIA_NEXT, MEDIA_PAUSE, MEDIA_PLAY,
@@ -1649,6 +1652,7 @@ class MessagingManager @Inject constructor(
             RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume, audioManager)
             CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume, audioManager)
             SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume, audioManager)
+            DTMF_STREAM -> adjustVolumeStream(AudioManager.STREAM_DTMF, volume, audioManager)
             else -> Log.d(TAG, "Skipping command due to invalid channel stream")
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -157,6 +157,8 @@ class MessagingManager @Inject constructor(
         const val MUSIC_STREAM = "music_stream"
         const val NOTIFICATION_STREAM = "notification_stream"
         const val RING_STREAM = "ring_stream"
+        const val SYSTEM_STREAM = "system_stream"
+        const val CALL_STREAM = "call_stream"
 
         // Enable/Disable Commands
         const val TURN_ON = "turn_on"
@@ -205,7 +207,7 @@ class MessagingManager @Inject constructor(
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
         val CHANNEL_VOLUME_STREAM =
-            listOf(ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM)
+            listOf(ALARM_STREAM, MUSIC_STREAM, NOTIFICATION_STREAM, RING_STREAM, CALL_STREAM, SYSTEM_STREAM)
         val ENABLE_COMMANDS = listOf(TURN_OFF, TURN_ON)
         val MEDIA_COMMANDS = listOf(
             MEDIA_FAST_FORWARD, MEDIA_NEXT, MEDIA_PAUSE, MEDIA_PLAY,
@@ -1640,54 +1642,28 @@ class MessagingManager @Inject constructor(
     }
 
     private fun processStreamVolume(audioManager: AudioManager, stream: String, volume: Int) {
-        var volumeLevel = volume
         when (stream) {
-            ALARM_STREAM -> {
-                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM))
-                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_ALARM)
-                else if (volumeLevel < 0)
-                    volumeLevel = 0
-                audioManager.setStreamVolume(
-                    AudioManager.STREAM_ALARM,
-                    volumeLevel,
-                    AudioManager.FLAG_SHOW_UI
-                )
-            }
-            MUSIC_STREAM -> {
-                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC))
-                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
-                else if (volumeLevel < 0)
-                    volumeLevel = 0
-                audioManager.setStreamVolume(
-                    AudioManager.STREAM_MUSIC,
-                    volumeLevel,
-                    AudioManager.FLAG_SHOW_UI
-                )
-            }
-            NOTIFICATION_STREAM -> {
-                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_NOTIFICATION))
-                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_NOTIFICATION)
-                else if (volumeLevel < 0)
-                    volumeLevel = 0
-                audioManager.setStreamVolume(
-                    AudioManager.STREAM_NOTIFICATION,
-                    volumeLevel,
-                    AudioManager.FLAG_SHOW_UI
-                )
-            }
-            RING_STREAM -> {
-                if (volumeLevel > audioManager.getStreamMaxVolume(AudioManager.STREAM_RING))
-                    volumeLevel = audioManager.getStreamMaxVolume(AudioManager.STREAM_RING)
-                else if (volumeLevel < 0)
-                    volumeLevel = 0
-                audioManager.setStreamVolume(
-                    AudioManager.STREAM_RING,
-                    volumeLevel,
-                    AudioManager.FLAG_SHOW_UI
-                )
-            }
+            ALARM_STREAM -> adjustVolumeStream(AudioManager.STREAM_ALARM, volume, audioManager)
+            MUSIC_STREAM -> adjustVolumeStream(AudioManager.STREAM_MUSIC, volume, audioManager)
+            NOTIFICATION_STREAM -> adjustVolumeStream(AudioManager.STREAM_NOTIFICATION, volume, audioManager)
+            RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume, audioManager)
+            CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume, audioManager)
+            SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume, audioManager)
             else -> Log.d(TAG, "Skipping command due to invalid channel stream")
         }
+    }
+
+    private fun adjustVolumeStream(stream: Int, volume: Int, audioManager: AudioManager) {
+        var volumeLevel = volume
+        if (volumeLevel > audioManager.getStreamMaxVolume(stream))
+            volumeLevel = audioManager.getStreamMaxVolume(stream)
+        else if (volumeLevel < 0)
+            volumeLevel = 0
+        audioManager.setStreamVolume(
+            stream,
+            volumeLevel,
+            AudioManager.FLAG_SHOW_UI
+        )
     }
 
     private fun processActivityCommand(data: Map<String, String>) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/AudioSensorManager.kt
@@ -76,6 +76,20 @@ class AudioSensorManager : SensorManager {
             commonR.string.sensor_description_volume_ring,
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )
+        private val volNotification = SensorManager.BasicSensor(
+            "volume_notification",
+            "sensor",
+            commonR.string.sensor_name_volume_notification,
+            commonR.string.sensor_description_volume_notification,
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+        )
+        private val volSystem = SensorManager.BasicSensor(
+            "volume_system",
+            "sensor",
+            commonR.string.sensor_name_volume_system,
+            commonR.string.sensor_description_volume_system,
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+        )
     }
 
     override fun docsLink(): String {
@@ -89,7 +103,10 @@ class AudioSensorManager : SensorManager {
         get() = commonR.string.sensor_name_audio
 
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(audioSensor, audioState, headphoneState, micMuted, speakerphoneState, musicActive, volAlarm, volCall, volMusic, volRing)
+        return listOf(
+            audioSensor, audioState, headphoneState, micMuted, speakerphoneState,
+            musicActive, volAlarm, volCall, volMusic, volRing, volNotification, volSystem
+        )
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -108,6 +125,8 @@ class AudioSensorManager : SensorManager {
         updateVolumeCall(context, audioManager)
         updateVolumeMusic(context, audioManager)
         updateVolumeRing(context, audioManager)
+        updateVolumeNotification(context, audioManager)
+        updateVolumeSystem(context, audioManager)
     }
 
     private fun updateAudioSensor(context: Context, audioManager: AudioManager) {
@@ -305,6 +324,40 @@ class AudioSensorManager : SensorManager {
             context,
             volRing,
             volumeLevelRing,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateVolumeNotification(context: Context, audioManager: AudioManager) {
+        if (!isEnabled(context, volNotification.id))
+            return
+
+        val volumeLevelNotification = audioManager.getStreamVolume(AudioManager.STREAM_NOTIFICATION)
+
+        val icon = "mdi:bell-ring"
+
+        onSensorUpdated(
+            context,
+            volNotification,
+            volumeLevelNotification,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateVolumeSystem(context: Context, audioManager: AudioManager) {
+        if (!isEnabled(context, volSystem.id))
+            return
+
+        val volumeLevelSystem = audioManager.getStreamVolume(AudioManager.STREAM_SYSTEM)
+
+        val icon = "mdi:cellphone-sound"
+
+        onSensorUpdated(
+            context,
+            volSystem,
+            volumeLevelSystem,
             icon,
             mapOf()
         )

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -800,4 +800,8 @@
     <string name="undo">Undo</string>
     <string name="basic_sensor_name_network_type">Network Type</string>
     <string name="sensor_description_network_type">The type of transport the current active network is using</string>
+    <string name="sensor_name_volume_notification">Volume Level Notification</string>
+    <string name="sensor_description_volume_notification">Volume level for notifications on the device</string>
+    <string name="sensor_name_volume_system">Volume Level System</string>
+    <string name="sensor_description_volume_system">Volume level for the system on the device</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -804,4 +804,8 @@
     <string name="sensor_description_volume_notification">Volume level for notifications on the device</string>
     <string name="sensor_name_volume_system">Volume Level System</string>
     <string name="sensor_description_volume_system">Volume level for the system on the device</string>
+    <string name="sensor_name_volume_accessibility">Volume Level Accessibility</string>
+    <string name="sensor_description_volume_accessibility">Volume level for accessibility prompts on the device</string>
+    <string name="sensor_name_volume_dtmf">Volume Level DTMF</string>
+    <string name="sensor_description_volume_dtmf">Volume level for DTMF tones on the device</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that we were missing some of the volume streams, not all devices show to the user all the streams so better to cover all our bases. Samsung devices for example show System volume while others do not. All are still controllable and report data.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#720

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->