### PR TITLE
Breaking change: hide hidden entities on Wear home screen

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
@@ -4,5 +4,6 @@ data class EntityRegistryResponse(
     val areaId: String?,
     val deviceId: String?,
     val entityCategory: String?,
-    val entityId: String
+    val entityId: String,
+    val hiddenBy: String?
 )

--- a/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/RegistriesDataHandler.kt
@@ -33,4 +33,11 @@ object RegistriesDataHandler {
     ): String? {
         return entityRegistry?.firstOrNull { it.entityId == entityId }?.entityCategory
     }
+
+    fun getHiddenByForEntity(
+        entityId: String,
+        entityRegistry: List<EntityRegistryResponse>?
+    ): String? {
+        return entityRegistry?.firstOrNull { it.entityId == entityId }?.hiddenBy
+    }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -281,6 +281,9 @@ class MainViewModel @Inject constructor(application: Application) : AndroidViewM
     fun getCategoryForEntity(entityId: String): String? =
         RegistriesDataHandler.getCategoryForEntity(entityId, entityRegistry)
 
+    fun getHiddenByForEntity(entityId: String): String? =
+        RegistriesDataHandler.getHiddenByForEntity(entityId, entityRegistry)
+
     /**
      * Clears all favorites in the database.
      */

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -174,7 +174,10 @@ fun MainView(
                 }
 
                 if (mainViewModel.entitiesByArea.values.any {
-                    it.isNotEmpty() && it.any { entity -> mainViewModel.getCategoryForEntity(entity.entityId) == null }
+                    it.isNotEmpty() && it.any { entity ->
+                        mainViewModel.getCategoryForEntity(entity.entityId) == null &&
+                            mainViewModel.getHiddenByForEntity(entity.entityId) == null
+                    }
                 }
                 ) {
                     item {
@@ -182,7 +185,10 @@ fun MainView(
                     }
                     for (id in mainViewModel.entitiesByAreaOrder) {
                         val entities = mainViewModel.entitiesByArea[id]
-                        val entitiesToShow = entities?.filter { mainViewModel.getCategoryForEntity(it.entityId) == null }
+                        val entitiesToShow = entities?.filter {
+                            mainViewModel.getCategoryForEntity(it.entityId) == null &&
+                                mainViewModel.getHiddenByForEntity(it.entityId) == null
+                        }
                         if (!entitiesToShow.isNullOrEmpty()) {
                             val area = mainViewModel.areas.first { it.areaId == id }
                             item {
@@ -195,7 +201,10 @@ fun MainView(
                                         onTestClicked(
                                             mapOf(area.name to entities),
                                             listOf(area.name)
-                                        ) { mainViewModel.getCategoryForEntity(it.entityId) == null }
+                                        ) {
+                                            mainViewModel.getCategoryForEntity(it.entityId) == null &&
+                                                mainViewModel.getHiddenByForEntity(it.entityId) == null
+                                        }
                                     },
                                     colors = ChipDefaults.primaryChipColors()
                                 )
@@ -205,7 +214,11 @@ fun MainView(
                 }
 
                 val domainEntitiesFilter: (entity: Entity<*>) -> Boolean =
-                    { mainViewModel.getAreaForEntity(it.entityId) == null && mainViewModel.getCategoryForEntity(it.entityId) == null }
+                    {
+                        mainViewModel.getAreaForEntity(it.entityId) == null &&
+                            mainViewModel.getCategoryForEntity(it.entityId) == null &&
+                            mainViewModel.getHiddenByForEntity(it.entityId) == null
+                    }
                 if (mainViewModel.entities.values.any(domainEntitiesFilter)) {
                     item {
                         ListHeader(id = commonR.string.more_entities)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR will hide any entities marked as 'hidden' using [2022.4's option for this](https://www.home-assistant.io/blog/2022/04/06/release-20224/#hide-entities) from the Wear OS home screen (Areas / More entities lists).

These entities are still available when using the 'All entities' button and in other places in the app. This behavior is consistent with how the Wear OS app treats non-primary entities (#2216), and also mostly with frontend (not visible on autogenerated dashboards, but still available in the full list/search/automations UI/device page/...).

Because this might hide entities users are currently seeing on the app's home screen, this is a **breaking change**.

Resolves #2507

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
As an example, I've hidden a light named "Balk ✨", which you can see in HA's frontend: "(Hidden)" is shown after the entity name. Note the area name in the top-left of the screen.
![Home Assistant frontend page for a light called "Balk ✨". It is placed in an area named "Boven", which is highlighted. The control for the light is visible on this page but shows "(Hidden)" at the end of the name to indicate it is hidden.](https://user-images.githubusercontent.com/8148535/167257536-86dfd40b-1da9-4a4c-8ded-57a5b9e5c04f.png)

When viewing this area in the Wear app, the light is not shown:
![The Wear OS app showing the same "Boven" area as the mentioned light, but only another light and a scene are visible on this screen.](https://user-images.githubusercontent.com/8148535/167257552-7a0715b6-abe2-4da1-b965-91aff7b83c91.png)

The light is still available in 'All entities':
![The Wear OS app showing the full list of entities. The header is "Lights" and the "Balk ✨" light is now visible once again.](https://user-images.githubusercontent.com/8148535/167257572-631c865a-038b-4014-9b17-b178ba9fd4e2.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#744

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->