### PR TITLE
Rename Lovelace to Dashboard

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -12,10 +12,6 @@
         <item>@string/themes_option_value_light</item>
         <item>@string/themes_option_value_dark</item>
     </string-array>
-    <string-array name="shortcutTypes">
-        <item>@string/entity_id</item>
-        <item>@string/lovelace</item>
-    </string-array>
     <string-array name="tile_ids">
         <item>tile_1</item>
         <item>tile_2</item>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -276,8 +276,8 @@
     <string name="login">Login</string>
     <string name="login_wear_os_device">Login Wear OS Device</string>
     <string name="logout">Logout</string>
-    <string name="lovelace_view_dashboard">Lovelace View or Dashboard</string>
-    <string name="lovelace">Lovelace</string>
+    <string name="lovelace_view_dashboard">Dashboard View or Dashboard</string>
+    <string name="lovelace">Dashboard</string>
     <string name="mailbox">Mailbox</string>
     <string name="manage_all_notifications">Manage All Notifications</string>
     <string name="manage_all_sensors_summary">This device has %1$d available sensors to utilize.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Renames Lovelace to Dashboard to follow core 2022.4
 - Remove unused string array that also included Lovelace

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![Snippet of the shortcut settings page showing 'Select shortcut type' with two options: 'Dashboard' or 'Entity ID', and a text input field with the hint 'Dashboard View or Dashboard', light mode](https://user-images.githubusercontent.com/8148535/162074647-3737cedf-1825-4c5f-b4af-0760604e55e1.png)|![Snippet of the shortcut settings page showing 'Select shortcut type' with two options: 'Dashboard' or 'Entity ID', and a text input field with the hint 'Dashboard View or Dashboard', dark mode](https://user-images.githubusercontent.com/8148535/162074798-057bca25-6483-4811-ac32-4b8fe8472ab4.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#730

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->