### PR TITLE
Fix syncing sensor enabled state if all sensors are disabled on device

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
@@ -272,16 +272,6 @@ abstract class SensorReceiverBase : BroadcastReceiver() {
                     } catch (e: Exception) {
                         Log.e(tag, "Issue re-registering sensor ${basicSensor.id}", e)
                     }
-                } else if (
-                    supportsDisabledSensors &&
-                    sensor.enabled != sensor.registered &&
-                    (!hasSensor || basicSensor.type.isBlank())
-                ) {
-                    // Unsupported sensors or sensors without a type (= location sensors) in the database shouldn't/can't
-                    // be registered but they will have a 'registered' state. Manually update when on core >=2022.6 by
-                    // setting it to the enabled state to stop the app from continuing to do updates because of these sensors.
-                    sensor.registered = sensor.enabled
-                    sensorDao.update(sensor)
                 }
                 if (canBeRegistered && sensor.enabled && sensor.registered != null && sensor.state != sensor.lastSentState) {
                     enabledRegistrations.add(fullSensor.toSensorRegistration(basicSensor))

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
@@ -36,8 +36,7 @@ abstract class SensorWorkerBase(
         val sensorDao = AppDatabase.getInstance(applicationContext).sensorDao()
         val enabledSensorCount = sensorDao.getEnabledCount() ?: 0
         val currentCoreSupportsDisabledSensors = integrationUseCase.isHomeAssistantVersionAtLeast(2022, 6, 0)
-        val enabledNotInSyncSensorCount = sensorDao.getEnabledNotInSyncCount() ?: 0
-        if (enabledSensorCount > 0 || (currentCoreSupportsDisabledSensors && enabledNotInSyncSensorCount > 0)) {
+        if (enabledSensorCount > 0 || currentCoreSupportsDisabledSensors) {
             Log.d(TAG, "Updating all Sensors.")
             createNotificationChannel()
             val notification = NotificationCompat.Builder(applicationContext, sensorWorkerChannel)

--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -75,9 +75,6 @@ interface SensorDao {
     @Query("SELECT COUNT(id) FROM sensors WHERE enabled = 1")
     suspend fun getEnabledCount(): Int?
 
-    @Query("SELECT COUNT(id) FROM sensors WHERE enabled != registered")
-    suspend fun getEnabledNotInSyncCount(): Int?
-
     @Transaction
     suspend fun setSensorsEnabled(sensorIds: List<String>, enabled: Boolean) {
         coroutineScope {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When using core 2022.6+, the `SensorWorker` should also run if all sensors in the app are currently disabled because the user might have enabled a sensor in the frontend.

As a result, it will basically always run when on core 2022.6+ so I've also removed a workaround to update the registered status in the database for sensors that cannot be registered.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->