### PR TITLE
Fix background crash due to button widgets without size

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -177,10 +177,16 @@ class ButtonWidget : AppWidgetProvider() {
                 // Determine reasonable dimensions for drawing vector icon as a bitmap
                 val aspectRatio = iconDrawable.intrinsicWidth / iconDrawable.intrinsicHeight.toDouble()
                 val awo = if (widget != null) AppWidgetManager.getInstance(context).getAppWidgetOptions(widget.id) else null
-                val maxWidth = awo?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH) ?: DEFAULT_MAX_ICON_SIZE
-                val maxHeight = awo?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT) ?: DEFAULT_MAX_ICON_SIZE
-                var width: Int
-                var height: Int
+                val maxWidth = (
+                    awo?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_WIDTH, DEFAULT_MAX_ICON_SIZE)
+                        ?: DEFAULT_MAX_ICON_SIZE
+                    ).coerceAtLeast(16)
+                val maxHeight = (
+                    awo?.getInt(AppWidgetManager.OPTION_APPWIDGET_MAX_HEIGHT, DEFAULT_MAX_ICON_SIZE)
+                        ?: DEFAULT_MAX_ICON_SIZE
+                    ).coerceAtLeast(16)
+                val width: Int
+                val height: Int
                 if (maxWidth > maxHeight) {
                     width = maxWidth
                     height = (maxWidth * (1 / aspectRatio)).toInt()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #2647 by improving the null check + ensuring that the button's icon has a minimum size, to prevent crashes due to a size of `0`

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->