### PR TITLE
Improve time zone sensor state

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -49,18 +49,17 @@ class TimeZoneManager : SensorManager {
             return
 
         val timeZone: TimeZone = TimeZone.getDefault()
-        val currentZone = timeZone.getDisplayName(Locale.ENGLISH)
-        val date = Date()
+        val currentlyInDst = timeZone.inDaylightTime(Date())
 
         onSensorUpdated(
             context,
             currentTimeZone,
-            currentZone,
+            timeZone.getDisplayName(currentlyInDst, TimeZone.LONG, Locale.getDefault()),
             currentTimeZone.statelessIcon,
             mapOf(
-                "in_daylight_time" to timeZone.inDaylightTime(date),
+                "in_daylight_time" to currentlyInDst,
                 "time_zone_id" to timeZone.id,
-                "time_zone_short" to timeZone.getDisplayName(timeZone.inDaylightTime(date), TimeZone.SHORT, Locale.ENGLISH),
+                "time_zone_short" to timeZone.getDisplayName(currentlyInDst, TimeZone.SHORT, Locale.getDefault()),
                 "uses_daylight_time" to timeZone.useDaylightTime(),
                 "utc_offset" to timeZone.getOffset(System.currentTimeMillis())
             )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/TimeZoneManager.kt
@@ -54,12 +54,12 @@ class TimeZoneManager : SensorManager {
         onSensorUpdated(
             context,
             currentTimeZone,
-            timeZone.getDisplayName(currentlyInDst, TimeZone.LONG, Locale.getDefault()),
+            timeZone.getDisplayName(currentlyInDst, TimeZone.LONG, Locale.ENGLISH),
             currentTimeZone.statelessIcon,
             mapOf(
                 "in_daylight_time" to currentlyInDst,
                 "time_zone_id" to timeZone.id,
-                "time_zone_short" to timeZone.getDisplayName(currentlyInDst, TimeZone.SHORT, Locale.getDefault()),
+                "time_zone_short" to timeZone.getDisplayName(currentlyInDst, TimeZone.SHORT, Locale.ENGLISH),
                 "uses_daylight_time" to timeZone.useDaylightTime(),
                 "utc_offset" to timeZone.getOffset(System.currentTimeMillis())
             )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR changes the time zone sensor's state to the 'current' name that reflects whether the time zone is in summer/daylight savings time or not (bonus: it 'fixes' 50% of #2530).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The sensor previously had 'Central European Standard Time' as the state.
|Light|Dark|
|-----|-----|
|![Time zone sensor showing 'Central European Summer Time' as the state, light mode](https://user-images.githubusercontent.com/8148535/169397594-807cb533-4854-4b12-bd9d-47116050084e.png)|![Time zone sensor showing 'Central European Summer Time' as the state, dark mode](https://user-images.githubusercontent.com/8148535/169397568-767df4d1-1ddf-49d9-8dfa-fc36d1289806.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->