### PR TITLE
Fix crash on app start/API use on SDK <26

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -154,6 +154,7 @@ dependencies {
     implementation("com.google.android.material:material:1.5.0")
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") // remove when jackson-module-kotlin version is higher
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.picasso:picasso:2.8")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-jackson:2.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
     implementation("com.squareup.okhttp3:logging-interceptor:4.9.3")
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") // remove when jackson-module-kotlin version is higher
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
     implementation("org.altbeacon:android-beacon-library:2.19.4")
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.41")
     kapt("com.google.dagger:hilt-android-compiler:2.41")
 
+    implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2") // remove when jackson-module-kotlin version is higher
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.2")
     implementation("com.squareup.okhttp3:okhttp:4.9.3")
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2465, fixes #2477

https://github.com/FasterXML/jackson-databind/issues/3412 results in a crash when the app tries to use the Jackson databind library on devices with API level < 26 (= basically any API call, so from the moment the app starts and tries to contact the server). Manually specify the `jackson-databind` dependency with the latest version that includes a fix for now, Gradle will choose the highest version which solves the problem.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->