### PR TITLE
Remove external storage permission for logs, completely on Android 10+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,8 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.PACKAGE_USAGE_STATS"

--- a/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.settings.log
 
-import android.Manifest
 import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -15,10 +14,8 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import android.widget.Toast
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
-import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -50,33 +47,11 @@ class LogFragment : Fragment() {
     private var processLog = ""
     private var crashLog: String? = null
     private var currentLog = ""
-    private val requestPermission =
-        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
-            if (granted) {
-                shareLog()
-            }
-        }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             R.id.share_log -> {
-                val permission = Manifest.permission.WRITE_EXTERNAL_STORAGE
-                if (ContextCompat.checkSelfPermission(requireContext(), permission) == PackageManager.PERMISSION_DENIED) {
-                    Log.d(TAG, "Click on share logs without WRITE_EXTERNAL_STORAGE permission")
-                    AlertDialog.Builder(requireActivity())
-                        .setTitle(getString(commonR.string.share_logs))
-                        .setMessage(getString(commonR.string.share_logs_perm_message))
-                        .setPositiveButton(commonR.string.confirm_positive) { _, _ ->
-                            Log.i(TAG, "Request WRITE_EXTERNAL_STORAGE permission, to create log file")
-                            requestPermission.launch(permission)
-                        }
-                        .setNegativeButton(commonR.string.confirm_negative) { _, _ ->
-                            Log.w(TAG, "User cancel request for WRITE_EXTERNAL_STORAGE permission")
-                            // Do nothing
-                        }.show()
-                } else {
-                    shareLog()
-                }
+                shareLog()
                 return true
             }
             R.id.refresh_log -> {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -607,7 +607,6 @@
     <string name="setting_toast_label">Enable Toast Confirmation</string>
     <string name="settings">Settings</string>
     <string name="share_failed">Sharing with Home Assistant Failed!</string>
-    <string name="share_logs_perm_message">In order to prepare the logs for sharing, the app needs permissions to access the external storage. Otherwise the log cannot be shared.\n\nDo you want to continue?</string>
     <string name="share_logs_sens_message">Please note: By sharing the log, you could share sensitive data like location data or your Home Assistant URL.\n\nDo you want to continue?</string>
     <string name="share_logs">Share logs</string>
     <string name="share_success">Shared with Home Assistant</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When targeting Android 13, [the `WRITE_EXTERNAL_STORAGE` permission will stop working](https://developer.android.com/about/versions/13/behavior-changes-13#granular-media-permissions) (requesting it simply does nothing), which is currently used for saving the logs. Turns out it actually isn't required at all since Android 4.4 for the directory we're using according to the documentation! The permission request has been removed on Android 6 and above, still requesting it on Android 5 due to [a possible bug](https://issuetracker.google.com/issues/37013142) for some devices (the permission will automatically be granted on that version and it is still used for downloads in that case).

As a result, the `WRITE_EXTERNAL_STORAGE` permission is only required for devices on Android <10 to handle Downloads. The manifest has been updated to reflect this.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->