### PR TITLE
Fix unwanted reordering of Last Update Sensor's Intent list when there are 10+ entries

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -73,6 +73,8 @@ class LastUpdateManager : SensorManager {
         }
         val intentSettings = allSettings.filter {
             it.name.startsWith(INTENT_SETTING_PREFIX)
+        }.sortedBy {
+            it.name.removeSuffix(":").substringAfterLast(':').toInt()
         }
         val isSequenceContinuous = intentSettings.withIndex().all { (index, setting) ->
             val ordinal = setting.name.removePrefix(INTENT_SETTING_PREFIX).removeSuffix(":").toInt()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary <!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2703

The Last Update Sensor's list of Intents was reordered on every update when there were 10+ entries. It was caused by the lexicographic ordering of numbers (contained in the `name` DB field). It was caused by the sequence continuity detection I added recently because I haven't tested it with more than 10 entries. 

I fixed it by sorting it ~~like it is displayed on the UI~~ numerically.

<!-- ## Screenshots -->
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

<!-- ## Link to pull request in Documentation repository -->
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
<!-- Documentation: home-assistant/companion.home-assistant# -->

<!-- ## Any other notes -->
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->