### PR TITLE
Remove blocking calls from HaControls

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -13,149 +13,144 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class ClimateControl {
-    companion object : HaControl {
-        private const val SUPPORT_TARGET_TEMPERATURE = 1
-        private const val SUPPORT_TARGET_TEMPERATURE_RANGE = 2
-        private val temperatureControlModes = mapOf(
-            "cool" to TemperatureControlTemplate.MODE_COOL,
-            "heat" to TemperatureControlTemplate.MODE_HEAT,
-            "heat_cool" to TemperatureControlTemplate.MODE_HEAT_COOL,
-            "off" to TemperatureControlTemplate.MODE_OFF
-        )
-        private val temperatureControlModeFlags = mapOf(
-            "cool" to TemperatureControlTemplate.FLAG_MODE_COOL,
-            "heat" to TemperatureControlTemplate.FLAG_MODE_HEAT,
-            "heat_cool" to TemperatureControlTemplate.FLAG_MODE_HEAT_COOL,
-            "off" to TemperatureControlTemplate.FLAG_MODE_OFF
-        )
+object ClimateControl : HaControl {
+    private const val SUPPORT_TARGET_TEMPERATURE = 1
+    private const val SUPPORT_TARGET_TEMPERATURE_RANGE = 2
+    private val temperatureControlModes = mapOf(
+        "cool" to TemperatureControlTemplate.MODE_COOL,
+        "heat" to TemperatureControlTemplate.MODE_HEAT,
+        "heat_cool" to TemperatureControlTemplate.MODE_HEAT_COOL,
+        "off" to TemperatureControlTemplate.MODE_OFF
+    )
+    private val temperatureControlModeFlags = mapOf(
+        "cool" to TemperatureControlTemplate.FLAG_MODE_COOL,
+        "heat" to TemperatureControlTemplate.FLAG_MODE_HEAT,
+        "heat_cool" to TemperatureControlTemplate.FLAG_MODE_HEAT_COOL,
+        "off" to TemperatureControlTemplate.FLAG_MODE_OFF
+    )
 
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatusText(
-                when (entity.state) {
-                    "auto" -> context.getString(commonR.string.state_auto)
-                    "cool" -> context.getString(commonR.string.state_cool)
-                    "dry" -> context.getString(commonR.string.state_dry)
-                    "fan_only" -> context.getString(commonR.string.state_fan_only)
-                    "heat" -> context.getString(commonR.string.state_heat)
-                    "heat_cool" -> context.getString(commonR.string.state_heat_cool)
-                    "off" -> context.getString(commonR.string.state_off)
-                    "unavailable" -> context.getString(commonR.string.state_unavailable)
-                    else -> entity.state
-                }
-            )
-            val minValue = (entity.attributes["min_temp"] as? Number)?.toFloat() ?: 0f
-            val maxValue = (entity.attributes["max_temp"] as? Number)?.toFloat() ?: 100f
-            var currentValue = (entity.attributes["temperature"] as? Number)?.toFloat() ?: (
-                entity.attributes["current_temperature"] as? Number
-                )?.toFloat() ?: 0f
-            // Ensure the current value is never lower than the minimum or higher than the maximum
-            if (currentValue < minValue)
-                currentValue = minValue
-            if (currentValue > maxValue)
-                currentValue = maxValue
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatusText(
+            when (entity.state) {
+                "auto" -> context.getString(commonR.string.state_auto)
+                "cool" -> context.getString(commonR.string.state_cool)
+                "dry" -> context.getString(commonR.string.state_dry)
+                "fan_only" -> context.getString(commonR.string.state_fan_only)
+                "heat" -> context.getString(commonR.string.state_heat)
+                "heat_cool" -> context.getString(commonR.string.state_heat_cool)
+                "off" -> context.getString(commonR.string.state_off)
+                "unavailable" -> context.getString(commonR.string.state_unavailable)
+                else -> entity.state
+            }
+        )
+        val minValue = (entity.attributes["min_temp"] as? Number)?.toFloat() ?: 0f
+        val maxValue = (entity.attributes["max_temp"] as? Number)?.toFloat() ?: 100f
+        var currentValue = (entity.attributes["temperature"] as? Number)?.toFloat() ?: (
+            entity.attributes["current_temperature"] as? Number
+            )?.toFloat() ?: 0f
+        // Ensure the current value is never lower than the minimum or higher than the maximum
+        if (currentValue < minValue)
+            currentValue = minValue
+        if (currentValue > maxValue)
+            currentValue = maxValue
 
-            val temperatureUnit = entity.attributes["temperature_unit"] ?: ""
-            val temperatureStepSize = (entity.attributes["target_temperature_step"] as? Number)?.toFloat()
-                ?: when (temperatureUnit) {
-                    "°C" -> 0.5f
-                    else -> 1f
-                }
-            val temperatureFormatSize = if (temperatureStepSize < 1f) "1" else "0"
-            val rangeTemplate = RangeTemplate(
-                entity.entityId,
-                minValue,
-                maxValue,
-                currentValue,
-                temperatureStepSize,
-                "%.${temperatureFormatSize}f $temperatureUnit"
+        val temperatureUnit = entity.attributes["temperature_unit"] ?: ""
+        val temperatureStepSize = (entity.attributes["target_temperature_step"] as? Number)?.toFloat()
+            ?: when (temperatureUnit) {
+                "°C" -> 0.5f
+                else -> 1f
+            }
+        val temperatureFormatSize = if (temperatureStepSize < 1f) "1" else "0"
+        val rangeTemplate = RangeTemplate(
+            entity.entityId,
+            minValue,
+            maxValue,
+            currentValue,
+            temperatureStepSize,
+            "%.${temperatureFormatSize}f $temperatureUnit"
+        )
+        if (entityShouldBePresentedAsThermostat(entity)) {
+            var modesFlag = 0
+            (entity.attributes["hvac_modes"] as? List<String>)?.forEach {
+                modesFlag = modesFlag or temperatureControlModeFlags[it]!!
+            }
+            control.setControlTemplate(
+                TemperatureControlTemplate(
+                    entity.entityId,
+                    rangeTemplate,
+                    temperatureControlModes[entity.state]!!,
+                    temperatureControlModes[entity.state]!!,
+                    modesFlag
+                )
             )
-            if (entityShouldBePresentedAsThermostat(entity)) {
-                var modesFlag = 0
-                (entity.attributes["hvac_modes"] as? List<String>)?.forEach {
-                    modesFlag = modesFlag or temperatureControlModeFlags[it]!!
-                }
-                control.setControlTemplate(
-                    TemperatureControlTemplate(
-                        entity.entityId,
-                        rangeTemplate,
-                        temperatureControlModes[entity.state]!!,
-                        temperatureControlModes[entity.state]!!,
-                        modesFlag
+        } else {
+            control.setControlTemplate(rangeTemplate)
+        }
+
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        if (entityShouldBePresentedAsThermostat(entity))
+            DeviceTypes.TYPE_THERMOSTAT
+        else
+            DeviceTypes.TYPE_AC_HEATER
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_climate)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        return when (action) {
+            is FloatAction -> {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "set_temperature",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "temperature" to (action as? FloatAction)?.newValue.toString()
                     )
                 )
-            } else {
-                control.setControlTemplate(rangeTemplate)
+                true
             }
-
-            return control
-        }
-
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            if (entityShouldBePresentedAsThermostat(entity))
-                DeviceTypes.TYPE_THERMOSTAT
-            else
-                DeviceTypes.TYPE_AC_HEATER
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_climate)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                return@runBlocking when (action) {
-                    is FloatAction -> {
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            "set_temperature",
-                            hashMapOf(
-                                "entity_id" to action.templateId,
-                                "temperature" to (action as? FloatAction)?.newValue.toString()
+            is ModeAction -> {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "set_hvac_mode",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "hvac_mode" to (
+                            temperatureControlModes.entries.find {
+                                it.value == ((action as? ModeAction)?.newMode ?: -1)
+                            }?.key ?: ""
                             )
-                        )
-                        true
-                    }
-                    is ModeAction -> {
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            "set_hvac_mode",
-                            hashMapOf(
-                                "entity_id" to action.templateId,
-                                "hvac_mode" to (
-                                    temperatureControlModes.entries.find {
-                                        it.value == ((action as? ModeAction)?.newMode ?: -1)
-                                    }?.key ?: ""
-                                    )
-                            )
-                        )
-                        true
-                    }
-                    else -> {
-                        false
-                    }
-                }
-            }
-        }
-
-        private fun entityShouldBePresentedAsThermostat(entity: Entity<Map<String, Any>>): Boolean {
-            return temperatureControlModes.containsKey(entity.state) &&
-                ((entity.attributes["hvac_modes"] as? List<String>)?.isNotEmpty() == true) &&
-                ((entity.attributes["hvac_modes"] as? List<String>)?.all { temperatureControlModes.containsKey(it) } == true) &&
-                (
-                    ((entity.attributes["supported_features"] as Int) and SUPPORT_TARGET_TEMPERATURE == SUPPORT_TARGET_TEMPERATURE) ||
-                        ((entity.attributes["supported_features"] as Int) and SUPPORT_TARGET_TEMPERATURE_RANGE == SUPPORT_TARGET_TEMPERATURE_RANGE)
                     )
+                )
+                true
+            }
+            else -> {
+                false
+            }
         }
+    }
+
+    private fun entityShouldBePresentedAsThermostat(entity: Entity<Map<String, Any>>): Boolean {
+        return temperatureControlModes.containsKey(entity.state) &&
+            ((entity.attributes["hvac_modes"] as? List<String>)?.isNotEmpty() == true) &&
+            ((entity.attributes["hvac_modes"] as? List<String>)?.all { temperatureControlModes.containsKey(it) } == true) &&
+            (
+                ((entity.attributes["supported_features"] as Int) and SUPPORT_TARGET_TEMPERATURE == SUPPORT_TARGET_TEMPERATURE) ||
+                    ((entity.attributes["supported_features"] as Int) and SUPPORT_TARGET_TEMPERATURE_RANGE == SUPPORT_TARGET_TEMPERATURE_RANGE)
+                )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -15,112 +15,107 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class CoverControl {
-    companion object : HaControl {
-        const val SUPPORT_SET_POSITION = 4
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatusText(
-                when (entity.state) {
-                    "closed" -> context.getString(commonR.string.state_closed)
-                    "closing" -> context.getString(commonR.string.state_closing)
-                    "open" -> context.getString(commonR.string.state_open)
-                    "opening" -> context.getString(commonR.string.state_opening)
-                    "unavailable" -> context.getString(commonR.string.state_unavailable)
-                    else -> entity.state
-                }
-            )
-            val minValue = 0f
-            val maxValue = 100f
-            var currentValue =
-                (entity.attributes["current_position"] as? Number)?.toFloat() ?: 0f
-            if (currentValue < minValue)
-                currentValue = minValue
-            if (currentValue > maxValue)
-                currentValue = maxValue
-            control.setControlTemplate(
-                if ((entity.attributes["supported_features"] as Int) and SUPPORT_SET_POSITION == SUPPORT_SET_POSITION)
-                    ToggleRangeTemplate(
+object CoverControl : HaControl {
+    const val SUPPORT_SET_POSITION = 4
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatusText(
+            when (entity.state) {
+                "closed" -> context.getString(commonR.string.state_closed)
+                "closing" -> context.getString(commonR.string.state_closing)
+                "open" -> context.getString(commonR.string.state_open)
+                "opening" -> context.getString(commonR.string.state_opening)
+                "unavailable" -> context.getString(commonR.string.state_unavailable)
+                else -> entity.state
+            }
+        )
+        val minValue = 0f
+        val maxValue = 100f
+        var currentValue =
+            (entity.attributes["current_position"] as? Number)?.toFloat() ?: 0f
+        if (currentValue < minValue)
+            currentValue = minValue
+        if (currentValue > maxValue)
+            currentValue = maxValue
+        control.setControlTemplate(
+            if ((entity.attributes["supported_features"] as Int) and SUPPORT_SET_POSITION == SUPPORT_SET_POSITION)
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    entity.state in listOf("open", "opening"),
+                    "",
+                    RangeTemplate(
                         entity.entityId,
+                        minValue,
+                        maxValue,
+                        currentValue,
+                        1f,
+                        "%.0f%%"
+                    )
+                )
+            else
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
                         entity.state in listOf("open", "opening"),
-                        "",
-                        RangeTemplate(
-                            entity.entityId,
-                            minValue,
-                            maxValue,
-                            currentValue,
-                            1f,
-                            "%.0f%%"
-                        )
+                        "Description"
                     )
-                else
-                    ToggleTemplate(
-                        entity.entityId,
-                        ControlButton(
-                            entity.state in listOf("open", "opening"),
-                            "Description"
-                        )
-                    )
-            )
-            return control
+                )
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        when (entity.attributes["device_class"]) {
+            "awning" -> DeviceTypes.TYPE_AWNING
+            "blind" -> DeviceTypes.TYPE_BLINDS
+            "curtain" -> DeviceTypes.TYPE_CURTAIN
+            "door" -> DeviceTypes.TYPE_DOOR
+            "garage" -> DeviceTypes.TYPE_GARAGE
+            "gate" -> DeviceTypes.TYPE_GATE
+            "shutter" -> DeviceTypes.TYPE_SHUTTER
+            "window" -> DeviceTypes.TYPE_WINDOW
+            else -> DeviceTypes.TYPE_GENERIC_OPEN_CLOSE
         }
 
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            when (entity.attributes["device_class"]) {
-                "awning" -> DeviceTypes.TYPE_AWNING
-                "blind" -> DeviceTypes.TYPE_BLINDS
-                "curtain" -> DeviceTypes.TYPE_CURTAIN
-                "door" -> DeviceTypes.TYPE_DOOR
-                "garage" -> DeviceTypes.TYPE_GARAGE
-                "gate" -> DeviceTypes.TYPE_GATE
-                "shutter" -> DeviceTypes.TYPE_SHUTTER
-                "window" -> DeviceTypes.TYPE_WINDOW
-                else -> DeviceTypes.TYPE_GENERIC_OPEN_CLOSE
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_cover)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        return when (action) {
+            is BooleanAction -> {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if ((action as? BooleanAction)?.newState == true) "open_cover" else "close_cover",
+                    hashMapOf(
+                        "entity_id" to action.templateId
+                    )
+                )
+                true
             }
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_cover)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                return@runBlocking when (action) {
-                    is BooleanAction -> {
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            if ((action as? BooleanAction)?.newState == true) "open_cover" else "close_cover",
-                            hashMapOf(
-                                "entity_id" to action.templateId
-                            )
-                        )
-                        true
-                    }
-                    is FloatAction -> {
-                        val convertPosition = action.newValue
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            "set_cover_position",
-                            hashMapOf(
-                                "entity_id" to action.templateId,
-                                "position" to convertPosition.toInt()
-                            )
-                        )
-                        true
-                    }
-                    else -> {
-                        false
-                    }
-                }
+            is FloatAction -> {
+                val convertPosition = action.newValue
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "set_cover_position",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "position" to convertPosition.toInt()
+                    )
+                )
+                true
+            }
+            else -> {
+                false
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
@@ -11,57 +11,52 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class DefaultButtonControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatusText("")
-            control.setControlTemplate(
-                StatelessTemplate(
-                    entity.entityId
-                )
+object DefaultButtonControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatusText("")
+        control.setControlTemplate(
+            StatelessTemplate(
+                entity.entityId
             )
-            return control
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        when (entity.domain) {
+            "scene", "script" -> DeviceTypes.TYPE_ROUTINE
+            else -> DeviceTypes.TYPE_UNKNOWN
         }
 
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            when (entity.domain) {
-                "scene", "script" -> DeviceTypes.TYPE_ROUTINE
-                else -> DeviceTypes.TYPE_UNKNOWN
-            }
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            when (entity.domain) {
-                "button" -> context.getString(commonR.string.domain_button)
-                "input_button" -> context.getString(commonR.string.domain_input_button)
-                "scene" -> context.getString(commonR.string.domain_scene)
-                "script" -> context.getString(commonR.string.domain_script)
-                else -> entity.domain.capitalize()
-            }
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                integrationRepository.callService(
-                    action.templateId.split(".")[0],
-                    when (action.templateId.split(".")[0]) {
-                        "button", "input_button" -> "press"
-                        else -> "turn_on"
-                    },
-                    hashMapOf("entity_id" to action.templateId)
-                )
-                return@runBlocking true
-            }
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        when (entity.domain) {
+            "button" -> context.getString(commonR.string.domain_button)
+            "input_button" -> context.getString(commonR.string.domain_input_button)
+            "scene" -> context.getString(commonR.string.domain_scene)
+            "script" -> context.getString(commonR.string.domain_script)
+            else -> entity.domain.replaceFirstChar { it.titlecase() }
         }
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        integrationRepository.callService(
+            action.templateId.split(".")[0],
+            when (action.templateId.split(".")[0]) {
+                "button", "input_button" -> "press"
+                else -> "turn_on"
+            },
+            hashMapOf("entity_id" to action.templateId)
+        )
+        return true
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -15,49 +15,47 @@ import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class DefaultSliderControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatusText("")
-            control.setControlTemplate(
-                RangeTemplate(
-                    entity.entityId,
-                    (entity.attributes["min"] as? Number)?.toFloat() ?: 0f,
-                    (entity.attributes["max"] as? Number)?.toFloat() ?: 1f,
-                    entity.state.toFloatOrNull() ?: 0f,
-                    (entity.attributes["step"] as? Number)?.toFloat() ?: 1f,
-                    null
+object DefaultSliderControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatusText("")
+        control.setControlTemplate(
+            RangeTemplate(
+                entity.entityId,
+                (entity.attributes["min"] as? Number)?.toFloat() ?: 0f,
+                (entity.attributes["max"] as? Number)?.toFloat() ?: 1f,
+                entity.state.toFloatOrNull() ?: 0f,
+                (entity.attributes["step"] as? Number)?.toFloat() ?: 1f,
+                null
+            )
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_UNKNOWN
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_input_number)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        return runBlocking {
+            integrationRepository.callService(
+                action.templateId.split(".")[0],
+                "set_value",
+                hashMapOf(
+                    "entity_id" to action.templateId,
+                    "value" to (action as? FloatAction)?.newValue.toString()
                 )
             )
-            return control
-        }
-
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_UNKNOWN
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_input_number)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                integrationRepository.callService(
-                    action.templateId.split(".")[0],
-                    "set_value",
-                    hashMapOf(
-                        "entity_id" to action.templateId,
-                        "value" to (action as? FloatAction)?.newValue.toString()
-                    )
-                )
-                return@runBlocking true
-            }
+            return@runBlocking true
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -13,56 +13,51 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class DefaultSwitchControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setControlTemplate(
-                ToggleTemplate(
-                    entity.entityId,
-                    ControlButton(
-                        entity.state == "on",
-                        "Description"
-                    )
+object DefaultSwitchControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setControlTemplate(
+            ToggleTemplate(
+                entity.entityId,
+                ControlButton(
+                    entity.state == "on",
+                    "Description"
                 )
             )
-            return control
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        when (entity.domain) {
+            "switch" -> DeviceTypes.TYPE_SWITCH
+            else -> DeviceTypes.TYPE_GENERIC_ON_OFF
         }
 
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            when (entity.domain) {
-                "switch" -> DeviceTypes.TYPE_SWITCH
-                else -> DeviceTypes.TYPE_GENERIC_ON_OFF
-            }
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            when (entity.domain) {
-                "automation" -> context.getString(commonR.string.domain_automation)
-                "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
-                "switch" -> context.getString(commonR.string.domain_switch)
-                else -> entity.domain.capitalize()
-            }
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                integrationRepository.callService(
-                    action.templateId.split(".")[0],
-                    if ((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off",
-                    hashMapOf("entity_id" to action.templateId)
-                )
-                return@runBlocking true
-            }
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        when (entity.domain) {
+            "automation" -> context.getString(commonR.string.domain_automation)
+            "input_boolean" -> context.getString(commonR.string.domain_input_boolean)
+            "switch" -> context.getString(commonR.string.domain_switch)
+            else -> entity.domain.replaceFirstChar { it.titlecase() }
         }
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        integrationRepository.callService(
+            action.templateId.split(".")[0],
+            if ((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off",
+            hashMapOf("entity_id" to action.templateId)
+        )
+        return true
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -16,89 +16,84 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class FanControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            if (entity.supportsFanSetSpeed()) {
-                val minValue = 0f
-                val maxValue = 100f
-                var currentValue =
-                    (entity.attributes["percentage"] as? Number)?.toFloat() ?: 0f
-                if (currentValue < minValue)
-                    currentValue = minValue
-                if (currentValue > maxValue)
-                    currentValue = maxValue
-                control.setControlTemplate(
-                    ToggleRangeTemplate(
+object FanControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        if (entity.supportsFanSetSpeed()) {
+            val minValue = 0f
+            val maxValue = 100f
+            var currentValue =
+                (entity.attributes["percentage"] as? Number)?.toFloat() ?: 0f
+            if (currentValue < minValue)
+                currentValue = minValue
+            if (currentValue > maxValue)
+                currentValue = maxValue
+            control.setControlTemplate(
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    entity.state == "on",
+                    "",
+                    RangeTemplate(
                         entity.entityId,
+                        minValue,
+                        maxValue,
+                        currentValue,
+                        1f,
+                        "%.0f%%"
+                    )
+                )
+            )
+        } else {
+            control.setControlTemplate(
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
                         entity.state == "on",
-                        "",
-                        RangeTemplate(
-                            entity.entityId,
-                            minValue,
-                            maxValue,
-                            currentValue,
-                            1f,
-                            "%.0f%%"
-                        )
+                        ""
                     )
                 )
-            } else {
-                control.setControlTemplate(
-                    ToggleTemplate(
-                        entity.entityId,
-                        ControlButton(
-                            entity.state == "on",
-                            ""
-                        )
+            )
+        }
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_FAN
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_fan)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        when (action) {
+            is BooleanAction -> {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if (action.newState) "turn_on" else "turn_off",
+                    hashMapOf("entity_id" to action.templateId)
+                )
+            }
+            is FloatAction -> {
+                val convertPercentage = action.newValue
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "set_percentage",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "percentage" to convertPercentage.toInt()
                     )
                 )
             }
-            return control
         }
-
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_FAN
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_fan)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                when (action) {
-                    is BooleanAction -> {
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            if (action.newState) "turn_on" else "turn_off",
-                            hashMapOf("entity_id" to action.templateId)
-                        )
-                    }
-                    is FloatAction -> {
-                        val convertPercentage = action.newValue
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            "set_percentage",
-                            hashMapOf(
-                                "entity_id" to action.templateId,
-                                "percentage" to convertPercentage.toInt()
-                            )
-                        )
-                    }
-                }
-                return@runBlocking true
-            }
-        }
+        return true
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -54,5 +54,5 @@ interface HaControl {
 
     fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String
 
-    fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
+    suspend fun performAction(integrationRepository: IntegrationRepository, action: ControlAction): Boolean
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
@@ -13,35 +13,33 @@ import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
-class HaFailedControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatus(if (entity.state == "notfound") Control.STATUS_NOT_FOUND else Control.STATUS_ERROR)
-            control.setStatusText("")
-            control.setControlTemplate(
-                StatelessTemplate(
-                    entity.entityId
-                )
+object HaFailedControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatus(if (entity.state == "notfound") Control.STATUS_NOT_FOUND else Control.STATUS_ERROR)
+        control.setStatusText("")
+        control.setControlTemplate(
+            StatelessTemplate(
+                entity.entityId
             )
-            return control
-        }
+        )
+        return control
+    }
 
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_UNKNOWN
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_UNKNOWN
 
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            entity.domain.capitalize()
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        entity.domain.replaceFirstChar { it.titlecase() }
 
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return false
-        }
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        return false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -16,90 +16,85 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class LightControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            val minValue = 0f
-            val maxValue = 100f
-            var currentValue = (entity.attributes["brightness"] as? Number)?.toFloat()?.div(255f)?.times(100) ?: 0f
-            if (currentValue < minValue)
-                currentValue = minValue
-            if (currentValue > maxValue)
-                currentValue = maxValue
-            control.setControlTemplate(
-                if (entity.supportsLightBrightness())
-                    ToggleRangeTemplate(
+object LightControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        val minValue = 0f
+        val maxValue = 100f
+        var currentValue = (entity.attributes["brightness"] as? Number)?.toFloat()?.div(255f)?.times(100) ?: 0f
+        if (currentValue < minValue)
+            currentValue = minValue
+        if (currentValue > maxValue)
+            currentValue = maxValue
+        control.setControlTemplate(
+            if (entity.supportsLightBrightness())
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    entity.state == "on",
+                    "",
+                    RangeTemplate(
                         entity.entityId,
+                        minValue,
+                        maxValue,
+                        currentValue,
+                        1f,
+                        "%.0f%%"
+                    )
+                )
+            else
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
                         entity.state == "on",
-                        "",
-                        RangeTemplate(
-                            entity.entityId,
-                            minValue,
-                            maxValue,
-                            currentValue,
-                            1f,
-                            "%.0f%%"
-                        )
+                        "Description"
                     )
-                else
-                    ToggleTemplate(
-                        entity.entityId,
-                        ControlButton(
-                            entity.state == "on",
-                            "Description"
-                        )
+                )
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_LIGHT
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_light)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        return when (action) {
+            is BooleanAction -> {
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    if (action.newState) "turn_on" else "turn_off",
+                    hashMapOf(
+                        "entity_id" to action.templateId
                     )
-            )
-            return control
-        }
-
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_LIGHT
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_light)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                return@runBlocking when (action) {
-                    is BooleanAction -> {
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            if (action.newState) "turn_on" else "turn_off",
-                            hashMapOf(
-                                "entity_id" to action.templateId
-                            )
-                        )
-                        true
-                    }
-                    is FloatAction -> {
-                        val convertBrightness = action.newValue.div(100).times(255)
-                        integrationRepository.callService(
-                            action.templateId.split(".")[0],
-                            "turn_on",
-                            hashMapOf(
-                                "entity_id" to action.templateId,
-                                "brightness" to convertBrightness.toInt()
-                            )
-                        )
-                        true
-                    }
-                    else -> {
-                        false
-                    }
-                }
+                )
+                true
+            }
+            is FloatAction -> {
+                val convertBrightness = action.newValue.div(100).times(255)
+                integrationRepository.callService(
+                    action.templateId.split(".")[0],
+                    "turn_on",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "brightness" to convertBrightness.toInt()
+                    )
+                )
+                true
+            }
+            else -> {
+                false
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -12,59 +12,54 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class LockControl {
-    companion object : HaControl {
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            control.setStatusText(
-                when (entity.state) {
-                    "jammed" -> context.getString(commonR.string.state_jammed)
-                    "locked" -> context.getString(commonR.string.state_locked)
-                    "locking" -> context.getString(commonR.string.state_locking)
-                    "unlocked" -> context.getString(commonR.string.state_unlocked)
-                    "unlocking" -> context.getString(commonR.string.state_unlocking)
-                    "unavailable" -> context.getString(commonR.string.state_unavailable)
-                    else -> context.getString(commonR.string.state_unknown)
-                }
-            )
-            control.setControlTemplate(
-                ToggleTemplate(
-                    entity.entityId,
-                    ControlButton(
-                        entity.state == "locked",
-                        "Description"
-                    )
-                )
-            )
-            return control
-        }
-
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_LOCK
-
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_lock)
-
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                integrationRepository.callService(
-                    action.templateId.split(".")[0],
-                    if ((action as? BooleanAction)?.newState == true) "lock" else "unlock",
-                    hashMapOf("entity_id" to action.templateId)
-                )
-                return@runBlocking true
+object LockControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        control.setStatusText(
+            when (entity.state) {
+                "jammed" -> context.getString(commonR.string.state_jammed)
+                "locked" -> context.getString(commonR.string.state_locked)
+                "locking" -> context.getString(commonR.string.state_locking)
+                "unlocked" -> context.getString(commonR.string.state_unlocked)
+                "unlocking" -> context.getString(commonR.string.state_unlocking)
+                "unavailable" -> context.getString(commonR.string.state_unavailable)
+                else -> context.getString(commonR.string.state_unknown)
             }
-        }
+        )
+        control.setControlTemplate(
+            ToggleTemplate(
+                entity.entityId,
+                ControlButton(
+                    entity.state == "locked",
+                    "Description"
+                )
+            )
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_LOCK
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_lock)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        integrationRepository.callService(
+            action.templateId.split(".")[0],
+            if ((action as? BooleanAction)?.newState == true) "lock" else "unlock",
+            hashMapOf("entity_id" to action.templateId)
+        )
+        return true
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -12,73 +12,68 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
-class VacuumControl {
-    companion object : HaControl {
-        private const val SUPPORT_TURN_ON = 1
-        private var entitySupportedFeatures = 0
+object VacuumControl : HaControl {
+    private const val SUPPORT_TURN_ON = 1
+    private var entitySupportedFeatures = 0
 
-        override fun provideControlFeatures(
-            context: Context,
-            control: Control.StatefulBuilder,
-            entity: Entity<Map<String, Any>>,
-            area: AreaRegistryResponse?
-        ): Control.StatefulBuilder {
-            entitySupportedFeatures = entity.attributes["supported_features"] as Int
-            if (entitySupportedFeatures and SUPPORT_TURN_ON != SUPPORT_TURN_ON) {
-                control.setStatusText(
-                    when (entity.state) {
-                        "cleaning" -> context.getString(commonR.string.state_cleaning)
-                        "docked" -> context.getString(commonR.string.state_docked)
-                        "error" -> context.getString(commonR.string.state_error)
-                        "idle" -> context.getString(commonR.string.state_idle)
-                        "paused" -> context.getString(commonR.string.state_paused)
-                        "returning" -> context.getString(commonR.string.state_returning)
-                        "unavailable" -> context.getString(commonR.string.state_unavailable)
-                        else -> context.getString(commonR.string.state_unknown)
-                    }
-                )
-            }
-            control.setControlTemplate(
-                ToggleTemplate(
-                    entity.entityId,
-                    ControlButton(
-                        if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
-                            entity.state == "on"
-                        else
-                            entity.state == "cleaning",
-                        "Description"
-                    )
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?
+    ): Control.StatefulBuilder {
+        entitySupportedFeatures = entity.attributes["supported_features"] as Int
+        if (entitySupportedFeatures and SUPPORT_TURN_ON != SUPPORT_TURN_ON) {
+            control.setStatusText(
+                when (entity.state) {
+                    "cleaning" -> context.getString(commonR.string.state_cleaning)
+                    "docked" -> context.getString(commonR.string.state_docked)
+                    "error" -> context.getString(commonR.string.state_error)
+                    "idle" -> context.getString(commonR.string.state_idle)
+                    "paused" -> context.getString(commonR.string.state_paused)
+                    "returning" -> context.getString(commonR.string.state_returning)
+                    "unavailable" -> context.getString(commonR.string.state_unavailable)
+                    else -> context.getString(commonR.string.state_unknown)
+                }
+            )
+        }
+        control.setControlTemplate(
+            ToggleTemplate(
+                entity.entityId,
+                ControlButton(
+                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
+                        entity.state == "on"
+                    else
+                        entity.state == "cleaning",
+                    "Description"
                 )
             )
-            return control
-        }
+        )
+        return control
+    }
 
-        override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
-            DeviceTypes.TYPE_VACUUM
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_VACUUM
 
-        override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
-            context.getString(commonR.string.domain_vacuum)
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_vacuum)
 
-        override fun performAction(
-            integrationRepository: IntegrationRepository,
-            action: ControlAction
-        ): Boolean {
-            return runBlocking {
-                integrationRepository.callService(
-                    action.templateId.split(".")[0],
-                    if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
-                        if ((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off"
-                    else if ((action as? BooleanAction)?.newState == true) "start" else "return_to_base",
-                    hashMapOf(
-                        "entity_id" to action.templateId
-                    )
-                )
-                true
-            }
-        }
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        integrationRepository.callService(
+            action.templateId.split(".")[0],
+            if (entitySupportedFeatures and SUPPORT_TURN_ON == SUPPORT_TURN_ON)
+                if ((action as? BooleanAction)?.newState == true) "turn_on" else "turn_off"
+            else if ((action as? BooleanAction)?.newState == true) "start" else "return_to_base",
+            hashMapOf(
+                "entity_id" to action.templateId
+            )
+        )
+        return true
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Updates HaControls and ControlsProviderService to use coroutines, avoiding `runBlocking` calls. Every call to `performAction` used `runBlocking` to call a coroutine, and it would be more efficient to launch so the main thread doesn't block.

## Any other notes
Additionally replaces companion objects with plain objects, since the classes didn't do anything.