### PR TITLE
Use suspend and transactions for Favorites dao

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/database/wear/Favorites.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/wear/Favorites.kt
@@ -4,11 +4,14 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+/**
+ * Represents a favorite entity
+ */
 @Entity(tableName = "favorites")
 data class Favorites(
     @PrimaryKey
     @ColumnInfo(name = "id")
-    var id: String,
+    val id: String,
     @ColumnInfo(name = "position")
-    var position: Int?
+    val position: Int
 )

--- a/common/src/main/java/io/homeassistant/companion/android/database/wear/FavoritesDao.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/wear/FavoritesDao.kt
@@ -4,30 +4,59 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Update
+import androidx.room.Transaction
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 @Dao
 interface FavoritesDao {
 
-    @Query("SELECT * FROM favorites where id = :id")
-    fun get(id: String): Favorites?
+    @Query("SELECT * FROM favorites ORDER BY position ASC")
+    fun getAllFavoritesFlow(): Flow<List<Favorites>>
 
     @Query("SELECT * FROM favorites ORDER BY position ASC")
-    fun getAllFlow(): Flow<List<Favorites>>?
-
-    @Query("SELECT * FROM favorites ORDER BY position ASC")
-    fun getAll(): List<Favorites>?
+    suspend fun getAllFavorites(): List<Favorites>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun add(favorite: Favorites)
+    suspend fun add(favorite: Favorites)
 
-    @Update
-    fun update(favorite: Favorites)
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun addAll(favorites: List<Favorites>)
+
+    @Query("SELECT position FROM favorites ORDER BY position DESC LIMIT 1")
+    suspend fun getLargestPosition(): Int?
 
     @Query("DELETE FROM favorites where id = :id")
-    fun delete(id: String)
+    suspend fun delete(id: String)
 
     @Query("DELETE FROM favorites")
-    fun deleteAll()
+    suspend fun deleteAll()
+
+    /**
+     * Delete all favorites and insert new entries.
+     */
+    @Transaction
+    suspend fun replaceAll(favorites: List<Favorites>) {
+        deleteAll()
+        addAll(favorites)
+    }
+
+    /**
+     * Insert a new favorite at the end of the list.
+     */
+    @Transaction
+    suspend fun addToEnd(favoriteEntityId: String) {
+        val largestPosition = getLargestPosition() ?: 0
+        add(Favorites(favoriteEntityId, position = largestPosition + 1))
+    }
+}
+
+// Hide position from the get/set operations, since its just used for sorting.
+
+fun FavoritesDao.getAllFlow() = getAllFavoritesFlow().map { favorites -> favorites.map { it.id } }
+
+suspend fun FavoritesDao.getAll() = getAllFavorites().map { it.id }
+
+suspend fun FavoritesDao.replaceAll(favoriteEntityIds: List<String>) {
+    replaceAll(favoriteEntityIds.mapIndexed { index, entityId -> Favorites(entityId, index) })
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.home
 
 import android.app.Application
 import android.util.Log
+import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
@@ -21,7 +22,7 @@ import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorDao
-import io.homeassistant.companion.android.database.wear.Favorites
+import io.homeassistant.companion.android.database.wear.getAllFlow
 import io.homeassistant.companion.android.util.RegistriesDataHandler
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -51,15 +52,18 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         this.homePresenter = homePresenter
         loadSettings()
         loadEntities()
-        getFavorites()
         getSensors()
     }
 
     // entities
     var entities = mutableStateMapOf<String, Entity<*>>()
         private set
-    var favoriteEntityIds = mutableStateListOf<String>()
-        private set
+
+    /**
+     * IDs of favorites in the Favorites database.
+     */
+    val favoriteEntityIds = favoritesDao.getAllFlow().collectAsState(initial = emptyList())
+
     var shortcutEntities = mutableStateListOf<SimplifiedEntity>()
         private set
     var areas = mutableListOf<AreaRegistryResponse>()
@@ -92,8 +96,6 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         private set
     var templateTileRefreshInterval = mutableStateOf(0)
         private set
-
-    private fun favorites(): Flow<List<Favorites>>? = favoritesDao.getAllFlow()
 
     private fun sensors(): Flow<List<Sensor>>? = sensorsDao.getAllFlow()
 
@@ -292,20 +294,13 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     fun getCategoryForEntity(entityId: String): String? =
         RegistriesDataHandler.getCategoryForEntity(entityId, entityRegistry)
 
-    private fun getFavorites() {
-        viewModelScope.launch {
-            favorites()?.collect {
-                favoriteEntityIds.clear()
-                for (favorite in it) {
-                    favoriteEntityIds.add(favorite.id)
-                }
-            }
-        }
-    }
-
+    /**
+     * Clears all favorites in the database.
+     */
     fun clearFavorites() {
-        favoriteEntityIds.clear()
-        favoritesDao.deleteAll()
+        viewModelScope.launch {
+            favoritesDao.deleteAll()
+        }
     }
 
     private fun getSensors() {
@@ -374,33 +369,32 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
         }
     }
 
-    fun addFavorites(favorites: Favorites) {
-        favoritesDao.add(favorites)
-        updateFavoritePositions()
-    }
-
-    private fun updateFavorites(favorites: Favorites) {
-        favoritesDao.update(favorites)
-        updateFavoritePositions()
-    }
-
-    fun removeFavorites(id: String) {
-        favoritesDao.delete(id)
-        updateFavoritePositions()
-    }
-
-    private fun updateFavoritePositions() {
-        var i = 1
+    fun addFavoriteEntity(entityId: String) {
         viewModelScope.launch {
-            favoritesDao.getAll()?.forEach { favorites ->
-                if (i != i)
-                    updateFavorites(Favorites(favorites.id, i))
-                i++
-            }
+            favoritesDao.addToEnd(entityId)
+        }
+    }
+
+    fun removeFavoriteEntity(entityId: String) {
+        viewModelScope.launch {
+            favoritesDao.delete(entityId)
         }
     }
 
     fun logout() {
         homePresenter.onLogoutClicked()
+    }
+
+    /**
+     * Convert a Flow into a State object that updates until the view model is cleared.
+     */
+    private fun <T> Flow<T>.collectAsState(
+        initial: T
+    ): State<T> {
+        val state = mutableStateOf(initial)
+        viewModelScope.launch {
+            collect { state.value = it }
+        }
+        return state
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -23,7 +23,6 @@ import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
 import androidx.wear.tiles.TileService
 import io.homeassistant.companion.android.common.sensors.id
-import io.homeassistant.companion.android.database.wear.Favorites
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.tiles.ShortcutsTile
@@ -54,7 +53,7 @@ fun LoadHomePage(
 
     WearAppTheme {
         if (mainViewModel.loadingState.value == MainViewModel.LoadingState.LOADING &&
-            mainViewModel.favoriteEntityIds.isNullOrEmpty()
+            mainViewModel.favoriteEntityIds.value.isEmpty()
         ) {
             Column {
                 ListHeader(id = commonR.string.loading)
@@ -80,7 +79,7 @@ fun LoadHomePage(
                 composable(SCREEN_LANDING) {
                     MainView(
                         mainViewModel = mainViewModel,
-                        favoriteEntityIds = mainViewModel.favoriteEntityIds,
+                        favoriteEntityIds = mainViewModel.favoriteEntityIds.value,
                         onEntityClicked = { id, state -> mainViewModel.toggleEntity(id, state) },
                         onEntityLongClicked = { entityId ->
                             swipeDismissableNavController.navigate("$SCREEN_ENTITY_DETAIL/$entityId")
@@ -97,7 +96,7 @@ fun LoadHomePage(
                         },
                         isHapticEnabled = mainViewModel.isHapticEnabled.value,
                         isToastEnabled = mainViewModel.isToastEnabled.value,
-                        deleteFavorite = { id -> mainViewModel.removeFavorites(id) }
+                        deleteFavorite = { id -> mainViewModel.removeFavoriteEntity(id) }
                     )
                 }
                 composable("$SCREEN_ENTITY_DETAIL/{entityId}") {
@@ -146,7 +145,7 @@ fun LoadHomePage(
                 }
                 composable(SCREEN_SETTINGS) {
                     SettingsView(
-                        favorites = mainViewModel.favoriteEntityIds,
+                        favorites = mainViewModel.favoriteEntityIds.value,
                         onClickSetFavorites = {
                             swipeDismissableNavController.navigate(
                                 SCREEN_SET_FAVORITES
@@ -173,13 +172,12 @@ fun LoadHomePage(
                 composable(SCREEN_SET_FAVORITES) {
                     SetFavoritesView(
                         mainViewModel,
-                        mainViewModel.favoriteEntityIds
-                    ) { entityId, position, isSelected ->
-                        val favorites = Favorites(entityId, position)
+                        mainViewModel.favoriteEntityIds.value
+                    ) { entityId, isSelected ->
                         if (isSelected) {
-                            mainViewModel.addFavorites(favorites)
+                            mainViewModel.addFavoriteEntity(entityId)
                         } else {
-                            mainViewModel.removeFavorites(entityId)
+                            mainViewModel.removeFavoriteEntity(entityId)
                         }
                     }
                 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -27,7 +27,7 @@ import io.homeassistant.companion.android.common.R as commonR
 fun SetFavoritesView(
     mainViewModel: MainViewModel,
     favoriteEntityIds: List<String>,
-    onFavoriteSelected: (entityId: String, entityPosition: Int, isSelected: Boolean) -> Unit
+    onFavoriteSelected: (entityId: String, isSelected: Boolean) -> Unit
 ) {
     // Remember expanded state of each header
     val expandedStates = rememberExpandedStates(mainViewModel.supportedDomains())
@@ -80,7 +80,7 @@ private fun FavoriteToggleChip(
     entityList: List<Entity<*>>,
     index: Int,
     favoriteEntityIds: List<String>,
-    onFavoriteSelected: (entityId: String, entityPosition: Int, isSelected: Boolean) -> Unit
+    onFavoriteSelected: (entityId: String, isSelected: Boolean) -> Unit
 ) {
     val attributes = entityList[index].attributes as Map<*, *>
     val iconBitmap = getIcon(
@@ -94,7 +94,7 @@ private fun FavoriteToggleChip(
     ToggleChip(
         checked = checked,
         onCheckedChange = {
-            onFavoriteSelected(entityId, favoriteEntityIds.size + 1, it)
+            onFavoriteSelected(entityId, it)
         },
         modifier = Modifier
             .fillMaxWidth(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Updating the Favorites Dao to remove blocking operations, and instead use coroutines. Also tried to make updates so the code is easier to follow.

- Flow and List aren't nullable, so I removed the `?` annotations.
- Tried to change `position` to be an implementation detail. `position` is updated so resembles an auto-incrementing value, and there can be "gaps" in the rows. i.e., position 0 may be followed by position 2 if position 1 was deleted.
- Grouped multiple operations into Transactions

## Any other notes
- https://developer.android.com/reference/androidx/room/Query
- https://developer.android.com/reference/androidx/room/Transaction