### PR TITLE
Don't crash manage widgets screen on duplicate id

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -196,7 +196,7 @@ private fun <T : WidgetEntity> LazyListScope.widgetItems(
         item {
             Text(stringResource(id = title))
         }
-        items(widgetList, key = { it.id }) { item ->
+        items(widgetList, key = { "$widgetType-${it.id}" }) { item ->
             WidgetRow(widgetLabel = widgetLabel(item), widgetId = item.id, widgetType = widgetType)
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes a potential crash found while discussing issue #2421 ([comment](https://github.com/home-assistant/android/issues/2421#issuecomment-1159768481)), where the app crashed because of a duplicate widget ID in the list (Compose uses widget IDs as stable keys).

Presumably this can be achieved when doing a partial restore, where the database will contain a widget with ID `x` which is not added to the launcher. When the launcher then creates a new widget for ID `x` that is of another type, the previous data is not replaced by the app because the ID is in another table. This change will make sure the app doesn't crash in that case and the user can still clear out the previously deleted widget(s).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->