### PR TITLE
Fix Wear OS Settings endlessly loading with no connected devices

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
@@ -97,6 +97,7 @@ class SettingsWearActivity : AppCompatActivity(), CapabilityClient.OnCapabilityC
 
     override fun onResume() {
         super.onResume()
+        title = getString(commonR.string.wear_os_settings_title)
         capabilityClient.addListener(this, CAPABILITY_WEAR_APP)
     }
 
@@ -162,7 +163,7 @@ class SettingsWearActivity : AppCompatActivity(), CapabilityClient.OnCapabilityC
             }
             allConnectedNodes.isEmpty() -> {
                 Log.d(TAG, "No devices")
-                binding.informationTextView.text = getString(commonR.string.message_checking)
+                binding.informationTextView.text = getString(commonR.string.message_no_connected_nodes)
                 binding.remoteOpenButton.isInvisible = true
             }
             wearNodesWithApp.isEmpty() -> {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -301,10 +301,10 @@
     <string name="map">Map</string>
     <string name="maximum">Maximum</string>
     <string name="media_player_widget_desc">Control any media player and see current now playing image</string>
-    <string name="message_all_installed">The Wear app is installed on all of your wear devices! \n\nStay tuned for more updates to this page.</string>
     <string name="message_checking">Checking Wear Devices with App</string>
     <string name="message_missing_all">The Wear app is missing on your watch, click the button below to install the app.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
-    <string name="message_some_installed">The Wear app is installed on some of your wear devices: (%1$s)\n\nClick the button below to install the app on the other devices.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
+    <string name="message_no_connected_nodes">No connected Wear devices, please make sure Bluetooth is on and your watch is paired.</string>
+    <string name="message_some_installed">The Wear app is installed on some of your Wear devices: (%1$s)\n\nClick the button below to install the app on the other devices.\n\nNote: Currently the Wear OS app requires you to be enrolled in the beta for the phone app. If the button does not work then please join the beta: https://play.google.com/apps/testing/io.homeassistant.companion.android</string>
     <string name="mfa_title">Two-factor\nAuthentication</string>
     <string name="mfa_hint">Code</string>
     <string name="missing_command_permission">Please open the Home Assistant app and send the command again in order to grant the proper permissions. You will be taken to a page to either grant the Home Assistant app the permission, or you will need to select Permissions from the details page and then grant the missing permission. For command_bluetooth the name of the permission is Nearby devices. If you are attempting to use command_activity to make a phone call you will also need to grant Phone permissions.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If the Wear OS app is installed but there are no connected devices, the Wear OS Settings section of the app seemingly endlessly loads, while in fact it simply didn't show a proper error message for the situation. This PR fixes that.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![A screenshot of a screen with the title 'Wear OS Settings', showing a message that reads 'No connected Wear devices, please make sure Bluetooth is on and your watch is paired.', light mode](https://user-images.githubusercontent.com/8148535/165370280-a2c1b762-f5db-458c-9a30-30dc5f7a9b5f.png)|![A screenshot of a screen with the title 'Wear OS Settings', showing a message that reads 'No connected Wear devices, please make sure Bluetooth is on and your watch is paired.', dark mode](https://user-images.githubusercontent.com/8148535/165370416-ee78ff8f-690c-44cf-8f23-48003d7c9cb1.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->