### PR TITLE
Catch exceptions during app registration

### DIFF
--- a/app/src/main/res/values-v31/styles.xml
+++ b/app/src/main/res/values-v31/styles.xml
@@ -6,6 +6,7 @@
         <item name="android:colorBackground">@color/colorLaunchScreenBackground</item>
         <item name="android:statusBarColor">@color/colorLaunchScreenBackground</item>
         <item name="android:navigationBarColor">@color/colorLaunchScreenBackground</item>
+        <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert.Launch</item>
     </style>
 
     <style name="Theme.HomeAssistant.DynamicColorWidget">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
 
     <style name="Theme.LaunchScreen" parent="Theme.LaunchScreen.Base">
         <item name="android:background">@drawable/launch_screen_background</item>
+        <item name="alertDialogTheme">@style/Theme.HomeAssistant.Dialog.Alert.Launch</item>
     </style>
 
     <style name="Theme.HomeAssistant" parent="Theme.MaterialComponents.DayNight.NoActionBar">
@@ -59,6 +60,10 @@
         <item name="android:textColorPrimary">@color/colorOnBackground</item>
         <item name="colorControlNormal">@color/colorOnBackground</item>
         <item name="popupTheme">@style/Theme.HomeAssistant.PopupTheme</item>
+    </style>
+
+    <style name="Theme.HomeAssistant.Dialog.Alert.Launch" parent="Theme.HomeAssistant.Dialog.Alert">
+        <item name="android:background">@null</item>
     </style>
 
     <style name="Theme.HomeAssistant.Dialog.Alert" parent="Theme.MaterialComponents.Light.Dialog.Alert">


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR handles any exceptions thrown after logging in to Home Assistant while doing initial registration of the app (issue #2519), by asking the user to check their configuration.

I've also updated the launch screen theme's AlertDialog theme to remove the Home Assistant logo as the dialog's background on API < 31.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![A dialog with the text 'Unable to connect to Home Assistant. Failed to perform SSL handshake, please ensure your certificate is valid.', light theme](https://user-images.githubusercontent.com/8148535/168920141-a61ed4bd-2b3b-407c-b63b-ed59a1d57666.png)|![A dialog with the text 'Unable to connect to Home Assistant. Failed to perform SSL handshake, please ensure your certificate is valid.', dark theme](https://user-images.githubusercontent.com/8148535/168920320-4fb74cbe-eff9-4448-bf2a-de73fbf0a8cb.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The next step to really fix/solve #2519 would be to bundle an up-to-date version of [Conscrypt with the app for OkHttp](https://square.github.io/okhttp/#:~:text=OkHttp%20uses%20your%20platform%E2%80%99s%20built%2Din%20TLS%20implementation.%20On%20Java%20platforms%20OkHttp%20also%20supports%20Conscrypt%2C%20which%20integrates%20BoringSSL%20with%20Java.%20OkHttp%20will%20use%20Conscrypt%20if%20it%20is%20the%20first%20security%20provider%3A). I'm not including that here because it would create a conflict with #2526, let's allow that to be merged first.