### PR TITLE
Remove toast when failing to send notification clear event

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationDeleteReceiver.kt
@@ -4,14 +4,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import android.widget.Toast
 import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
-import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
 class NotificationDeleteReceiver : BroadcastReceiver() {
@@ -44,11 +42,6 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
                 Log.d(TAG, "Notification cleared event successful!")
             } catch (e: Exception) {
                 Log.e(TAG, "Issue sending event to Home Assistant", e)
-                Toast.makeText(
-                    context,
-                    commonR.string.notification_clear_failure,
-                    Toast.LENGTH_LONG
-                ).show()
             }
         }
     }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -372,7 +372,6 @@
     <string name="none">None</string>
     <string name="none_selected">None selected</string>
     <string name="not_private">Your connection to this site is not private.</string>
-    <string name="notification_clear_failure">Failed to send event on notification cleared</string>
     <string name="notification_data">Full Notification Data</string>
     <string name="notification_dismiss_failure">Failed to send event on notification dismissed</string>
     <string name="notification_history_summary">History of Notifications (currently displays the last 25 notifications received)</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Removes the toast notification when we fail to send a notification clear event.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
I'm sending this out to see if there is interest in doing this. Here is my thinking for removing this notification:

For people that don't expose HA to the internet but still receive notifications there's no reason to continually show a toast every time a notification is swiped away. I personally feel a log is good enough (which the codebase already has) whereas a toast constantly gets in the way. If there was no other means of logging this then I could see the reasoning for having a toast.

My personal situation is nearly identical to the above. I don't expose anything out to the internet, instead I VPN back home when needed. I receive notifications from my cameras and VPN in to view them when needed. If I don't VPN in and swipe notifications away I constantly get the toast that I am removing here.

Would anyone be in favor of taking this patch?