### PR TITLE
Fix crash on widget update when internet is not connected

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -273,20 +273,25 @@ class WebSocketRepositoryImpl @Inject constructor(
                 .replace("http://", "ws://")
                 .plus("api/websocket")
 
-            connection = okHttpClient.newWebSocket(
-                Request.Builder().url(urlString).build(),
-                this
-            ).also {
-                // Preemptively send auth
-                connectionState = WebSocketState.AUTHENTICATING
-                it.send(
-                    mapper.writeValueAsString(
-                        mapOf(
-                            "type" to "auth",
-                            "access_token" to authenticationRepository.retrieveAccessToken()
+            try {
+                connection = okHttpClient.newWebSocket(
+                    Request.Builder().url(urlString).build(),
+                    this
+                ).also {
+                    // Preemptively send auth
+                    connectionState = WebSocketState.AUTHENTICATING
+                    it.send(
+                        mapper.writeValueAsString(
+                            mapOf(
+                                "type" to "auth",
+                                "access_token" to authenticationRepository.retrieveAccessToken()
+                            )
                         )
                     )
-                )
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Unable to connect", e)
+                return false
             }
 
             // Wait up to 30 seconds for auth response


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This is the best of what I could come with to solve my issue of this app crashing.
It happens when I have WiFi and mobile date turned off and I turn on the screen.
I also came into a conclusion that the culprit is my temperature widget, though it's nothing out of ordinary.
The error I got:
> java.net.UnknownHostException: Unable to resolve host "\<my domain\>": No address associated with hostname at java.net.Inet6AddressImpl.lookupHostByName(Inet6AddressImpl.java:124) ... and so on

I think it would be better to check for internet access before even doing the request but that's beyond my java skills.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->