### PR TITLE
Add additional location setting to combine connected BT devices and e…

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -50,6 +50,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         private const val SETTING_HIGH_ACCURACY_MODE_UPDATE_INTERVAL = "location_ham_update_interval"
         private const val SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES = "location_ham_only_bt_dev"
         private const val SETTING_HIGH_ACCURACY_MODE_ZONE = "location_ham_only_enter_zone"
+        private const val SETTING_HIGH_ACCURACY_BT_ZONE_COMBINED = "location_ham_zone_bt_combined"
         private const val SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE = "location_ham_trigger_range"
 
         private const val DEFAULT_MINIMUM_ACCURACY = 200
@@ -269,6 +270,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES, highAccuracyModeSettingEnabled)
             enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_ZONE, highAccuracyModeSettingEnabled && isZoneEnable)
             enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_MODE_TRIGGER_RANGE_ZONE, highAccuracyModeSettingEnabled && isZoneEnable)
+            enableDisableSetting(latestContext, backgroundLocation, SETTING_HIGH_ACCURACY_BT_ZONE_COMBINED, highAccuracyModeSettingEnabled && isZoneEnable)
 
             lastHighAccuracyZones = highAccuracyZones
             lastHighAccuracyTriggerRange = highAccuracyTriggerRange
@@ -354,6 +356,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             "list-bluetooth",
             ""
         )
+        val highAccuracyBtZoneCombined = getHighAccuracyBTZoneCombinedSetting()
 
         val useTriggerRange = getHighAccuracyModeTriggerRange() > 0
         val highAccuracyZones = getHighAccuracyModeZones(false)
@@ -400,13 +403,15 @@ class LocationSensorManager : LocationSensorManagerBase() {
         // true = High accuracy mode enabled
         // false = High accuracy mode disabled
         //
-        // if either BT Device is connected or in Zone -> High accuracy mode enabled (true)
+        // if BT device and zone are combined and BT device is connected AND in zone -> High accuracy mode enabled (true)
+        // if BT device and zone are NOT combined and either BT Device is connected OR in Zone -> High accuracy mode enabled (true)
         // Else (NO BT dev connected and NOT in Zone), if min. one constraint is used ->  High accuracy mode disabled (false)
         //                                             if no constraint is used ->  High accuracy mode enabled (true)
-        return if (btDevConnected || inZone) {
-            true
-        } else {
-            !constraintsUsed
+        return when {
+            highAccuracyBtZoneCombined && btDevConnected && inZone -> true
+            !highAccuracyBtZoneCombined && (btDevConnected || inZone) -> true
+            highAccuracyBtZoneCombined && !constraintsUsed -> false
+            else -> !constraintsUsed
         }
     }
 
@@ -415,6 +420,16 @@ class LocationSensorManager : LocationSensorManagerBase() {
             latestContext,
             backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE,
+            "toggle",
+            "false"
+        ).toBoolean()
+    }
+
+    private fun getHighAccuracyBTZoneCombinedSetting(): Boolean {
+        return getSetting(
+            latestContext,
+            backgroundLocation,
+            SETTING_HIGH_ACCURACY_BT_ZONE_COMBINED,
             "toggle",
             "false"
         ).toBoolean()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -551,6 +551,7 @@
     <string name="sensor_setting_lastupdate_add_new_intent_title">Add New Intent</string>
     <string name="sensor_setting_lastupdate_intent_title" translatable="false">Intent %1$1s</string>
     <string name="sensor_setting_location_ham_enabled_title">High accuracy mode (May drain battery fast)</string>
+    <string name="sensor_setting_location_ham_zone_bt_combined_title">High accuracy mode enabled only when in zone and BT device connected</string>
     <string name="sensor_setting_location_ham_only_bt_dev_title">High accuracy mode only when connected to BT devices</string>
     <string name="sensor_setting_location_ham_only_enter_zone_title">High accuracy mode only when entering zone</string>
     <string name="sensor_setting_location_ham_trigger_range_title">High accuracy mode trigger range for zone (meters)</string>


### PR DESCRIPTION
…ntering a zone to enable high accuracy mode


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Added a new setting to provide an "AND" functionality instead of only "OR" for combining connected BT devices and entering a specific zone to enable the high accuracy mode. This is related to the following issue: 
https://github.com/home-assistant/android/issues/1673

## Any other notes
Whenever there is no zone or device defined, but high accuracy is enabled as well as the combination, the combination setting will avoid to start the high accuracy mode as there is nothing to be combined. It made sense from my point of view (default is false anyways)