### PR TITLE
Handle individual exceptions while creating device controls better

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -147,6 +147,7 @@ object ClimateControl : HaControl {
     private fun entityShouldBePresentedAsThermostat(entity: Entity<Map<String, Any>>): Boolean {
         return temperatureControlModes.containsKey(entity.state) &&
             ((entity.attributes["hvac_modes"] as? List<String>)?.isNotEmpty() == true) &&
+            ((entity.attributes["hvac_modes"] as? List<String>)?.any { it == entity.state } == true) &&
             ((entity.attributes["hvac_modes"] as? List<String>)?.all { temperatureControlModes.containsKey(it) } == true) &&
             (
                 ((entity.attributes["supported_features"] as Int) and SUPPORT_TARGET_TEMPERATURE == SUPPORT_TARGET_TEMPERATURE) ||

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -79,11 +79,16 @@ class HaControlsProviderService : ControlsProviderService() {
                     entities
                         ?.sortedWith(compareBy(nullsLast()) { areaForEntity[it.entityId]?.name })
                         ?.mapNotNull {
-                            domainToHaControl[it.domain]?.createControl(
-                                applicationContext,
-                                it as Entity<Map<String, Any>>,
-                                areaForEntity[it.entityId]
-                            )
+                            try {
+                                domainToHaControl[it.domain]?.createControl(
+                                    applicationContext,
+                                    it as Entity<Map<String, Any>>,
+                                    areaForEntity[it.entityId]
+                                )
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Unable to create control for ${it.domain} entity, skipping", e)
+                                null
+                            }
                         }
                         ?.forEach {
                             subscriber.onNext(it)
@@ -124,14 +129,7 @@ class HaControlsProviderService : ControlsProviderService() {
                                     Log.e(TAG, "Unable to get $it from Home Assistant, null response.")
                                 }
                             } catch (e: Exception) {
-                                entities["ha_failed.$it"] = Entity(
-                                    entityId = it,
-                                    state = if (e is HttpException && e.code() == 404) "notfound" else "exception",
-                                    attributes = mapOf<String, String>(),
-                                    lastChanged = Calendar.getInstance(),
-                                    lastUpdated = Calendar.getInstance(),
-                                    context = null
-                                )
+                                entities["ha_failed.$it"] = getFailedEntity(it, e)
                                 Log.e(TAG, "Unable to get $it from Home Assistant, caught exception.", e)
                             }
                         }
@@ -218,12 +216,35 @@ class HaControlsProviderService : ControlsProviderService() {
         entityRegistry: List<EntityRegistryResponse>?
     ) {
         entities.forEach {
-            val control = domainToHaControl[it.value.domain]?.createControl(
-                applicationContext,
-                it.value,
-                RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)
-            )
+            val control = try {
+                domainToHaControl[it.value.domain]?.createControl(
+                    applicationContext,
+                    it.value,
+                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)
+                )
+            } catch (e: Exception) {
+                Log.e(TAG, "Unable to create control for ${it.value.domain} entity, sending error entity", e)
+                domainToHaControl["ha_failed"]?.createControl(
+                    applicationContext,
+                    getFailedEntity(it.value.entityId, e),
+                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)
+                )
+            }
             subscriber.onNext(control)
         }
+    }
+
+    private fun getFailedEntity(
+        entityId: String,
+        exception: Exception
+    ): Entity<Map<String, Any>> {
+        return Entity(
+            entityId = entityId,
+            state = if (exception is HttpException && exception.code() == 404) "notfound" else "exception",
+            attributes = mapOf<String, String>(),
+            lastChanged = Calendar.getInstance(),
+            lastUpdated = Calendar.getInstance(),
+            context = null
+        )
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2481, [confirmed by user](https://github.com/home-assistant/android/issues/2481#issuecomment-1111157550).

Specifically for this issue: make sure that the current mode of a climate entity (= HA state) is in the list of supported modes before attempting to use the template that includes state. The entity that caused problems in the issue will now use the more generic / simple range template for the control.

In general for future bugs that haven't been found yet: handle errors when creating individual controls. When trying to add a new control, the app will skip a control for a specific entity if it throws an exception instead of skipping all controls, and for existing controls it will show a control with an error state similar to network errors instead of crashing.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Example of a control when an exception is thrown during control creation, next to a functional control:
![Two device controls, one of them showing 'Can't load status' as the status and the other one showing 'On 22%'](https://user-images.githubusercontent.com/8148535/165549590-f6271e23-bd68-431f-84a3-4b130c33c449.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not necessary

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->