### PR TITLE
Use Bluetooth device address for high accuracy mode BT constraint, fixes settings crash

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -376,13 +376,16 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
     private fun shouldEnableHighAccuracyMode(): Boolean {
 
-        val highAccuracyModeBTDevices = getSetting(
+        val highAccuracyModeBTDevicesSetting = getSetting(
             latestContext,
             LocationSensorManager.backgroundLocation,
             SETTING_HIGH_ACCURACY_MODE_BLUETOOTH_DEVICES,
             SensorSettingType.LIST_BLUETOOTH,
             ""
         )
+        val highAccuracyModeBTDevices = highAccuracyModeBTDevicesSetting
+            .split(", ")
+            .mapNotNull { it.trim().ifBlank { null } }
         val highAccuracyBtZoneCombined = getHighAccuracyBTZoneCombinedSetting()
 
         val useTriggerRange = getHighAccuracyModeTriggerRange() > 0
@@ -397,11 +400,11 @@ class LocationSensorManager : LocationSensorManagerBase() {
         var inZone = false
         var constraintsUsed = false
 
-        if (!highAccuracyModeBTDevices.isNullOrEmpty()) {
+        if (highAccuracyModeBTDevices.isNotEmpty()) {
             constraintsUsed = true
 
             val bluetoothDevices = BluetoothUtils.getBluetoothDevices(latestContext)
-            btDevConnected = bluetoothDevices.any { it.connected && highAccuracyModeBTDevices.contains(it.name) }
+            btDevConnected = bluetoothDevices.any { it.connected && highAccuracyModeBTDevices.contains(it.address) }
 
             if (!forceHighAccuracyModeOn) {
                 if (!btDevConnected) Log.d(TAG, "High accuracy mode disabled, because defined ($highAccuracyModeBTDevices) bluetooth device(s) not connected (Connected devices: $bluetoothDevices)")

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -135,7 +135,7 @@ class BluetoothSensorManager : SensorManager {
 
         if (checkPermission(context, bluetoothConnection.id)) {
 
-            val bluetoothDevices = BluetoothUtils.getBluetoothDevices(context)
+            val bluetoothDevices = BluetoothUtils.getBluetoothDevices(context, true)
             pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { it.address }
             connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { it.address }
             connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { it.address }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -311,10 +311,14 @@ class SensorDetailViewModel @Inject constructor(
                     ?.map { packageItem -> packageItem.packageName }
                     ?.sorted()
                     .orEmpty()
-            SensorSettingType.LIST_BLUETOOTH ->
-                BluetoothUtils.getBluetoothDevices(getApplication())
+            SensorSettingType.LIST_BLUETOOTH -> {
+                val devices = BluetoothUtils.getBluetoothDevices(getApplication())
                     .filter { entries == null || entries.contains(it.address) }
-                    .map { it.name }
+                val entriesNotInDevices = entries
+                    ?.filter { entry -> !devices.any { it.address == entry } }
+                    .orEmpty()
+                devices.map { it.name }.plus(entriesNotInDevices)
+            }
             SensorSettingType.LIST_ZONES ->
                 entries ?: zones
             else ->

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -207,21 +207,12 @@ fun SensorDetailView(
                                         }
                                     )
                                 }
-                                SensorSettingType.LIST -> {
-                                    SensorDetailRow(
-                                        title = viewModel.getSettingTranslatedTitle(setting.name),
-                                        summary = viewModel.getSettingTranslatedEntry(setting.name, setting.value),
-                                        enabled = setting.enabled,
-                                        clickable = setting.enabled,
-                                        onClick = { onDialogSettingClicked(setting) }
-                                    )
-                                }
-                                SensorSettingType.LIST_APPS, SensorSettingType.LIST_BLUETOOTH, SensorSettingType.LIST_ZONES -> {
+                                SensorSettingType.LIST, SensorSettingType.LIST_APPS, SensorSettingType.LIST_BLUETOOTH, SensorSettingType.LIST_ZONES -> {
                                     val summaryValues = setting.value.split(", ").mapNotNull { it.ifBlank { null } }
                                     SensorDetailRow(
                                         title = viewModel.getSettingTranslatedTitle(setting.name),
                                         summary =
-                                        if (summaryValues.any()) summaryValues.toString()
+                                        if (summaryValues.any()) viewModel.getSettingEntries(setting, summaryValues).joinToString(", ")
                                         else stringResource(commonR.string.none_selected),
                                         enabled = setting.enabled,
                                         clickable = setting.enabled,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -112,7 +112,7 @@ fun SensorDetailView(
         }.launchIn(this)
     }
 
-    Scaffold(scaffoldState = scaffoldState) {
+    Scaffold(scaffoldState = scaffoldState) { contentPadding ->
         if (sensorUpdateTypeInfo && viewModel.basicSensor != null) {
             SensorDetailUpdateInfoDialog(
                 basicSensor = viewModel.basicSensor,
@@ -128,7 +128,7 @@ fun SensorDetailView(
                 onSubmit = { state -> onDialogSettingSubmitted(state) }
             )
         }
-        LazyColumn {
+        LazyColumn(modifier = Modifier.padding(contentPadding)) {
             if (viewModel.sensorManager != null && viewModel.basicSensor != null) {
                 item {
                     SensorDetailTopPanel(

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
@@ -7,7 +7,7 @@ import androidx.core.content.getSystemService
 import java.lang.reflect.Method
 
 object BluetoothUtils {
-    fun getBluetoothDevices(context: Context): List<BluetoothDevice> {
+    fun getBluetoothDevices(context: Context, allowDuplicates: Boolean = false): List<BluetoothDevice> {
         val devices: MutableList<BluetoothDevice> = ArrayList()
 
         val bluetoothManager =
@@ -33,6 +33,7 @@ object BluetoothUtils {
                 }
                 val btConnectedDevices = bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)
                 for (btDev in btConnectedDevices) {
+                    if (!allowDuplicates && devices.any { it.address == btDev.address }) continue
                     val name = btDev.name ?: btDev.address
                     devices.add(
                         BluetoothDevice(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #2579 by changing the location high accuracy mode Bluetooth device constraint to use Bluetooth device addresses instead of device names, to ensure values are unique. Device names that are currently stored in the database will be converted to a device address when possible, making the change invisible to most users.

This PR also includes changes to be able to display a friendly name instead of the stored value (like the Bluetooth device name instead of the device address) for all list types in the sensor settings details screen.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The Bluetooth device list setting now looks like this:
|Light|Dark|
|-----|-----|
|![Sensor settings for the background location sensor, showing a value of 'Steel HR FD, OnePlus Bullets Wireless' for the 'High accuracy mode only when connected to BT devices' setting, light mode](https://user-images.githubusercontent.com/8148535/172180163-240c7da8-44d5-4a87-b77c-8254cbb33130.png)|![Sensor settings for the background location sensor, showing a value of 'Steel HR FD, OnePlus Bullets Wireless' for the 'High accuracy mode only when connected to BT devices' setting, dark mode](https://user-images.githubusercontent.com/8148535/172180178-b88661b9-6070-407d-8c91-2390c53edef0.png)|

While the stored data in the database actually uses device addresses:
![Screenshot of a database entry using Android Studio's database inspector, showing the setting 'location_ham_only_bt_dev' with a value that has two (partially obscured) device addresses and not the string from the previous screenshots](https://user-images.githubusercontent.com/8148535/172180274-984a14f0-f97c-47e0-aded-bdac942dcea3.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->