### PR TITLE
Fix sensor setting type converter

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorSetting.kt
@@ -46,7 +46,7 @@ class EntriesTypeConverter {
 class SensorSettingTypeConverter {
     @TypeConverter
     fun fromStringToEnum(value: String): SensorSettingType {
-        return enumValues<SensorSettingType>().find { it.string === value }
+        return enumValues<SensorSettingType>().find { it.string == value }
             ?: SensorSettingType.STRING
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
#2469 introduced a bug which resulted in sensor settings always being considered of the type `STRING` when read from the database because [`===`](https://kotlinlang.org/docs/equality.html#referential-equality) was used in the type converter. It looks like there is some magic in the database that breaks this comparison for strings, so only compare the contents instead.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->