### PR TITLE
Improve discovery reliability for some devices

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -30,6 +30,7 @@ class OnboardingViewModel @Inject constructor(
 
     private val _homeAssistantSearcher = HomeAssistantSearcher(
         nsdManager = app.getSystemService()!!,
+        wifiManager = app.getSystemService(),
         onInstanceFound = { instance ->
             if (foundInstances.none { it.url == instance.url }) {
                 foundInstances.add(instance)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After complaining on Discord that discovery of Home Assistant instances on Android wasn't working for me most of the time, it turns out the solution was a quick search away. Some devices, most notably Google Pixels, require manually requesting a multicast lock in order for DNS-SD to work reliably (see [this comment](https://github.com/andriydruk/RxDNSSD/issues/38#issuecomment-392206040)). After including this change, it now works 100% of the time for me, hopefully also for others.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, discovery isn't a new interface

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->