### PR TITLE
Allow setting push notification visibility/sensitivity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -105,6 +105,7 @@ class MessagingManager @Inject constructor(
         const val IMAGE_URL = "image"
         const val ICON_URL = "icon_url"
         const val VIDEO_URL = "video"
+        const val VISIBILITY = "visibility"
         const val LED_COLOR = "ledColor"
         const val VIBRATION_PATTERN = "vibrationPattern"
         const val PERSISTENT = "persistent"
@@ -893,6 +894,8 @@ class MessagingManager @Inject constructor(
 
         handleVideo(notificationBuilder, data)
 
+        handleVisibility(notificationBuilder, data)
+
         handleActions(notificationBuilder, tag, messageId, data)
 
         handleDeleteIntent(notificationBuilder, data, messageId, group, groupId)
@@ -1346,6 +1349,21 @@ class MessagingManager @Inject constructor(
         val newHeight = height / 4
         val newWidth = width / 4
         return Bitmap.createScaledBitmap(this, newWidth, newHeight, false)
+    }
+
+    private fun handleVisibility(
+        builder: NotificationCompat.Builder,
+        data: Map<String, String>
+    ) {
+        data[VISIBILITY]?.let {
+            builder.setVisibility(
+                when (it) {
+                    "public" -> NotificationCompat.VISIBILITY_PUBLIC
+                    "secret" -> NotificationCompat.VISIBILITY_SECRET
+                    else -> NotificationCompat.VISIBILITY_PRIVATE
+                }
+            )
+        }
     }
 
     private fun handleActions(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR ~+ home-assistant/mobile-apps-fcm-push#73~ adds support for setting the visibility* of push notifications, which allows you to control what notification content is visible on the lock screen when the device is locked.

Example use cases:
 - setting visibility to `secret` to completely hide a notification from the lock screen
 - setting visibility to `public` to make a notification visible on the lock screen, when in the system settings you've set it to hide sensitive content from the lock screen

Users on Android 5-7 will benefit most from this change because the system setting only allows controlling the visibility of all notifications. On Android 8+ notification channels allow limiting visibility beyond the general system setting (first use case), but they don't allow users to make a notification more visible (second use case).

\*or sensitivity, as user-facing settings call it

Edit: it turns out the FCM code already has a `visibility` attribute even though it isn't used anywhere in the Android app?

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The following device is set to hide sensitive content from the lock screen in system settings > Notifications. The locked lock screen shows a private notification and a public notification. 
|Light|Dark|
|-----|-----|
|![A lock screen showing two notifications, one collapsed with only the Home Assistant logo and 'Home Assistant - now' visible, the other one showing the Home Assistant logo and 'Public notification - 1m - Hello!', light theme](https://user-images.githubusercontent.com/8148535/167017091-1dacebb6-88a2-4190-b829-234c1e34a28f.png)|![A lock screen showing two notifications, one collapsed with only the Home Assistant logo and 'Home Assistant - now' visible, the other one showing the Home Assistant logo and 'Public notification - now - Hello!', dark theme](https://user-images.githubusercontent.com/8148535/167017103-9ab33e2c-4999-4c4c-9790-14cd4f47f211.png)|

Adding a screenshot of a secret notification wouldn't be useful, as it is just an empty lock screen.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#743

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->