### PR TITLE
Don't complete onboarding on registration error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
@@ -145,15 +146,24 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
             )
         } catch (e: Exception) {
             // Fatal errors: if one of these calls fail, the app cannot proceed.
-            // Because this runs after the webview, the only expected errors are system
-            // version related in OkHttp (cryptography), or general connection issues (offline/unknown).
+            // Show an error, clean up the session and require new registration.
+            // Because this runs after the webview, the only expected errors are:
+            // - missing mobile_app integration
+            // - system version related in OkHttp (cryptography)
+            // - general connection issues (offline/unknown)
             Log.e(TAG, "Exception while registering", e)
+            try {
+                authenticationRepository.revokeSession()
+            } catch (e: Exception) {
+                Log.e(TAG, "Can't revoke session", e)
+            }
             AlertDialog.Builder(this@LaunchActivity)
                 .setTitle(commonR.string.error_connection_failed)
                 .setMessage(
-                    when (e) {
-                        is SSLHandshakeException -> commonR.string.webview_error_FAILED_SSL_HANDSHAKE
-                        is SSLException -> commonR.string.webview_error_SSL_INVALID
+                    when {
+                        e is HttpException && e.code() == 404 -> commonR.string.error_with_registration
+                        e is SSLHandshakeException -> commonR.string.webview_error_FAILED_SSL_HANDSHAKE
+                        e is SSLException -> commonR.string.webview_error_SSL_INVALID
                         else -> commonR.string.webview_error
                     }
                 )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -94,13 +94,13 @@ class IntegrationRepositoryImpl @Inject constructor(
             Log.e(TAG, "Unable to register device due to missing URL")
             return
         }
+        val response =
+            integrationService.registerDevice(
+                url.newBuilder().addPathSegments("api/mobile_app/registrations").build(),
+                authenticationRepository.buildBearerToken(),
+                request
+            )
         try {
-            val response =
-                integrationService.registerDevice(
-                    url.newBuilder().addPathSegments("api/mobile_app/registrations").build(),
-                    authenticationRepository.buildBearerToken(),
-                    request
-                )
             persistDeviceRegistration(deviceRegistration)
             urlRepository.saveRegistrationUrls(
                 response.cloudhookUrl,
@@ -109,7 +109,7 @@ class IntegrationRepositoryImpl @Inject constructor(
             )
             localStorage.putString(PREF_SECRET, response.secret)
         } catch (e: Exception) {
-            Log.e(TAG, "Unable to register device", e)
+            Log.e(TAG, "Unable to save device registration", e)
         }
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -193,7 +193,7 @@
     <string name="error_loading_entities">Error loading entities</string>
     <string name="error_onboarding_connection_failed">Unable to connect to Home Assistant.</string>
     <string name="error_ssl">Unable to communicate with Home Assistant because of a SSL error.  Please ensure your certificate is valid.</string>
-    <string name="error_with_registration">Please check to ensure you have the mobile_app\nintegration enabled on your home assistant instance.</string>
+    <string name="error_with_registration">The \'Mobile App\' integration is required to use the app, but it is not available on your Home Assistant server. Please check your server configuration and try again.</string>
     <string name="errors">Errors</string>
     <string name="event_error">Failed to notify HA of picked option.</string>
     <string name="exit">Exit</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -109,25 +109,29 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
     }
 
     private fun login(dataMap: DataMap) = mainScope.launch {
-        val url = dataMap.getString("URL")
-        val authCode = dataMap.getString("AuthCode")
-        val deviceName = dataMap.getString("DeviceName")
-        val deviceTrackingEnabled = dataMap.getString("LocationTracking")
+        try {
+            val url = dataMap.getString("URL")
+            val authCode = dataMap.getString("AuthCode")
+            val deviceName = dataMap.getString("DeviceName")
+            val deviceTrackingEnabled = dataMap.getString("LocationTracking")
 
-        urlRepository.saveUrl(url)
-        authenticationRepository.registerAuthorizationCode(authCode)
-        integrationUseCase.registerDevice(
-            DeviceRegistration(
-                "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
-                deviceName
+            urlRepository.saveUrl(url)
+            authenticationRepository.registerAuthorizationCode(authCode)
+            integrationUseCase.registerDevice(
+                DeviceRegistration(
+                    "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
+                    deviceName
+                )
             )
-        )
+
+            val intent = HomeActivity.newInstance(applicationContext)
+            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(intent)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to login to Home Assistant", e)
+        }
 
         sendPhoneData()
-
-        val intent = HomeActivity.newInstance(applicationContext)
-        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        startActivity(intent)
     }
 
     private fun saveFavorites(dataMap: DataMap) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2217 - the app will no longer suppress/continue on failed registration during onboarding, and if it failed because the `mobile_app` integration is missing it will show a specific error message to indicate this

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![A dialog with the text 'Unable to connect to Home Assistant. The 'Mobile App' integration is required to use the app, but it is not available on your Home Assistant server. Please check your server configuration and try again. ', light mode](https://user-images.githubusercontent.com/8148535/176257550-61438868-3b5e-4c88-a53e-29d5ab895d92.png)|![A dialog with the text 'Unable to connect to Home Assistant. The 'Mobile App' integration is required to use the app, but it is not available on your Home Assistant server. Please check your server configuration and try again. ', dark mode](https://user-images.githubusercontent.com/8148535/176257534-aeebc944-adba-4af7-807a-abff7813ca88.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->