### PR TITLE
Deprecate Android WebView quick bar gesture support

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -245,7 +245,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         webView = binding.webview
         webView.apply {
-            // TODO This quick bar workaround only works on Home Assistant core versions up to 2022.7
+            // TODO This quick bar workaround only works on Home Assistant core versions <2022.7
             // If not 'fixed' or officially supported: should be removed in Android 2023.1 (GitHub: #2690)
             setOnTouchListener(object : OnSwipeListener() {
                 override fun onSwipe(

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -245,6 +245,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         webView = binding.webview
         webView.apply {
+            // TODO This quick bar workaround only works on Home Assistant core versions up to 2022.7
+            // If not 'fixed' or officially supported: should be removed in Android 2023.1 (GitHub: #2690)
             setOnTouchListener(object : OnSwipeListener() {
                 override fun onSwipe(
                     e1: MotionEvent,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A three finger swipe gesture was added as a workaround to open the quick bar while it was only possible with a physical keyboard; Home Assistant 2022.5 added a button for it to the toolbar and a later update broke support for the app's workaround (see [this comment](https://github.com/home-assistant/android/issues/2686#issuecomment-1186577056)). Because it is no longer functional on recent versions and an alternative is available, add a comment in the code to mark it for removal.

Closes #2686

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
The documentation is related but doesn't depend on this PR being merged to be true

Documentation: home-assistant/companion.home-assistant#777

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->