### PR TITLE
Fix webview restart on keyboard changes (#2622)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -275,7 +275,7 @@
 
         <activity
             android:name=".onboarding.OnboardingActivity"
-            android:configChanges="orientation|screenSize|keyboardHidden" />
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation" />
 
         <activity
             android:name=".settings.wear.SettingsWearActivity"
@@ -315,7 +315,7 @@
             android:supportsPictureInPicture="true"
             android:resizeableActivity="true"
             android:exported="false"
-            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout" />
+            android:configChanges="orientation|screenSize|smallestScreenSize|screenLayout|keyboard|keyboardHidden|navigation" />
 
         <activity
             android:name=".settings.SettingsActivity"


### PR DESCRIPTION
* The webview activity now handles keyboard|keyboardHidden|navigation
  configuration changes by keyboard connection changes, to avoid the
  activity restart which leads to frontend reload.


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

It fixes https://github.com/home-assistant/android/issues/2622

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->