### PR TITLE
Faster 'Detected Activity' sensor while updating fast

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -15,6 +15,8 @@ import com.google.android.gms.location.SleepSegmentEvent
 import com.google.android.gms.location.SleepSegmentRequest
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
+import java.util.concurrent.TimeUnit
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -211,7 +213,8 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             actReg.removeActivityUpdates(pendingIntent)
 
             Log.d(TAG, "Registering for activity updates.")
-            actReg.requestActivityUpdates(120000, pendingIntent)
+            val fastUpdate = SensorReceiverBase.shouldDoFastUpdates(context)
+            actReg.requestActivityUpdates(TimeUnit.MINUTES.toMillis(if (fastUpdate) 1 else 2), pendingIntent)
         }
         if ((
             isEnabled(context, sleepConfidence.id) || isEnabled(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Request an update for the detected activity sensor every minute if the app is currently doing faster sensor updates, instead of every 2 minutes, to try to have an up-to-date recognition value every time the data is sent.
 - Fix inconsistent update behaviour after changing the setting but before restarting when registered for the `ACTION_TIME_TICK` intent by always checking the setting, and not only when set to 'fast while charging'.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
No update required because when no update interval is mentioned, it should default to the sensor update frequency setting which this PR will accomplish.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->