### PR TITLE
Don't show changelog immediately on new app installs

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/ChangeLog.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/ChangeLog.kt
@@ -25,11 +25,11 @@ class ChangeLog @Inject constructor() {
         }
         if (isDarkTheme) {
             val darkThemeChangeLog = DarkThemeChangeLog(context)
-            if (darkThemeChangeLog.isFirstRun || forceShow)
+            if ((!darkThemeChangeLog.isFirstRunEver && darkThemeChangeLog.isFirstRun) || forceShow)
                 darkThemeChangeLog.fullLogDialog.show()
         } else {
             val changeLog = ChangeLog(context)
-            if (changeLog.isFirstRun || forceShow)
+            if ((!changeLog.isFirstRunEver && changeLog.isFirstRun) || forceShow)
                 changeLog.fullLogDialog.show()
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently, the changelog is shown every time a new version is detected, which includes a new app install. However, when the app has just been installed _everything_ is new, and this dialog is shown immediately after logging in which can be confusing ('do I need to do something with this information?'). I suggest adjusting it to only show up if the app has been used before to improve the first run experience.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, no dialog means you get to the frontend after logging in instead of being interrupted by the changelog

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->