### PR TITLE
Use enum for sensor setting type

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -10,6 +10,7 @@ import com.google.android.gms.location.LocationServices
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -73,7 +74,7 @@ class GeocodeSensorManager : SensorManager {
                 val minAccuracy = sensorSettings
                     .firstOrNull { it.name == SETTING_ACCURACY }?.value?.toIntOrNull()
                     ?: DEFAULT_MINIMUM_ACCURACY
-                sensorDao.add(SensorSetting(geocodedLocation.id, SETTING_ACCURACY, minAccuracy.toString(), "number"))
+                sensorDao.add(SensorSetting(geocodedLocation.id, SETTING_ACCURACY, minAccuracy.toString(), SensorSettingType.NUMBER))
 
                 if (location.accuracy <= minAccuracy)
                     address = Geocoder(context)

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -31,6 +31,7 @@ import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Attribute
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import io.homeassistant.companion.android.notifications.MessagingManager
 import kotlinx.coroutines.CoroutineScope
@@ -127,7 +128,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
             val sensorDao = AppDatabase.getInstance(context).sensorDao()
-            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, enabled.toString(), "toggle"))
+            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE, enabled.toString(), SensorSettingType.TOGGLE))
         }
 
         fun getHighAccuracyModeIntervalSetting(context: Context): Int {
@@ -138,7 +139,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
         fun setHighAccuracyModeIntervalSetting(context: Context, updateInterval: Int) {
             val sensorDao = AppDatabase.getInstance(context).sensorDao()
-            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL, updateInterval.toString(), "number"))
+            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL, updateInterval.toString(), SensorSettingType.NUMBER))
         }
     }
 
@@ -310,7 +311,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             LocationSensorManager.backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL,
-            "number",
+            SensorSettingType.NUMBER,
             DEFAULT_UPDATE_INTERVAL_HA_SECONDS.toString()
         )
 
@@ -351,7 +352,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             LocationSensorManager.backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES,
-            "list-bluetooth",
+            SensorSettingType.LIST_BLUETOOTH,
             ""
         )
 
@@ -415,7 +416,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE,
-            "toggle",
+            SensorSettingType.TOGGLE,
             "false"
         ).toBoolean()
     }
@@ -495,7 +496,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             val minAccuracy = sensorSettings
                 .firstOrNull { it.name == SETTING_ACCURACY }?.value?.toIntOrNull()
                 ?: DEFAULT_MINIMUM_ACCURACY
-            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_ACCURACY, minAccuracy.toString(), "number"))
+            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_ACCURACY, minAccuracy.toString(), SensorSettingType.NUMBER))
             if (location.accuracy > minAccuracy) {
                 Log.w(TAG, "Location accuracy didn't meet requirements, disregarding: $location")
             } else {
@@ -594,7 +595,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         val minAccuracy = sensorSettings
             .firstOrNull { it.name == SETTING_ACCURACY }?.value?.toIntOrNull()
             ?: DEFAULT_MINIMUM_ACCURACY
-        sensorDao.add(SensorSetting(zoneLocation.id, SETTING_ACCURACY, minAccuracy.toString(), "number"))
+        sensorDao.add(SensorSetting(zoneLocation.id, SETTING_ACCURACY, minAccuracy.toString(), SensorSettingType.NUMBER))
 
         if (geofencingEvent.triggeringLocation.accuracy > minAccuracy) {
             Log.w(
@@ -757,7 +758,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE,
-            "number",
+            SensorSettingType.NUMBER,
             DEFAULT_TRIGGER_RANGE_METERS.toString()
         )
 
@@ -766,7 +767,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             highAccuracyTriggerRangeInt = DEFAULT_TRIGGER_RANGE_METERS
 
             val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
-            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE, highAccuracyTriggerRangeInt.toString(), "number"))
+            sensorDao.add(SensorSetting(backgroundLocation.id, SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE, highAccuracyTriggerRangeInt.toString(), SensorSettingType.NUMBER))
         }
 
         return highAccuracyTriggerRangeInt
@@ -781,7 +782,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE_ZONE,
-            "list-zones",
+            SensorSettingType.LIST_ZONES,
             ""
         )
 
@@ -812,11 +813,11 @@ class LocationSensorManager : LocationSensorManagerBase() {
         val minAccuracy = sensorSettings
             .firstOrNull { it.name == SETTING_ACCURACY }?.value?.toIntOrNull()
             ?: DEFAULT_MINIMUM_ACCURACY
-        sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_ACCURACY, minAccuracy.toString(), "number"))
+        sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_ACCURACY, minAccuracy.toString(), SensorSettingType.NUMBER))
         val minTimeBetweenUpdates = sensorSettings
             .firstOrNull { it.name == SETTING_ACCURATE_UPDATE_TIME }?.value?.toIntOrNull()
             ?: 60000
-        sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_ACCURATE_UPDATE_TIME, minTimeBetweenUpdates.toString(), "number"))
+        sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_ACCURATE_UPDATE_TIME, minTimeBetweenUpdates.toString(), SensorSettingType.NUMBER))
 
         // Only update accurate location at most once a minute
         if (now < latestAccurateLocation + minTimeBetweenUpdates) {
@@ -938,6 +939,6 @@ class LocationSensorManager : LocationSensorManagerBase() {
                 )
             }
         } else
-            sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_INCLUDE_SENSOR_UPDATE, "false", "toggle"))
+            sensorDao.add(SensorSetting(singleAccurateLocation.id, SETTING_INCLUDE_SENSOR_UPDATE, "false", SensorSettingType.TOGGLE))
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -36,7 +36,7 @@ class BluetoothSensorManager : SensorManager {
         private const val DEFAULT_BLE_ADVERTISE_MODE = "lowPower"
         private const val DEFAULT_BLE_MAJOR = "100"
         private const val DEFAULT_BLE_MINOR = "1"
-        private const val DEFAULT_MEASURED_POWER_AT_1M = "-59"
+        private const val DEFAULT_MEASURED_POWER_AT_1M = -59
         private var priorBluetoothStateEnabled = false
 
         // private const val TAG = "BluetoothSM"
@@ -175,11 +175,11 @@ class BluetoothSensorManager : SensorManager {
     }
 
     private fun updateBLEDevice(context: Context) {
-        val transmitActive = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, SensorSettingType.TOGGLE, default = "true").toBoolean()
+        val transmitActive = getToggleSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, default = true)
         val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, SensorSettingType.STRING, default = UUID.randomUUID().toString())
         val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, SensorSettingType.STRING, default = DEFAULT_BLE_MAJOR)
         val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, SensorSettingType.STRING, default = DEFAULT_BLE_MINOR)
-        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, SensorSettingType.NUMBER, default = DEFAULT_MEASURED_POWER_AT_1M).toIntOrNull() ?: DEFAULT_MEASURED_POWER_AT_1M.toInt()
+        val measuredPower = getNumberSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, default = DEFAULT_MEASURED_POWER_AT_1M)
         val transmitPower = getSetting(
             context = context,
             sensor = bleTransmitter,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -9,6 +9,7 @@ import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import java.util.UUID
 import kotlin.collections.ArrayList
 import io.homeassistant.companion.android.common.R as commonR
@@ -80,7 +81,7 @@ class BluetoothSensorManager : SensorManager {
             if (transmitEnabled) {
                 TransmitterManager.startTransmitting(context, bleTransmitterDevice)
             }
-            sensorDao.add(SensorSetting(bleTransmitter.id, SETTING_BLE_TRANSMIT_ENABLED, transmitEnabled.toString(), "toggle"))
+            sensorDao.add(SensorSetting(bleTransmitter.id, SETTING_BLE_TRANSMIT_ENABLED, transmitEnabled.toString(), SensorSettingType.TOGGLE))
         }
     }
 
@@ -174,24 +175,30 @@ class BluetoothSensorManager : SensorManager {
     }
 
     private fun updateBLEDevice(context: Context) {
-        val transmitActive = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, "toggle", "true").toBoolean()
-        val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, "string", UUID.randomUUID().toString())
-        val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, "string", DEFAULT_BLE_MAJOR)
-        val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, "string", DEFAULT_BLE_MINOR)
-        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, "number", DEFAULT_MEASURED_POWER_AT_1M).toIntOrNull() ?: DEFAULT_MEASURED_POWER_AT_1M.toInt()
+        val transmitActive = getSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, SensorSettingType.TOGGLE, default = "true").toBoolean()
+        val uuid = getSetting(context, bleTransmitter, SETTING_BLE_ID1, SensorSettingType.STRING, default = UUID.randomUUID().toString())
+        val major = getSetting(context, bleTransmitter, SETTING_BLE_ID2, SensorSettingType.STRING, default = DEFAULT_BLE_MAJOR)
+        val minor = getSetting(context, bleTransmitter, SETTING_BLE_ID3, SensorSettingType.STRING, default = DEFAULT_BLE_MINOR)
+        val measuredPower = getSetting(context, bleTransmitter, SETTING_BLE_MEASURED_POWER, SensorSettingType.NUMBER, default = DEFAULT_MEASURED_POWER_AT_1M).toIntOrNull() ?: DEFAULT_MEASURED_POWER_AT_1M.toInt()
         val transmitPower = getSetting(
-            context, bleTransmitter, SETTING_BLE_TRANSMIT_POWER, "list",
-            listOf(
+            context = context,
+            sensor = bleTransmitter,
+            settingName = SETTING_BLE_TRANSMIT_POWER,
+            settingType = SensorSettingType.LIST,
+            entries = listOf(
                 BLE_TRANSMIT_ULTRA_LOW, BLE_TRANSMIT_LOW, BLE_TRANSMIT_MEDIUM, BLE_TRANSMIT_HIGH
             ),
-            DEFAULT_BLE_TRANSMIT_POWER
+            default = DEFAULT_BLE_TRANSMIT_POWER
         )
         val advertiseMode = getSetting(
-            context, bleTransmitter, SETTING_BLE_ADVERTISE_MODE, "list",
-            listOf(
+            context = context,
+            sensor = bleTransmitter,
+            settingName = SETTING_BLE_ADVERTISE_MODE,
+            settingType = SensorSettingType.LIST,
+            entries = listOf(
                 BLE_ADVERTISE_LOW_POWER, BLE_ADVERTISE_BALANCED, BLE_ADVERTISE_LOW_LATENCY
             ),
-            DEFAULT_BLE_ADVERTISE_MODE
+            default = DEFAULT_BLE_ADVERTISE_MODE
         )
 
         bleTransmitterDevice.restartRequired = false

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastRebootSensorManager.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -69,7 +70,7 @@ class LastRebootSensorManager : SensorManager {
         val sensorSetting = sensorDao.getSettings(lastRebootSensor.id)
         val lastTimeMillis = fullSensor?.attributes?.firstOrNull { it.name == TIME_MILLISECONDS }?.value?.toLongOrNull() ?: 0L
         val settingDeadband = sensorSetting.firstOrNull { it.name == SETTING_DEADBAND }?.value?.toIntOrNull() ?: 60000
-        sensorDao.add(SensorSetting(lastRebootSensor.id, SETTING_DEADBAND, settingDeadband.toString(), "number"))
+        sensorDao.add(SensorSetting(lastRebootSensor.id, SETTING_DEADBAND, settingDeadband.toString(), SensorSettingType.NUMBER))
         try {
             timeInMillis = System.currentTimeMillis() - SystemClock.elapsedRealtime()
             val diffMillis = (timeInMillis - lastTimeMillis).absoluteValue

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NextAlarmManager.kt
@@ -7,6 +7,7 @@ import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
@@ -83,7 +84,7 @@ class NextAlarmManager : SensorManager {
                         return
                     }
                 } else {
-                    sensorDao.add(SensorSetting(nextAlarm.id, SETTING_ALLOW_LIST, allowPackageList, "list-apps"))
+                    sensorDao.add(SensorSetting(nextAlarm.id, SETTING_ALLOW_LIST, allowPackageList, SensorSettingType.LIST_APPS))
                 }
 
                 val cal: Calendar = GregorianCalendar()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.common.R as commonR
 
 class NotificationSensorManager : NotificationListenerService(), SensorManager {
@@ -113,16 +114,16 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             applicationContext,
             lastNotification,
             SETTING_ALLOW_LIST,
-            "list-apps",
-            ""
+            SensorSettingType.LIST_APPS,
+            default = ""
         ).split(", ").filter { it.isNotBlank() }
 
         val disableAllowListRequirement = getSetting(
             applicationContext,
             lastNotification,
             SETTING_DISABLE_ALLOW_LIST,
-            "toggle",
-            "false"
+            SensorSettingType.TOGGLE,
+            default = "false"
         ).toBoolean()
 
         if (sbn.packageName == application.packageName ||
@@ -167,15 +168,15 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             applicationContext,
             lastRemovedNotification,
             SETTING_ALLOW_LIST,
-            "list-apps",
-            ""
+            SensorSettingType.LIST_APPS,
+            default = ""
         ).split(", ").filter { it.isNotBlank() }
 
         val disableAllowListRequirement = getSetting(
             applicationContext,
             lastRemovedNotification,
             SETTING_DISABLE_ALLOW_LIST,
-            "toggle",
+            SensorSettingType.TOGGLE,
             "false"
         ).toBoolean()
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -118,13 +118,12 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             default = ""
         ).split(", ").filter { it.isNotBlank() }
 
-        val disableAllowListRequirement = getSetting(
+        val disableAllowListRequirement = getToggleSetting(
             applicationContext,
             lastNotification,
             SETTING_DISABLE_ALLOW_LIST,
-            SensorSettingType.TOGGLE,
-            default = "false"
-        ).toBoolean()
+            default = false
+        )
 
         if (sbn.packageName == application.packageName ||
             (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) ||
@@ -172,13 +171,12 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             default = ""
         ).split(", ").filter { it.isNotBlank() }
 
-        val disableAllowListRequirement = getSetting(
+        val disableAllowListRequirement = getToggleSetting(
             applicationContext,
             lastRemovedNotification,
             SETTING_DISABLE_ALLOW_LIST,
-            SensorSettingType.TOGGLE,
-            "false"
-        ).toBoolean()
+            default = false
+        )
 
         if (sbn.packageName == application.packageName ||
             (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) ||

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StepsSensorManager.kt
@@ -49,11 +49,9 @@ class StepsSensorManager : SensorManager, SensorEventListener {
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            arrayOf(
-                Manifest.permission.ACTIVITY_RECOGNITION
-            )
+            arrayOf(Manifest.permission.ACTIVITY_RECOGNITION)
         } else {
-            arrayOf()
+            emptyArray()
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -19,6 +19,7 @@ import io.homeassistant.companion.android.common.sensors.NetworkSensorManager
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.database.sensor.SensorWithAttributes
 import io.homeassistant.companion.android.database.settings.SensorUpdateFrequencySetting
 import io.homeassistant.companion.android.sensors.LastAppSensorManager
@@ -149,20 +150,20 @@ class SensorDetailViewModel @Inject constructor(
     }
 
     fun onSettingWithDialogPressed(setting: SensorSetting) {
-        val listSetting = setting.valueType != "string" && setting.valueType != "number"
+        val listSetting = setting.valueType.listType
         val listEntries = getSettingEntries(setting)
         val state = SettingDialogState(
             setting = setting,
             entries = if (listSetting) listEntries else null,
             entriesIds = if (listSetting) {
-                if (setting.valueType == "list") setting.entries
+                if (setting.valueType == SensorSettingType.LIST) setting.entries
                 else listEntries
             } else {
                 null
             },
             entriesSelected = if (listSetting) {
                 setting.value.split(", ").filter {
-                    if (setting.valueType == "list") setting.entries.contains(it)
+                    if (setting.valueType == SensorSettingType.LIST) setting.entries.contains(it)
                     else listEntries.contains(it)
                 }
             } else {
@@ -269,17 +270,17 @@ class SensorDetailViewModel @Inject constructor(
 
     private fun getSettingEntries(setting: SensorSetting): List<String> {
         return when (setting.valueType) {
-            "list" ->
+            SensorSettingType.LIST ->
                 getSettingTranslatedEntries(setting.name, setting.entries)
-            "list-apps" ->
+            SensorSettingType.LIST_APPS ->
                 getApplication<Application>().packageManager
                     ?.getInstalledApplications(PackageManager.GET_META_DATA)
                     ?.map { packageItem -> packageItem.packageName }
                     ?.sorted()
                     .orEmpty()
-            "list-bluetooth" ->
+            SensorSettingType.LIST_BLUETOOTH ->
                 BluetoothUtils.getBluetoothDevices(getApplication()).map { it.name }
-            "list-zones" ->
+            SensorSettingType.LIST_ZONES ->
                 zones
             else ->
                 emptyList()

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -49,9 +49,10 @@ class SensorDetailViewModel @Inject constructor(
         )
         data class SettingDialogState(
             val setting: SensorSetting,
-            val entries: List<String>? = null,
-            val entriesIds: List<String>? = null,
-            val entriesSelected: List<String>? = null
+            /** List of entity ID to entity pairs */
+            val entries: List<Pair<String, String>>,
+            /** List of selected entity ID */
+            val entriesSelected: List<String>
         )
     }
 
@@ -149,17 +150,20 @@ class SensorDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Builds a SettingDialogState based on the given Sensor Setting.
+     * Should trigger a dialog open in view.
+     */
     fun onSettingWithDialogPressed(setting: SensorSetting) {
         val listSetting = setting.valueType.listType
         val listEntries = getSettingEntries(setting)
         val state = SettingDialogState(
             setting = setting,
-            entries = if (listSetting) listEntries else null,
-            entriesIds = if (listSetting) {
-                if (setting.valueType == SensorSettingType.LIST) setting.entries
-                else listEntries
+            entries = if (listSetting) {
+                if (setting.valueType == SensorSettingType.LIST) setting.entries.zip(listEntries)
+                else listEntries.map { it to it }
             } else {
-                null
+                emptyList()
             },
             entriesSelected = if (listSetting) {
                 setting.value.split(", ").filter {
@@ -167,7 +171,7 @@ class SensorDetailViewModel @Inject constructor(
                     else listEntries.contains(it)
                 }
             } else {
-                null
+                emptyList()
             }
         )
         sensorSettingsDialog = state

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.selection.SelectionContainer
@@ -404,7 +405,7 @@ fun SensorDetailSettingDialog(
     val keyboardController = LocalSoftwareKeyboardController.current
     val listSettingDialog = state.setting.valueType.listType
     val inputValue = remember { mutableStateOf(state.setting.value) }
-    val checkedValue = remember { mutableStateListOf(*state.entriesSelected?.toTypedArray() ?: emptyArray()) }
+    val checkedValue = remember { mutableStateListOf<String>().also { it.addAll(state.entriesSelected) } }
 
     MdcAlertDialog(
         onDismissRequest = onDismiss,
@@ -412,24 +413,21 @@ fun SensorDetailSettingDialog(
         content = {
             if (listSettingDialog) {
                 LazyColumn {
-                    state.entries?.forEachIndexed { index, entry ->
-                        val id = state.entriesIds?.get(index)!!
-                        item {
-                            SensorDetailSettingRow(
-                                label = entry,
-                                checked = if (state.setting.valueType == SensorSettingType.LIST) inputValue.value == id else checkedValue.contains(id),
-                                multiple = state.setting.valueType != SensorSettingType.LIST,
-                                onClick = { isChecked ->
-                                    if (state.setting.valueType == SensorSettingType.LIST) {
-                                        inputValue.value = id
-                                        onSubmit(state.copy().apply { setting.value = inputValue.value })
-                                    } else {
-                                        if (checkedValue.contains(id) && !isChecked) checkedValue.remove(id)
-                                        else if (!checkedValue.contains(id) && isChecked) checkedValue.add(id)
-                                    }
+                    items(state.entries, key = { (id) -> id }) { (id, entry) ->
+                        SensorDetailSettingRow(
+                            label = entry,
+                            checked = if (state.setting.valueType == SensorSettingType.LIST) inputValue.value == id else checkedValue.contains(id),
+                            multiple = state.setting.valueType != SensorSettingType.LIST,
+                            onClick = { isChecked ->
+                                if (state.setting.valueType == SensorSettingType.LIST) {
+                                    inputValue.value = id
+                                    onSubmit(state.copy().apply { setting.value = inputValue.value })
+                                } else {
+                                    if (checkedValue.contains(id) && !isChecked) checkedValue.remove(id)
+                                    else if (!checkedValue.contains(id) && isChecked) checkedValue.add(id)
                                 }
-                            )
-                        }
+                            }
+                        )
                     }
                 }
             } else {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.common.R as commonR
 
 class LastUpdateManager : SensorManager {
@@ -69,11 +70,11 @@ class LastUpdateManager : SensorManager {
         val intentSetting = allSettings.firstOrNull { it.name == intentSettingName }?.value ?: ""
         if (addNewIntent == "true") {
             if (intentSetting == "") {
-                sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", "toggle"))
-                sensorDao.add(SensorSetting(lastUpdate.id, intentSettingName, intentAction, "string"))
+                sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
+                sensorDao.add(SensorSetting(lastUpdate.id, intentSettingName, intentAction, SensorSettingType.STRING))
             }
         } else {
-            sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", "toggle"))
+            sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
         }
         for (setting in allSettings) {
             if (setting.value == "")

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -13,6 +13,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -230,8 +231,8 @@ class NetworkSensorManager : SensorManager {
         val currentSetting = sensorSettings.firstOrNull { it.name == settingName }?.value ?: ""
         if (getCurrentBSSID == "true") {
             if (currentSetting == "") {
-                sensorDao.add(SensorSetting(bssidState.id, SETTING_GET_CURRENT_BSSID, "false", "toggle"))
-                sensorDao.add(SensorSetting(bssidState.id, settingName, bssid, "string"))
+                sensorDao.add(SensorSetting(bssidState.id, SETTING_GET_CURRENT_BSSID, "false", SensorSettingType.TOGGLE))
+                sensorDao.add(SensorSetting(bssidState.id, settingName, bssid, SensorSettingType.STRING))
             }
         } else {
             if (currentSetting != "")
@@ -239,7 +240,7 @@ class NetworkSensorManager : SensorManager {
             else
                 sensorDao.removeSetting(bssidState.id, settingName)
 
-            sensorDao.add(SensorSetting(bssidState.id, SETTING_GET_CURRENT_BSSID, "false", "toggle"))
+            sensorDao.add(SensorSetting(bssidState.id, SETTING_GET_CURRENT_BSSID, "false", SensorSettingType.TOGGLE))
         }
 
         val icon = if (bssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -45,6 +45,9 @@ interface SensorManager {
         }
     }
 
+    /**
+     * URL to a documentation page that describes this sensor
+     */
     fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors"
     }
@@ -79,15 +82,20 @@ interface SensorManager {
         return sensor.enabled
     }
 
-    // Request to update a sensor, including any broadcast intent which may have triggered the request
-    // The intent will be null if the update is being done on a timer, rather than as a result
-    // of a broadcast being received.
+    /**
+     * Request to update a sensor, including any broadcast intent which may have triggered the request
+     * The intent will be null if the update is being done on a timer, rather than as a result
+     * of a broadcast being received.
+     */
     fun requestSensorUpdate(context: Context, intent: Intent?) {
         // Few sensors care about the intent, so allow them to just implement the interface that
         // does not get passed that parameter.
         requestSensorUpdate(context)
     }
 
+    /**
+     * Request to update a sensor, without a corresponding broadcast intent.
+     */
     fun requestSensorUpdate(context: Context)
 
     fun getAvailableSensors(context: Context): List<BasicSensor>
@@ -128,15 +136,24 @@ interface SensorManager {
         }
     }
 
-    fun getSetting(
+    fun getToggleSetting(
         context: Context,
         sensor: BasicSensor,
         settingName: String,
-        settingType: SensorSettingType,
-        default: String,
+        default: Boolean,
         enabled: Boolean = true
-    ): String {
-        return getSetting(context, sensor, settingName, settingType, arrayListOf(), default, enabled)
+    ): Boolean {
+        return getSetting(context, sensor, settingName, SensorSettingType.TOGGLE, default.toString(), enabled).toBoolean()
+    }
+
+    fun getNumberSetting(
+        context: Context,
+        sensor: BasicSensor,
+        settingName: String,
+        default: Int,
+        enabled: Boolean = true
+    ): Int {
+        return getSetting(context, sensor, settingName, SensorSettingType.NUMBER, default.toString(), enabled).toIntOrNull() ?: default
     }
 
     /**
@@ -148,9 +165,9 @@ interface SensorManager {
         sensor: BasicSensor,
         settingName: String,
         settingType: SensorSettingType,
-        entries: List<String> = arrayListOf(),
         default: String,
-        enabled: Boolean = true
+        enabled: Boolean = true,
+        entries: List<String> = arrayListOf(),
     ): String {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val setting = sensorDao

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -10,6 +10,7 @@ import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.Attribute
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import java.util.Locale
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -48,6 +49,9 @@ interface SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors"
     }
 
+    /**
+     * Get list of Android permissions that are required to use this sensor
+     */
     fun requiredPermissions(sensorId: String): Array<String>
 
     fun checkPermission(context: Context, sensorId: String): Boolean {
@@ -88,6 +92,9 @@ interface SensorManager {
 
     fun getAvailableSensors(context: Context): List<BasicSensor>
 
+    /**
+     * Check if the user's device supports this type of sensor
+     */
     fun hasSensor(context: Context): Boolean {
         return true
     }
@@ -96,7 +103,7 @@ interface SensorManager {
         context: Context,
         sensor: BasicSensor,
         settingName: String,
-        settingType: String,
+        settingType: SensorSettingType,
         default: String,
         enabled: Boolean = true
     ) {
@@ -125,18 +132,22 @@ interface SensorManager {
         context: Context,
         sensor: BasicSensor,
         settingName: String,
-        settingType: String,
+        settingType: SensorSettingType,
         default: String,
         enabled: Boolean = true
     ): String {
         return getSetting(context, sensor, settingName, settingType, arrayListOf(), default, enabled)
     }
 
+    /**
+     * Get the stored setting value for...
+     * @param default Value to use if the setting does not exist
+     */
     fun getSetting(
         context: Context,
         sensor: BasicSensor,
         settingName: String,
-        settingType: String,
+        settingType: SensorSettingType,
         entries: List<String> = arrayListOf(),
         default: String,
         enabled: Boolean = true
@@ -147,7 +158,7 @@ interface SensorManager {
             .firstOrNull { it.name == settingName }
             ?.value
         if (setting == null)
-            sensorDao.add(SensorSetting(sensor.id, settingName, default, settingType, entries, enabled))
+            sensorDao.add(SensorSetting(sensor.id, settingName, default, settingType, enabled, entries = entries))
 
         return setting ?: default
     }

--- a/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.database.sensor.EntriesTypeConverter
 import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingTypeConverter
 import io.homeassistant.companion.android.database.settings.LocalNotificationSettingConverter
 import io.homeassistant.companion.android.database.settings.LocalSensorSettingConverter
 import io.homeassistant.companion.android.database.settings.Setting
@@ -76,7 +77,8 @@ import io.homeassistant.companion.android.common.R as commonR
 @TypeConverters(
     LocalNotificationSettingConverter::class,
     LocalSensorSettingConverter::class,
-    EntriesTypeConverter::class
+    EntriesTypeConverter::class,
+    SensorSettingTypeConverter::class
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun authenticationDao(): AuthenticationDao

--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
@@ -26,7 +26,7 @@ data class SensorSetting(
     @ColumnInfo(name = "value_type")
     val valueType: SensorSettingType,
     @ColumnInfo(name = "enabled")
-    var enabled: Boolean = true,
+    val enabled: Boolean = true,
     @ColumnInfo(name = "entries")
     val entries: List<String> = arrayListOf(),
 )

--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
@@ -4,6 +4,16 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.TypeConverter
 
+enum class SensorSettingType(val string: String, val listType: Boolean = false) {
+    STRING("string"),
+    NUMBER("number"),
+    TOGGLE("toggle"),
+    LIST("list", listType = true),
+    LIST_APPS("list-apps", listType = true),
+    LIST_BLUETOOTH("list-bluetooth", listType = true),
+    LIST_ZONES("list-zones", listType = true),
+}
+
 @Entity(tableName = "sensor_settings", primaryKeys = ["sensor_id", "name"])
 data class SensorSetting(
     @ColumnInfo(name = "sensor_id")
@@ -12,16 +22,14 @@ data class SensorSetting(
     val name: String,
     @ColumnInfo(name = "value")
     var value: String,
+    /** Indicates the data type of the `value`. */
     @ColumnInfo(name = "value_type")
-    var valueType: String,
-    @ColumnInfo(name = "entries")
-    var entries: List<String> = arrayListOf(),
+    val valueType: SensorSettingType,
     @ColumnInfo(name = "enabled")
-    var enabled: Boolean = true
-) {
-
-    constructor(sensorId: String, name: String, value: String, valueType: String, enabled: Boolean) : this(sensorId, name, value, valueType, arrayListOf(), enabled)
-}
+    var enabled: Boolean = true,
+    @ColumnInfo(name = "entries")
+    val entries: List<String> = arrayListOf(),
+)
 
 class EntriesTypeConverter {
     @TypeConverter
@@ -32,5 +40,18 @@ class EntriesTypeConverter {
     @TypeConverter
     fun toStringFromList(list: List<String>): String {
         return list.joinToString(separator = "|")
+    }
+}
+
+class SensorSettingTypeConverter {
+    @TypeConverter
+    fun fromStringToEnum(value: String): SensorSettingType {
+        return enumValues<SensorSettingType>().find { it.string === value }
+            ?: SensorSettingType.STRING
+    }
+
+    @TypeConverter
+    fun toStringFromEnum(enum: SensorSettingType): String {
+        return enum.string
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Moving off a string type to a strict enum, since there are only certain valid values. Added a type converter to Room so this should be backwards compatible.