### PR TITLE
Fix settings fragment backstack on recreation

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -47,24 +47,26 @@ class SettingsActivity : BaseActivity() {
 
         setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-        val settingsNavigation = intent.getStringExtra("fragment")
 
-        supportFragmentManager
-            .beginTransaction()
-            .replace(
-                R.id.content,
-                when {
-                    settingsNavigation == "websocket" -> WebsocketSettingFragment::class.java
-                    settingsNavigation == "notification_history" -> NotificationHistoryFragment::class.java
-                    settingsNavigation?.startsWith("sensors/") == true -> SensorDetailFragment::class.java
-                    else -> SettingsFragment::class.java
-                },
-                if (settingsNavigation?.startsWith("sensors/") == true) {
-                    val sensorId = settingsNavigation.split("/")[1]
-                    SensorDetailFragment.newInstance(sensorId).arguments
-                } else null
-            )
-            .commit()
+        if (savedInstanceState == null) {
+            val settingsNavigation = intent.getStringExtra("fragment")
+            supportFragmentManager
+                .beginTransaction()
+                .replace(
+                    R.id.content,
+                    when {
+                        settingsNavigation == "websocket" -> WebsocketSettingFragment::class.java
+                        settingsNavigation == "notification_history" -> NotificationHistoryFragment::class.java
+                        settingsNavigation?.startsWith("sensors/") == true -> SensorDetailFragment::class.java
+                        else -> SettingsFragment::class.java
+                    },
+                    if (settingsNavigation?.startsWith("sensors/") == true) {
+                        val sensorId = settingsNavigation.split("/")[1]
+                        SensorDetailFragment.newInstance(sensorId).arguments
+                    } else null
+                )
+                .commit()
+        }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragmentFactory.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragmentFactory.kt
@@ -5,14 +5,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentFactory
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.settings.language.LanguagesProvider
-import io.homeassistant.companion.android.settings.log.LogFragment
-import io.homeassistant.companion.android.settings.notification.NotificationDetailFragment
-import io.homeassistant.companion.android.settings.notification.NotificationHistoryFragment
 import io.homeassistant.companion.android.settings.qs.ManageTilesFragment
-import io.homeassistant.companion.android.settings.sensor.SensorDetailFragment
-import io.homeassistant.companion.android.settings.sensor.SensorSettingsFragment
-import io.homeassistant.companion.android.settings.shortcuts.ManageShortcutsSettingsFragment
-import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
 import javax.inject.Inject
 
 class SettingsFragmentFactory @Inject constructor(
@@ -24,14 +17,7 @@ class SettingsFragmentFactory @Inject constructor(
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
         return when (className) {
             SettingsFragment::class.java.name -> SettingsFragment(settingsPresenter, languagesProvider)
-            LogFragment::class.java.name -> LogFragment()
-            NotificationDetailFragment::class.java.name -> NotificationDetailFragment()
-            NotificationHistoryFragment::class.java.name -> NotificationHistoryFragment()
-            SensorSettingsFragment::class.java.name -> SensorSettingsFragment()
-            SensorDetailFragment::class.java.name -> SensorDetailFragment("")
             ManageTilesFragment::class.java.name -> ManageTilesFragment(integrationRepository)
-            ManageShortcutsSettingsFragment::class.java.name -> ManageShortcutsSettingsFragment()
-            ManageWidgetsSettingsFragment::class.java.name -> ManageWidgetsSettingsFragment()
             else -> super.instantiate(classLoader, className)
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailFragment.kt
@@ -21,11 +21,11 @@ import io.homeassistant.companion.android.common.util.LocationPermissionInfoHand
 import io.homeassistant.companion.android.settings.sensor.views.SensorDetailView
 
 @AndroidEntryPoint
-class SensorDetailFragment(val sensorId: String) : Fragment() {
+class SensorDetailFragment : Fragment() {
 
     companion object {
         fun newInstance(sensorId: String): SensorDetailFragment {
-            return SensorDetailFragment(sensorId).apply {
+            return SensorDetailFragment().apply {
                 arguments = Bundle().apply { putString("id", sensorId) }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The problem described in #2592 also applies to the settings screen; after recreation you always end up in the main settings screen but when you press back things get interesting with an unexpected backstack and multiple fragments/layers of text. This PR fixes it by only replacing `R.id.content` with a fragment if there were none.

I've also updated the `SettingsFragmentFactory` used during recreation to remove all classes without constructor arguments, for these fragments the `else` branch can be used.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->