### PR TITLE
Fix manage tiles screen crash if there are tiles, updating tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -45,6 +45,8 @@ class ManageTilesViewModel @Inject constructor(
         private set
     var selectedIconDrawable by mutableStateOf(AppCompatResources.getDrawable(application, R.drawable.ic_stat_ic_notification))
         private set
+    var selectedTileId by mutableStateOf(0)
+        private set
     var selectedEntityId by mutableStateOf("")
     var tileLabel by mutableStateOf("")
     var tileSubtitle by mutableStateOf<String?>(null)
@@ -73,7 +75,10 @@ class ManageTilesViewModel @Inject constructor(
         val tile = slots[index]
         selectedTile = tile
         viewModelScope.launch {
-            tileDao.get(tile.id)?.let { updateExistingTileFields(it) }
+            tileDao.get(tile.id).also {
+                selectedTileId = it?.id ?: 0
+                it?.let { updateExistingTileFields(it) }
+            }
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -87,16 +87,14 @@ class ManageTilesViewModel @Inject constructor(
         selectedIconDrawable = icon?.drawable?.let { DrawableCompat.wrap(it) }
     }
 
-    private suspend fun updateExistingTileFields(currentTile: TileEntity) {
+    private fun updateExistingTileFields(currentTile: TileEntity) {
         tileLabel = currentTile.label
         tileSubtitle = currentTile.subtitle
         selectedEntityId = currentTile.entityId
         selectIcon(
-            withContext(Dispatchers.IO) {
-                return@withContext currentTile.iconId?.let {
-                    if (::iconPack.isInitialized) iconPack.getIcon(it)
-                    else null
-                }
+            currentTile.iconId?.let {
+                if (::iconPack.isInitialized) iconPack.getIcon(it)
+                else null
             }
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/views/ManageTilesView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/views/ManageTilesView.kt
@@ -130,6 +130,7 @@ fun ManageTilesView(
             Button(
                 onClick = {
                     val tileData = TileEntity(
+                        id = viewModel.selectedTileId,
                         tileId = viewModel.selectedTile.id,
                         iconId = viewModel.selectedIcon,
                         entityId = viewModel.selectedEntityId,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
#2540 introduced two potential crashes when opening the 'Manage Tiles' screen if there are any tiles stored in the database and a bug for updating existing tiles. I guess everyone tested a fresh install and didn't press back?

1: A crash because we're trying to update [state used by Compose while it is a snapshot](https://stackoverflow.com/q/66891349/4214819) on the IO thread. Fixed by switching to the main thread when updating these variables.
<details>
<summary>java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied</summary>

```
2022-05-31 19:20:29.420 11315-11371/io.homeassistant.companion.android.debug E/AndroidRuntime: FATAL EXCEPTION: DefaultDispatcher-worker-2
    Process: io.homeassistant.companion.android.debug, PID: 11315
    java.lang.IllegalStateException: Reading a state that was created after the snapshot was taken or in a snapshot that has not yet been applied
        at androidx.compose.runtime.snapshots.SnapshotKt.readError(Snapshot.kt:1826)
        at androidx.compose.runtime.snapshots.SnapshotKt.current(Snapshot.kt:2070)
        at androidx.compose.runtime.SnapshotMutableStateImpl.setValue(SnapshotState.kt:299)
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel.setTileLabel(ManageTilesViewModel.kt:111)
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel.updateExistingTileFields(ManageTilesViewModel.kt:81)
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel.access$updateExistingTileFields(ManageTilesViewModel.kt:27)
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel$selectTile$1.invokeSuspend(ManageTilesViewModel.kt:71)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
    	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@b4b2720, Dispatchers.IO]
```
</details>

2: A crash because we launch multiple suspending functions in the `init` block, which can cause a race condition for a `lateinit` variable. Fixed by checking if it is initialized before using it.

<details>
<summary>kotlin.UninitializedPropertyAccessException: lateinit property iconPack has not been initialized</summary>

```
2022-05-31 19:56:23.937 15603-15603/io.homeassistant.companion.android.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: io.homeassistant.companion.android.debug, PID: 15603
    kotlin.UninitializedPropertyAccessException: lateinit property iconPack has not been initialized
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel.getIconPack(ManageTilesViewModel.kt:34)
        at io.homeassistant.companion.android.settings.qs.ManageTilesViewModel$updateExistingTileFields$2.invokeSuspend(ManageTilesViewModel.kt:86)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:749)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
    	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@cc32aa3, Dispatchers.Main.immediate]
```
</details>

3: When the `id` of a tile is set to 0, Room will autogenerate a new ID and the existing data in the database is never updated. Fixed by correctly reading and re-using the ID of the database entry like before. (`id` != `tileId`, I'm not entirely sure why we have two IDs and that's likely why this mistake was made)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
cc @NotWoods 