### PR TITLE
Add haptic + toast feedback to Wear OS details screen

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -605,6 +605,11 @@
     <string name="show_share_logs_summary">Sharing logs with the Home Assistant team will help to solve issues. Please share the logs only if you have been asked to do so by a Home Assistant developer</string>
     <string name="show_share_logs">Show and Share Logs</string>
     <string name="sign_in_on_phone">Sign in on phone</string>
+    <string name="slider_decreased">%1$s decreased</string>
+    <string name="slider_increased">%1$s increased</string>
+    <string name="slider_fan_speed">Fan speed</string>
+    <string name="slider_light_brightness">Brightness</string>
+    <string name="slider_light_colortemp">Color temperature</string>
     <string name="skip">Skip</string>
     <string name="speed">Speed: %1$d%%</string>
     <string name="state_auto">Auto</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -124,7 +124,9 @@ fun LoadHomePage(
                                     entity.entityId,
                                     colorTemp
                                 )
-                            }
+                            },
+                            isToastEnabled = mainViewModel.isToastEnabled.value,
+                            isHapticEnabled = mainViewModel.isHapticEnabled.value
                         )
                     }
                 }

--- a/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -124,8 +124,13 @@ private fun coverIcon(state: String?, entity: Entity<Map<String, Any>>?): IIcon?
 }
 
 fun onEntityClickedFeedback(isToastEnabled: Boolean, isHapticEnabled: Boolean, context: Context, friendlyName: String, haptic: HapticFeedback) {
+    val message = context.getString(commonR.string.toast_message, friendlyName)
+    onEntityFeedback(isToastEnabled, isHapticEnabled, message, context, haptic)
+}
+
+fun onEntityFeedback(isToastEnabled: Boolean, isHapticEnabled: Boolean, message: String, context: Context, haptic: HapticFeedback) {
     if (isToastEnabled)
-        Toast.makeText(context, context.getString(commonR.string.toast_message, friendlyName), Toast.LENGTH_SHORT).show()
+        Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
     if (isHapticEnabled)
         haptic.performHapticFeedback(HapticFeedbackType.LongPress)
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Resolves #2449

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![A details screen showing a toast message that the entity was selected](https://user-images.githubusercontent.com/8148535/163143560-7aa78573-ed79-43ad-9ce8-567f3766561a.png)
![A details screen showing a toast message that the fan speed was increased](https://user-images.githubusercontent.com/8148535/163143571-90a8c3f9-3928-48ce-8eec-afdc3edfd4aa.png)
![A details screen showing a toast message that the brightness was decreased](https://user-images.githubusercontent.com/8148535/163143581-bfe7c4fe-6718-48c7-8b4d-6cde5019f6a5.png)

\+ (emulator buzzes)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not needed

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->