### PR TITLE
Minor location update fixes

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -18,6 +18,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import io.homeassistant.companion.android.common.util.highAccuracyChannel
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.util.ForegroundServiceLauncher
@@ -188,12 +189,12 @@ class HighAccuracyLocationService : Service() {
 
     @SuppressLint("MissingPermission")
     private fun requestLocationUpdates(intervalInSeconds: Int) {
-        val request = LocationRequest()
+        val request = LocationRequest.create()
 
         val intervalInMS = (intervalInSeconds * 1000).toLong()
         request.interval = intervalInMS
         request.fastestInterval = intervalInMS / 2
-        request.priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+        request.priority = Priority.PRIORITY_HIGH_ACCURACY
 
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
         fusedLocationProviderClient?.requestLocationUpdates(request, getLocationUpdateIntent())

--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -183,7 +183,7 @@ class HighAccuracyLocationService : Service() {
 
     private fun getLocationUpdateIntent(): PendingIntent {
         val intent = Intent(this, LocationSensorManager::class.java)
-        intent.action = LocationSensorManager.ACTION_PROCESS_LOCATION
+        intent.action = LocationSensorManager.ACTION_PROCESS_HIGH_ACCURACY_LOCATION
         return PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
     }
 

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -21,6 +21,7 @@ import com.google.android.gms.location.LocationCallback
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -37,6 +38,7 @@ import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import io.homeassistant.companion.android.notifications.MessagingManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -265,6 +267,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                     } else {
                         Log.d(TAG, "High accuracy mode parameters changed. Disable high accuracy mode.")
                         stopHighAccuracyService()
+                        delay(500)
                         requestLocationUpdates()
                     }
                 }
@@ -764,13 +767,13 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun createLocationRequest(): LocationRequest {
-        val locationRequest = LocationRequest()
+        val locationRequest = LocationRequest.create()
 
         locationRequest.interval = 60000 // Every 60 seconds
         locationRequest.fastestInterval = 30000 // Every 30 seconds
         locationRequest.maxWaitTime = 200000 // Every 5 minutes
 
-        locationRequest.priority = LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY
+        locationRequest.priority = Priority.PRIORITY_BALANCED_POWER_ACCURACY
 
         return locationRequest
     }
@@ -900,7 +903,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
         val maxRetries = 5
         val request = createLocationRequest().apply {
-            priority = LocationRequest.PRIORITY_HIGH_ACCURACY
+            priority = Priority.PRIORITY_HIGH_ACCURACY
             numUpdates = maxRetries
             interval = 10000
             fastestInterval = 5000

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -38,7 +38,6 @@ import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import io.homeassistant.companion.android.notifications.MessagingManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
@@ -67,6 +66,8 @@ class LocationSensorManager : LocationSensorManagerBase() {
             "io.homeassistant.companion.android.background.REQUEST_ACCURATE_UPDATE"
         const val ACTION_PROCESS_LOCATION =
             "io.homeassistant.companion.android.background.PROCESS_UPDATES"
+        const val ACTION_PROCESS_HIGH_ACCURACY_LOCATION =
+            "io.homeassistant.companion.android.background.PROCESS_HIGH_ACCURACY_UPDATES"
         const val ACTION_PROCESS_GEO =
             "io.homeassistant.companion.android.background.PROCESS_GEOFENCE"
         const val ACTION_FORCE_HIGH_ACCURACY =
@@ -168,7 +169,8 @@ class LocationSensorManager : LocationSensorManagerBase() {
         when (intent.action) {
             Intent.ACTION_BOOT_COMPLETED,
             ACTION_REQUEST_LOCATION_UPDATES -> setupLocationTracking()
-            ACTION_PROCESS_LOCATION -> handleLocationUpdate(intent)
+            ACTION_PROCESS_LOCATION,
+            ACTION_PROCESS_HIGH_ACCURACY_LOCATION -> handleLocationUpdate(intent)
             ACTION_PROCESS_GEO -> handleGeoUpdate(intent)
             ACTION_REQUEST_ACCURATE_LOCATION_UPDATE -> requestSingleAccurateLocation()
             ACTION_FORCE_HIGH_ACCURACY -> {
@@ -267,7 +269,6 @@ class LocationSensorManager : LocationSensorManagerBase() {
                     } else {
                         Log.d(TAG, "High accuracy mode parameters changed. Disable high accuracy mode.")
                         stopHighAccuracyService()
-                        delay(500)
                         requestLocationUpdates()
                     }
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

- Stops using deprecated priority constants introduced in latest [location dependency update](https://developers.google.com/android/guides/releases#june_07_2022)
- Stops using deprecated constructor usage, not sure when this was deprecated
- Adds a short delay when high accuracy mode is disabling so we can ensure the request to remove location updates has completed before we register for normal background updates. During testing I found that when I was manually enabling and disabling high accuracy mode from settings the updates were not coming in consistently (if at all) anymore and it turns out we were requesting updates before the service was successfully destroyed. After adding this delay the frequency in updates returned.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->