### PR TITLE
Save + show crash stacktrace in app settings logs

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -1,24 +1,56 @@
 package io.homeassistant.companion.android
 
 import android.content.Context
+import android.util.Log
+import io.sentry.SentryOptions
 import io.sentry.android.core.SentryAndroid
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.PrintWriter
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLProtocolException
 
+private const val FATAL_CRASH_FILE = "/fatalcrash/last_crash"
+
 fun initCrashReporting(context: Context, enabled: Boolean) {
     // Don't init on debug builds or when disabled
-    if (BuildConfig.DEBUG || !enabled)
+    if (!shouldEnableCrashHandling(enabled))
         return
 
     SentryAndroid.init(context) { options ->
         options.isEnableAutoSessionTracking = true
         options.isEnableNdk = false
         options.dsn = "https://2d646f40f9574e0b9579e301a69bb030@o427061.ingest.sentry.io/5372876"
+
+        options.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->
+            if (event.isCrashed && event.throwable != null) {
+                try {
+                    val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
+                    if (!crashFile.exists()) {
+                        crashFile.parentFile?.mkdirs()
+                        crashFile.createNewFile()
+                    }
+                    val stacktraceWriter = PrintWriter(crashFile)
+                    val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault()).format(event.timestamp)
+                    stacktraceWriter.print("$timestamp: ")
+                    event.throwable?.printStackTrace(stacktraceWriter)
+                    stacktraceWriter.close()
+                } catch (e: Exception) {
+                    Log.i("CrashHandling", "Tried saving fatal crash but encountered exception", e)
+                }
+            }
+
+            return@BeforeSendCallback event
+        }
 
         val ignoredEvents = arrayOf(
             ConnectException::class.java,
@@ -33,3 +65,23 @@ fun initCrashReporting(context: Context, enabled: Boolean) {
         options.ignoredExceptionsForType.addAll(ignoredEvents)
     }
 }
+
+suspend fun getLatestFatalCrash(context: Context, enabled: Boolean): String? = withContext(Dispatchers.IO) {
+    if (!shouldEnableCrashHandling(enabled))
+        return@withContext null
+
+    var toReturn: String? = null
+    try {
+        val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
+        if (crashFile.exists() &&
+            crashFile.lastModified() >= (System.currentTimeMillis() - TimeUnit.HOURS.toMillis(12))
+        ) { // Existing, recent file
+            toReturn = crashFile.readText().trim().ifBlank { null }
+        }
+    } catch (e: Exception) {
+        Log.e("CrashHandling", "Encountered exception while reading crash log file", e)
+    }
+    return@withContext toReturn
+}
+
+private fun shouldEnableCrashHandling(enabled: Boolean) = !BuildConfig.DEBUG && enabled

--- a/app/src/main/res/layout/fragment_log.xml
+++ b/app/src/main/res/layout/fragment_log.xml
@@ -1,29 +1,58 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ScrollView
-        android:id="@+id/logScrollview"
+    <LinearLayout
+        android:id="@+id/logContents"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fillViewport="true"
-        android:visibility="gone">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <HorizontalScrollView
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/logTabLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:tabMode="fixed">
+
+            <com.google.android.material.tabs.TabItem
+                android:id="@+id/logTabProcess"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/log_loader_process"/>
+
+            <com.google.android.material.tabs.TabItem
+                android:id="@+id/logTabCrash"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/log_loader_crash"/>
+
+        </com.google.android.material.tabs.TabLayout>
+
+        <ScrollView
+            android:id="@+id/logScrollview"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:fillViewport="true">
 
-            <TextView
-                android:id="@+id/logTextView"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:scrollbars="none"
-                android:textIsSelectable="true"
-                android:textSize="15sp" />
-        </HorizontalScrollView>
-    </ScrollView>
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fillViewport="true">
+
+                <TextView
+                    android:id="@+id/logTextView"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:scrollbars="none"
+                    android:textIsSelectable="true"
+                    android:textSize="15sp" />
+            </HorizontalScrollView>
+        </ScrollView>
+
+    </LinearLayout>
 
     <LinearLayout
         android:id="@+id/logLoader"

--- a/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -1,7 +1,14 @@
 package io.homeassistant.companion.android
 
 import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 fun initCrashReporting(context: Context, enabled: Boolean) {
     // Noop
+}
+
+suspend fun getLatestFatalCrash(context: Context, enabled: Boolean): String? = withContext(Dispatchers.IO) {
+    // Noop
+    return@withContext null
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -273,6 +273,8 @@
     <string name="lockscreen_title">App Locked !</string>
     <string name="log_file_not_created">Log file could not be created.</string>
     <string name="log_loader_text">Collecting logs…</string>
+    <string name="log_loader_process">Current log</string>
+    <string name="log_loader_crash">Recent crash</string>
     <string name="log">Log</string>
     <string name="logbook">Logbook</string>
     <string name="login">Login</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To make fixing app crashes easier, let's save the stacktrace for a crash and show it in the app settings' log viewer. This should allow most users to provide a crash log that can be used to fix issues without having to reproduce it, install another app and/or use a computer. Sentry already records these errors, this PR simply adds a hook to also store it somewhere the app can use.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
If crash reporting is enabled and there was a crash in the last 12 hours (if it is older, it's probably not relevant), a tab row will be added to the top of the screen to allow the user to view the crash stacktrace.
|Light|Dark|
|-----|-----|
|![image](https://user-images.githubusercontent.com/8148535/168430849-55d7f1b2-e737-4573-891e-4371cc197557.png)|![image](https://user-images.githubusercontent.com/8148535/168430853-a18ea573-2269-4d31-9c1d-b05d17d7c475.png)|

<details>
<summary>Output from share</summary>

```
2022-05-14 16:43:07.604: java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:558)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	... 1 more
Caused by: java.lang.Exception: Crashing for testing
	at io.homeassistant.companion.android.settings.SettingsFragment.onCreatePreferences$lambda-30$lambda-29(SettingsFragment.kt:298)
	at io.homeassistant.companion.android.settings.SettingsFragment.$r8$lambda$lI2xVFX887i1RMI00sbNdIWGI7c(Unknown Source:0)
	at io.homeassistant.companion.android.settings.SettingsFragment$$ExternalSyntheticLambda13.onPreferenceClick(Unknown Source:0)
	at androidx.preference.Preference.performClick(Preference.java:1184)
	at androidx.preference.Preference.performClick(Preference.java:1166)
	at androidx.preference.Preference$1.onClick(Preference.java:181)
	at android.view.View.performClick(View.java:7455)
	at android.view.View.performClickInternal(View.java:7432)
	at android.view.View.access$3700(View.java:835)
	at android.view.View$PerformClick.run(View.java:28810)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7870)
	... 3 more
```
</details>

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I think the tab titles are easy enough to understand

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The easist way to test this PR would be to remove the debug build check in `shouldEnableCrashHandling` in `CrashHandling.kt` and throw an exception somewhere.