### PR TITLE
Convert HomeAssistantSearcher to LifecycleObserver

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -3,10 +3,13 @@ package io.homeassistant.companion.android.onboarding
 import android.app.Application
 import android.webkit.URLUtil
 import android.widget.Toast
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LifecycleObserver
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
@@ -20,48 +23,44 @@ class OnboardingViewModel @Inject constructor(
     val authenticationRepository: AuthenticationRepository
 ) : AndroidViewModel(app) {
 
-    private val homeAssistantSearcher = HomeAssistantSearcher(
-        app.getSystemService()!!,
-        { instance ->
+    private val _homeAssistantSearcher = HomeAssistantSearcher(
+        nsdManager = app.getSystemService()!!,
+        onInstanceFound = { instance ->
             if (foundInstances.none { it.url == instance.url }) {
                 foundInstances.add(instance)
             }
         },
-        {
+        onError = {
             Toast.makeText(app, R.string.failed_scan, Toast.LENGTH_LONG).show()
             // TODO: Go to manual setup?
         }
     )
+    val homeAssistantSearcher: LifecycleObserver = _homeAssistantSearcher
+
     val foundInstances = mutableStateListOf<HomeAssistantInstance>()
     val manualUrl = mutableStateOf("")
-    val manualContinueEnabled = mutableStateOf(false)
-    val authCode = mutableStateOf("")
+    var manualContinueEnabled by mutableStateOf(false)
+        private set
+    var authCode by mutableStateOf("")
+        private set
     val deviceName = mutableStateOf("")
     val locationTrackingPossible = mutableStateOf(false)
     val locationTrackingEnabled = mutableStateOf(false)
 
     fun onManualUrlUpdated(url: String) {
         manualUrl.value = url
-        manualContinueEnabled.value = URLUtil.isValidUrl(url)
+        manualContinueEnabled = URLUtil.isValidUrl(url)
     }
 
     fun registerAuthCode(code: String) {
-        authCode.value = code
+        authCode = code
     }
 
     fun onDeviceNameUpdated(name: String) {
         deviceName.value = name
     }
 
-    fun startSearch() {
-        homeAssistantSearcher.beginSearch()
-    }
-
-    fun stopSearch() {
-        homeAssistantSearcher.stopSearch()
-    }
-
     override fun onCleared() {
-        stopSearch()
+        _homeAssistantSearcher.stopSearch()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
@@ -36,6 +36,8 @@ class DiscoveryFragment @Inject constructor() : Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
+        lifecycle.addObserver(viewModel.homeAssistantSearcher)
+
         return ComposeView(requireContext()).apply {
             setContent {
                 MdcTheme {
@@ -48,16 +50,6 @@ class DiscoveryFragment @Inject constructor() : Fragment() {
                 }
             }
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        viewModel.startSearch()
-    }
-
-    override fun onPause() {
-        super.onPause()
-        viewModel.stopSearch()
     }
 
     private fun openHomeAssistantHomePage() {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/HomeAssistantSearcher.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/HomeAssistantSearcher.kt
@@ -3,6 +3,8 @@ package io.homeassistant.companion.android.onboarding.discovery
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import okio.internal.commonToUtf8String
 import java.net.URL
 import java.util.concurrent.locks.ReentrantLock
@@ -11,7 +13,7 @@ class HomeAssistantSearcher constructor(
     private val nsdManager: NsdManager,
     private val onInstanceFound: (instance: HomeAssistantInstance) -> Unit,
     private val onError: () -> Unit
-) : NsdManager.DiscoveryListener {
+) : NsdManager.DiscoveryListener, DefaultLifecycleObserver {
 
     companion object {
         private const val SERVICE_TYPE = "_home-assistant._tcp"
@@ -46,6 +48,10 @@ class HomeAssistantSearcher constructor(
             Log.e(TAG, "Issue stopping discovery", e)
         }
     }
+
+    override fun onResume(owner: LifecycleOwner) = beginSearch()
+
+    override fun onPause(owner: LifecycleOwner) = stopSearch()
 
     // Called as soon as service discovery begins.
     override fun onDiscoveryStarted(regType: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -176,7 +176,7 @@ class MobileAppIntegrationFragment : Fragment() {
     private fun onComplete() {
         val retData = OnboardApp.Output(
             url = viewModel.manualUrl.value,
-            authCode = viewModel.authCode.value,
+            authCode = viewModel.authCode,
             deviceName = viewModel.deviceName.value,
             deviceTrackingEnabled = viewModel.locationTrackingEnabled.value
         )

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupView.kt
@@ -64,7 +64,7 @@ fun ManualSetupView(
         )
 
         Button(
-            enabled = onboardingViewModel.manualContinueEnabled.value,
+            enabled = onboardingViewModel.manualContinueEnabled,
             onClick = connectedClicked,
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Small cleanup in OnboardingViewModel. Most notably HomeAssistantSearcher is now a lifecycle observer.