### PR TITLE
Fix device controls crashing System UI on long press

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -17,13 +17,14 @@ import io.homeassistant.companion.android.webview.WebViewActivity
 interface HaControl {
 
     fun createControl(context: Context, entity: Entity<Map<String, Any>>, area: AreaRegistryResponse?): Control {
+        val controlPath = "entityId:${entity.entityId}"
         val control = Control.StatefulBuilder(
             entity.entityId,
             PendingIntent.getActivity(
                 context,
-                0,
-                WebViewActivity.newInstance(context.applicationContext, "entityId:${entity.entityId}").addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                controlPath.hashCode(),
+                WebViewActivity.newInstance(context.applicationContext, controlPath).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
             )
         )
         control.setTitle((entity.attributes["friendly_name"] ?: entity.entityId) as CharSequence)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2251 (the functionality, not the System UI crash)

I've commented on the reason for these changes on the [Google issue tracker](https://issuetracker.google.com/issues/218542096#comment9), but the short version is: due to a security-related change the app needs to provide unique, mutable `PendingIntent`s to the system for the device control app intents.

Tested on a device with Android 11 + an emulator with Android 12 on the November 2021 security patch (to make sure controls still work as they did before on those versions), as well as a device with Android 12 on the May 2022 security patch (to see if the changes 'fix' the issue).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->