### PR TITLE
Don't block UI thread when opening tile + shortcuts settings

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragmentFactory.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragmentFactory.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.settings
 
+import android.annotation.SuppressLint
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -19,6 +20,7 @@ class SettingsFragmentFactory @Inject constructor(
     private val languagesProvider: LanguagesProvider,
     private val integrationRepository: IntegrationRepository
 ) : FragmentFactory() {
+    @SuppressLint("NewApi")
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {
             SettingsFragment::class.java.name -> SettingsFragment(settingsPresenter, languagesProvider)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.composethemeadapter.MdcTheme
 import com.maltaisn.icondialog.IconDialog
 import com.maltaisn.icondialog.IconDialogSettings
@@ -22,6 +23,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.settings.qs.views.ManageTilesView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -43,6 +47,14 @@ class ManageTilesFragment constructor(
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                val loader = IconPackLoader(requireContext())
+                iconPack = createMaterialDesignIconPack(loader)
+                iconPack.loadDrawables(loader.drawableLoader)
+            }
+        }
     }
 
     override fun onPrepareOptionsMenu(menu: Menu) {
@@ -75,11 +87,6 @@ class ManageTilesFragment constructor(
 
     override fun onResume() {
         super.onResume()
-
-        val loader = IconPackLoader(requireContext())
-        iconPack = createMaterialDesignIconPack(loader)
-        iconPack.loadDrawables(loader.drawableLoader)
-
         activity?.title = getString(commonR.string.tiles)
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.composethemeadapter.MdcTheme
 import com.maltaisn.icondialog.IconDialog
 import com.maltaisn.icondialog.IconDialogSettings
@@ -25,9 +26,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.settings.shortcuts.views.ManageShortcutsView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
+@RequiresApi(Build.VERSION_CODES.N_MR1)
 @AndroidEntryPoint
 class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
 
@@ -43,6 +48,14 @@ class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                val loader = IconPackLoader(requireContext())
+                iconPack = createMaterialDesignIconPack(loader)
+                iconPack.loadDrawables(loader.drawableLoader)
+            }
+        }
     }
 
     override fun onPrepareOptionsMenu(menu: Menu) {
@@ -56,7 +69,6 @@ class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
     @Inject
     lateinit var integrationUseCase: IntegrationRepository
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -79,10 +91,6 @@ class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
     @RequiresApi(Build.VERSION_CODES.N_MR1)
     override fun onResume() {
         super.onResume()
-
-        val loader = IconPackLoader(requireContext())
-        iconPack = createMaterialDesignIconPack(loader)
-        iconPack.loadDrawables(loader.drawableLoader)
 
         viewModel.updatePinnedShortcuts()
         activity?.title = getString(commonR.string.shortcuts)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
@@ -44,10 +44,8 @@ class ManageShortcutsViewModel @Inject constructor(
     private lateinit var iconPack: IconPack
     private var shortcutManager = application.applicationContext.getSystemService<ShortcutManager>()!!
     val canPinShortcuts = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && shortcutManager.isRequestPinShortcutSupported
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     var pinnedShortcuts: MutableList<ShortcutInfo> = shortcutManager.pinnedShortcuts
         private set
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     var dynamicShortcuts: MutableList<ShortcutInfo> = shortcutManager.dynamicShortcuts
         private set
 
@@ -102,7 +100,6 @@ class ManageShortcutsViewModel @Inject constructor(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     fun createShortcut(shortcutId: String, shortcutLabel: String, shortcutDesc: String, shortcutPath: String, bitmap: Bitmap? = null, iconId: Int) {
         Log.d(TAG, "Attempt to add shortcut $shortcutId")
         val intent = Intent(
@@ -149,13 +146,11 @@ class ManageShortcutsViewModel @Inject constructor(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     fun deleteShortcut(shortcutId: String) {
         shortcutManager.removeDynamicShortcuts(listOf(shortcutId))
         dynamicShortcuts = shortcutManager.dynamicShortcuts
     }
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     fun setPinnedShortcutData(shortcutId: String) {
         for (item in pinnedShortcuts) {
             if (item.id == shortcutId) {
@@ -174,7 +169,6 @@ class ManageShortcutsViewModel @Inject constructor(
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     fun setDynamicShortcutData(shortcutId: String, index: Int) {
         if (dynamicShortcuts.isNotEmpty()) {
             for (item in dynamicShortcuts) {
@@ -208,7 +202,6 @@ class ManageShortcutsViewModel @Inject constructor(
         return null
     }
 
-    @RequiresApi(Build.VERSION_CODES.N_MR1)
     fun updatePinnedShortcuts() {
         pinnedShortcuts = shortcutManager.pinnedShortcuts
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Did you ever notice that opening the tile and shortcuts settings takes a little longer than other settings fragments? Turns out it is because the app was loading all the icons for the icon picker on the main thread, every time the fragment resumed. This PR fixes that by moving it to a background thread and only doing it once.

(also cleaning up some annotations for the shortcuts fragment)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->