### PR TITLE
Better SSL error handling in WebViewActivity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -270,7 +270,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     description: String?,
                     failingUrl: String?
                 ) {
-                    Log.e(TAG, "onReceivedHttpError: errorCode: $errorCode url:$failingUrl")
+                    Log.e(TAG, "onReceivedError: errorCode: $errorCode url:$failingUrl")
                     if (failingUrl == loadedUrl) {
                         showError()
                     }
@@ -323,8 +323,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     handler: SslErrorHandler?,
                     error: SslError?
                 ) {
-                    Log.e(TAG, "onReceivedHttpError: $error")
-                    showError()
+                    Log.e(TAG, "onReceivedSslError: $error")
+                    showError(
+                        io.homeassistant.companion.android.webview.WebView.ErrorType.SSL,
+                        error,
+                        null
+                    )
                 }
 
                 override fun onLoadResource(
@@ -517,6 +521,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     fun getExternalAuth(payload: String) {
                         JSONObject(payload).let {
                             presenter.onGetExternalAuth(
+                                this@WebViewActivity,
                                 it.getString("callback"),
                                 it.has("force") && it.getBoolean("force")
                             )

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -1,10 +1,12 @@
 package io.homeassistant.companion.android.webview
 
+import android.content.Context
+
 interface WebViewPresenter {
 
     fun onViewReady(path: String?)
 
-    fun onGetExternalAuth(callback: String, force: Boolean)
+    fun onGetExternalAuth(context: Context, callback: String, force: Boolean)
 
     fun checkSecurityVersion()
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR improves error handling for SSL-related errors in the WebViewActivity to match the error handling during onboarding, by showing the correct error message more often;
 - Actually use the `onReceivedSslError` callback error (the code for error messages was already there, but it simply wasn't being used?)
 - Also show SSL errors in the external auth callback
 - If the user has to check the logs, use the correct function name to allow identifying which function receives an error

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->