### PR TITLE
Add theming to widgets: Dynamic color (Material You) and Transparent

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -184,7 +184,7 @@ open class HomeAssistantApplication : Application() {
                 IntentFilter(Intent.ACTION_TIME_TICK)
             )
 
-        // Update widgets when the screen turns on, updates are skipped if widgets were not added
+        // Update widgets when the screen turns on or configuration changes, updates are skipped if widgets were not added
         val buttonWidget = ButtonWidget()
         val entityWidget = EntityWidget()
         val mediaPlayerWidget = MediaPlayerControlsWidget()
@@ -193,6 +193,7 @@ open class HomeAssistantApplication : Application() {
         val screenIntentFilter = IntentFilter()
         screenIntentFilter.addAction(Intent.ACTION_SCREEN_ON)
         screenIntentFilter.addAction(Intent.ACTION_SCREEN_OFF)
+        screenIntentFilter.addAction(Intent.ACTION_CONFIGURATION_CHANGED)
 
         registerReceiver(buttonWidget, screenIntentFilter)
         registerReceiver(entityWidget, screenIntentFilter)

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -184,7 +184,7 @@ open class HomeAssistantApplication : Application() {
                 IntentFilter(Intent.ACTION_TIME_TICK)
             )
 
-        // Update widgets when the screen turns on or configuration changes, updates are skipped if widgets were not added
+        // Update widgets when the screen turns on, updates are skipped if widgets were not added
         val buttonWidget = ButtonWidget()
         val entityWidget = EntityWidget()
         val mediaPlayerWidget = MediaPlayerControlsWidget()
@@ -193,7 +193,6 @@ open class HomeAssistantApplication : Application() {
         val screenIntentFilter = IntentFilter()
         screenIntentFilter.addAction(Intent.ACTION_SCREEN_ON)
         screenIntentFilter.addAction(Intent.ACTION_SCREEN_OFF)
-        screenIntentFilter.addAction(Intent.ACTION_CONFIGURATION_CHANGED)
 
         registerReceiver(buttonWidget, screenIntentFilter)
         registerReceiver(entityWidget, screenIntentFilter)

--- a/app/src/main/java/io/homeassistant/companion/android/util/ContextExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/ContextExtensions.kt
@@ -2,9 +2,16 @@ package io.homeassistant.companion.android.util
 
 import android.content.Context
 import android.util.TypedValue
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
 
 fun Context.getAttribute(attr: Int, fallbackAttr: Int): Int {
     val value = TypedValue()
     theme.resolveAttribute(attr, value, true)
     return if (value.resourceId != 0) attr else fallbackAttr
+}
+
+fun Context.getHexForColor(@ColorRes attr: Int): String {
+    val color = ContextCompat.getColor(this, attr)
+    return String.format("#%06X", 0xFFFFFF and color) // https://stackoverflow.com/a/6540378
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -64,12 +63,6 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
             }
             Intent.ACTION_SCREEN_ON -> onScreenOn(context)
             Intent.ACTION_SCREEN_OFF -> onScreenOff()
-            Intent.ACTION_CONFIGURATION_CHANGED -> {
-                mainScope.launch {
-                    delay(300L) // delay to ensure new colors are loaded
-                    updateAllWidgets(context)
-                }
-            }
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -63,6 +64,12 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
             }
             Intent.ACTION_SCREEN_ON -> onScreenOn(context)
             Intent.ACTION_SCREEN_OFF -> onScreenOff()
+            Intent.ACTION_CONFIGURATION_CHANGED -> {
+                mainScope.launch {
+                    delay(300L) // delay to ensure new colors are loaded
+                    updateAllWidgets(context)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -34,7 +34,6 @@ import io.homeassistant.companion.android.util.getAttribute
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -134,12 +133,6 @@ class ButtonWidget : AppWidgetProvider() {
             CALL_SERVICE -> callConfiguredService(context, appWidgetId)
             RECEIVE_DATA -> saveServiceCallConfiguration(context, intent.extras, appWidgetId)
             Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, buttonWidgetDao.getAll())
-            Intent.ACTION_CONFIGURATION_CHANGED -> {
-                mainScope.launch {
-                    delay(300L) // delay to ensure new colors are loaded
-                    updateAllWidgets(context, buttonWidgetDao.getAll())
-                }
-            }
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -12,8 +13,10 @@ import android.util.Log
 import android.view.View
 import android.widget.RemoteViews
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.graphics.toColorInt
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.maltaisn.icondialog.pack.IconPack
@@ -25,9 +28,11 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.widget.ButtonWidgetDao
 import io.homeassistant.companion.android.database.widget.ButtonWidgetEntity
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.regex.Pattern
 import javax.inject.Inject
@@ -47,6 +52,8 @@ class ButtonWidget : AppWidgetProvider() {
         internal const val EXTRA_SERVICE_DATA = "EXTRA_SERVICE_DATA"
         internal const val EXTRA_LABEL = "EXTRA_LABEL"
         internal const val EXTRA_ICON = "EXTRA_ICON"
+        internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
+        internal const val EXTRA_TEXT_COLOR = "EXTRA_TEXT_COLOR"
     }
 
     @Inject
@@ -86,11 +93,6 @@ class ButtonWidget : AppWidgetProvider() {
                 views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
                 views.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
                 views.setViewVisibility(R.id.widgetLabelLayout, View.VISIBLE)
-                views.setInt(
-                    R.id.widgetLayout,
-                    "setBackgroundResource",
-                    R.drawable.widget_button_background
-                )
                 appWidgetManager.updateAppWidget(item.id, views)
             }
         }
@@ -130,6 +132,12 @@ class ButtonWidget : AppWidgetProvider() {
             CALL_SERVICE -> callConfiguredService(context, appWidgetId)
             RECEIVE_DATA -> saveServiceCallConfiguration(context, intent.extras, appWidgetId)
             Intent.ACTION_SCREEN_ON -> updateAllWidgets(context, buttonWidgetDao.getAll())
+            Intent.ACTION_CONFIGURATION_CHANGED -> {
+                mainScope.launch {
+                    delay(300L) // delay to ensure new colors are loaded
+                    updateAllWidgets(context, buttonWidgetDao.getAll())
+                }
+            }
         }
     }
 
@@ -153,11 +161,20 @@ class ButtonWidget : AppWidgetProvider() {
             iconPack!!.loadDrawables(loader.drawableLoader)
         }
         return RemoteViews(context.packageName, R.layout.widget_button).apply {
+            // Theming
+            var textColor: Int = ContextCompat.getColor(context, commonR.color.colorWidgetButtonLabel)
+            if (widget?.backgroundType == WidgetBackgroundType.TRANSPARENT) {
+                widget.textColor?.let { textColor = it.toColorInt() }
+            }
+            setWidgetBackground(this, widget)
+            setTextColor(R.id.widgetLabel, textColor)
+
+            // Content
             val iconId = widget?.iconId ?: 988171 // Lightning bolt
 
             val iconDrawable = iconPack?.icons?.get(iconId)?.drawable
             if (iconDrawable != null) {
-                val icon = DrawableCompat.wrap(iconDrawable)
+                val icon = DrawableCompat.wrap(iconDrawable).apply { setTint(textColor) }
                 setImageViewBitmap(R.id.widgetImageButton, icon.toBitmap())
             }
 
@@ -174,6 +191,17 @@ class ButtonWidget : AppWidgetProvider() {
                 R.id.widgetLabel,
                 widget?.label ?: ""
             )
+        }
+    }
+
+    private fun setWidgetBackground(views: RemoteViews, widget: ButtonWidgetEntity?) {
+        when (widget?.backgroundType) {
+            WidgetBackgroundType.TRANSPARENT -> {
+                views.setInt(R.id.widgetLayout, "setBackgroundColor", Color.TRANSPARENT)
+            }
+            else -> { // WidgetBackgroundType.DAYNIGHT and null widget
+                views.setInt(R.id.widgetLayout, "setBackgroundResource", R.drawable.widget_button_background)
+            }
         }
     }
 
@@ -265,11 +293,7 @@ class ButtonWidget : AppWidgetProvider() {
             Handler(Looper.getMainLooper()).postDelayed(
                 {
                     views.setViewVisibility(R.id.widgetLabelLayout, View.VISIBLE)
-                    views.setInt(
-                        R.id.widgetLayout,
-                        "setBackgroundResource",
-                        R.drawable.widget_button_background
-                    )
+                    setWidgetBackground(views, widget)
                     appWidgetManager.updateAppWidget(appWidgetId, views)
                 },
                 1000
@@ -285,6 +309,8 @@ class ButtonWidget : AppWidgetProvider() {
         val serviceData: String? = extras.getString(EXTRA_SERVICE_DATA)
         val label: String? = extras.getString(EXTRA_LABEL)
         val icon: Int = extras.getInt(EXTRA_ICON)
+        val backgroundType: WidgetBackgroundType = extras.getSerializable(EXTRA_BACKGROUND_TYPE) as WidgetBackgroundType
+        val textColor: String? = extras.getString(EXTRA_TEXT_COLOR)
 
         if (domain == null || service == null || serviceData == null) {
             Log.e(TAG, "Did not receive complete service call data")
@@ -301,7 +327,7 @@ class ButtonWidget : AppWidgetProvider() {
                     "label: " + label
             )
 
-            val widget = ButtonWidgetEntity(appWidgetId, icon, domain, service, serviceData, label)
+            val widget = ButtonWidgetEntity(appWidgetId, icon, domain, service, serviceData, label, backgroundType, textColor)
             buttonWidgetDao.add(widget)
 
             // It is the responsibility of the configuration activity to update the app widget

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -45,7 +45,6 @@ import io.homeassistant.companion.android.util.getHexForColor
 import io.homeassistant.companion.android.widgets.common.ServiceFieldBinder
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetDynamicFieldAdapter
-import io.homeassistant.companion.android.widgets.entity.EntityWidget
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -105,6 +105,9 @@ class EntityWidget : BaseWidgetProvider() {
                         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
                     )
                 )
+            } else {
+                setTextViewText(R.id.widgetText, "")
+                setTextViewText(R.id.widgetLabel, "")
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.widget.RemoteViews
 import android.widget.Toast
 import androidx.core.content.getSystemService
+import com.google.android.material.color.DynamicColors
 import com.mikepenz.iconics.IconicsDrawable
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.AndroidEntryPoint
@@ -24,6 +25,7 @@ import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetDao
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetEntity
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -58,6 +60,7 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         internal const val EXTRA_SHOW_VOLUME = "EXTRA_SHOW_VOLUME"
         internal const val EXTRA_SHOW_SKIP = "EXTRA_INCLUDE_SKIP"
         internal const val EXTRA_SHOW_SEEK = "EXTRA_INCLUDE_SEEK"
+        internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
     }
 
     @Inject
@@ -137,8 +140,9 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
         }
 
-        return RemoteViews(context.packageName, R.layout.widget_media_controls).apply {
-            val widget = mediaPlayCtrlWidgetDao.get(appWidgetId)
+        val widget = mediaPlayCtrlWidgetDao.get(appWidgetId)
+        val useDynamicColors = widget?.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable()
+        return RemoteViews(context.packageName, if (useDynamicColors) R.layout.widget_media_controls_wrapper_dynamiccolor else R.layout.widget_media_controls_wrapper_default).apply {
             if (widget != null) {
                 val entityId: String = widget.entityId
                 var label: String? = widget.label
@@ -446,6 +450,7 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         val showSkip: Boolean? = extras.getBoolean(EXTRA_SHOW_SKIP)
         val showSeek: Boolean? = extras.getBoolean(EXTRA_SHOW_SEEK)
         val showVolume: Boolean? = extras.getBoolean(EXTRA_SHOW_VOLUME)
+        val backgroundType: WidgetBackgroundType = extras.getSerializable(EXTRA_BACKGROUND_TYPE) as WidgetBackgroundType
 
         if (entitySelection == null || showSkip == null || showSeek == null || showVolume == null) {
             Log.e(TAG, "Did not receive complete configuration data")
@@ -465,7 +470,8 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
                     labelSelection,
                     showSkip,
                     showSeek,
-                    showVolume
+                    showVolume,
+                    backgroundType
                 )
             )
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -382,6 +382,8 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
                     setViewVisibility(R.id.widgetRewindButton, View.GONE)
                     setViewVisibility(R.id.widgetFastForwardButton, View.GONE)
                 }
+            } else {
+                setTextViewText(R.id.widgetLabel, "")
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -13,12 +13,14 @@ import android.widget.AdapterView
 import android.widget.AutoCompleteTextView
 import android.widget.Toast
 import androidx.core.content.getSystemService
+import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.database.AppDatabase
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import io.homeassistant.companion.android.databinding.WidgetMediaControlsConfigureBinding
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
@@ -101,6 +103,9 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
 
         val mediaPlayerControlsWidgetDao = AppDatabase.getInstance(applicationContext).mediaPlayCtrlWidgetDao()
         val mediaPlayerWidget = mediaPlayerControlsWidgetDao.get(appWidgetId)
+
+        binding.backgroundType.visibility = if (DynamicColors.isDynamicColorAvailable()) View.VISIBLE else View.GONE
+
         if (mediaPlayerWidget != null) {
             binding.label.setText(mediaPlayerWidget.label)
             binding.widgetTextConfigEntityId.setText(mediaPlayerWidget.entityId)
@@ -117,6 +122,8 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
                     null
                 }
             }
+            binding.backgroundTypeDynamiccolor.isChecked = mediaPlayerWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable()
+            binding.backgroundTypeDaynight.isChecked = mediaPlayerWidget.backgroundType == WidgetBackgroundType.DAYNIGHT
             if (entity != null)
                 selectedEntity = entity as Entity<Any>?
             binding.addButton.setText(commonR.string.update_widget)
@@ -197,6 +204,13 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
             intent.putExtra(
                 MediaPlayerControlsWidget.EXTRA_SHOW_SEEK,
                 binding.widgetShowSeekButtonsCheckbox.isChecked
+            )
+            intent.putExtra(
+                MediaPlayerControlsWidget.EXTRA_BACKGROUND_TYPE,
+                when {
+                    binding.backgroundTypeDynamiccolor.isChecked && DynamicColors.isDynamicColorAvailable() -> WidgetBackgroundType.DYNAMICCOLOR
+                    else -> WidgetBackgroundType.DAYNIGHT
+                }
             )
 
             context.sendBroadcast(intent)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import android.widget.AdapterView
+import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import android.widget.Toast
 import androidx.core.content.getSystemService
@@ -104,7 +105,17 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
         val mediaPlayerControlsWidgetDao = AppDatabase.getInstance(applicationContext).mediaPlayCtrlWidgetDao()
         val mediaPlayerWidget = mediaPlayerControlsWidgetDao.get(appWidgetId)
 
-        binding.backgroundType.visibility = if (DynamicColors.isDynamicColorAvailable()) View.VISIBLE else View.GONE
+        val backgroundTypeValues = mutableListOf(
+            getString(commonR.string.widget_background_type_dynamiccolor),
+            getString(commonR.string.widget_background_type_daynight)
+        )
+        if (DynamicColors.isDynamicColorAvailable()) {
+            binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
+            binding.backgroundType.setSelection(0)
+            binding.backgroundTypeParent.visibility = View.VISIBLE
+        } else {
+            binding.backgroundTypeParent.visibility = View.GONE
+        }
 
         if (mediaPlayerWidget != null) {
             binding.label.setText(mediaPlayerWidget.label)
@@ -122,8 +133,14 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
                     null
                 }
             }
-            binding.backgroundTypeDynamiccolor.isChecked = mediaPlayerWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable()
-            binding.backgroundTypeDaynight.isChecked = mediaPlayerWidget.backgroundType == WidgetBackgroundType.DAYNIGHT
+            binding.backgroundType.setSelection(
+                when {
+                    mediaPlayerWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
+                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_dynamiccolor))
+                    else ->
+                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_daynight))
+                }
+            )
             if (entity != null)
                 selectedEntity = entity as Entity<Any>?
             binding.addButton.setText(commonR.string.update_widget)
@@ -207,8 +224,8 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseActivity() {
             )
             intent.putExtra(
                 MediaPlayerControlsWidget.EXTRA_BACKGROUND_TYPE,
-                when {
-                    binding.backgroundTypeDynamiccolor.isChecked && DynamicColors.isDynamicColorAvailable() -> WidgetBackgroundType.DYNAMICCOLOR
+                when (binding.backgroundType.selectedItem as String?) {
+                    getString(commonR.string.widget_background_type_dynamiccolor) -> WidgetBackgroundType.DYNAMICCOLOR
                     else -> WidgetBackgroundType.DAYNIGHT
                 }
             )

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -102,6 +102,8 @@ class TemplateWidget : BaseWidgetProvider() {
                     TypedValue.COMPLEX_UNIT_SP,
                     widget.textSize
                 )
+            } else {
+                setTextViewText(R.id.widgetTemplateText, "")
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -8,6 +8,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.text.Html.fromHtml
 import android.util.Log
+import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.content.ContextCompat
@@ -21,7 +22,6 @@ import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import io.homeassistant.companion.android.util.getAttribute
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
-import io.homeassistant.companion.android.widgets.entity.EntityWidget
 import kotlinx.coroutines.launch
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -30,6 +30,7 @@ class TemplateWidget : BaseWidgetProvider() {
     companion object {
         private const val TAG = "TemplateWidget"
         internal const val EXTRA_TEMPLATE = "extra_template"
+        internal const val EXTRA_TEXT_SIZE = "EXTRA_TEXT_SIZE"
         internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
         internal const val EXTRA_TEXT_COLOR = "EXTRA_TEXT_COLOR"
     }
@@ -96,6 +97,11 @@ class TemplateWidget : BaseWidgetProvider() {
                     R.id.widgetTemplateText,
                     fromHtml(renderedTemplate)
                 )
+                setTextViewTextSize(
+                    R.id.widgetTemplateText,
+                    TypedValue.COMPLEX_UNIT_SP,
+                    widget.textSize
+                )
             }
         }
     }
@@ -104,8 +110,9 @@ class TemplateWidget : BaseWidgetProvider() {
         if (extras == null) return
 
         val template: String? = extras.getString(EXTRA_TEMPLATE)
-        val backgroundTypeSelection: WidgetBackgroundType = extras.getSerializable(EntityWidget.EXTRA_BACKGROUND_TYPE) as WidgetBackgroundType
-        val textColorSelection: String? = extras.getString(EntityWidget.EXTRA_TEXT_COLOR)
+        val textSize: Float = extras.getFloat(EXTRA_TEXT_SIZE)
+        val backgroundTypeSelection: WidgetBackgroundType = extras.getSerializable(EXTRA_BACKGROUND_TYPE) as WidgetBackgroundType
+        val textColorSelection: String? = extras.getString(EXTRA_TEXT_COLOR)
 
         if (template == null) {
             Log.e(TAG, "Did not receive complete widget data")
@@ -118,6 +125,7 @@ class TemplateWidget : BaseWidgetProvider() {
                 TemplateWidgetEntity(
                     appWidgetId,
                     template,
+                    textSize,
                     templateWidgetDao.get(appWidgetId)?.lastUpdate ?: "Loading",
                     backgroundTypeSelection,
                     textColorSelection

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -87,6 +87,7 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
 
         if (templateWidget != null) {
             binding.templateText.setText(templateWidget.template)
+            binding.textSize.setText(templateWidget.textSize.toInt().toString())
             binding.addButton.setText(commonR.string.update_widget)
             if (templateWidget.template.isNotEmpty())
                 renderTemplateText(templateWidget.template)
@@ -155,6 +156,7 @@ class TemplateWidgetConfigureActivity : BaseActivity() {
             component = ComponentName(applicationContext, TemplateWidget::class.java)
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             putExtra(TemplateWidget.EXTRA_TEMPLATE, binding.templateText.text.toString())
+            putExtra(TemplateWidget.EXTRA_TEXT_SIZE, binding.textSize.text.toString().toFloat())
             putExtra(
                 TemplateWidget.EXTRA_BACKGROUND_TYPE,
                 when {

--- a/app/src/main/res/drawable/widget_button_background.xml
+++ b/app/src/main/res/drawable/widget_button_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
-    <solid android:color="@color/colorWidgetButtonBackground"/>
+    <solid android:color="?colorWidgetBackground"/>
     <corners android:radius="8dp"/>
 </shape>

--- a/app/src/main/res/drawable/widget_button_background.xml
+++ b/app/src/main/res/drawable/widget_button_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="?colorWidgetBackground"/>
-    <corners android:radius="8dp"/>
+    <corners android:radius="?dimenWidgetCornerRadius"/>
 </shape>

--- a/app/src/main/res/layout-v31/widget_button_wrapper_dynamiccolor.xml
+++ b/app/src/main/res/layout-v31/widget_button_wrapper_dynamiccolor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.DynamicColorWidget">
+
+    <include layout="@layout/widget_button" />
+
+</FrameLayout>

--- a/app/src/main/res/layout-v31/widget_media_controls_wrapper_dynamiccolor.xml
+++ b/app/src/main/res/layout-v31/widget_media_controls_wrapper_dynamiccolor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.DynamicColorWidget">
+
+    <include layout="@layout/widget_media_controls" />
+
+</FrameLayout>

--- a/app/src/main/res/layout-v31/widget_static_wrapper_dynamiccolor.xml
+++ b/app/src/main/res/layout-v31/widget_static_wrapper_dynamiccolor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.DynamicColorWidget">
+
+    <include layout="@layout/widget_static" />
+
+</FrameLayout>

--- a/app/src/main/res/layout-v31/widget_template_wrapper_dynamiccolor.xml
+++ b/app/src/main/res/layout-v31/widget_template_wrapper_dynamiccolor.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.DynamicColorWidget">
+
+    <include layout="@layout/widget_template" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -39,14 +39,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="@string/widget_label_placeholder_text"
+                android:text="@string/widget_label_placeholder_text_button"
                 android:textSize="12sp"
                 android:textAlignment="center"
                 android:gravity="center"
                 android:textColor="?colorWidgetOnBackground"
                 android:minLines="1"
-                android:maxLines="2"
-                />
+                android:maxLines="2" />
         </LinearLayout>
     </LinearLayout>
 

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -23,9 +23,7 @@
             android:layout_weight="1"
             android:src="@drawable/ic_flash_on_24dp"
             android:contentDescription="@string/widget_button_image_description"
-            android:gravity="center"
-            android:tint="@color/colorIcon"
-            tools:ignore="UseAppTint" />
+            android:gravity="center" />
 
         <LinearLayout
             android:id="@+id/widgetLabelLayout"

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -23,7 +23,9 @@
             android:layout_weight="1"
             android:src="@drawable/ic_flash_on_24dp"
             android:contentDescription="@string/widget_button_image_description"
-            android:gravity="center" />
+            android:gravity="center"
+            android:tint="?colorWidgetPrimary"
+            tools:ignore="UseAppTint" />
 
         <LinearLayout
             android:id="@+id/widgetLabelLayout"
@@ -41,7 +43,7 @@
                 android:textSize="12sp"
                 android:textAlignment="center"
                 android:gravity="center"
-                android:textColor="@color/colorWidgetButtonLabel"
+                android:textColor="?colorWidgetOnBackground"
                 android:minLines="1"
                 android:maxLines="2"
                 />

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -112,47 +112,27 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_background_type_label" />
 
-            <RadioGroup
+            <Spinner
+                android:id="@+id/background_type"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="end">
-                <RadioButton
-                    android:id="@+id/background_type_dynamiccolor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_dynamiccolor"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
-                <RadioButton
-                    android:id="@+id/background_type_daynight"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_daynight"
-                    android:checked="true"/>
-                <RadioButton
-                    android:id="@+id/background_type_transparent"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_transparent"/>
-            </RadioGroup>
+                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <LinearLayout
             android:id="@+id/text_color"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
@@ -161,14 +141,14 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_text_color_label_icon" />
 
             <RadioGroup
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="end">
+                android:orientation="horizontal">
                 <RadioButton
                     android:id="@+id/text_color_white"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -110,6 +110,72 @@
                 android:inputType="text" />
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_background_type_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/background_type_daynight"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_daynight"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/background_type_transparent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_transparent"/>
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/text_color"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_text_color_label_icon" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/text_color_white"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_white"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/text_color_black"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_black"/>
+            </RadioGroup>
+        </LinearLayout>
+
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_button"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -128,6 +128,13 @@
                 android:layout_height="wrap_content"
                 android:gravity="end">
                 <RadioButton
+                    android:id="@+id/background_type_dynamiccolor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_dynamiccolor"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+                <RadioButton
                     android:id="@+id/background_type_daynight"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/widget_button_wrapper_default.xml
+++ b/app/src/main/res/layout/widget_button_wrapper_default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.Widget">
+
+    <include layout="@layout/widget_button" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/widget_camera.xml
+++ b/app/src/main/res/layout/widget_camera.xml
@@ -5,7 +5,8 @@
     android:layout_height="match_parent"
     android:minHeight="40dp"
     android:minWidth="40dp"
-    android:background="@drawable/widget_button_background">
+    android:background="@drawable/widget_button_background"
+    android:theme="@style/Theme.HomeAssistant.Widget">
 
     <ImageView
         android:id="@+id/widgetCameraImage"

--- a/app/src/main/res/layout/widget_media_controls.xml
+++ b/app/src/main/res/layout/widget_media_controls.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/widgetLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:minHeight="40dp"
     android:minWidth="40dp"
-    android:background="@drawable/widget_button_background">
+    android:background="@drawable/widget_button_background"
+    tools:ignore="UseAppTint">
 
     <LinearLayout
         android:id="@+id/widgetImageButtonLayout"
@@ -56,7 +57,7 @@
                 android:layout_alignParentEnd="true"
                 android:padding="8dp"
                 android:visibility="invisible"
-                android:tint="@color/colorWidgetButtonLabel"
+                android:tint="?colorWidgetOnBackground"
                 android:src="@drawable/app_icon_round" />
 
             <LinearLayout
@@ -81,7 +82,7 @@
                     android:minLines="1"
                     android:text="@string/widget_label_placeholder_text"
                     android:textAlignment="center"
-                    android:textColor="@color/colorWidgetButtonLabel"
+                    android:textColor="?colorWidgetOnBackground"
                     android:textSize="24sp" />
 
                 <TextView
@@ -94,7 +95,7 @@
                     android:visibility="gone"
                     android:text="@string/widget_label_placeholder_text"
                     android:textAlignment="textStart"
-                    android:textColor="@color/colorWidgetButtonLabel"
+                    android:textColor="?colorWidgetOnBackground"
                     android:textSize="18sp" />
 
                 <TextView
@@ -107,7 +108,7 @@
                     android:visibility="gone"
                     android:text="@string/widget_label_placeholder_text"
                     android:textAlignment="textStart"
-                    android:textColor="@color/colorWidgetButtonLabel"
+                    android:textColor="?colorWidgetOnBackground"
                     android:textSize="14sp" />
             </LinearLayout>
 
@@ -128,7 +129,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_volume_down"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetVolumeUpButton"
@@ -140,7 +141,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_volume_up"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetPrevTrackButton"
@@ -152,7 +153,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_prev_track"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetRewindButton"
@@ -164,7 +165,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_rewind"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetPlayPauseButton"
@@ -176,7 +177,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_playpause"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetFastForwardButton"
@@ -188,7 +189,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_fastforward"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
 
                 <ImageButton
                     android:id="@+id/widgetNextTrackButton"
@@ -200,7 +201,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_next_track"
-                    android:tint="@color/colorIcon" />
+                    android:tint="?colorWidgetButton" />
             </LinearLayout>
         </RelativeLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/widget_media_controls.xml
+++ b/app/src/main/res/layout/widget_media_controls.xml
@@ -7,6 +7,7 @@
     android:minHeight="40dp"
     android:minWidth="40dp"
     android:background="@drawable/widget_button_background"
+    android:clipToOutline="true"
     tools:ignore="UseAppTint">
 
     <LinearLayout
@@ -80,7 +81,7 @@
                     android:gravity="center"
                     android:maxLines="2"
                     android:minLines="1"
-                    android:text="@string/widget_label_placeholder_text"
+                    android:text="@string/widget_label_placeholder_text_media_player"
                     android:textAlignment="center"
                     android:textColor="?colorWidgetOnBackground"
                     android:textSize="24sp" />
@@ -93,7 +94,6 @@
                     android:maxLines="1"
                     android:minLines="1"
                     android:visibility="gone"
-                    android:text="@string/widget_label_placeholder_text"
                     android:textAlignment="textStart"
                     android:textColor="?colorWidgetOnBackground"
                     android:textSize="18sp" />
@@ -106,7 +106,6 @@
                     android:maxLines="1"
                     android:minLines="1"
                     android:visibility="gone"
-                    android:text="@string/widget_label_placeholder_text"
                     android:textAlignment="textStart"
                     android:textColor="?colorWidgetOnBackground"
                     android:textSize="14sp" />
@@ -129,6 +128,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_volume_down"
+                    android:visibility="gone"
                     android:tint="?colorWidgetButton" />
 
                 <ImageButton
@@ -141,6 +141,7 @@
                     android:padding="4dp"
                     android:scaleType="fitCenter"
                     android:src="@drawable/ic_volume_up"
+                    android:visibility="gone"
                     android:tint="?colorWidgetButton" />
 
                 <ImageButton

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -92,10 +92,9 @@
         </LinearLayout>
 
         <LinearLayout
-            android:id="@+id/background_type"
+            android:id="@+id/background_type_parent"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
@@ -104,25 +103,14 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_background_type_label" />
 
-            <RadioGroup
+            <Spinner
+                android:id="@+id/background_type"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="end">
-                <RadioButton
-                    android:id="@+id/background_type_dynamiccolor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_dynamiccolor"
-                    android:checked="true"/>
-                <RadioButton
-                    android:id="@+id/background_type_daynight"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_daynight"/>
-            </RadioGroup>
+                android:layout_height="wrap_content" />
         </LinearLayout>
 
         <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -88,6 +89,40 @@
                 android:hint="@string/widget_text_hint_label"
                 android:imeOptions="actionDone"
                 android:inputType="text" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/background_type"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_background_type_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/background_type_dynamiccolor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_dynamiccolor"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/background_type_daynight"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_daynight"/>
+            </RadioGroup>
         </LinearLayout>
 
         <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/widget_media_controls_wrapper_default.xml
+++ b/app/src/main/res/layout/widget_media_controls_wrapper_default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.Widget">
+
+    <include layout="@layout/widget_media_controls" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/widget_static.xml
+++ b/app/src/main/res/layout/widget_static.xml
@@ -21,10 +21,10 @@
             android:layout_weight="1"
             android:layout_gravity="center"
             android:gravity="center"
+            android:text="@string/widget_label_placeholder_text_static_state"
             android:textStyle="bold"
             android:textSize="30sp"
-            android:textColor="?colorWidgetPrimary"
-            />
+            android:textColor="?colorWidgetPrimary" />
 
         <LinearLayout
             android:id="@+id/widgetLabelLayout"
@@ -47,14 +47,13 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:text="@string/widget_label_placeholder_text"
+                android:text="@string/widget_label_placeholder_text_static_label"
                 android:textSize="12sp"
                 android:textAlignment="center"
                 android:textColor="?colorWidgetOnBackground"
                 android:gravity="center"
                 android:minLines="1"
-                android:maxLines="2"
-                />
+                android:maxLines="2" />
         </LinearLayout>
     </LinearLayout>
 </FrameLayout>

--- a/app/src/main/res/layout/widget_static.xml
+++ b/app/src/main/res/layout/widget_static.xml
@@ -23,7 +23,7 @@
             android:gravity="center"
             android:textStyle="bold"
             android:textSize="30sp"
-            android:textColor="@color/colorWidgetButtonLabel"
+            android:textColor="?colorWidgetPrimary"
             />
 
         <LinearLayout
@@ -50,7 +50,7 @@
                 android:text="@string/widget_label_placeholder_text"
                 android:textSize="12sp"
                 android:textAlignment="center"
-                android:textColor="@color/colorWidgetButtonLabel"
+                android:textColor="?colorWidgetOnBackground"
                 android:gravity="center"
                 android:minLines="1"
                 android:maxLines="2"

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -192,6 +192,13 @@
                 android:layout_height="wrap_content"
                 android:gravity="end">
                 <RadioButton
+                    android:id="@+id/background_type_dynamiccolor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_dynamiccolor"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+                <RadioButton
                     android:id="@+id/background_type_daynight"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -176,47 +176,28 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_background_type_label" />
 
-            <RadioGroup
+            <Spinner
+                android:id="@+id/background_type"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="end">
-                <RadioButton
-                    android:id="@+id/background_type_dynamiccolor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_dynamiccolor"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
-                <RadioButton
-                    android:id="@+id/background_type_daynight"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_daynight"
-                    android:checked="true"/>
-                <RadioButton
-                    android:id="@+id/background_type_transparent"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_transparent"/>
-            </RadioGroup>
+                android:layout_gravity="center_vertical" />
         </LinearLayout>
 
         <LinearLayout
             android:id="@+id/text_color"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
@@ -225,14 +206,14 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_text_color_label" />
 
             <RadioGroup
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="end">
+                android:orientation="horizontal">
                 <RadioButton
                     android:id="@+id/text_color_white"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -174,6 +174,72 @@
                 android:inputType="text" />
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_background_type_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/background_type_daynight"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_daynight"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/background_type_transparent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_transparent"/>
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/text_color"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_text_color_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/text_color_white"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_white"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/text_color_black"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_black"/>
+            </RadioGroup>
+        </LinearLayout>
+
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_button"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/widget_static_wrapper_default.xml
+++ b/app/src/main/res/layout/widget_static_wrapper_default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.Widget">
+
+    <include layout="@layout/widget_static" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/widget_template.xml
+++ b/app/src/main/res/layout/widget_template.xml
@@ -15,7 +15,7 @@
         android:layout_gravity="center"
         android:gravity="center"
         android:textAlignment="center"
-        android:textColor="@color/colorWidgetButtonLabel"
+        android:textColor="?colorWidgetOnBackground"
         android:textSize="12sp" />
 
     <ImageView

--- a/app/src/main/res/layout/widget_template.xml
+++ b/app/src/main/res/layout/widget_template.xml
@@ -14,6 +14,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:gravity="center"
+        android:text="@string/widget_label_placeholder_text_template"
         android:textAlignment="center"
         android:textColor="?colorWidgetOnBackground"
         android:textSize="12sp" />

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -2,7 +2,8 @@
 <androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -31,6 +32,72 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/template_widget_default" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_background_type_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/background_type_daynight"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_daynight"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/background_type_transparent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_transparent"/>
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/text_color"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="50dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:padding="5dp"
+                android:text="@string/widget_text_color_label" />
+
+            <RadioGroup
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="end">
+                <RadioButton
+                    android:id="@+id/text_color_white"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_white"
+                    android:checked="true"/>
+                <RadioButton
+                    android:id="@+id/text_color_black"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_text_color_black"/>
+            </RadioGroup>
+        </LinearLayout>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/add_button"

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -35,6 +35,30 @@
 
         <LinearLayout
             android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:padding="5dp"
+                android:text="@string/widget_text_size_label"/>
+
+            <androidx.appcompat.widget.AppCompatEditText
+                android:id="@+id/textSize"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:imeOptions="actionDone"
+                android:textAlignment="center"
+                android:inputType="number"
+                android:text="@string/widget_text_size_template" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="50dp"
             android:gravity="center"

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -51,6 +51,13 @@
                 android:layout_height="wrap_content"
                 android:gravity="end">
                 <RadioButton
+                    android:id="@+id/background_type_dynamiccolor"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/widget_background_type_dynamiccolor"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
+                <RadioButton
                     android:id="@+id/background_type_daynight"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -59,47 +59,28 @@
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_background_type_label" />
 
-            <RadioGroup
+            <Spinner
+                android:id="@+id/background_type"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="end">
-                <RadioButton
-                    android:id="@+id/background_type_dynamiccolor"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_dynamiccolor"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
-                <RadioButton
-                    android:id="@+id/background_type_daynight"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_daynight"
-                    android:checked="true"/>
-                <RadioButton
-                    android:id="@+id/background_type_transparent"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/widget_background_type_transparent"/>
-            </RadioGroup>
+                android:layout_gravity="center_vertical" />
         </LinearLayout>
 
         <LinearLayout
             android:id="@+id/text_color"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="50dp"
+            android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
@@ -108,14 +89,14 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
                 android:padding="5dp"
                 android:text="@string/widget_text_color_label" />
 
             <RadioGroup
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:gravity="end">
+                android:orientation="horizontal">
                 <RadioButton
                     android:id="@+id/text_color_white"
                     android:layout_width="wrap_content"

--- a/app/src/main/res/layout/widget_template_wrapper_default.xml
+++ b/app/src/main/res/layout/widget_template_wrapper_default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:theme="@style/Theme.HomeAssistant.Widget">
+
+    <include layout="@layout/widget_template" />
+
+</FrameLayout>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -13,5 +13,6 @@
         <item name="colorWidgetButton">@color/colorDynamicWidgetPrimary</item>
         <item name="colorWidgetBackground">@color/colorDynamicWidgetBackground</item>
         <item name="colorWidgetOnBackground">@color/colorDynamicWidgetOnBackground</item>
+        <item name="dimenWidgetCornerRadius">@android:dimen/system_app_widget_background_radius</item>
     </style>
 </resources>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -7,4 +7,10 @@
         <item name="android:statusBarColor">@color/colorLaunchScreenBackground</item>
         <item name="android:navigationBarColor">@color/colorLaunchScreenBackground</item>
     </style>
+
+    <style name="Theme.HomeAssistant.DynamicColorWidget">
+        <item name="colorWidgetPrimary">@color/colorDynamicWidgetPrimary</item>
+        <item name="colorWidgetBackground">@color/colorDynamicWidgetBackground</item>
+        <item name="colorWidgetOnBackground">@color/colorDynamicWidgetOnBackground</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -10,6 +10,7 @@
 
     <style name="Theme.HomeAssistant.DynamicColorWidget">
         <item name="colorWidgetPrimary">@color/colorDynamicWidgetPrimary</item>
+        <item name="colorWidgetButton">@color/colorDynamicWidgetPrimary</item>
         <item name="colorWidgetBackground">@color/colorDynamicWidgetBackground</item>
         <item name="colorWidgetOnBackground">@color/colorDynamicWidgetOnBackground</item>
     </style>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -6,6 +6,7 @@
 
     <declare-styleable name="Theme.HomeAssistant.Widget">
         <attr name="colorWidgetPrimary" format="color" />
+        <attr name="colorWidgetButton" format="color" />
         <attr name="colorWidgetBackground" format="color" />
         <attr name="colorWidgetOnBackground" format="color" />
     </declare-styleable>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -3,4 +3,10 @@
     <declare-styleable name="SsidPreference">
         <attr name="summaryMaxLines" format="integer"/>
     </declare-styleable>
+
+    <declare-styleable name="Theme.HomeAssistant.Widget">
+        <attr name="colorWidgetPrimary" format="color" />
+        <attr name="colorWidgetBackground" format="color" />
+        <attr name="colorWidgetOnBackground" format="color" />
+    </declare-styleable>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,5 +9,6 @@
         <attr name="colorWidgetButton" format="color" />
         <attr name="colorWidgetBackground" format="color" />
         <attr name="colorWidgetOnBackground" format="color" />
+        <attr name="dimenWidgetCornerRadius" format="dimension" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
     <dimen name="activity_margin">16dp</dimen>
-
+    <dimen name="widget_corner_radius">8dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -74,6 +74,7 @@
 
     <style name="Theme.HomeAssistant.Widget">
         <item name="colorWidgetPrimary">@color/colorWidgetButtonLabel</item>
+        <item name="colorWidgetButton">@color/colorIcon</item>
         <item name="colorWidgetBackground">@color/colorWidgetButtonBackground</item>
         <item name="colorWidgetOnBackground">@color/colorWidgetButtonLabel</item>
     </style>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -72,6 +72,12 @@
         <item name="colorControlNormal">@color/colorDialogMessage</item>
     </style>
 
+    <style name="Theme.HomeAssistant.Widget">
+        <item name="colorWidgetPrimary">@color/colorWidgetButtonLabel</item>
+        <item name="colorWidgetBackground">@color/colorWidgetButtonBackground</item>
+        <item name="colorWidgetOnBackground">@color/colorWidgetButtonLabel</item>
+    </style>
+
     <style name="Authentication_Dialog" parent="Theme.MaterialComponents.Light.Dialog">
         <item name="android:textColor">@color/colorDialogTitle</item>
         <item name="buttonBarPositiveButtonStyle">@style/Alert.Button.Positive</item>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -77,6 +77,7 @@
         <item name="colorWidgetButton">@color/colorIcon</item>
         <item name="colorWidgetBackground">@color/colorWidgetButtonBackground</item>
         <item name="colorWidgetOnBackground">@color/colorWidgetButtonLabel</item>
+        <item name="dimenWidgetCornerRadius">@dimen/widget_corner_radius</item>
     </style>
 
     <style name="Authentication_Dialog" parent="Theme.MaterialComponents.Light.Dialog">

--- a/app/src/main/res/xml/button_widget_info.xml
+++ b/app/src/main/res/xml/button_widget_info.xml
@@ -12,4 +12,5 @@
     android:widgetFeatures="reconfigurable"
     android:description="@string/button_widget_desc"
     android:widgetCategory="home_screen"
-    android:previewImage="@drawable/widget_example_button" />
+    android:previewImage="@drawable/widget_example_button"
+    android:previewLayout="@layout/widget_button_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/entity_widget_info.xml
+++ b/app/src/main/res/xml/entity_widget_info.xml
@@ -8,8 +8,11 @@
     android:minResizeWidth="40dp"
     android:minResizeHeight="40dp"
     android:resizeMode="vertical|horizontal"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
     android:updatePeriodMillis="1800000"
     android:widgetFeatures="reconfigurable"
     android:description="@string/entity_widget_desc"
     android:widgetCategory="home_screen"
-    android:previewImage="@drawable/widget_example_entity" />
+    android:previewImage="@drawable/widget_example_entity"
+    android:previewLayout="@layout/widget_static_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/media_player_control_widget_info.xml
+++ b/app/src/main/res/xml/media_player_control_widget_info.xml
@@ -12,4 +12,5 @@
     android:widgetFeatures="reconfigurable"
     android:description="@string/media_player_widget_desc"
     android:widgetCategory="home_screen"
-    android:previewImage="@drawable/widget_example_media_player_controls" />
+    android:previewImage="@drawable/widget_example_media_player_controls"
+    android:previewLayout="@layout/widget_media_controls_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/template_widget_info.xml
+++ b/app/src/main/res/xml/template_widget_info.xml
@@ -8,8 +8,11 @@
     android:minResizeWidth="40dp"
     android:minResizeHeight="40dp"
     android:resizeMode="vertical|horizontal"
+    android:targetCellWidth="2"
+    android:targetCellHeight="1"
     android:widgetFeatures="reconfigurable"
     android:description="@string/template_widget_desc"
     android:updatePeriodMillis="1800000"
     android:widgetCategory="home_screen"
-    android:previewImage="@drawable/widget_example_template" />
+    android:previewImage="@drawable/widget_example_template"
+    android:previewLayout="@layout/widget_template_wrapper_dynamiccolor" />

--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
@@ -1,0 +1,651 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 26,
+    "identityHash": "c3c93f360310bd4e759cdda6323296b4",
+    "entities": [
+      {
+        "tableName": "sensor_attributes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "Authentication_List",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`host` TEXT NOT NULL, `Username` TEXT NOT NULL, `Password` TEXT NOT NULL, PRIMARY KEY(`host`))",
+        "fields": [
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "Username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "Password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "host"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sensors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `registered` INTEGER NOT NULL, `state` TEXT NOT NULL, `last_sent_state` TEXT NOT NULL, `state_type` TEXT NOT NULL, `type` TEXT NOT NULL, `icon` TEXT NOT NULL, `name` TEXT NOT NULL, `device_class` TEXT, `unit_of_measurement` TEXT, `state_class` TEXT, `entity_category` TEXT, `core_registration` TEXT, `app_registration` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentState",
+            "columnName": "last_sent_state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateType",
+            "columnName": "state_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceClass",
+            "columnName": "device_class",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "unitOfMeasurement",
+            "columnName": "unit_of_measurement",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "stateClass",
+            "columnName": "state_class",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "entityCategory",
+            "columnName": "entity_category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coreRegistration",
+            "columnName": "core_registration",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appRegistration",
+            "columnName": "app_registration",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sensor_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `entries` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entries",
+            "columnName": "entries",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "button_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `icon_id` INTEGER NOT NULL, `domain` TEXT NOT NULL, `service` TEXT NOT NULL, `service_data` TEXT NOT NULL, `label` TEXT, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "icon_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceData",
+            "columnName": "service_data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "camera_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entityId` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "mediaplayctrls_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entityId` TEXT NOT NULL, `label` TEXT, `showSkip` INTEGER NOT NULL, `showSeek` INTEGER NOT NULL, `showVolume` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "showSkip",
+            "columnName": "showSkip",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showSeek",
+            "columnName": "showSeek",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showVolume",
+            "columnName": "showVolume",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "static_widget",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT NOT NULL, `attribute_ids` TEXT, `label` TEXT, `text_size` REAL NOT NULL, `state_separator` TEXT NOT NULL, `attribute_separator` TEXT NOT NULL, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeIds",
+            "columnName": "attribute_ids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateSeparator",
+            "columnName": "state_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeSeparator",
+            "columnName": "attribute_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "template_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `template` TEXT NOT NULL, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "template",
+            "columnName": "template",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notification_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL, `source` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received",
+            "columnName": "received",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "qs_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tileId` TEXT NOT NULL, `icon_id` INTEGER, `entityId` TEXT NOT NULL, `label` TEXT NOT NULL, `subtitle` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileId",
+            "columnName": "tileId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconId",
+            "columnName": "icon_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entityId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `websocketSetting` TEXT NOT NULL, `sensorUpdateFrequency` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "websocketSetting",
+            "columnName": "websocketSetting",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorUpdateFrequency",
+            "columnName": "sensorUpdateFrequency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c3c93f360310bd4e759cdda6323296b4')"
+    ]
+  }
+}

--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 26,
-    "identityHash": "c3c93f360310bd4e759cdda6323296b4",
+    "identityHash": "a3bde7b3862bff358bfa363a76510d21",
     "entities": [
       {
         "tableName": "sensor_attributes",
@@ -321,7 +321,7 @@
       },
       {
         "tableName": "mediaplayctrls_widgets",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entityId` TEXT NOT NULL, `label` TEXT, `showSkip` INTEGER NOT NULL, `showSeek` INTEGER NOT NULL, `showVolume` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entityId` TEXT NOT NULL, `label` TEXT, `showSkip` INTEGER NOT NULL, `showSeek` INTEGER NOT NULL, `showVolume` INTEGER NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -358,6 +358,19 @@
             "columnName": "showVolume",
             "affinity": "INTEGER",
             "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
           }
         ],
         "primaryKey": {
@@ -645,7 +658,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c3c93f360310bd4e759cdda6323296b4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a3bde7b3862bff358bfa363a76510d21')"
     ]
   }
 }

--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/26.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 26,
-    "identityHash": "a3bde7b3862bff358bfa363a76510d21",
+    "identityHash": "e2fbc1aa21f36bfb07234f8fd52506bc",
     "entities": [
       {
         "tableName": "sensor_attributes",
@@ -459,7 +459,7 @@
       },
       {
         "tableName": "template_widgets",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `template` TEXT NOT NULL, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `template` TEXT NOT NULL, `text_size` REAL NOT NULL DEFAULT 12.0, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
         "fields": [
           {
             "fieldPath": "id",
@@ -472,6 +472,13 @@
             "columnName": "template",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "12.0"
           },
           {
             "fieldPath": "lastUpdate",
@@ -658,7 +665,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a3bde7b3862bff358bfa363a76510d21')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e2fbc1aa21f36bfb07234f8fd52506bc')"
     ]
   }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -50,6 +50,7 @@ import io.homeassistant.companion.android.database.widget.StaticWidgetDao
 import io.homeassistant.companion.android.database.widget.StaticWidgetEntity
 import io.homeassistant.companion.android.database.widget.TemplateWidgetDao
 import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundTypeConverter
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -69,16 +70,18 @@ import io.homeassistant.companion.android.common.R as commonR
         Favorites::class,
         Setting::class
     ],
-    version = 25,
+    version = 26,
     autoMigrations = [
-        AutoMigration(from = 24, to = 25)
+        AutoMigration(from = 24, to = 25),
+        AutoMigration(from = 25, to = 26)
     ]
 )
 @TypeConverters(
     LocalNotificationSettingConverter::class,
     LocalSensorSettingConverter::class,
     EntriesTypeConverter::class,
-    SensorSettingTypeConverter::class
+    SensorSettingTypeConverter::class,
+    WidgetBackgroundTypeConverter::class
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun authenticationDao(): AuthenticationDao

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/ButtonWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/ButtonWidgetEntity.kt
@@ -17,5 +17,9 @@ data class ButtonWidgetEntity(
     @ColumnInfo(name = "service_data")
     val serviceData: String,
     @ColumnInfo(name = "label")
-    val label: String?
-) : WidgetEntity
+    val label: String?,
+    @ColumnInfo(name = "background_type", defaultValue = "DAYNIGHT")
+    override val backgroundType: WidgetBackgroundType = WidgetBackgroundType.DAYNIGHT,
+    @ColumnInfo(name = "text_color")
+    override val textColor: String? = null
+) : WidgetEntity, ThemeableWidgetEntity

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetEntity.kt
@@ -17,5 +17,9 @@ data class MediaPlayerControlsWidgetEntity(
     @ColumnInfo(name = "showSeek")
     val showSeek: Boolean,
     @ColumnInfo(name = "showVolume")
-    val showVolume: Boolean
-) : WidgetEntity
+    val showVolume: Boolean,
+    @ColumnInfo(name = "background_type", defaultValue = "DAYNIGHT")
+    override val backgroundType: WidgetBackgroundType = WidgetBackgroundType.DAYNIGHT,
+    @ColumnInfo(name = "text_color")
+    override val textColor: String? = null
+) : WidgetEntity, ThemeableWidgetEntity

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/StaticWidgetEntity.kt
@@ -21,5 +21,9 @@ data class StaticWidgetEntity(
     @ColumnInfo(name = "attribute_separator")
     val attributeSeparator: String = "",
     @ColumnInfo(name = "last_update")
-    val lastUpdate: String
-) : WidgetEntity
+    val lastUpdate: String,
+    @ColumnInfo(name = "background_type", defaultValue = "DAYNIGHT")
+    override val backgroundType: WidgetBackgroundType = WidgetBackgroundType.DAYNIGHT,
+    @ColumnInfo(name = "text_color")
+    override val textColor: String? = null
+) : WidgetEntity, ThemeableWidgetEntity

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
@@ -10,6 +10,8 @@ data class TemplateWidgetEntity(
     override val id: Int,
     @ColumnInfo(name = "template")
     val template: String,
+    @ColumnInfo(name = "text_size", defaultValue = "12.0")
+    val textSize: Float,
     @ColumnInfo(name = "last_update")
     val lastUpdate: String,
     @ColumnInfo(name = "background_type", defaultValue = "DAYNIGHT")

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/TemplateWidgetEntity.kt
@@ -11,5 +11,9 @@ data class TemplateWidgetEntity(
     @ColumnInfo(name = "template")
     val template: String,
     @ColumnInfo(name = "last_update")
-    val lastUpdate: String
-) : WidgetEntity
+    val lastUpdate: String,
+    @ColumnInfo(name = "background_type", defaultValue = "DAYNIGHT")
+    override val backgroundType: WidgetBackgroundType = WidgetBackgroundType.DAYNIGHT,
+    @ColumnInfo(name = "text_color")
+    override val textColor: String? = null
+) : WidgetEntity, ThemeableWidgetEntity

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/ThemeableWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/ThemeableWidgetEntity.kt
@@ -8,7 +8,7 @@ interface ThemeableWidgetEntity {
 }
 
 enum class WidgetBackgroundType {
-    DAYNIGHT, TRANSPARENT
+    DYNAMICCOLOR, DAYNIGHT, TRANSPARENT
 }
 
 class WidgetBackgroundTypeConverter {

--- a/common/src/main/java/io/homeassistant/companion/android/database/widget/ThemeableWidgetEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/widget/ThemeableWidgetEntity.kt
@@ -1,0 +1,19 @@
+package io.homeassistant.companion.android.database.widget
+
+import androidx.room.TypeConverter
+
+interface ThemeableWidgetEntity {
+    val backgroundType: WidgetBackgroundType
+    val textColor: String?
+}
+
+enum class WidgetBackgroundType {
+    DAYNIGHT, TRANSPARENT
+}
+
+class WidgetBackgroundTypeConverter {
+    @TypeConverter
+    fun toWidgetBackgroundType(setting: String): WidgetBackgroundType = WidgetBackgroundType.valueOf(setting)
+    @TypeConverter
+    fun fromWidgetBackgroundType(setting: WidgetBackgroundType): String = setting.name
+}

--- a/common/src/main/res/values-night-v31/colors.xml
+++ b/common/src/main/res/values-night-v31/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_700</color>
-    <color name="colorDynamicWidgetOnBackground">@android:color/system_accent2_100</color>
-    <color name="colorDynamicWidgetPrimary">@android:color/system_accent1_200</color>
+    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_800</color> <!-- M3 colorSecondaryContainer + 1 level-->
+    <color name="colorDynamicWidgetOnBackground">@android:color/system_accent2_100</color> <!-- M3 colorOnSecondaryContainer -->
+    <color name="colorDynamicWidgetPrimary">@android:color/system_accent1_100</color> <!-- M3 colorPrimary - 1 level -->
 </resources>

--- a/common/src/main/res/values-night-v31/colors.xml
+++ b/common/src/main/res/values-night-v31/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_700</color>
+    <color name="colorDynamicWidgetOnBackground">@android:color/system_accent2_100</color>
+    <color name="colorDynamicWidgetPrimary">@android:color/system_accent1_200</color>
+</resources>

--- a/common/src/main/res/values-night/colors.xml
+++ b/common/src/main/res/values-night/colors.xml
@@ -18,7 +18,7 @@
     <color name="colorSensorTopEnabled">#192d36</color>
     <color name="colorSwitchUncheckedThumb">#b9b9b9</color>
     <color name="colorWidgetButtonBackground">#1c1c1c</color>
-    <color name="colorWidgetButtonLabel">#E6E6E6</color>
+    <color name="colorWidgetButtonLabel">@color/colorWidgetButtonLabelWhite</color>
     <color name="colorActionBarPopupBackground">#2B2B2B</color>
     <color name="colorLaunchScreenBackground">#111111</color>
     <color name="colorCodeBackground">#282828</color>

--- a/common/src/main/res/values-v31/colors.xml
+++ b/common/src/main/res/values-v31/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_100</color> <!-- M3 colorSecondaryContainer -->
+    <color name="colorDynamicWidgetOnBackground">@android:color/system_accent2_900</color> <!-- M3 colorOnSecondaryContainer -->
+    <color name="colorDynamicWidgetPrimary">@android:color/system_accent1_600</color> <!-- M3 colorPrimary -->
+</resources>

--- a/common/src/main/res/values-v31/colors.xml
+++ b/common/src/main/res/values-v31/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_100</color> <!-- M3 colorSecondaryContainer -->
+    <color name="colorDynamicWidgetBackground">@android:color/system_accent2_50</color> <!-- M3 colorSecondaryContainer - 1 level-->
     <color name="colorDynamicWidgetOnBackground">@android:color/system_accent2_900</color> <!-- M3 colorOnSecondaryContainer -->
     <color name="colorDynamicWidgetPrimary">@android:color/system_accent1_600</color> <!-- M3 colorPrimary -->
 </resources>

--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -19,7 +19,9 @@
     <color name="colorSensorIconEnabled">#44739e</color>
     <color name="colorSwitchUncheckedThumb">#ececec</color>
     <color name="colorWidgetButtonBackground">@android:color/white</color>
-    <color name="colorWidgetButtonLabel">#3A3A3A</color>
+    <color name="colorWidgetButtonLabel">@color/colorWidgetButtonLabelBlack</color>
+    <color name="colorWidgetButtonLabelBlack">#3A3A3A</color>
+    <color name="colorWidgetButtonLabelWhite">#E6E6E6</color>
     <color name="colorActionBarPopupBackground">@android:color/white</color>
     <color name="colorLaunchScreenBackground">#fafafa</color>
     <color name="colorCodeBackground">#f5f5f5</color>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -732,8 +732,9 @@
     <string name="what_is_this_crash">Unable to load Home Assistant home page, do you have a browser installed?</string>
     <string name="what_is_this">What is this?</string>
     <string name="widget_attribute_separator_label">Separator between attributes:</string>
-    <string name="widget_background_type_label">Widget background:</string>
+    <string name="widget_background_type_label">Widget theme:</string>
     <string name="widget_background_type_daynight">Light/dark theme</string>
+    <string name="widget_background_type_dynamiccolor">Dynamic color</string>
     <string name="widget_background_type_transparent">Transparent</string>
     <string name="widget_button_image_description">Service Button</string>
     <string name="widget_camera_description">Camera Widget</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -742,7 +742,11 @@
     <string name="widget_creation_error">Unable to create widget.</string>
     <string name="widget_entity_fetch_error">Unable to fetch data for configured entity.</string>
     <string name="widget_image_description">Home Assistant Widget</string>
-    <string name="widget_label_placeholder_text">Label</string>
+    <string name="widget_label_placeholder_text_button">Toggle</string>
+    <string name="widget_label_placeholder_text_media_player">Living Room</string>
+    <string name="widget_label_placeholder_text_static_state">72.9 °F</string>
+    <string name="widget_label_placeholder_text_static_label">Office Temp</string>
+    <string name="widget_label_placeholder_text_template">The office temperature is currently at 72 °F</string>
     <string name="widget_media_fastforward_button">Fast Forward</string>
     <string name="widget_media_image_description">Media Playing Preview Image</string>
     <string name="widget_media_next_track_button">Next Track</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -767,6 +767,7 @@
     <string name="widget_text_hint_service_service">Service</string>
     <string name="widget_text_size_default">30</string>
     <string name="widget_text_size_label">Widget text size:</string>
+    <string name="widget_text_size_template">12</string>
     <string name="widget_text_color_black">Black</string>
     <string name="widget_text_color_label">Widget text color:</string>
     <string name="widget_text_color_label_icon">Widget text/icon color:</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -732,6 +732,9 @@
     <string name="what_is_this_crash">Unable to load Home Assistant home page, do you have a browser installed?</string>
     <string name="what_is_this">What is this?</string>
     <string name="widget_attribute_separator_label">Separator between attributes:</string>
+    <string name="widget_background_type_label">Widget background:</string>
+    <string name="widget_background_type_daynight">Light/dark theme</string>
+    <string name="widget_background_type_transparent">Transparent</string>
     <string name="widget_button_image_description">Service Button</string>
     <string name="widget_camera_description">Camera Widget</string>
     <string name="widget_config_service_error">A custom component is preventing service data from loading.</string>
@@ -763,6 +766,10 @@
     <string name="widget_text_hint_service_service">Service</string>
     <string name="widget_text_size_default">30</string>
     <string name="widget_text_size_label">Widget text size:</string>
+    <string name="widget_text_color_black">Black</string>
+    <string name="widget_text_color_label">Widget text color:</string>
+    <string name="widget_text_color_label_icon">Widget text/icon color:</string>
+    <string name="widget_text_color_white">White</string>
     <string name="widgets">Widgets</string>
     <string name="zone_event_failure">Unable to send zone event to Home Assistant</string>
     <string name="failed_wear_config_request">Failed to send config request to wear device</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds theming options to most widgets:
 - **Dynamic color**: uses colors from the device theme (eg. Material You) on supported Android 12+ devices. Default for new widgets on devices that support it.
 - **Light/dark theme**: the existing widget theme. Default for new widgets on devices that don't support dynamic color.
 - **Transparent**: removes the widget background, user can choose whether the content should be black or white.

The text size for template widget can now also be set.

More minor changes for Android 12 to improve the widget theme:

 - Album art now is correctly clipped by the widget corner radius
 - `android:previewLayout` is set to the dynamic color layout file, to provide dynamic previews and better match the widget that'll be added
 - Suggested size for entity state and template widgets is updated to 2x1, to match the preview images
 - When using dynamic color, the system widget corner radius is used

Resolves #1852: this PR adds options for background and font size, and additional formatting can be done using HTML tags.

Any widgets that are already added won't change with this PR, they are migrated to settings that match the existing widget theme. The camera widget doesn't get any theming options because you should only see a camera image most of the time. The media player widget doesn't get a transparent theme because floating text and buttons next to album art doesn't make sense.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Theming options when creating a widget. Also shows the template widget text size option.
|Light|Dark|
|-----|-----|
|![image](https://user-images.githubusercontent.com/8148535/166332430-bb6d4381-20a5-4143-ac63-3160621ffbb8.png)|![image](https://user-images.githubusercontent.com/8148535/166332461-44bbb3f0-8799-4721-b381-e4e0046f548a.png)|

When the 'Transparent' theme is selected, an additional option for the widget's text/icon color will be shown.
|Light|Dark|
|-----|-----|
|![image](https://user-images.githubusercontent.com/8148535/166332604-162fa7a5-f730-48ee-9a06-3422d0f28237.png)|![image](https://user-images.githubusercontent.com/8148535/166332619-b5fea19b-7677-4b37-a455-ab56c0d50a77.png)|

Transparent widgets, from left to right: entity state, button, template
|'White' text color|'Black' text color|
|-----|-----|
|![image](https://user-images.githubusercontent.com/8148535/166152331-5f4a7281-be1b-4aa4-a665-4aa348a9835d.png)|![image](https://user-images.githubusercontent.com/8148535/166152335-d839b968-a89d-47b2-b124-d49f2fc665d5.png)|

Dynamic color widgets, a few examples. The colors used match widgets provided by Google apps. The corner radius for these widgets also matches the system value, which for this device is larger than the value normally used by the app. (Color varies slightly between widgets because it actually uses the widget location on the background!)
|Light|![image](https://user-images.githubusercontent.com/8148535/166152777-467b4ac9-7981-421e-bf5f-a11b17d1f284.png)|![image](https://user-images.githubusercontent.com/8148535/166152780-06cd31a0-6837-4c64-88b6-418a893a1280.png)|![image](https://user-images.githubusercontent.com/8148535/166152781-ab7d5626-f6c4-4056-89ea-6f0cdb6bd0a7.png)|![image](https://user-images.githubusercontent.com/8148535/166152789-45e8c3f1-ea99-4167-932f-6c669ee70b31.png)|
|-----|-----|-----|-----|-----|
|Dark|![image](https://user-images.githubusercontent.com/8148535/166152796-96f8f7e4-cc35-4fd2-a53f-8c3fd8c2b726.png)|![image](https://user-images.githubusercontent.com/8148535/166152798-fc537845-a228-4702-97af-e955d4e09d04.png)|![image](https://user-images.githubusercontent.com/8148535/166152801-88f88a3a-91b7-4005-9acd-383551312a19.png)|![image](https://user-images.githubusercontent.com/8148535/166152806-fb45a866-4d82-48cd-8cd1-5f07f7746705.png)|

Launcher providing dynamic previews of widgets:
|Light|Dark|
|-----|-----|
|![image](https://user-images.githubusercontent.com/8148535/166152942-46630708-00e3-42e4-800e-64fe467f751b.png)|![image](https://user-images.githubusercontent.com/8148535/166152945-e55f7173-94f4-4462-9d2c-a81d86493f9c.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#740

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->