### PR TITLE
Fix Storage sensors to update continuously and display correct size unit

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -33,19 +33,11 @@ class StorageSensorManager : SensorManager {
             stateClass = SensorManager.STATE_CLASS_MEASUREMENT,
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )
-        val path: File = Environment.getDataDirectory()
-        private val stat = StatFs(path.path)
-        var availableBlocks = stat.availableBlocksLong
-        var blockSize = stat.blockSizeLong
-        var totalBlocks = stat.blockCountLong
-        var blockSizeSD = 0L
-        var availableBlocksSD = 0L
-        var totalBlocksSD = 0L
-        private var externalPath: File? = null
 
-        private fun externalMemoryAvailable(context: Context): File? {
+        private fun getExternalStoragePathIfAvailable(context: Context): File? {
             val pathsSD = context.getExternalFilesDirs(null)
             var removable: Boolean
+            var externalPath: File? = null
             Log.d(TAG, "PATHS SD ${pathsSD.size}")
             for (item in pathsSD) {
                 if (item != null) {
@@ -85,26 +77,25 @@ class StorageSensorManager : SensorManager {
     override fun requestSensorUpdate(
         context: Context
     ) {
-        updateStorageSensor(context)
+        updateInternalStorageSensor(context)
         updateExternalStorageSensor(context)
     }
 
-    private fun updateStorageSensor(context: Context) {
+    private fun updateInternalStorageSensor(context: Context) {
         if (!isEnabled(context, storageSensor.id))
             return
 
-        val totalInternalStorage = getTotalInternalMemorySize()
-        val freeInternalStorage = getAvailableInternalMemorySize()
-        val percentageFreeInternalStorage = getPercentageInternal()
+        val path = Environment.getDataDirectory()
+        val internalStorageStats = getStorageStats(path)
 
         onSensorUpdated(
             context,
             storageSensor,
-            percentageFreeInternalStorage,
+            internalStorageStats.percentage,
             storageSensor.statelessIcon,
             mapOf(
-                "Free internal storage" to freeInternalStorage,
-                "Total internal storage" to totalInternalStorage
+                "Free internal storage" to internalStorageStats.freeBytes,
+                "Total internal storage" to internalStorageStats.totalBytes
             )
         )
     }
@@ -113,29 +104,19 @@ class StorageSensorManager : SensorManager {
         if (!isEnabled(context, externalStorage.id))
             return
 
-        externalPath = externalMemoryAvailable(context)
-        var totalExternalStorage = "No SD Card"
-        var freeExternalStorage = "No SD Card"
-        var percentFreeExternal = 0
-
-        if (externalPath != null) {
-            val statSD = StatFs(externalPath.toString())
-            blockSizeSD = statSD.blockSizeLong
-            availableBlocksSD = statSD.availableBlocksLong
-            totalBlocksSD = statSD.blockCountLong
-            totalExternalStorage = getTotalExternalMemorySize()
-            freeExternalStorage = getAvailableExternalMemorySize()
-            percentFreeExternal = ((availableBlocksSD.toDouble() / totalBlocksSD.toDouble()) * 100).roundToInt()
+        val externalStoragePath = getExternalStoragePathIfAvailable(context)
+        val externalStorageStats = externalStoragePath?.let {
+            getStorageStats(it)
         }
 
         onSensorUpdated(
             context,
             externalStorage,
-            percentFreeExternal,
+            externalStorageStats?.percentage ?: 0,
             externalStorage.statelessIcon,
             mapOf(
-                "free_external_storage" to freeExternalStorage,
-                "total_external_storage" to totalExternalStorage
+                "free_external_storage" to (externalStorageStats?.freeBytes ?: "No SD Card"),
+                "total_external_storage" to (externalStorageStats?.totalBytes ?: "No SD Card")
             )
         )
     }
@@ -169,23 +150,17 @@ class StorageSensorManager : SensorManager {
         return resultBuffer.toString()
     }
 
-    private fun getTotalInternalMemorySize(): String {
-        return formatSize(totalBlocks * blockSize)
-    }
+    private data class StorageStats(
+        val totalBytes: String,
+        val freeBytes: String,
+        val percentage: Int
+    )
 
-    private fun getAvailableInternalMemorySize(): String {
-        return formatSize(availableBlocks * blockSize)
-    }
-
-    private fun getPercentageInternal(): Int {
-        return ((availableBlocks.toDouble() / totalBlocks.toDouble()) * 100).roundToInt()
-    }
-
-    private fun getAvailableExternalMemorySize(): String {
-        return formatSize(availableBlocksSD * blockSizeSD)
-    }
-
-    private fun getTotalExternalMemorySize(): String {
-        return formatSize(totalBlocksSD * blockSizeSD)
+    private fun getStorageStats(path: File) = with(StatFs(path.path)) {
+        StorageStats(
+            totalBytes = formatSize(blockCountLong * blockSizeLong),
+            freeBytes = formatSize(availableBlocksLong * blockSizeLong),
+            percentage = ((availableBlocksLong.toDouble() / blockCountLong.toDouble()) * 100).roundToInt()
+        )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -138,16 +138,8 @@ class StorageSensorManager : SensorManager {
             }
         }
 
-        val resultBuffer = StringBuilder(sizeLong.toString())
-
-        var commaOffset = resultBuffer.length - 3
-        while (commaOffset > 0) {
-            resultBuffer.insert(commaOffset, ',')
-            commaOffset -= 3
-        }
-
-        resultBuffer.append(suffix)
-        return resultBuffer.toString()
+        val sizeWithThousandsSeparator = String.format("%,d", sizeLong)
+        return "$sizeWithThousandsSeparator$suffix"
     }
 
     private data class StorageStats(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/StorageSensorManager.kt
@@ -125,13 +125,13 @@ class StorageSensorManager : SensorManager {
         var suffix = ""
 
         var sizeLong = size
-        if (size >= 1024) {
+        if (sizeLong >= 1024) {
             suffix = "KB"
             sizeLong /= 1024
-            if (size >= 1024) {
+            if (sizeLong >= 1024) {
                 suffix = "MB"
                 sizeLong /= 1024
-                if (size >= 1024) {
+                if (sizeLong >= 1024) {
                     suffix = "GB"
                     sizeLong /= 1024
                 }


### PR DESCRIPTION
Fixes #2637 


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The state of the Internal Storage sensor was stored in the `companion object` of `StorageSensorManager`. It was calculated once when the `companion object` was initialized. I fixed it and also did some refactoring.

Based on the code, the Free and the Total attributes' unit was supposed to be dynamic (KB / MB / GB), but it always displayed GB because the logic was flawed. Now it can not only output 0GB for smaller values (<1GB) but also 345MB or 640KB for example.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This app may come in handy for testing this:
[Fill Storage – Google Play](https://play.google.com/store/apps/details?id=com.arumcomm.fillstorage)