### PR TITLE
Fix slow service button widgets

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -215,9 +215,6 @@ class ButtonWidget : AppWidgetProvider() {
         val widget = buttonWidgetDao.get(appWidgetId)
 
         mainScope.launch {
-            // Change color of background image for feedback
-            var views = getWidgetRemoteViews(context, appWidgetId)
-
             // Set default feedback as negative
             var feedbackColor = R.drawable.widget_button_background_red
             var feedbackIcon = R.drawable.ic_clear_black
@@ -274,6 +271,7 @@ class ButtonWidget : AppWidgetProvider() {
             }
 
             // Update widget and set visibilities for feedback
+            var views = getWidgetRemoteViews(context, appWidgetId)
             views.setInt(R.id.widgetLayout, "setBackgroundResource", feedbackColor)
             views.setImageViewResource(R.id.widgetImageButton, feedbackIcon)
             views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)

--- a/app/src/main/res/drawable/widget_button_background_green.xml
+++ b/app/src/main/res/drawable/widget_button_background_green.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#FF00FF00"/>
-    <corners android:radius="8dp"/>
+    <corners android:radius="?dimenWidgetCornerRadius"/>
 </shape>

--- a/app/src/main/res/drawable/widget_button_background_red.xml
+++ b/app/src/main/res/drawable/widget_button_background_red.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="rectangle">
     <solid android:color="#FFFF0000"/>
-    <corners android:radius="8dp"/>
+    <corners android:radius="?dimenWidgetCornerRadius"/>
 </shape>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes the (relatively) long time between tapping a service button widget and the service being called, which makes them feel slow ([reported by a user on Discord](https://discord.com/channels/330944238910963714/562408603345092636/983813484888350781)). This is done by first making the network request before trying to reload the widget's `RemoteViews` twice.

You can see the difference when profiling the process:

 - A: reading widget from database / parsing / preparing network call
 - B: loading `RemoteViews` for initial feedback
 - Between B and C: calling `appWidgetManager.updateAppWidget`
 - C: loading `RemoteViews` to restore state to original/without feedback

Before the line in `callConfiguredService` was moved, B and between B and C was called before A.

![image](https://user-images.githubusercontent.com/8148535/172693807-8500b7d5-999b-41d0-81f4-8f6aaab440a1.png)

Also including a minor fix for the background corner radius for success/failure feedback, it should follow the widget style instead of always using 8dp.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->