### PR TITLE
Breaking Change: Add friendly BT name next to the mac address if we have it

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Build
 import io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter
 import io.homeassistant.companion.android.bluetooth.ble.TransmitterManager
+import io.homeassistant.companion.android.common.bluetooth.BluetoothDevice
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils.supportsTransmitter
 import io.homeassistant.companion.android.common.sensors.SensorManager
@@ -135,9 +136,9 @@ class BluetoothSensorManager : SensorManager {
         if (checkPermission(context, bluetoothConnection.id)) {
 
             val bluetoothDevices = BluetoothUtils.getBluetoothDevices(context, true)
-            pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { "${it.address} (${it.name})" }
-            connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { "${it.address} (${it.name})" }
-            connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { "${it.address} (${it.name})" }
+            pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { checkNameAddress(it) }
+            connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { checkNameAddress(it) }
+            connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { checkNameAddress(it) }
             totalConnectedDevices = bluetoothDevices.count { b -> b.connected }
         }
         onSensorUpdated(
@@ -258,5 +259,9 @@ class BluetoothSensorManager : SensorManager {
                 "Supports transmitter" to supportsTransmitter(context)
             )
         )
+    }
+
+    private fun checkNameAddress(bt: BluetoothDevice): String {
+        return if (bt.address != bt.name) "${bt.address} (${bt.name})" else bt.address
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -40,7 +40,6 @@ class BluetoothSensorManager : SensorManager {
         private const val DEFAULT_MEASURED_POWER_AT_1M = -59
         private var priorBluetoothStateEnabled = false
 
-        // private const val TAG = "BluetoothSM"
         private var bleTransmitterDevice = IBeaconTransmitter("", "", "", transmitPowerSetting = "", measuredPowerSetting = 0, advertiseModeSetting = "", transmitting = false, state = "", restartRequired = false)
         val bluetoothConnection = SensorManager.BasicSensor(
             "bluetooth_connection",
@@ -136,10 +135,10 @@ class BluetoothSensorManager : SensorManager {
         if (checkPermission(context, bluetoothConnection.id)) {
 
             val bluetoothDevices = BluetoothUtils.getBluetoothDevices(context, true)
-            pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { it.address }
-            connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { it.address }
-            connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { it.address }
-            totalConnectedDevices = bluetoothDevices.filter { b -> b.connected }.count()
+            pairedDevices = bluetoothDevices.filter { b -> b.paired }.map { "${it.address} (${it.name})" }
+            connectedPairedDevices = bluetoothDevices.filter { b -> b.paired && b.connected }.map { "${it.address} (${it.name})" }
+            connectedNotPairedDevices = bluetoothDevices.filter { b -> !b.paired && b.connected }.map { "${it.address} (${it.name})" }
+            totalConnectedDevices = bluetoothDevices.count { b -> b.connected }
         }
         onSensorUpdated(
             context,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2696 

This is a breaking change because the friendly name will now be added to the Mac address if we have it, otherwise it will print the address again.

New format will be: `MAC (Name)`

Also cleaned up some warnings and removed a commented line

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/180288709-0408c2c6-0656-4eda-8899-36bd64268a99.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->