### PR TITLE
Automatically delete 'stale'/old widgets from database

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetConfigureActivity.kt
@@ -1,48 +1,16 @@
 package io.homeassistant.companion.android.widgets
 
 import android.appwidget.AppWidgetManager
-import android.content.Context
-import android.view.View
 import android.widget.Toast
-import androidx.lifecycle.lifecycleScope
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.database.widget.WidgetDao
-import kotlinx.coroutines.launch
 
 abstract class BaseWidgetConfigureActivity : BaseActivity() {
 
     protected var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
 
     abstract val dao: WidgetDao
-
-    protected val onDeleteWidget = View.OnClickListener { deleteConfirmation(it.context) }
-
-    private fun deleteConfirmation(context: Context) {
-        val builder: android.app.AlertDialog.Builder = android.app.AlertDialog.Builder(context)
-
-        builder.setTitle(R.string.confirm_delete_this_widget_title)
-        builder.setMessage(R.string.confirm_delete_this_widget_message)
-
-        builder.setPositiveButton(
-            R.string.confirm_positive
-        ) { dialog, _ ->
-            lifecycleScope.launch {
-                dao.delete(appWidgetId)
-                dialog.dismiss()
-                finish()
-            }
-        }
-
-        builder.setNegativeButton(
-            R.string.confirm_negative
-        ) { dialog, _ -> // Do nothing
-            dialog.dismiss()
-        }
-
-        val alert: android.app.AlertDialog? = builder.create()
-        alert?.show()
-    }
 
     protected fun showAddWidgetError() {
         Toast.makeText(applicationContext, R.string.widget_creation_error, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -223,8 +223,6 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity(), IconDialog.
                 buttonWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, commonR.color.colorWidgetButtonLabelBlack) } ?: false
 
             binding.addButton.setText(commonR.string.update_widget)
-            binding.deleteButton.visibility = VISIBLE
-            binding.deleteButton.setOnClickListener(onDeleteWidget)
         } else {
             binding.backgroundType.setSelection(0)
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.widgets.camera
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
@@ -84,10 +85,21 @@ class CameraWidget : AppWidgetProvider() {
 
     private fun updateAllWidgets(context: Context) {
         mainScope.launch {
-            val cameraWidgetList = cameraWidgetDao.getAll()
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val systemWidgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, CameraWidget::class.java))
+            val dbWidgetList = cameraWidgetDao.getAll()
+
+            val invalidWidgetIds = dbWidgetList
+                .filter { !systemWidgetIds.contains(it.id) }
+                .map { it.id }
+            if (invalidWidgetIds.isNotEmpty()) {
+                Log.i(TAG, "Found widgets $invalidWidgetIds in database, but not in AppWidgetManager - sending onDeleted")
+                onDeleted(context, invalidWidgetIds.toIntArray())
+            }
+
+            val cameraWidgetList = dbWidgetList.filter { systemWidgetIds.contains(it.id) }
             if (cameraWidgetList.isNotEmpty()) {
                 Log.d(TAG, "Updating all widgets")
-                val appWidgetManager = AppWidgetManager.getInstance(context)
                 for (item in cameraWidgetList) {
                     updateAppWidget(context, item.id, appWidgetManager)
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
@@ -98,8 +98,6 @@ class CameraWidgetConfigureActivity : BaseWidgetConfigureActivity() {
         if (cameraWidget != null) {
             binding.widgetTextConfigEntityId.setText(cameraWidget.entityId)
             binding.addButton.setText(commonR.string.update_widget)
-            binding.deleteButton.visibility = View.VISIBLE
-            binding.deleteButton.setOnClickListener(onDeleteWidget)
             val entity = runBlocking {
                 try {
                     integrationUseCase.getEntity(cameraWidget.entityId)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.widgets.entity
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
@@ -45,6 +46,9 @@ class EntityWidget : BaseWidgetProvider() {
 
     @Inject
     lateinit var staticWidgetDao: StaticWidgetDao
+
+    override fun getWidgetProvider(context: Context): ComponentName =
+        ComponentName(context, EntityWidget::class.java)
 
     override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>?): RemoteViews {
         val intent = Intent(context, EntityWidget::class.java).apply {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
@@ -166,8 +166,6 @@ class EntityWidgetConfigureActivity : BaseWidgetConfigureActivity() {
                 staticWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, commonR.color.colorWidgetButtonLabelBlack) } ?: false
 
             binding.addButton.setText(commonR.string.update_widget)
-            binding.deleteButton.visibility = VISIBLE
-            binding.deleteButton.setOnClickListener(onDeleteWidget)
         } else {
             binding.backgroundType.setSelection(0)
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.widgets.media_player_controls
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
@@ -70,6 +71,9 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
 
     @Inject
     lateinit var mediaPlayCtrlWidgetDao: MediaPlayerControlsWidgetDao
+
+    override fun getWidgetProvider(context: Context): ComponentName =
+        ComponentName(context, MediaPlayerControlsWidget::class.java)
 
     override fun onUpdate(
         context: Context,

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -143,8 +143,6 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
             if (entities != null)
                 selectedEntities.addAll(entities)
             binding.addButton.setText(commonR.string.update_widget)
-            binding.deleteButton.visibility = View.VISIBLE
-            binding.deleteButton.setOnClickListener(onDeleteWidget)
         }
         val entityAdapter = SingleItemArrayAdapter<Entity<Any>>(this) { it?.entityId ?: "" }
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.widgets.template
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
@@ -45,6 +46,9 @@ class TemplateWidget : BaseWidgetProvider() {
             templateWidgetDao.deleteAll(appWidgetIds)
         }
     }
+
+    override fun getWidgetProvider(context: Context): ComponentName =
+        ComponentName(context, TemplateWidget::class.java)
 
     override suspend fun getAllWidgetIds(context: Context): List<Int> {
         return templateWidgetDao.getAll().map { it.id }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -114,9 +114,6 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
                 templateWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, android.R.color.white) } ?: true
             binding.textColorBlack.isChecked =
                 templateWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, commonR.color.colorWidgetButtonLabelBlack) } ?: false
-
-            binding.deleteButton.visibility = View.VISIBLE
-            binding.deleteButton.setOnClickListener(onDeleteWidget)
         } else {
             binding.backgroundType.setSelection(0)
         }

--- a/app/src/main/res/layout/widget_button_configure.xml
+++ b/app/src/main/res/layout/widget_button_configure.xml
@@ -171,14 +171,5 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:visibility="gone"
-            android:text="@string/delete_widget" />
-
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_camera_configure.xml
+++ b/app/src/main/res/layout/widget_camera_configure.xml
@@ -46,14 +46,5 @@
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
 
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:visibility="gone"
-            android:text="@string/delete_widget" />
-
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -130,13 +130,5 @@
             android:layout_gravity="end"
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:visibility="gone"
-            android:text="@string/delete_widget" />
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_static_configure.xml
+++ b/app/src/main/res/layout/widget_static_configure.xml
@@ -235,15 +235,6 @@
             android:layout_gravity="end"
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:visibility="gone"
-            android:text="@string/delete_widget" />
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/widget_template_configure.xml
+++ b/app/src/main/res/layout/widget_template_configure.xml
@@ -118,15 +118,6 @@
             android:layout_gravity="end"
             android:layout_marginTop="8dp"
             android:text="@string/add_widget" />
-
-        <androidx.appcompat.widget.AppCompatButton
-            android:id="@+id/delete_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="8dp"
-            android:visibility="gone"
-            android:text="@string/delete_widget" />
     </LinearLayout>
 
 </androidx.core.widget.NestedScrollView>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -119,8 +119,6 @@
     <string name="confirm_delete_all_notification_title">Confirm deleting all notifications</string>
     <string name="confirm_delete_this_notification_message">Are you sure? This cannot be undone</string>
     <string name="confirm_delete_this_notification_title">Confirm deleting this notification</string>
-    <string name="confirm_delete_this_widget_message">Are you sure? This cannot be undone. If you accidentally deleted the wrong widget you will need to remove the bad widget from the home screen and create a new one.</string>
-    <string name="confirm_delete_this_widget_title">Confirm deleting this widget</string>
     <string name="confirm_negative">NO</string>
     <string name="confirm_positive">YES</string>
     <string name="continue_on_phone">Continue on your phone</string>
@@ -138,7 +136,6 @@
     <string name="delete_all_notifications">Delete all notifications from history</string>
     <string name="delete_shortcut">Delete Shortcut</string>
     <string name="delete_this_notification">Delete this notification from history</string>
-    <string name="delete_widget">Delete Widget</string>
     <string name="description">Description</string>
     <string name="details">Details</string>
     <string name="developer_tools">Developer Tools</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Automatically deletes widgets from the database that are no longer bound to the widget provider but that are still in the database when asked to update all widgets. This will remove unnecessary updates (and websocket connections!) due to 'stale'/old widgets that aren't exposed to the user. The PR also removes the "Delete widget" button on the widget configuration screen as it is no longer required.

No issue to link here, but "remove unused widgets from Settings > Companion app > Manage Widgets" has been a 'solution' for multiple issues in the past.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The "Delete widget" button has been removed when updating a widget:
|Light|Dark|
|-----|-----|
|![Settings for a template widget, with the only button being 'Update Widget' and no longer also including 'Delete Widget', light mode](https://user-images.githubusercontent.com/8148535/180604819-f2eb1b52-af0b-47e1-be71-8b4bc092b53c.png)|![Settings for a template widget, with the only button being 'Update Widget' and no longer also including 'Delete Widget', dark mode](https://user-images.githubusercontent.com/8148535/180604825-f49a2824-eedd-4060-89cb-8949a1387a07.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a, the documentation didn't mention the delete functionality

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing to make sure widgets aren't accidentally deleted: I've been running this code for a few hours now and tried several things to imitate running it for a longer period of time (manually triggering doze, killing the launcher, rebooting a few times).