### PR TITLE
Breaking change: send sensor list attributes as list to server

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -129,12 +129,12 @@ class BluetoothSensorManager : SensorManager {
         var totalConnectedDevices = 0
         var connectedPairedDevices: List<String> = ArrayList()
         var connectedNotPairedDevices: List<String> = ArrayList()
-        var bondedString = ""
+        var pairedDevices: List<String> = ArrayList()
 
         if (checkPermission(context, bluetoothConnection.id)) {
 
             val bluetoothDevices = BluetoothUtils.getBluetoothDevices(context)
-            bondedString = bluetoothDevices.filter { b -> b.paired }.map { it.address }.toString()
+            pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { it.address }
             connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { it.address }
             connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { it.address }
             totalConnectedDevices = bluetoothDevices.filter { b -> b.connected }.count()
@@ -147,7 +147,7 @@ class BluetoothSensorManager : SensorManager {
             mapOf(
                 "connected_paired_devices" to connectedPairedDevices,
                 "connected_not_paired_devices" to connectedNotPairedDevices,
-                "paired_devices" to bondedString
+                "paired_devices" to pairedDevices
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -76,6 +78,7 @@ fun SensorDetailView(
 ) {
     val context = LocalContext.current
     var sensorUpdateTypeInfo by remember { mutableStateOf(false) }
+    val jsonMapper by lazy { jacksonObjectMapper() }
 
     val sensorEnabled = viewModel.sensor?.sensor?.enabled
         ?: (
@@ -143,9 +146,17 @@ fun SensorDetailView(
                     }
                     sensor.attributes.forEach { attribute ->
                         item {
+                            val summary = when (attribute.valueType) {
+                                "listboolean" -> jsonMapper.readValue<List<Boolean>>(attribute.value).toString()
+                                "listfloat" -> jsonMapper.readValue<List<Number>>(attribute.value).toString()
+                                "listlong" -> jsonMapper.readValue<List<Long>>(attribute.value).toString()
+                                "listint" -> jsonMapper.readValue<List<Int>>(attribute.value).toString()
+                                "liststring" -> jsonMapper.readValue<List<String>>(attribute.value).toString()
+                                else -> attribute.value
+                            }
                             SensorDetailRow(
                                 title = attribute.name,
-                                summary = attribute.value,
+                                summary = summary,
                                 clickable = false,
                                 selectingEnabled = true
                             )

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -189,6 +189,7 @@ interface SensorManager {
                     is Number -> "float"
                     is List<*> -> {
                         when {
+                            (item.value as List<*>).any { it is String && it.contains(", ") } -> "string"
                             (item.value as List<*>).all { it is Boolean } -> "listboolean"
                             (item.value as List<*>).all { it is Int } -> "listint"
                             (item.value as List<*>).all { it is Long } -> "listlong"

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -187,6 +187,15 @@ interface SensorManager {
                     is Int -> "int"
                     is Long -> "long"
                     is Number -> "float"
+                    is List<*> -> {
+                        when {
+                            (item.value as List<*>).all { it is Boolean } -> "listboolean"
+                            (item.value as List<*>).all { it is Int } -> "listint"
+                            (item.value as List<*>).all { it is Long } -> "listlong"
+                            (item.value as List<*>).all { it is Number } -> "listfloat"
+                            else -> "liststring"
+                        }
+                    }
                     else -> "string" // Always default to String for attributes
                 }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -189,7 +189,7 @@ interface SensorManager {
                     is Number -> "float"
                     is List<*> -> {
                         when {
-                            (item.value as List<*>).any { it is String && it.contains(", ") } -> "string"
+                            (item.value as List<*>).any { it.toString().contains(", ") } -> "string"
                             (item.value as List<*>).all { it is Boolean } -> "listboolean"
                             (item.value as List<*>).all { it is Int } -> "listint"
                             (item.value as List<*>).all { it is Long } -> "listlong"

--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
@@ -2,6 +2,9 @@ package io.homeassistant.companion.android.database.sensor
 
 import androidx.room.Embedded
 import androidx.room.Relation
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.homeassistant.companion.android.common.data.integration.SensorRegistration
 
 data class SensorWithAttributes(
@@ -14,17 +17,20 @@ data class SensorWithAttributes(
     val attributes: List<Attribute>
 ) {
     fun toSensorRegistration(): SensorRegistration<Any> {
+        var objectMapper: ObjectMapper? = null
         val attributes = attributes.map {
             val attributeValue = when (it.valueType) {
                 "listboolean", "listfloat", "listlong", "listint", "liststring" -> {
-                    val list = it.value.removeSurrounding("[", "]").split(", ")
-                    when (it.valueType) {
-                        "listboolean" -> list.map { item -> item.toBoolean() }
-                        "listfloat" -> list.map { item -> item.toFloat() }
-                        "listlong" -> list.map { item -> item.toLong() }
-                        "listint" -> list.map { item -> item.toInt() }
-                        else -> list
-                    }
+                    if (objectMapper == null) objectMapper = jacksonObjectMapper()
+                    objectMapper?.let { mapper ->
+                        when (it.valueType) {
+                            "listboolean" -> mapper.readValue<List<Boolean>>(it.value)
+                            "listfloat" -> mapper.readValue<List<Number>>(it.value)
+                            "listlong" -> mapper.readValue<List<Long>>(it.value)
+                            "listint" -> mapper.readValue<List<Int>>(it.value)
+                            else -> mapper.readValue<List<String>>(it.value)
+                        }
+                    } ?: it.value // Fallback: provide JSON string, but shouldn't happen
                 }
                 "boolean" -> it.value.toBoolean()
                 "float" -> it.value.toFloat()

--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorWithAttributes.kt
@@ -16,6 +16,16 @@ data class SensorWithAttributes(
     fun toSensorRegistration(): SensorRegistration<Any> {
         val attributes = attributes.map {
             val attributeValue = when (it.valueType) {
+                "listboolean", "listfloat", "listlong", "listint", "liststring" -> {
+                    val list = it.value.removeSurrounding("[", "]").split(", ")
+                    when (it.valueType) {
+                        "listboolean" -> list.map { item -> item.toBoolean() }
+                        "listfloat" -> list.map { item -> item.toFloat() }
+                        "listlong" -> list.map { item -> item.toLong() }
+                        "listint" -> list.map { item -> item.toInt() }
+                        else -> list
+                    }
+                }
                 "boolean" -> it.value.toBoolean()
                 "float" -> it.value.toFloat()
                 "long" -> it.value.toLong()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When the app collects sensor attributes, it is stored in the app's database as a string and converted back to it's original type when sent to the server, if possible. This PR updates the "if possible" part to also include lists. This will allow users to use array features in HA templating for these values.

Because this changes the format for attribute values, this is a **breaking change**. Based on a quick search, this will have changes for the following sensors:
 - Bluetooth Connection
 - Last Notification
 - Last Removed Notification
 - Active Notification Count

I've tested this with core 2022.4.7. Fixes #2474.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->