### PR TITLE
Android 13 notification changes + target

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -23,7 +23,7 @@ android {
     defaultConfig {
         applicationId = "io.homeassistant.companion.android"
         minSdk = 21
-        targetSdk = 31
+        targetSdk = 33
 
         versionName = System.getenv("VERSION") ?: "LOCAL"
         versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
@@ -175,13 +175,15 @@ class SettingsWearViewModel @Inject constructor(
         url: String,
         authCode: String,
         deviceName: String,
-        deviceTrackingEnabled: Boolean
+        deviceTrackingEnabled: Boolean,
+        notificationsEnabled: Boolean
     ) {
         val putDataRequest = PutDataMapRequest.create("/authenticate").run {
             dataMap.putString("URL", url)
             dataMap.putString("AuthCode", authCode)
             dataMap.putString("DeviceName", deviceName)
             dataMap.putBoolean("LocationTracking", deviceTrackingEnabled)
+            dataMap.putBoolean("Notifications", notificationsEnabled)
             setUrgent()
             asPutDataRequest()
         }

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
@@ -74,15 +74,16 @@ class SettingsWearMainView : AppCompatActivity() {
             OnboardApp.Input(
                 url = registerUrl,
                 defaultDeviceName = currentNodes.firstOrNull()?.displayName ?: "unknown",
-                locationTrackingPossible = false
-            )
+                locationTrackingPossible = false,
+                notificationsPossible = false
+            ) // While notifications are technically possible, the app can't handle this for the Wear device
         )
     }
 
     private fun onOnboardingComplete(result: OnboardApp.Output?) {
         if (result != null) {
-            val (url, authCode, deviceName, deviceTrackingEnabled) = result
-            settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled)
+            val (url, authCode, deviceName, deviceTrackingEnabled, _) = result
+            settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled, true)
         } else
             Log.e(TAG, "onOnboardingComplete: Activity result returned null intent data")
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -39,6 +39,7 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"
         tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WRITE_SETTINGS"
         tools:ignore="ProtectedPermissions"/>
 

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -204,6 +204,7 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
         // Full: this only refers to the system permission on Android 13+ so no changes are necessary.
         // Minimal: change persistent connection setting to reflect preference.
         if (BuildConfig.FLAVOR != "full") {
+            settingViewModel.getSetting(0) // Required to create initial value
             settingViewModel.updateWebsocketSetting(
                 0,
                 if (enabled) WebsocketSetting.ALWAYS else WebsocketSetting.NEVER

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -386,7 +386,11 @@ class MessagingManager @Inject constructor(
                         }
                     }
                     COMMAND_BLUETOOTH -> {
-                        if (!jsonData[COMMAND].isNullOrEmpty() && jsonData[COMMAND] in ENABLE_COMMANDS)
+                        if (
+                            !jsonData[COMMAND].isNullOrEmpty() &&
+                            jsonData[COMMAND] in ENABLE_COMMANDS &&
+                            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
+                        )
                             handleDeviceCommands(jsonData)
                         else {
                             mainScope.launch {
@@ -770,9 +774,10 @@ class MessagingManager @Inject constructor(
                         }
                     }
                 }
+                @Suppress("DEPRECATION")
                 if (command == TURN_OFF)
                     bluetoothAdapter?.disable()
-                if (command == TURN_ON)
+                else if (command == TURN_ON)
                     bluetoothAdapter?.enable()
             }
             COMMAND_BLE_TRANSMITTER -> {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardApp.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardApp.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.onboarding
 
 import android.content.Context
 import android.content.Intent
-import android.icu.util.Output
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContract
 import io.homeassistant.companion.android.BuildConfig
@@ -13,25 +12,29 @@ class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>(
         private const val EXTRA_URL = "extra_url"
         private const val EXTRA_DEFAULT_DEVICE_NAME = "extra_default_device_name"
         private const val EXTRA_LOCATION_TRACKING_POSSIBLE = "location_tracking_possible"
+        private const val EXTRA_NOTIFICATIONS_POSSIBLE = "notifications_possible"
 
         fun parseInput(intent: Intent): Input = Input(
             url = intent.getStringExtra(EXTRA_URL),
             defaultDeviceName = intent.getStringExtra(EXTRA_DEFAULT_DEVICE_NAME) ?: Build.MODEL,
             locationTrackingPossible = intent.getBooleanExtra(EXTRA_LOCATION_TRACKING_POSSIBLE, false),
+            notificationsPossible = intent.getBooleanExtra(EXTRA_NOTIFICATIONS_POSSIBLE, true)
         )
     }
 
     data class Input(
         val url: String? = null,
         val defaultDeviceName: String = Build.MODEL,
-        val locationTrackingPossible: Boolean = BuildConfig.FLAVOR == "full"
+        val locationTrackingPossible: Boolean = BuildConfig.FLAVOR == "full",
+        val notificationsPossible: Boolean = true
     )
 
     data class Output(
         val url: String,
         val authCode: String,
         val deviceName: String,
-        val deviceTrackingEnabled: Boolean
+        val deviceTrackingEnabled: Boolean,
+        val notificationsEnabled: Boolean
     ) {
         fun toIntent(): Intent {
             return Intent().apply {
@@ -39,6 +42,7 @@ class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>(
                 putExtra("AuthCode", authCode)
                 putExtra("DeviceName", deviceName)
                 putExtra("LocationTracking", deviceTrackingEnabled)
+                putExtra("Notifications", notificationsEnabled)
             }
         }
     }
@@ -48,6 +52,7 @@ class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>(
             putExtra(EXTRA_URL, input.url)
             putExtra(EXTRA_DEFAULT_DEVICE_NAME, input.defaultDeviceName)
             putExtra(EXTRA_LOCATION_TRACKING_POSSIBLE, input.locationTrackingPossible)
+            putExtra(EXTRA_NOTIFICATIONS_POSSIBLE, input.notificationsPossible)
         }
     }
 
@@ -60,11 +65,13 @@ class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>(
         val authCode = intent.getStringExtra("AuthCode").toString()
         val deviceName = intent.getStringExtra("DeviceName").toString()
         val deviceTrackingEnabled = intent.getBooleanExtra("LocationTracking", false)
+        val notificationsEnabled = intent.getBooleanExtra("Notifications", true)
         return Output(
             url = url,
             authCode = authCode,
             deviceName = deviceName,
-            deviceTrackingEnabled = deviceTrackingEnabled
+            deviceTrackingEnabled = deviceTrackingEnabled,
+            notificationsEnabled = notificationsEnabled
         )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -5,8 +5,10 @@ import android.os.Bundle
 import android.view.KeyEvent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.commit
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
 import io.homeassistant.companion.android.onboarding.discovery.DiscoveryFragment
@@ -29,6 +31,14 @@ class OnboardingActivity : AppCompatActivity() {
         val input = OnboardApp.parseInput(intent)
         viewModel.deviceName.value = input.defaultDeviceName
         viewModel.locationTrackingPossible.value = input.locationTrackingPossible
+        viewModel.notificationsPossible.value = input.notificationsPossible
+        viewModel.notificationsEnabled = if (input.notificationsPossible) {
+            BuildConfig.FLAVOR == "full" &&
+                (
+                    Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+                        NotificationManagerCompat.from(this).areNotificationsEnabled()
+                    )
+        } else false
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -86,7 +86,7 @@ class OnboardingViewModel @Inject constructor(
         notificationsEnabled = enabled
     }
 
-    fun getOutput(): OnboardApp.Output = OnboardApp.Output(
+    fun getOutput() = OnboardApp.Output(
         url = manualUrl.value,
         authCode = authCode,
         deviceName = deviceName.value,

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -52,6 +52,8 @@ class OnboardingViewModel @Inject constructor(
     val deviceName = mutableStateOf("")
     val locationTrackingPossible = mutableStateOf(false)
     var locationTrackingEnabled by mutableStateOf(false)
+    val notificationsPossible = mutableStateOf(true)
+    var notificationsEnabled by mutableStateOf(false)
 
     fun onManualUrlUpdated(url: String) {
         manualUrl.value = url
@@ -79,6 +81,18 @@ class OnboardingViewModel @Inject constructor(
         }
         locationTrackingEnabled = enabled
     }
+
+    fun setNotifications(enabled: Boolean) {
+        notificationsEnabled = enabled
+    }
+
+    fun getOutput(): OnboardApp.Output = OnboardApp.Output(
+        url = manualUrl.value,
+        authCode = authCode,
+        deviceName = deviceName.value,
+        deviceTrackingEnabled = locationTrackingEnabled,
+        notificationsEnabled = notificationsEnabled
+    )
 
     override fun onCleared() {
         _homeAssistantSearcher.stopSearch()

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -20,9 +20,10 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
-import io.homeassistant.companion.android.onboarding.OnboardApp
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
+import io.homeassistant.companion.android.onboarding.notifications.NotificationPermissionFragment
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -151,14 +152,16 @@ class MobileAppIntegrationFragment : Fragment() {
     }
 
     private fun onComplete() {
-        val retData = OnboardApp.Output(
-            url = viewModel.manualUrl.value,
-            authCode = viewModel.authCode,
-            deviceName = viewModel.deviceName.value,
-            deviceTrackingEnabled = viewModel.locationTrackingEnabled
-        )
-        activity?.setResult(Activity.RESULT_OK, retData.toIntent())
-        activity?.finish()
+        if (viewModel.notificationsPossible.value != viewModel.notificationsEnabled) {
+            parentFragmentManager
+                .beginTransaction()
+                .replace(R.id.content, NotificationPermissionFragment::class.java, null)
+                .addToBackStack(null)
+                .commit()
+        } else { // Complete onboarding
+            activity?.setResult(Activity.RESULT_OK, viewModel.getOutput().toIntent())
+            activity?.finish()
+        }
     }
 
     private fun openPrivacyPolicy() {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
@@ -88,7 +88,7 @@ fun MobileAppIntegrationView(
             onClick = onFinishClicked,
             modifier = Modifier.align(Alignment.End)
         ) {
-            Text(stringResource(id = commonR.string.finish))
+            Text(stringResource(id = commonR.string.continue_connect))
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionFragment.kt
@@ -1,0 +1,84 @@
+package io.homeassistant.companion.android.onboarding.notifications
+
+import android.Manifest
+import android.app.Activity
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.app.NotificationManagerCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import io.homeassistant.companion.android.onboarding.OnboardingViewModel
+import io.homeassistant.companion.android.common.R as commonR
+
+class NotificationPermissionFragment : Fragment() {
+
+    companion object {
+        private const val TAG = "NotificationPermFrag"
+    }
+
+    private val viewModel by activityViewModels<OnboardingViewModel>()
+
+    private val permissionsRequest = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+        Log.i(TAG, "Notification permission was ${if (isGranted) "granted" else "not granted"}")
+        viewModel.setNotifications(isGranted)
+
+        if (isGranted) onComplete()
+        else showPermissionDeniedDialog()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MdcTheme {
+                    NotificationPermissionView(
+                        onSetNotificationsEnabled = ::setNotifications
+                    )
+                }
+            }
+        }
+    }
+
+    private fun setNotifications(enabled: Boolean) {
+        if (enabled) {
+            if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                !NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
+            ) {
+                permissionsRequest.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else {
+                viewModel.setNotifications(true)
+                onComplete()
+            }
+        } else {
+            viewModel.setNotifications(false)
+            onComplete()
+        }
+    }
+
+    private fun showPermissionDeniedDialog() {
+        AlertDialog.Builder(requireContext())
+            .setMessage(commonR.string.onboarding_notifications_denied)
+            .setPositiveButton(commonR.string.continue_connect) { _, _ ->
+                onComplete()
+            }
+            .setCancelable(false)
+            .show()
+    }
+
+    private fun onComplete() {
+        activity?.setResult(Activity.RESULT_OK, viewModel.getOutput().toIntent())
+        activity?.finish()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
@@ -1,0 +1,127 @@
+package io.homeassistant.companion.android.onboarding.notifications
+
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.google.android.material.composethemeadapter.MdcTheme
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.common.R as commonR
+
+@Composable
+fun NotificationPermissionView(
+    onSetNotificationsEnabled: (Boolean) -> Unit
+) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .fillMaxHeight()
+            .padding(16.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .scrollable(scrollState, Orientation.Vertical)
+                .fillMaxWidth()
+                .padding(top = 32.dp)
+                .weight(1f)
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Notifications,
+                contentDescription = stringResource(id = commonR.string.notifications),
+                tint = colorResource(id = commonR.color.colorAccent),
+                modifier = Modifier
+                    .size(48.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+            Text(
+                text = stringResource(id = commonR.string.notifications),
+                style = MaterialTheme.typography.h5,
+                modifier = Modifier
+                    .padding(vertical = 16.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+            Text(
+                text = stringResource(id = commonR.string.onboarding_notifications_subtitle),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(bottom = 48.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+            NotificationPermissionBullet(
+                icon = CommunityMaterial.Icon.cmd_alert_decagram,
+                text = stringResource(id = commonR.string.onboarding_notifications_bullet_alert)
+            )
+            NotificationPermissionBullet(
+                icon = CommunityMaterial.Icon3.cmd_text,
+                text = stringResource(id = commonR.string.onboarding_notifications_bullet_commands)
+            )
+        }
+        Row(modifier = Modifier.padding(top = 16.dp)) {
+            TextButton(onClick = { onSetNotificationsEnabled(false) }) {
+                Text(stringResource(id = commonR.string.skip))
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            Button(onClick = { onSetNotificationsEnabled(true) }) {
+                Text(stringResource(id = commonR.string.continue_connect))
+            }
+        }
+    }
+}
+
+@Composable
+fun NotificationPermissionBullet(
+    icon: IIcon,
+    text: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 12.dp)
+    ) {
+        Image(
+            asset = icon,
+            colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
+            contentDescription = null
+        )
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .fillMaxWidth()
+        )
+    }
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun NotificationPermissionViewPreview() {
+    MdcTheme {
+        NotificationPermissionView(
+            onSetNotificationsEnabled = {}
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
@@ -1,7 +1,5 @@
 package io.homeassistant.companion.android.onboarding.notifications
 
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -10,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
 import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
@@ -45,14 +44,14 @@ fun NotificationPermissionView(
     ) {
         Column(
             modifier = Modifier
-                .scrollable(scrollState, Orientation.Vertical)
+                .verticalScroll(scrollState)
                 .fillMaxWidth()
                 .padding(top = 32.dp)
                 .weight(1f)
         ) {
             Icon(
                 imageVector = Icons.Outlined.Notifications,
-                contentDescription = stringResource(id = commonR.string.notifications),
+                contentDescription = null,
                 tint = colorResource(id = commonR.color.colorAccent),
                 modifier = Modifier
                     .size(48.dp)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -18,6 +18,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.biometric.BiometricManager
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
@@ -71,6 +72,10 @@ class SettingsFragment constructor(
 
     private val requestBackgroundAccessResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         updateBackgroundAccessPref()
+    }
+
+    private val requestNotificationPermissionResult = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+        updateNotificationChannelPrefs()
     }
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
@@ -245,10 +250,17 @@ class SettingsFragment constructor(
             }
         }
 
+        updateNotificationChannelPrefs()
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            findPreference<Preference>("notification_permission")?.let {
+                it.setOnPreferenceClickListener {
+                    openNotificationSettings()
+                    return@setOnPreferenceClickListener true
+                }
+            }
+
             findPreference<Preference>("notification_channels")?.let { pref ->
-                val uiManager = requireContext().getSystemService<UiModeManager>()
-                pref.isVisible = uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
                 pref.setOnPreferenceClickListener {
                     parentFragmentManager
                         .beginTransaction()
@@ -516,6 +528,23 @@ class SettingsFragment constructor(
         }
     }
 
+    private fun updateNotificationChannelPrefs() {
+        val notificationsEnabled =
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.O ||
+                NotificationManagerCompat.from(requireContext()).areNotificationsEnabled()
+
+        findPreference<Preference>("notification_permission")?.let {
+            it.isVisible = !notificationsEnabled
+        }
+        findPreference<Preference>("notification_channels")?.let {
+            val uiManager = requireContext().getSystemService<UiModeManager>()
+            it.isVisible =
+                notificationsEnabled &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+                uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
+        }
+    }
+
     @SuppressLint("BatteryLife")
     private fun requestBackgroundAccess() {
         if (!isIgnoringBatteryOptimizations()) {
@@ -524,6 +553,16 @@ class SettingsFragment constructor(
                     Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
                     Uri.parse("package:${activity?.packageName}")
                 )
+            )
+        }
+    }
+
+    private fun openNotificationSettings() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            requestNotificationPermissionResult.launch(
+                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_APP_PACKAGE, requireContext().packageName)
+                }
             )
         }
     }

--- a/app/src/main/res/drawable/ic_notification_off.xml
+++ b/app/src/main/res/drawable/ic_notification_off.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="@color/colorAccent"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,18.69L7.84,6.14 5.27,3.49 4,4.76l2.8,2.8v0.01c-0.52,0.99 -0.8,2.16 -0.8,3.42v5l-2,2v1h13.73l2,2L21,19.72l-1,-1.03zM12,22c1.11,0 2,-0.89 2,-2h-4c0,1.11 0.89,2 2,2zM18,14.68L18,11c0,-3.08 -1.64,-5.64 -4.5,-6.32L13.5,4c0,-0.83 -0.67,-1.5 -1.5,-1.5s-1.5,0.67 -1.5,1.5v0.68c-0.15,0.03 -0.29,0.08 -0.42,0.12 -0.1,0.03 -0.2,0.07 -0.3,0.11h-0.01c-0.01,0 -0.01,0 -0.02,0.01 -0.23,0.09 -0.46,0.2 -0.68,0.31 0,0 -0.01,0 -0.01,0.01L18,14.68z"/>
+</vector>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -130,6 +130,12 @@
         android:key="notifications"
         app:isPreferenceVisible="false">
         <Preference
+            android:key="notification_permission"
+            android:title="@string/notification_permission"
+            android:summary="@string/notification_permission_summary"
+            app:isPreferenceVisible="false"
+            android:icon="@drawable/ic_notification_off" />
+        <Preference
             android:key="notification_channels"
             android:title="@string/notification_channels"
             android:summary="@string/notification_channels_summary"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -856,6 +856,8 @@
     <string name="websocket_notification_issues">Persistent Connection Issues</string>
     <string name="notification_channels">Notification Channels</string>
     <string name="notification_channels_summary">Manage all notification channels configured on the device. Channels control the behavior of its notifications including visibility and sound.</string>
+    <string name="notification_permission">Notification Permission</string>
+    <string name="notification_permission_summary">Home Assistant does not have permission to send you notifications. Click here to enable sending notifications.</string>
     <string name="info">Information</string>
     <string name="show_changelog">Show Change Log</string>
     <string name="show_changelog_summary">Show the change log dialog from when the app was updated</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -390,6 +390,10 @@
     <string name="notification_source">Notification Source</string>
     <string name="notifications">Notifications</string>
     <string name="ok">OK</string>
+    <string name="onboarding_notifications_denied">If you want to enable notifications in the future, you can change this in Settings.</string>
+    <string name="onboarding_notifications_bullet_alert">Get alerted from notifications</string>
+    <string name="onboarding_notifications_bullet_commands">Send commands to your device</string>
+    <string name="onboarding_notifications_subtitle">Enable notifications to create a notify service for your device</string>
     <string name="other_settings">Other Settings</string>
     <string name="other">Other</string>
     <string name="password">Password</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -114,6 +114,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
             val authCode = dataMap.getString("AuthCode", "")
             val deviceName = dataMap.getString("DeviceName")
             val deviceTrackingEnabled = dataMap.getBoolean("LocationTracking")
+            val notificationsEnabled = dataMap.getString("Notifications")
 
             urlRepository.saveUrl(url)
             authenticationRepository.registerAuthorizationCode(authCode)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR includes updates to handle the [notification changes in Android 13](https://developer.android.com/about/versions/13/changes/notification-permission). It will also change the app's target Android version to Android 13, as being able to request notification permission when we want instead of when Android decides to, requires targeting Android 13.

A new screen is added to onboarding that requests the user to grant the notification permission on Android 13+ or when using the minimal version, and the app settings have also been updated to check if notifications are enabled on Android 8+.  I've opted to show the screen in onboarding to minimal version users on _all_ Android versions; on Android 13 denying the notification permission will also turn off the websocket service, so to provide a consistent experience I believe it makes sense to show it on all versions.

Based on my testing disabling notifications doesn't produce any major issues, this behaves the same as if notifications were manually turned off on Android 12 (Android silently blocks them, the app doesn't really notice). 

<details>
<summary>There are a few notifications sent by the app that might be missed when the permission is denied. All of these notifications are for failures that will still be visible to the user, either because something isn't changing as expected or something breaks.</summary>

 - notification command received but the app is missing the required permission(s)
 - location disabled might result in degraded experience, on app startup
 - sensor sync from core tried to enable a sensor but the app is missing the required permission(s)
 - database migration failed
</details>

---

Targeting Android 13 also results in other behavior changes:

 - [x] External storage permission is no longer supported -> #2691
 - [x] Intent filter changes -> Wear dependency bumped in #2910, otherwise it doesn't impact the app much [as described in more detail here](https://github.com/home-assistant/android/pull/2901#issuecomment-1255538200)
 - [x] WebView [force dark changes](https://developer.android.com/about/versions/13/behavior-changes-13#webview-color-theme) -> #2923
 - [x] Turning Bluetooth on/off [is deprecated](https://developer.android.com/reference/kotlin/android/bluetooth/BluetoothAdapter?hl=en#enable) -> adjusted to post notification on Android 13 as invalid in 1d7d70b2d5be61116d712ac88fb95f11a568dd09

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|Permission screen in onboarding, shown after entering device name. This will be skipped when using the full version and on Android <13 or permission already granted.|![image](https://user-images.githubusercontent.com/8148535/179318627-8efac55d-b586-4f68-9724-7b6d18bfd8d8.png)|![image](https://user-images.githubusercontent.com/8148535/179318632-b31ef648-16db-4e9a-9527-566cdcd07e8b.png)|
|Tapping Continue will show the system's permission prompt.|![image](https://user-images.githubusercontent.com/8148535/179318684-d3d7c191-c573-4bbf-ae19-2a5da76c0aab.png)|![image](https://user-images.githubusercontent.com/8148535/179318693-3d5f7aab-7187-4474-9155-a12c3a2d8f83.png)|
|If the permission is denied, the app will inform you where you can change it|![image](https://user-images.githubusercontent.com/8148535/179318746-a8e70063-07ed-4c5e-b9bd-ace8d6d6f4f5.png)|![image](https://user-images.githubusercontent.com/8148535/179318750-8450ab89-76c1-4746-ad2f-20b7f85aafa3.png)|
|In the app's settings, the 'Notification Channels' setting will be replaced by the 'Notification Permission' setting if the permission is denied/all channels are turned off. Selecting it takes you to the system list of app notification channels where the permission can be granted/they can be turned on (on Android 8+).|![image](https://user-images.githubusercontent.com/8148535/179318832-df488c51-36da-470b-98a7-a9928b49f851.png)|![image](https://user-images.githubusercontent.com/8148535/179318841-186861c8-02cf-4c86-bff1-eb6ecdc9811c.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#831

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->