### PR TITLE
BLE Transmit fix blank state and check device supports advertising

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -94,8 +94,7 @@ class BluetoothSensorManager : SensorManager {
     override val name: Int
         get() = commonR.string.sensor_name_bluetooth
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        val list = listOf(bluetoothConnection, bluetoothState)
-        return if (supportsTransmitter(context)) list.plus(bleTransmitter) else list
+        return listOf(bluetoothConnection, bluetoothState, bleTransmitter)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -256,7 +255,8 @@ class BluetoothSensorManager : SensorManager {
                 "id" to bleTransmitterDevice.uuid + "-" + bleTransmitterDevice.major + "-" + bleTransmitterDevice.minor,
                 "Transmitting power" to bleTransmitterDevice.transmitPowerSetting,
                 "Advertise mode" to bleTransmitterDevice.advertiseModeSetting,
-                "Measured power" to bleTransmitterDevice.measuredPowerSetting
+                "Measured power" to bleTransmitterDevice.measuredPowerSetting,
+                "Supports transmitter" to supportsTransmitter(context)
             )
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -244,12 +244,13 @@ class BluetoothSensorManager : SensorManager {
             TransmitterManager.stopTransmitting(bleTransmitterDevice)
         }
 
+        val lastState = AppDatabase.getInstance(context).sensorDao().get(bleTransmitter.id)?.state ?: "unknown"
         val state = if (isBtOn(context)) bleTransmitterDevice.state else "Bluetooth is turned off"
         val icon = if (bleTransmitterDevice.transmitting) "mdi:bluetooth" else "mdi:bluetooth-off"
         onSensorUpdated(
             context,
             bleTransmitter,
-            state,
+            if (state != "") state else lastState,
             icon,
             mapOf(
                 "id" to bleTransmitterDevice.uuid + "-" + bleTransmitterDevice.major + "-" + bleTransmitterDevice.minor,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter
 import io.homeassistant.companion.android.bluetooth.ble.TransmitterManager
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils
+import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils.supportsTransmitter
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
@@ -93,7 +94,8 @@ class BluetoothSensorManager : SensorManager {
     override val name: Int
         get() = commonR.string.sensor_name_bluetooth
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(bluetoothConnection, bluetoothState, bleTransmitter)
+        val list = listOf(bluetoothConnection, bluetoothState)
+        return if (supportsTransmitter(context)) list.plus(bleTransmitter) else list
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
@@ -65,4 +65,11 @@ object BluetoothUtils {
             throw IllegalStateException(e)
         }
     }
+    fun supportsTransmitter(context: Context): Boolean {
+        val bluetoothManager =
+            context.applicationContext.getSystemService<BluetoothManager>()!!
+        val adapter = bluetoothManager.adapter
+
+        return adapter?.isMultipleAdvertisementSupported ?: false
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2499 by sending the last state if the string is blank, the default will be `unknown` unless there is a better default to use? Either way we shouldn't send a blank string :)

Noticed one of my devices failed to start the transmitter and this is caused by the BT on the device not supporting advertising so adding a check for that.  Here is the failure I noticed:

```
[05-01 12:15:00.337 27750:28542 E/BeaconTransmitter]
Cannot start advertising due to exception
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.bluetooth.le.BluetoothLeAdvertiser.startAdvertising(android.bluetooth.le.AdvertiseSettings, android.bluetooth.le.AdvertiseData, android.bluetooth.le.AdvertiseCallback)' on a null object reference
	at org.altbeacon.beacon.BeaconTransmitter.startAdvertising(BeaconTransmitter.java:213)
	at org.altbeacon.beacon.BeaconTransmitter.startAdvertising(BeaconTransmitter.java:159)
	at io.homeassistant.companion.android.bluetooth.ble.TransmitterManager.startTransmitting(TransmitterManager.kt:65)
	at io.homeassistant.companion.android.sensors.BluetoothSensorManager.updateBLESensor(BluetoothSensorManager.kt:236)
	at io.homeassistant.companion.android.sensors.BluetoothSensorManager.requestSensorUpdate(BluetoothSensorManager.kt:123)
	at io.homeassistant.companion.android.common.sensors.SensorManager$DefaultImpls.requestSensorUpdate(SensorManager.kt:94)
	at io.homeassistant.companion.android.sensors.BluetoothSensorManager.requestSensorUpdate(BluetoothSensorManager.kt:17)
	at io.homeassistant.companion.android.common.sensors.SensorReceiverBase.updateSensors(SensorReceiverBase.kt:144)
	at io.homeassistant.companion.android.common.sensors.SensorReceiverBase$onReceive$2.invokeSuspend(SensorReceiverBase.kt:106)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->