### PR TITLE
Allow connected not paired devices to trigger high accuracy mode

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -409,7 +409,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         if (highAccuracyModeBTDevices.isNotEmpty()) {
             constraintsUsed = true
 
-            val bluetoothDevices = BluetoothUtils.getBluetoothDevices(latestContext)
+            val bluetoothDevices = BluetoothUtils.getBluetoothDevices(latestContext, true)
 
             // If any of the stored devices aren't a Bluetooth device address, try to match them to a device
             var updatedBtDeviceNames = false

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -288,7 +288,7 @@ class SensorDetailViewModel @Inject constructor(
             SensorSettingType.LIST ->
                 setting.entries
             SensorSettingType.LIST_BLUETOOTH ->
-                BluetoothUtils.getBluetoothDevices(getApplication()).map { it.address }
+                BluetoothUtils.getBluetoothDevices(getApplication(), true).map { it.address }
             else ->
                 emptyList()
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2726 

Can't think of a reason why we would want to exclude them, we did have quite a bit of code improvement here so might be why it was a quick switch :)

With this change I can now select my Mi Band 7 which is a connected but not paired device. One thing to keep in mind is that the device needs to be currently connected to select it in the list. Otherwise we don't know it exists. Paired devices will always show up.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant# Not sure if its completely necessary as the docs do not mention the device has to be paired.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->