### PR TITLE
Add attribute to network type sensor if network is metered

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -460,6 +460,7 @@ class NetworkSensorManager : SensorManager {
         val capabilities = connectivityManager?.getNetworkCapabilities(activeNetwork)
 
         var networkCapability = "unavailable"
+        var metered = false
         if (capabilities != null) {
             networkCapability =
                 when {
@@ -473,6 +474,8 @@ class NetworkSensorManager : SensorManager {
                     (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) -> "wifi_aware"
                     else -> "unknown"
                 }
+
+            metered = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)
         }
 
         val icon = when (networkCapability) {
@@ -489,7 +492,9 @@ class NetworkSensorManager : SensorManager {
             networkType,
             networkCapability,
             icon,
-            mapOf()
+            mapOf(
+                "metered" to metered
+            )
         )
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2586 by providing a `metered` attribute for the network type sensor.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/174450071-352d8c39-85bc-4ff1-b952-2bb4d2b0840b.png)

![image](https://user-images.githubusercontent.com/1634145/174450076-43b53ba6-8c12-422a-931f-2ad18a5cede0.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#763

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->