### PR TITLE
Use correct default value for update interval to avoid double registrations on cold start

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -132,7 +132,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         private var geofenceRegistered = false
 
         private var lastHighAccuracyMode = false
-        private var lastHighAccuracyUpdateInterval = DEFAULT_MINIMUM_ACCURACY
+        private var lastHighAccuracyUpdateInterval = DEFAULT_UPDATE_INTERVAL_HA_SECONDS
         private var forceHighAccuracyModeOn = false
         private var highAccuracyModeEnabled = false
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I noticed on a cold start that we did some weird double registration of location updates.

```
2022-07-25 08:53:47.589 32009-32109/? D/LocBroadcastReceiver: Registering for zone based location updates
2022-07-25 08:53:47.604 32009-32107/? D/LocBroadcastReceiver: Registering for location updates.
2022-07-25 08:53:47.616 32009-32108/? D/LocBroadcastReceiver: High accuracy mode parameters changed. Disable high accuracy mode.
2022-07-25 08:53:47.623 32009-32108/? D/LocBroadcastReceiver: Registering for location updates.
2022-07-25 08:53:47.624 32009-32108/? D/LocBroadcastReceiver: High accuracy mode geo parameters changed. Reconfigure zones.
2022-07-25 08:53:47.624 32009-32108/? D/LocBroadcastReceiver: Removing geofence location requests.
2022-07-25 08:53:47.624 32009-32108/? D/LocBroadcastReceiver: Registering for zone based location updates
```

Turns out we had the incorrect default starting value for update interval.  After setting a correct interval at least in my case I no longer see double registrations.

```
2022-07-25 08:54:28.440 32424-32461/io.homeassistant.companion.android.debug D/LocBroadcastReceiver: Registering for zone based location updates
2022-07-25 08:54:28.615 32424-32461/io.homeassistant.companion.android.debug D/LocBroadcastReceiver: Registering for location updates.
2022-07-25 08:54:28.822 32424-32424/io.homeassistant.companion.android.debug D/LocBroadcastReceiver: Received location update.
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

There may be more areas of improvement here and I am not sure if this is causing any issues but I dont think we should be doing double registrations like that.  