### PR TITLE
Allow refreshing Wear template tile by tapping anywhere

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -128,18 +128,7 @@ class TemplateTile : TileService() {
                                 .setResourceId("refresh")
                                 .setWidth(dp(24f))
                                 .setHeight(dp(24f))
-                                .setModifiers(
-                                    ModifiersBuilders.Modifiers.Builder()
-                                        .setClickable(
-                                            ModifiersBuilders.Clickable.Builder()
-                                                .setOnClick(
-                                                    ActionBuilders.LoadAction.Builder().build()
-                                                )
-                                                .setId("refresh")
-                                                .build()
-                                        )
-                                        .build()
-                                )
+                                .setModifiers(getRefreshModifiers())
                                 .build()
                         )
                         .setRotateContents(false)
@@ -147,6 +136,20 @@ class TemplateTile : TileService() {
                 )
                 .build()
         )
+        setModifiers(getRefreshModifiers())
     }
         .build()
+
+    private fun getRefreshModifiers(): ModifiersBuilders.Modifiers {
+        return ModifiersBuilders.Modifiers.Builder()
+            .setClickable(
+                ModifiersBuilders.Clickable.Builder()
+                    .setOnClick(
+                        ActionBuilders.LoadAction.Builder().build()
+                    )
+                    .setId("refresh")
+                    .build()
+            )
+            .build()
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2492

I opted to keep the refresh icon on the tile because it still is a good reminder that this functionality exists

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Template used: `It is currently {{ now() }}`

https://user-images.githubusercontent.com/8148535/167253933-55145f91-a42a-4b78-b827-186a88c0be33.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->