### PR TITLE
Fix removing non-last list items from Last Update Trigger sensor's settings

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -65,13 +65,13 @@ class LastUpdateManager : SensorManager {
 
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val allSettings = sensorDao.getSettings(lastUpdate.id)
-        val intentSettingName = "lastupdate_intent_var1:${allSettings.size}:"
-        val addNewIntent = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }?.value ?: "false"
-        val intentSetting = allSettings.firstOrNull { it.name == intentSettingName }?.value ?: ""
-        if (addNewIntent == "true") {
-            if (intentSetting == "") {
+        val shouldAddNewIntent = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }?.value == "true"
+        if (shouldAddNewIntent) {
+            val newIntentSettingName = "lastupdate_intent_var1:${allSettings.size}:"
+            val intentSettingAlreadyExists = allSettings.any { it.name == newIntentSettingName }
+            if (!intentSettingAlreadyExists) {
                 sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
-                sensorDao.add(SensorSetting(lastUpdate.id, intentSettingName, intentAction, SensorSettingType.STRING))
+                sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
             }
         } else {
             sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -85,7 +85,14 @@ class LastUpdateManager : SensorManager {
             }
         }
         if (!isSequenceContinuous) {
-            // TODO fix the DB entries to make their IDs a continuous sequence
+            // create new settings with sequential IDs:
+            val newIntentSettings = intentSettings.mapIndexed { index, it ->
+                it.copy(name = "lastupdate_intent_var1:${index + 1}:")
+            }
+            // delete old settings from DB:
+            sensorDao.removeSettings(lastUpdate.id, intentSettings.map { it.name })
+            // add new settings to DB:
+            newIntentSettings.forEach(sensorDao::add)
         }
         val shouldAddNewIntent = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }?.value == "true"
         if (shouldAddNewIntent) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -93,11 +93,12 @@ class LastUpdateManager : SensorManager {
             val newIntentSettingOrdinal = intentSettings.size + 1
             val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
             val intentSettingAlreadyExists = allSettings.any { it.name == newIntentSettingName }
-            check(!intentSettingAlreadyExists)
-            // turn off the toggle:
-            sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
-            // add the new Intent:
-            sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
+            if (!intentSettingAlreadyExists) {
+                // turn off the toggle:
+                sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
+                // add the new Intent:
+                sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
+            }
         }
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -11,6 +11,7 @@ class LastUpdateManager : SensorManager {
     companion object {
         private const val TAG = "LastUpdate"
         private const val SETTING_ADD_NEW_INTENT = "lastupdate_add_new_intent"
+        private const val INTENT_SETTING_PREFIX = "lastupdate_intent_var1:"
 
         val lastUpdate = SensorManager.BasicSensor(
             "last_update",
@@ -73,10 +74,10 @@ class LastUpdateManager : SensorManager {
         var isSequenceContinuous = true
         var currentHighestIntentSettingOrdinal = 0
         val intentSettings = allSettings.filter {
-            it.name.startsWith("lastupdate_intent_var1:")
+            it.name.startsWith(INTENT_SETTING_PREFIX)
         }
         intentSettings.forEachIndexed { index, setting ->
-            val currentOrdinal = setting.name.removePrefix("lastupdate_intent_var1:").removeSuffix(":").toInt()
+            val currentOrdinal = setting.name.removePrefix(INTENT_SETTING_PREFIX).removeSuffix(":").toInt()
             if (currentOrdinal != index + 1) {
                 isSequenceContinuous = false
             }
@@ -87,7 +88,7 @@ class LastUpdateManager : SensorManager {
         if (!isSequenceContinuous) {
             // create new settings with sequential IDs:
             val newIntentSettings = intentSettings.mapIndexed { index, it ->
-                it.copy(name = "lastupdate_intent_var1:${index + 1}:")
+                it.copy(name = "$INTENT_SETTING_PREFIX${index + 1}:")
             }
             // delete old settings from DB:
             sensorDao.removeSettings(lastUpdate.id, intentSettings.map { it.name })
@@ -97,7 +98,7 @@ class LastUpdateManager : SensorManager {
         val shouldAddNewIntent = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }?.value == "true"
         if (shouldAddNewIntent) {
             val newIntentSettingOrdinal = currentHighestIntentSettingOrdinal + 1
-            val newIntentSettingName = "lastupdate_intent_var1:$newIntentSettingOrdinal:"
+            val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
             val intentSettingAlreadyExists = allSettings.any { it.name == newIntentSettingName }
             check(!intentSettingAlreadyExists)
             // turn off the toggle:

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -92,8 +92,7 @@ class LastUpdateManager : SensorManager {
         if (shouldAddNewIntent) {
             val newIntentSettingOrdinal = intentSettings.size + 1
             val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
-            val intentSettingAlreadyExists = allSettings.any { it.name == newIntentSettingName }
-            if (!intentSettingAlreadyExists) {
+            if (allSettings.none { it.name == newIntentSettingName }) {
                 // turn off the toggle:
                 sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
                 // add the new Intent:

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -73,8 +73,6 @@ class LastUpdateManager : SensorManager {
                 sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
                 sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
             }
-        } else {
-            sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
         }
 
         val settingsToRemove = allSettings


### PR DESCRIPTION
Fixes #2550 _Cannot add new Intent to Last Update Trigger sensor_

## Summary
Now the `Last Update Trigger` sensor's settings screen handles removing non-last list items correctly.

The fix is intended to be backwards compatible, so existing installations with incorrect state will be fixed automatically upon the first call of the `sendLastUpdate()` method (= by an update in the background, or when the user edits the list).

## Screen recordings
[video before the fix: reproduction of the bug](https://user-images.githubusercontent.com/1349654/171994081-0fede94b-c223-46db-93b6-f2c23244b48a.mp4)

[video after the fix: the bug cannot be reproduced anymore](https://user-images.githubusercontent.com/1349654/171994305-86835a33-8b1d-4f8f-a1ff-ada6da129341.mp4)

<!-- ## Link to pull request in Documentation repository -->
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
<!-- Documentation: home-assistant/companion.home-assistant# -->

## Any other notes
I did some refactoring in the `sendLastUpdate()` method to clarify and optimize things a bit, but I tried to not go too far to keep the changes focused on the bugfix.

Useful command for testing if `Intent`s are received:
`adb shell am broadcast -a com.example.test1`
(don't forget to force close and reopen the app after adding new `Intent`s to the list!)