### PR TITLE
Register for the shutdown intent to send 1 final sensor update before device restarts or powers down

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -153,6 +153,12 @@ open class HomeAssistantApplication : Application() {
             )
         }
 
+        // Add a receiver for the shutdown event to attempt to send 1 final sensor update
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter(Intent.ACTION_SHUTDOWN)
+        )
+
         // Register for all saved user intents
         val sensorDao = AppDatabase.getInstance(applicationContext).sensorDao()
         val allSettings = sensorDao.getSettings(LastUpdateManager.lastUpdate.id)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2545 the state of the last update sensor will reflect this intent

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/171457280-2adb793d-1e01-4ee4-b8e4-4ed52def2659.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

This intent will not be guaranteed however it does show up in testing

https://developer.android.com/reference/android/content/Intent#ACTION_SHUTDOWN