### PR TITLE
Fix last update add new intent toggle not showing up on new installs

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -92,16 +92,14 @@ class LastUpdateManager : SensorManager {
         if (addNewIntentToggle == null) {
             // add the toggle if it was not already added.
             sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
-        } else {
-            if (addNewIntentToggle.value == "true") {
-                val newIntentSettingOrdinal = intentSettings.size + 1
-                val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
-                if (allSettings.none { it.name == newIntentSettingName }) {
-                    // turn off the toggle:
-                    sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
-                    // add the new Intent:
-                    sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
-                }
+        } else if (addNewIntentToggle.value == "true") {
+            val newIntentSettingOrdinal = intentSettings.size + 1
+            val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
+            if (allSettings.none { it.name == newIntentSettingName }) {
+                // turn off the toggle:
+                sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
+                // add the new Intent:
+                sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
             }
         }
     }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -98,6 +98,9 @@ class LastUpdateManager : SensorManager {
                 // add the new Intent:
                 sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
             }
+        } else {
+            // add the toggle if it was not already added.
+            sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
         }
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -88,19 +88,21 @@ class LastUpdateManager : SensorManager {
             // add new settings to DB:
             newIntentSettings.forEach(sensorDao::add)
         }
-        val shouldAddNewIntent = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }?.value == "true"
-        if (shouldAddNewIntent) {
-            val newIntentSettingOrdinal = intentSettings.size + 1
-            val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
-            if (allSettings.none { it.name == newIntentSettingName }) {
-                // turn off the toggle:
-                sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
-                // add the new Intent:
-                sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
-            }
-        } else {
+        val addNewIntentToggle = allSettings.firstOrNull { it.name == SETTING_ADD_NEW_INTENT }
+        if (addNewIntentToggle == null) {
             // add the toggle if it was not already added.
             sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
+        } else {
+            if (addNewIntentToggle.value == "true") {
+                val newIntentSettingOrdinal = intentSettings.size + 1
+                val newIntentSettingName = "$INTENT_SETTING_PREFIX$newIntentSettingOrdinal:"
+                if (allSettings.none { it.name == newIntentSettingName }) {
+                    // turn off the toggle:
+                    sensorDao.add(SensorSetting(lastUpdate.id, SETTING_ADD_NEW_INTENT, "false", SensorSettingType.TOGGLE))
+                    // add the new Intent:
+                    sensorDao.add(SensorSetting(lastUpdate.id, newIntentSettingName, intentAction, SensorSettingType.STRING))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2673 

Need to make sure on a new install the setting toggle shows up as well.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->