### PR TITLE
Add channel, category and group to notification sensor attributes

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -8,6 +8,7 @@ import android.content.res.Configuration
 import android.media.MediaMetadata
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
+import android.os.Build
 import android.os.Bundle
 import android.service.notification.NotificationListenerService
 import android.service.notification.StatusBarNotification
@@ -138,6 +139,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             .plus("post_time" to sbn.postTime)
             .plus("is_clearable" to sbn.isClearable)
             .plus("is_ongoing" to sbn.isOngoing)
+            .plus("group_id" to sbn.notification.group)
+            .plus("category" to sbn.notification.category).toMutableMap()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            attr += attr.plus("channel_id" to sbn.notification.channelId)
 
         // Attempt to use the text of the notification but fallback to package name if all else fails.
         val state = attr["android.text"] ?: attr["android.title"] ?: sbn.packageName
@@ -189,6 +195,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             .plus("post_time" to sbn.postTime)
             .plus("is_clearable" to sbn.isClearable)
             .plus("is_ongoing" to sbn.isOngoing)
+            .plus("group_id" to sbn.notification.group)
+            .plus("category" to sbn.notification.category).toMutableMap()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            attr += attr.plus("channel_id" to sbn.notification.channelId)
 
         // Attempt to use the text of the notification but fallback to package name if all else fails.
         val state = attr["android.text"] ?: attr["android.title"] ?: sbn.packageName
@@ -216,6 +227,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
                     .plus(item.packageName + "_" + item.id + "_post_time" to item.postTime)
                     .plus(item.packageName + "_" + item.id + "_is_ongoing" to item.isOngoing)
                     .plus(item.packageName + "_" + item.id + "_is_clearable" to item.isClearable)
+                    .plus(item.packageName + "_" + item.id + "_group_id" to item.notification.group)
+                    .plus(item.packageName + "_" + item.id + "_category" to item.notification.category)
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    attr += attr.plus(item.packageName + "_" + item.id + "_channel_id" to item.notification.channelId)
             }
             onSensorUpdated(
                 applicationContext,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -140,10 +140,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             .plus("is_clearable" to sbn.isClearable)
             .plus("is_ongoing" to sbn.isOngoing)
             .plus("group_id" to sbn.notification.group)
-            .plus("category" to sbn.notification.category).toMutableMap()
+            .plus("category" to sbn.notification.category)
+            .toMutableMap()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            attr += attr.plus("channel_id" to sbn.notification.channelId)
+            attr["channel_id"] = sbn.notification.channelId
 
         // Attempt to use the text of the notification but fallback to package name if all else fails.
         val state = attr["android.text"] ?: attr["android.title"] ?: sbn.packageName
@@ -196,10 +197,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             .plus("is_clearable" to sbn.isClearable)
             .plus("is_ongoing" to sbn.isOngoing)
             .plus("group_id" to sbn.notification.group)
-            .plus("category" to sbn.notification.category).toMutableMap()
+            .plus("category" to sbn.notification.category)
+            .toMutableMap()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            attr += attr.plus("channel_id" to sbn.notification.channelId)
+            attr["channel_id"] = sbn.notification.channelId
 
         // Attempt to use the text of the notification but fallback to package name if all else fails.
         val state = attr["android.text"] ?: attr["android.title"] ?: sbn.packageName
@@ -231,7 +233,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
                     .plus(item.packageName + "_" + item.id + "_category" to item.notification.category)
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    attr += attr.plus(item.packageName + "_" + item.id + "_channel_id" to item.notification.channelId)
+                    attr[item.packageName + "_" + item.id + "_channel_id"] = item.notification.channelId
             }
             onSensorUpdated(
                 applicationContext,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2675 

Adds Channel ID, Category and also Group ID from notifications.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#774

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->