### PR TITLE
Add camera device control

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
@@ -49,7 +49,7 @@ object CameraControl : HaControl {
         val icon = if (image != null) {
             Icon.createWithBitmap(image)
         } else {
-            Icon.createWithResource(context, R.drawable.ic_sync_problem)
+            Icon.createWithResource(context, R.drawable.control_camera_placeholder)
         }
         control.setControlTemplate(
             ThumbnailTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
@@ -1,0 +1,92 @@
+package io.homeassistant.companion.android.controls
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.ControlAction
+import android.service.controls.templates.ThumbnailTemplate
+import android.util.Log
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.net.URL
+import java.util.concurrent.TimeUnit
+import io.homeassistant.companion.android.common.R as commonR
+
+@RequiresApi(Build.VERSION_CODES.S)
+object CameraControl : HaControl {
+    private const val TAG = "CameraControl"
+
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?,
+        baseUrl: String?
+    ): Control.StatefulBuilder {
+        control.setStatusText(
+            when (entity.state) {
+                "idle" -> context.getString(commonR.string.state_idle)
+                "recording" -> context.getString(commonR.string.state_recording)
+                "streaming" -> context.getString(commonR.string.state_streaming)
+                else -> entity.state
+            }
+        )
+
+        val image = if (baseUrl != null && (entity.attributes["entity_picture"] as? String)?.isNotBlank() == true) {
+            getThumbnail(baseUrl + entity.attributes["entity_picture"] as String)
+        } else null
+        val icon = if (image != null) {
+            Icon.createWithBitmap(image)
+        } else {
+            Icon.createWithResource(context, R.drawable.ic_sync_problem)
+        }
+        control.setControlTemplate(
+            ThumbnailTemplate(
+                entity.entityId,
+                entity.state != "idle",
+                icon,
+                context.getString(commonR.string.widget_camera_contentdescription)
+            )
+        )
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_CAMERA
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.domain_camera)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        // No action is received, Android immediately invokes long press
+        return true
+    }
+
+    private fun getThumbnail(path: String): Bitmap? = runBlocking {
+        var image: Bitmap? = null
+        withTimeoutOrNull(TimeUnit.SECONDS.toMillis(2)) {
+            withContext(Dispatchers.IO) {
+                try {
+                    image = BitmapFactory.decodeStream(URL(path).openStream())
+                } catch (e: Exception) {
+                    Log.e(TAG, "Couldn't download image for control", e)
+                }
+            }
+        }
+        return@runBlocking image
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -36,7 +36,8 @@ object ClimateControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatusText(
             when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -25,7 +25,8 @@ object CoverControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatusText(
             when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
@@ -19,7 +19,8 @@ object DefaultButtonControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatusText("")
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -20,7 +20,8 @@ object DefaultSliderControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatusText("")
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -21,7 +21,8 @@ object DefaultSwitchControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setControlTemplate(
             ToggleTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -25,7 +25,8 @@ object FanControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         if (entity.supportsFanSetSpeed()) {
             val position = entity.getFanSpeed()

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -16,7 +16,12 @@ import io.homeassistant.companion.android.webview.WebViewActivity
 @RequiresApi(Build.VERSION_CODES.R)
 interface HaControl {
 
-    fun createControl(context: Context, entity: Entity<Map<String, Any>>, area: AreaRegistryResponse?): Control {
+    fun createControl(
+        context: Context,
+        entity: Entity<Map<String, Any>>,
+        area: AreaRegistryResponse?,
+        baseUrl: String?
+    ): Control {
         val controlPath = "entityId:${entity.entityId}"
         val control = Control.StatefulBuilder(
             entity.entityId,
@@ -41,14 +46,15 @@ interface HaControl {
             }
         )
 
-        return provideControlFeatures(context, control, entity, area).build()
+        return provideControlFeatures(context, control, entity, area, baseUrl).build()
     }
 
     fun provideControlFeatures(
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder
 
     fun getDeviceType(entity: Entity<Map<String, Any>>): Int

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
@@ -41,12 +42,15 @@ class HaControlsProviderService : ControlsProviderService() {
     @Inject
     lateinit var webSocketRepository: WebSocketRepository
 
+    @Inject
+    lateinit var urlRepository: UrlRepository
+
     private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     private val domainToHaControl = mapOf(
         "automation" to DefaultSwitchControl,
         "button" to DefaultButtonControl,
-        "camera" to null,
+        "camera" to CameraControl,
         "climate" to ClimateControl,
         "cover" to CoverControl,
         "fan" to FanControl,
@@ -62,6 +66,9 @@ class HaControlsProviderService : ControlsProviderService() {
         "script" to DefaultButtonControl,
         "switch" to DefaultSwitchControl,
         "vacuum" to VacuumControl
+    )
+    private val domainToMinimumApi = mapOf(
+        "camera" to Build.VERSION_CODES.S
     )
 
     override fun createPublisherForAllAvailable(): Flow.Publisher<Control> {
@@ -84,12 +91,17 @@ class HaControlsProviderService : ControlsProviderService() {
 
                     entities
                         ?.sortedWith(compareBy(nullsLast()) { areaForEntity[it.entityId]?.name })
+                        ?.filter {
+                            domainToMinimumApi[it.domain] == null ||
+                                Build.VERSION.SDK_INT >= domainToMinimumApi[it.domain]!!
+                        }
                         ?.mapNotNull {
                             try {
                                 domainToHaControl[it.domain]?.createControl(
                                     applicationContext,
                                     it as Entity<Map<String, Any>>,
-                                    areaForEntity[it.entityId]
+                                    areaForEntity[it.entityId],
+                                    null // Prevent downloading camera images
                                 )
                             } catch (e: Exception) {
                                 Log.e(TAG, "Unable to create control for ${it.domain} entity, skipping", e)
@@ -139,7 +151,9 @@ class HaControlsProviderService : ControlsProviderService() {
                         var deviceRegistry = getDeviceRegistry.await()
                         var entityRegistry = getEntityRegistry.await()
 
-                        sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)
+                        val baseUrl = urlRepository.getUrl().toString().removeSuffix("/")
+
+                        sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry, baseUrl)
 
                         // Listen for the state changed events.
                         webSocketScope.launch {
@@ -148,7 +162,8 @@ class HaControlsProviderService : ControlsProviderService() {
                                     val control = domainToHaControl[it.domain]?.createControl(
                                         applicationContext,
                                         it as Entity<Map<String, Any>>,
-                                        RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry)
+                                        RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry),
+                                        baseUrl
                                     )
                                     subscriber.onNext(control)
                                 }
@@ -157,20 +172,20 @@ class HaControlsProviderService : ControlsProviderService() {
                         webSocketScope.launch {
                             webSocketRepository.getAreaRegistryUpdates()?.collect {
                                 areaRegistry = webSocketRepository.getAreaRegistry()
-                                sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)
+                                sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry, baseUrl)
                             }
                         }
                         webSocketScope.launch {
                             webSocketRepository.getDeviceRegistryUpdates()?.collect {
                                 deviceRegistry = webSocketRepository.getDeviceRegistry()
-                                sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)
+                                sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry, baseUrl)
                             }
                         }
                         webSocketScope.launch {
                             webSocketRepository.getEntityRegistryUpdates()?.collect { event ->
                                 if (event.action == "update" && controlIds.contains(event.entityId)) {
                                     entityRegistry = webSocketRepository.getEntityRegistry()
-                                    sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry)
+                                    sendEntitiesToSubscriber(subscriber, entities, areaRegistry, deviceRegistry, entityRegistry, baseUrl)
                                 }
                             }
                         }
@@ -219,21 +234,24 @@ class HaControlsProviderService : ControlsProviderService() {
         entities: Map<String, Entity<Map<String, Any>>>,
         areaRegistry: List<AreaRegistryResponse>?,
         deviceRegistry: List<DeviceRegistryResponse>?,
-        entityRegistry: List<EntityRegistryResponse>?
+        entityRegistry: List<EntityRegistryResponse>?,
+        baseUrl: String
     ) {
         entities.forEach {
             val control = try {
                 domainToHaControl[it.value.domain]?.createControl(
                     applicationContext,
                     it.value,
-                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)
+                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry),
+                    baseUrl
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Unable to create control for ${it.value.domain} entity, sending error entity", e)
                 domainToHaControl["ha_failed"]?.createControl(
                     applicationContext,
                     getFailedEntity(it.value.entityId, e),
-                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry)
+                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry),
+                    baseUrl
                 )
             }
             subscriber.onNext(control)

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -239,10 +239,10 @@ class HaControlsProviderService : ControlsProviderService() {
     ) {
         entities.forEach {
             val control = try {
-                domainToHaControl[it.value.domain]?.createControl(
+                domainToHaControl[it.key.split(".")[0]]?.createControl(
                     applicationContext,
                     it.value,
-                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry),
+                    RegistriesDataHandler.getAreaForEntity(it.value.entityId, areaRegistry, deviceRegistry, entityRegistry),
                     baseUrl
                 )
             } catch (e: Exception) {
@@ -250,7 +250,7 @@ class HaControlsProviderService : ControlsProviderService() {
                 domainToHaControl["ha_failed"]?.createControl(
                     applicationContext,
                     getFailedEntity(it.value.entityId, e),
-                    RegistriesDataHandler.getAreaForEntity(it.key, areaRegistry, deviceRegistry, entityRegistry),
+                    RegistriesDataHandler.getAreaForEntity(it.value.entityId, areaRegistry, deviceRegistry, entityRegistry),
                     baseUrl
                 )
             }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
@@ -18,7 +18,8 @@ object HaFailedControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatus(if (entity.state == "notfound") Control.STATUS_NOT_FOUND else Control.STATUS_ERROR)
         control.setStatusText("")

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -25,7 +25,8 @@ object LightControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         val position = entity.getLightBrightness()
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -20,7 +20,8 @@ object LockControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         control.setStatusText(
             when (entity.state) {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -23,7 +23,8 @@ object VacuumControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?
+        area: AreaRegistryResponse?,
+        baseUrl: String?
     ): Control.StatefulBuilder {
         entitySupportedFeatures = entity.attributes["supported_features"] as Int
         if (entitySupportedFeatures and SUPPORT_TURN_ON != SUPPORT_TURN_ON) {

--- a/app/src/main/res/drawable/control_camera_placeholder.xml
+++ b/app/src/main/res/drawable/control_camera_placeholder.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#202124" />
+</shape>

--- a/app/src/main/res/layout/widget_camera.xml
+++ b/app/src/main/res/layout/widget_camera.xml
@@ -13,7 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="invisible"
-        android:contentDescription="@string/widget_camera_description"
+        android:contentDescription="@string/widget_camera_contentdescription"
         android:scaleType="centerInside" />
     <ImageView
         android:id="@+id/widgetCameraPlaceholder"
@@ -23,7 +23,7 @@
         android:layout_marginTop="4dp"
         android:layout_marginBottom="4dp"
         android:src="@drawable/app_icon_round"
-        android:contentDescription="@string/widget_camera_description"
+        android:contentDescription="@string/widget_camera_contentdescription"
         android:scaleType="fitCenter" />
     <ImageView
         android:id="@+id/widgetCameraError"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -153,6 +153,7 @@
     <string name="documentation">Documentation</string>
     <string name="domain_automation">Automation</string>
     <string name="domain_button">Button</string>
+    <string name="domain_camera">Camera</string>
     <string name="domain_climate">Climate</string>
     <string name="domain_cover">Cover</string>
     <string name="domain_fan">Fan</string>
@@ -665,6 +666,8 @@
     <string name="state_unknown">Unknown</string>
     <string name="state_unlocked">Unlocked</string>
     <string name="state_unlocking">Unlocking</string>
+    <string name="state_recording">Recording</string>
+    <string name="state_streaming">Streaming</string>
     <string name="state">State</string>
     <string name="state_name">State: %1$s</string>
     <string name="states">Overview</string>
@@ -764,6 +767,7 @@
     <string name="widget_background_type_transparent">Transparent</string>
     <string name="widget_button_image_description">Service Button</string>
     <string name="widget_camera_description">Camera Widget</string>
+    <string name="widget_camera_contentdescription">Camera image</string>
     <string name="widget_config_service_error">A custom component is preventing service data from loading.</string>
     <string name="widget_creation_error">Unable to create widget.</string>
     <string name="widget_entity_fetch_error">Unable to fetch data for configured entity.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add support for `camera` entities to device controls. The control is only supported on Android 12+.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
As usual with device controls, the appearance depends on the manufacturer. These screenshots are for Google's implementation, note that if the camera isn't active they decided to not show the snapshot:
|State: `idle`|State: `recording` or `streaming`|
|-----|-----|
|![A device control tile with a camera icon, the state 'Idle', the title 'RTSP camera' and a gray background](https://user-images.githubusercontent.com/8148535/178028050-29ae1196-f549-437b-8868-f8e894bdaec1.png)|![A device control tile with a camera icon and the state 'Streaming', no title is shown and the background of the tile is a still image of the stream](https://user-images.githubusercontent.com/8148535/178028126-dd36b7c9-f470-4172-89e9-a2e083d78577.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#769

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->