### PR TITLE
Update compose items loops to use keys

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -146,75 +146,71 @@ fun SensorDetailView(
                     item {
                         SensorDetailHeader(stringResource(commonR.string.attributes))
                     }
-                    sensor.attributes.forEach { attribute ->
-                        item {
-                            val summary = when (attribute.valueType) {
-                                "listboolean" -> jsonMapper.readValue<List<Boolean>>(attribute.value).toString()
-                                "listfloat" -> jsonMapper.readValue<List<Number>>(attribute.value).toString()
-                                "listlong" -> jsonMapper.readValue<List<Long>>(attribute.value).toString()
-                                "listint" -> jsonMapper.readValue<List<Int>>(attribute.value).toString()
-                                "liststring" -> jsonMapper.readValue<List<String>>(attribute.value).toString()
-                                else -> attribute.value
-                            }
-                            SensorDetailRow(
-                                title = attribute.name,
-                                summary = summary,
-                                clickable = false,
-                                selectingEnabled = true
-                            )
+                    items(sensor.attributes, key = { "${it.sensorId}-${it.name}" }) { attribute ->
+                        val summary = when (attribute.valueType) {
+                            "listboolean" -> jsonMapper.readValue<List<Boolean>>(attribute.value).toString()
+                            "listfloat" -> jsonMapper.readValue<List<Number>>(attribute.value).toString()
+                            "listlong" -> jsonMapper.readValue<List<Long>>(attribute.value).toString()
+                            "listint" -> jsonMapper.readValue<List<Int>>(attribute.value).toString()
+                            "liststring" -> jsonMapper.readValue<List<String>>(attribute.value).toString()
+                            else -> attribute.value
                         }
+                        SensorDetailRow(
+                            title = attribute.name,
+                            summary = summary,
+                            clickable = false,
+                            selectingEnabled = true
+                        )
                     }
                 }
                 if (sensor.sensor.enabled && viewModel.sensorSettings.value.isNotEmpty()) {
                     item {
                         SensorDetailHeader(stringResource(commonR.string.sensor_settings))
                     }
-                    viewModel.sensorSettings.value.forEach { setting ->
-                        item {
-                            when (setting.valueType) {
-                                SensorSettingType.TOGGLE -> {
-                                    SensorDetailRow(
-                                        title = viewModel.getSettingTranslatedTitle(setting.name),
-                                        switch = setting.value == "true",
-                                        enabled = setting.enabled,
-                                        clickable = setting.enabled,
-                                        onClick = { isEnabled ->
-                                            onToggleSettingSubmitted(
-                                                SensorSetting(viewModel.basicSensor.id, setting.name, isEnabled.toString(), SensorSettingType.TOGGLE, setting.enabled)
-                                            )
-                                        }
-                                    )
-                                }
-                                SensorSettingType.LIST -> {
-                                    SensorDetailRow(
-                                        title = viewModel.getSettingTranslatedTitle(setting.name),
-                                        summary = viewModel.getSettingTranslatedEntry(setting.name, setting.value),
-                                        enabled = setting.enabled,
-                                        clickable = setting.enabled,
-                                        onClick = { onDialogSettingClicked(setting) }
-                                    )
-                                }
-                                SensorSettingType.LIST_APPS, SensorSettingType.LIST_BLUETOOTH, SensorSettingType.LIST_ZONES -> {
-                                    val summaryValues = setting.value.split(", ").mapNotNull { it.ifBlank { null } }
-                                    SensorDetailRow(
-                                        title = viewModel.getSettingTranslatedTitle(setting.name),
-                                        summary =
-                                        if (summaryValues.any()) summaryValues.toString()
-                                        else stringResource(commonR.string.none_selected),
-                                        enabled = setting.enabled,
-                                        clickable = setting.enabled,
-                                        onClick = { onDialogSettingClicked(setting) }
-                                    )
-                                }
-                                SensorSettingType.STRING, SensorSettingType.NUMBER -> {
-                                    SensorDetailRow(
-                                        title = viewModel.getSettingTranslatedTitle(setting.name),
-                                        summary = setting.value,
-                                        enabled = setting.enabled,
-                                        clickable = setting.enabled,
-                                        onClick = { onDialogSettingClicked(setting) }
-                                    )
-                                }
+                    items(viewModel.sensorSettings.value, key = { "${it.sensorId}-${it.name}" }) { setting ->
+                        when (setting.valueType) {
+                            SensorSettingType.TOGGLE -> {
+                                SensorDetailRow(
+                                    title = viewModel.getSettingTranslatedTitle(setting.name),
+                                    switch = setting.value == "true",
+                                    enabled = setting.enabled,
+                                    clickable = setting.enabled,
+                                    onClick = { isEnabled ->
+                                        onToggleSettingSubmitted(
+                                            SensorSetting(viewModel.basicSensor.id, setting.name, isEnabled.toString(), SensorSettingType.TOGGLE, setting.enabled)
+                                        )
+                                    }
+                                )
+                            }
+                            SensorSettingType.LIST -> {
+                                SensorDetailRow(
+                                    title = viewModel.getSettingTranslatedTitle(setting.name),
+                                    summary = viewModel.getSettingTranslatedEntry(setting.name, setting.value),
+                                    enabled = setting.enabled,
+                                    clickable = setting.enabled,
+                                    onClick = { onDialogSettingClicked(setting) }
+                                )
+                            }
+                            SensorSettingType.LIST_APPS, SensorSettingType.LIST_BLUETOOTH, SensorSettingType.LIST_ZONES -> {
+                                val summaryValues = setting.value.split(", ").mapNotNull { it.ifBlank { null } }
+                                SensorDetailRow(
+                                    title = viewModel.getSettingTranslatedTitle(setting.name),
+                                    summary =
+                                    if (summaryValues.any()) summaryValues.toString()
+                                    else stringResource(commonR.string.none_selected),
+                                    enabled = setting.enabled,
+                                    clickable = setting.enabled,
+                                    onClick = { onDialogSettingClicked(setting) }
+                                )
+                            }
+                            SensorSettingType.STRING, SensorSettingType.NUMBER -> {
+                                SensorDetailRow(
+                                    title = viewModel.getSettingTranslatedTitle(setting.name),
+                                    summary = setting.value,
+                                    enabled = setting.enabled,
+                                    clickable = setting.enabled,
+                                    onClick = { onDialogSettingClicked(setting) }
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsViewModel.kt
@@ -38,11 +38,10 @@ class ManageWidgetsViewModel @Inject constructor(
     val staticWidgetList = staticWidgetDao.getAllFlow().collectAsState()
     val mediaWidgetList = mediaPlayerControlsWidgetDao.getAllFlow().collectAsState()
     val templateWidgetList = templateWidgetDao.getAllFlow().collectAsState()
-    var supportsAddingWidgets = mutableStateOf(false)
-        private set
+    val supportsAddingWidgets: Boolean
 
     init {
-        supportsAddingWidgets.value = checkSupportsAddingWidgets()
+        supportsAddingWidgets = checkSupportsAddingWidgets()
     }
 
     private fun checkSupportsAddingWidgets(): Boolean {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Button
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.Icon
@@ -70,7 +71,7 @@ fun ManageWidgetsView(
 ) {
     var expandedAddWidget by remember { mutableStateOf(false) }
     Scaffold(floatingActionButton = {
-        if (viewModel.supportsAddingWidgets.value) {
+        if (viewModel.supportsAddingWidgets) {
             ExtendedFloatingActionButton(
                 backgroundColor = MaterialTheme.colors.primary,
                 contentColor = MaterialTheme.colors.onPrimary,
@@ -94,8 +95,7 @@ fun ManageWidgetsView(
                 title = { Text(stringResource(R.string.add_widget)) },
                 content = {
                     LazyColumn {
-                        items(availableWidgets.size) { index ->
-                            val (key, widgetType) = availableWidgets[index]
+                        items(availableWidgets, key = { (key) -> key }) { (key, widgetType) ->
                             PopupWidgetRow(widgetLabel = key, widgetType = widgetType) {
                                 expandedAddWidget = false
                             }
@@ -196,8 +196,7 @@ private fun <T : WidgetEntity> LazyListScope.widgetItems(
         item {
             Text(stringResource(id = title))
         }
-        items(widgetList.size, key = { index -> widgetList[index].id }) { index ->
-            val item = widgetList[index]
+        items(widgetList, key = { it.id }) { item ->
             WidgetRow(widgetLabel = widgetLabel(item), widgetId = item.id, widgetType = widgetType)
         }
     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/ChooseEntityView.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.items
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -61,10 +62,9 @@ fun ChooseEntityView(
                         )
                     }
                     if (expandedStates[domain] == true) {
-                        items(entities.size) { index ->
+                        items(entities, key = { it.entityId }) { entity ->
                             ChooseEntityChip(
-                                entityList = entities,
-                                index = index,
+                                entity = entity,
                                 onEntitySelected = onEntitySelected
                             )
                         }
@@ -77,14 +77,13 @@ fun ChooseEntityView(
 
 @Composable
 private fun ChooseEntityChip(
-    entityList: List<Entity<*>>,
-    index: Int,
+    entity: Entity<*>,
     onEntitySelected: (entity: SimplifiedEntity) -> Unit
 ) {
-    val attributes = entityList[index].attributes as Map<*, *>
+    val attributes = entity.attributes as Map<*, *>
     val iconBitmap = getIcon(
-        entityList[index] as Entity<Map<String, Any>>,
-        entityList[index].domain,
+        entity as Entity<Map<String, Any>>,
+        entity.domain,
         LocalContext.current
     )
     Chip(
@@ -103,12 +102,12 @@ private fun ChooseEntityChip(
                 overflow = TextOverflow.Ellipsis
             )
         },
-        enabled = entityList[index].state != "unavailable",
+        enabled = entity.state != "unavailable",
         onClick = {
             onEntitySelected(
                 SimplifiedEntity(
-                    entityList[index].entityId,
-                    attributes["friendly_name"] as String? ?: entityList[index].entityId,
+                    entity.entityId,
+                    attributes["friendly_name"] as String? ?: entity.entityId,
                     attributes["icon"] as String? ?: ""
                 )
             )

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.items
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.util.playPreviewEntityScene1
@@ -48,9 +49,9 @@ fun EntityViewList(
                     }
                     if (expandedStates[header.hashCode()]!!) {
                         val filtered = entities.filter { entityListFilter(it) }
-                        items(filtered.size) { index ->
+                        items(filtered, key = { it.entityId }) { entity ->
                             EntityUi(
-                                filtered[index],
+                                entity,
                                 onEntityClicked,
                                 isHapticEnabled,
                                 isToastEnabled

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -12,6 +12,7 @@ import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
+import androidx.wear.compose.material.items
 import androidx.wear.compose.material.rememberScalingLazyListState
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -59,10 +60,9 @@ fun SetFavoritesView(
                             )
                         }
                         if (expandedStates[domain] == true) {
-                            items(entities.size) { index ->
+                            items(entities, key = { it.entityId }) { entity ->
                                 FavoriteToggleChip(
-                                    entityList = entities,
-                                    index = index,
+                                    entity = entity,
                                     favoriteEntityIds = favoriteEntityIds,
                                     onFavoriteSelected = onFavoriteSelected
                                 )
@@ -77,19 +77,18 @@ fun SetFavoritesView(
 
 @Composable
 private fun FavoriteToggleChip(
-    entityList: List<Entity<*>>,
-    index: Int,
+    entity: Entity<*>,
     favoriteEntityIds: List<String>,
     onFavoriteSelected: (entityId: String, isSelected: Boolean) -> Unit
 ) {
-    val attributes = entityList[index].attributes as Map<*, *>
+    val attributes = entity.attributes as Map<*, *>
     val iconBitmap = getIcon(
-        entityList[index] as Entity<Map<String, Any>>,
-        entityList[index].domain,
+        entity as Entity<Map<String, Any>>,
+        entity.domain,
         LocalContext.current
     )
 
-    val entityId = entityList[index].entityId
+    val entityId = entity.entityId
     val checked = favoriteEntityIds.contains(entityId)
     ToggleChip(
         checked = checked,


### PR DESCRIPTION
## Summary
Small change to use the `key` property in `items` loops in LazyColumns. This helps reduce re-renders and improve performance, by telling Compose which rendered item corresponds with which data item.