### PR TITLE
Fix widget settings scrolling with narrow buttons

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -106,7 +106,10 @@ fun ManageWidgetsView(
                 contentPadding = PaddingValues(all = 0.dp)
             )
         }
-        LazyColumn(modifier = Modifier.padding(all = 16.dp)) {
+        LazyColumn(
+            contentPadding = PaddingValues(all = 16.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
             if (viewModel.buttonWidgetList.value.isEmpty() && viewModel.staticWidgetList.value.isEmpty() &&
                 viewModel.mediaWidgetList.value.isEmpty() && viewModel.templateWidgetList.value.isEmpty() &&
                 viewModel.cameraWidgetList.value.isEmpty()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR sets the width of the `LazyColumn` in the widget settings screen to the full width of the screen to also allow scrolling the screen when touching in the empty space next to the buttons. Before this PR, the scrollable area is only as wide as the widest composable in the column, while most users expect to be able to scroll anywhere.

(To reproduce: create a lot of widgets with short names, for example 1/2/3/4/5/etc, and try dragging to scroll to the right of the buttons in the empty space.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->