### PR TITLE
Fix editing service button widget shows/creates incorrect field values

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -244,8 +244,9 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity(), IconDialog.
                     services[getServiceString(it)] = it
                 }
                 Log.d(TAG, "Services found: $services")
+                serviceAdapter.addAll(services.values)
+                serviceAdapter.sort()
                 if (buttonWidget != null) {
-                    serviceAdapter.add(services[serviceText])
                     val serviceData = services[serviceText]!!.serviceData
                     val target = serviceData.target
                     val fields = serviceData.fields
@@ -279,13 +280,12 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity(), IconDialog.
                         entities[it.entityId] = it
                     }
                     dynamicFieldAdapter.notifyDataSetChanged()
-                } else
-                    serviceAdapter.addAll(services.values)
-                serviceAdapter.sort()
+                }
 
                 // Update service adapter
                 runOnUiThread {
                     serviceAdapter.notifyDataSetChanged()
+                    serviceAdapter.filter.filter(binding.widgetTextConfigService.text)
                 }
             } catch (e: Exception) {
                 // Custom components can cause services to not load

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -131,18 +131,22 @@ class WidgetDynamicFieldAdapter(
                 autoCompleteTextView.setText(serviceFieldList[position].value as String)
             } catch (e: Exception) {
                 Log.d(TAG, "Unable to get service field list", e)
+                // Set text to empty string to prevent a recycled, incorrect value
+                autoCompleteTextView.setText("")
             }
         }
 
         // Have the text view store its text for later recall
         autoCompleteTextView.doAfterTextChanged {
             // Only attempt to store data if we are in bounds
-            if (serviceFieldList.size >= position) {
+            if (serviceFieldList.size >= holder.bindingAdapterPosition &&
+                holder.bindingAdapterPosition != RecyclerView.NO_POSITION
+            ) {
                 // Don't store data that's empty (or just whitespace)
                 if (it.isNullOrBlank()) {
-                    serviceFieldList[position].value = null
+                    serviceFieldList[holder.bindingAdapterPosition].value = null
                 } else {
-                    serviceFieldList[position].value = it.toString().toJsonType()
+                    serviceFieldList[holder.bindingAdapterPosition].value = it.toString().toJsonType()
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -79,6 +79,8 @@ class WidgetDynamicFieldAdapter(
             } catch (e: Exception) {
                 // Who knows what custom components will break here
             }
+        } else {
+            autoCompleteTextView.hint = null
         }
 
         // If field is looking for an entity_id,
@@ -121,6 +123,10 @@ class WidgetDynamicFieldAdapter(
             autoCompleteTextView.setAdapter(fieldAdapter)
             autoCompleteTextView.setTokenizer(CommaTokenizer())
             autoCompleteTextView.onFocusChangeListener = dropDownOnFocus
+        } else {
+            autoCompleteTextView.setAdapter(null)
+            autoCompleteTextView.setTokenizer(null)
+            autoCompleteTextView.onFocusChangeListener = null
         }
 
         // Populate textview with stored text for that field


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2604 and visual issues for the service fields

These fixes don't really relate to the changes included in the version I mentioned in the issue, but were mainly caused by race conditions/re-use of resources so I'm going to blame it on the app got faster 🙂

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->