### PR TITLE
Restart location updates if we detect too much time passed since last update

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -238,12 +238,14 @@ class LocationSensorManager : LocationSensorManagerBase() {
                     ((lastLocationReceived + (DEFAULT_LOCATION_MAX_WAIT_TIME * 2L)) < now)
                 ) {
                     Log.d(TAG, "Background location updates appear to have stopped, restarting location updates")
+                    isBackgroundLocationSetup = false
                     removeBackgroundUpdateRequests()
                 } else if (
                     highAccuracyModeEnabled &&
                     ((lastLocationReceived + (getHighAccuracyModeUpdateInterval().toLong() * 2000L)) < now)
                 ) {
                     Log.d(TAG, "High accuracy mode appears to have stopped, restarting high accuracy mode")
+                    isBackgroundLocationSetup = false
                     stopHighAccuracyService()
                 }
 
@@ -348,7 +350,6 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun stopHighAccuracyService() {
-        isBackgroundLocationSetup = false
         onSensorUpdated(
             latestContext,
             highAccuracyMode,
@@ -525,7 +526,6 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun removeBackgroundUpdateRequests() {
-        isBackgroundLocationSetup = false
         if (fusedLocationProviderClient != null) {
             Log.d(TAG, "Removing background location requests.")
             val backgroundIntent = getLocationUpdateIntent(false)

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -131,6 +131,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         private var isZoneLocationSetup = false
 
         private var lastLocationSend = 0L
+        private var lastLocationReceived = 0L
         private var lastUpdateLocation = ""
 
         private var geofenceRegistered = false
@@ -234,15 +235,15 @@ class LocationSensorManager : LocationSensorManagerBase() {
                 val now = System.currentTimeMillis()
                 if (
                     (!highAccuracyModeEnabled && isBackgroundLocationSetup) &&
-                    ((lastLocationSend + (DEFAULT_LOCATION_MAX_WAIT_TIME * 2)) < now)
+                    ((lastLocationReceived + (DEFAULT_LOCATION_MAX_WAIT_TIME * 2L)) < now)
                 ) {
                     Log.d(TAG, "Background location updates appear to have stopped, restarting location updates")
                     removeBackgroundUpdateRequests()
                 } else if (
                     highAccuracyModeEnabled &&
-                    ((lastLocationSend + (getHighAccuracyModeUpdateInterval() * 2000)) < now)
+                    ((lastLocationReceived + (getHighAccuracyModeUpdateInterval().toLong() * 2000L)) < now)
                 ) {
-                    Log.d(TAG, "Location updates with high accuracy mode appear to have stopped, restarting high accuracy mode")
+                    Log.d(TAG, "High accuracy mode appears to have stopped, restarting high accuracy mode")
                     stopHighAccuracyService()
                 }
 
@@ -587,6 +588,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
     private fun handleLocationUpdate(intent: Intent) {
         Log.d(TAG, "Received location update.")
+        lastLocationReceived = System.currentTimeMillis()
         LocationResult.extractResult(intent)?.lastLocation?.let { location ->
             val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
             val sensorSettings = sensorDao.getSettings(backgroundLocation.id)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Should hopefully fix #2681 and fix #2720 by evaluating how much time has passed since `lastLocationReceived`. If background location updates are supposed to be on we will check `lastLocationReceived` with the addition of double the max wait time. If high accuracy mode is on we will double the amount of time for the defined interval. If we detect too much time has passed we will stop services and start them again shortly thereafter.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->