### PR TITLE
Fix onboarding duplicate fragment on recreation

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -25,10 +25,12 @@ class OnboardingActivity : AppCompatActivity() {
         viewModel.deviceName.value = input.defaultDeviceName
         viewModel.locationTrackingPossible.value = input.locationTrackingPossible
 
-        supportFragmentManager
-            .beginTransaction()
-            .add(R.id.content, WelcomeFragment::class.java, null)
-            .commit()
+        if (savedInstanceState == null) {
+            supportFragmentManager
+                .beginTransaction()
+                .add(R.id.content, WelcomeFragment::class.java, null)
+                .commit()
+        }
     }
 
     override fun onBackPressed() {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2592 (previously added fragments [will be recreated by the `FragmentManager`](https://developer.android.com/guide/fragments/fragmentmanager#:~:text=However%2C%20during%20a,back%20stack%20state.))

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->