### PR TITLE
Improve service button widget feedback state speed

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -271,16 +271,16 @@ class ButtonWidget : AppWidgetProvider() {
             }
 
             // Update widget and set visibilities for feedback
-            var views = getWidgetRemoteViews(context, appWidgetId)
-            views.setInt(R.id.widgetLayout, "setBackgroundResource", feedbackColor)
-            views.setImageViewResource(R.id.widgetImageButton, feedbackIcon)
-            views.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
-            views.setViewVisibility(R.id.widgetLabelLayout, View.GONE)
-            views.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
-            appWidgetManager.updateAppWidget(appWidgetId, views)
+            val feedbackViews = RemoteViews(context.packageName, R.layout.widget_button)
+            feedbackViews.setInt(R.id.widgetLayout, "setBackgroundResource", feedbackColor)
+            feedbackViews.setImageViewResource(R.id.widgetImageButton, feedbackIcon)
+            feedbackViews.setViewVisibility(R.id.widgetProgressBar, View.INVISIBLE)
+            feedbackViews.setViewVisibility(R.id.widgetLabelLayout, View.GONE)
+            feedbackViews.setViewVisibility(R.id.widgetImageButtonLayout, View.VISIBLE)
+            appWidgetManager.partiallyUpdateAppWidget(appWidgetId, feedbackViews)
 
             // Reload default views in the coroutine to pass to the post handler
-            views = getWidgetRemoteViews(context, appWidgetId)
+            val views = getWidgetRemoteViews(context, appWidgetId)
 
             // Set a timer to change it back after 1 second
             Handler(Looper.getMainLooper()).postDelayed(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This is basically part 2 of #2597, as I realised earlier today that the app doesn't need to load everything and do a full update for the service button widget to show the feedback state. The ✅ (or ❌) will now show up a lot faster than before.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->