### PR TITLE
Remove error message on null template

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearViewModel.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.android.gms.wearable.CapabilityClient
@@ -112,12 +113,13 @@ class SettingsWearViewModel @Inject constructor(
             viewModelScope.launch {
                 try {
                     templateTileContentRendered.value =
-                        integrationUseCase.renderTemplate(template, mapOf()) ?: getApplication<Application>().getString(
-                            commonR.string.template_error
-                        )
+                        integrationUseCase.renderTemplate(template, mapOf()).toString()
                 } catch (e: Exception) {
+                    Log.e(TAG, "Exception while rendering template", e)
+                    // JsonMappingException suggests that template is not a String (= error)
                     templateTileContentRendered.value = getApplication<Application>().getString(
-                        commonR.string.template_render_error
+                        if (e.cause is JsonMappingException) commonR.string.template_error
+                        else commonR.string.template_render_error
                     )
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -91,17 +91,12 @@ class TemplateWidget : BaseWidgetProvider() {
                 // Content
                 var renderedTemplate: String? = templateWidgetDao.get(appWidgetId)?.lastUpdate ?: "Loading"
                 try {
-                    renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf())
-                    if (renderedTemplate != null) {
-                        templateWidgetDao.updateTemplateWidgetLastUpdate(
-                            appWidgetId,
-                            renderedTemplate
-                        )
-                        setViewVisibility(R.id.widgetTemplateError, View.GONE)
-                    } else {
-                        Log.e(TAG, "Template returned null: ${widget.template}")
-                        setViewVisibility(R.id.widgetTemplateError, View.VISIBLE)
-                    }
+                    renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf()).toString()
+                    templateWidgetDao.updateTemplateWidgetLastUpdate(
+                        appWidgetId,
+                        renderedTemplate
+                    )
+                    setViewVisibility(R.id.widgetTemplateError, View.GONE)
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to render template: ${widget.template}", e)
                     setViewVisibility(R.id.widgetTemplateError, View.VISIBLE)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.text.Html.fromHtml
+import android.util.Log
 import android.view.View
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
@@ -16,6 +17,7 @@ import androidx.core.graphics.toColorInt
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -213,10 +215,15 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
             var enabled: Boolean
             withContext(Dispatchers.IO) {
                 try {
-                    templateText = integrationUseCase.renderTemplate(template, mapOf()) ?: getString(commonR.string.template_error)
+                    templateText = integrationUseCase.renderTemplate(template, mapOf()).toString()
                     enabled = true
                 } catch (e: Exception) {
-                    templateText = getString(commonR.string.template_render_error)
+                    Log.e(TAG, "Exception while rendering template", e)
+                    // JsonMappingException suggests that template is not a String (= error)
+                    templateText = getString(
+                        if (e.cause is JsonMappingException) commonR.string.template_error
+                        else commonR.string.template_render_error
+                    )
                     enabled = false
                 }
             }

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -73,7 +73,7 @@ class TemplateTile : TileService() {
             val renderedText = try {
                 integrationUseCase.renderTemplate(template, mapOf()).toString()
             } catch (e: Exception) {
-                Log.i("TemplateTile", "Exception while rendering template", e)
+                Log.e("TemplateTile", "Exception while rendering template", e)
                 // JsonMappingException suggests that template is not a String (= error)
                 if (e.cause is JsonMappingException) getString(commonR.string.template_error)
                 else getString(commonR.string.template_render_error)

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -11,6 +11,7 @@ import android.text.style.ForegroundColorSpan
 import android.text.style.RelativeSizeSpan
 import android.text.style.StyleSpan
 import android.text.style.UnderlineSpan
+import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
 import androidx.core.text.HtmlCompat.fromHtml
@@ -32,6 +33,7 @@ import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
 import androidx.wear.tiles.TimelineBuilders.Timeline
 import androidx.wear.tiles.TimelineBuilders.TimelineEntry
+import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
@@ -69,11 +71,12 @@ class TemplateTile : TileService() {
 
             val template = integrationUseCase.getTemplateTileContent()
             val renderedText = try {
-                integrationUseCase.renderTemplate(template, mapOf()) ?: getString(
-                    commonR.string.template_error
-                )
+                integrationUseCase.renderTemplate(template, mapOf()).toString()
             } catch (e: Exception) {
-                getString(commonR.string.template_render_error)
+                Log.i("TemplateTile", "Exception while rendering template", e)
+                // JsonMappingException suggests that template is not a String (= error)
+                if (e.cause is JsonMappingException) getString(commonR.string.template_error)
+                else getString(commonR.string.template_render_error)
             }
 
             Tile.Builder()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In #2653 it was discovered that templates can be valid and return `null`, and some simple changes were made to handle it.

This PR builds on it and addresses a comment [by another user](https://github.com/home-assistant/android/issues/2714#issuecomment-1200244780):

>> The app presents `null` as "Error in template".
>
> IMO, that message is not correct given the template is syntactically valid and doesn't throw an exception: `null` is a perfectly valid, if not intended, result here. If I didn't know this now, I'd have been going over the template for syntax errors and ripping my hair out wondering why I couldn't find any; `null` would tell me that it's working, just not giving me the info I want. That said, this could've already been hashed out elsewhere and decided on already so I end my comments on it here.

`null` will now be shown as "null" like in the frontend, and "Error in template" will only be shown if there is actually an error. If users want to avoid seeing "null" it can be handled in the template.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, template widget/tile hasn't visually changed

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
On error the server will give the app a response like this:

```
{"template": {"error": "TemplateSyntaxError: expected name or number"}}
```

Which throws:

<details>
<summary>A stacktrace</summary>

```
2022-07-30 21:28:26.642 32676-32715/io.homeassistant.companion.android.debug E/TemplateWidgetConfigAct: Exception while rendering template
    io.homeassistant.companion.android.common.data.integration.IntegrationException: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
        at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 14] (through reference chain: java.util.LinkedHashMap["template"])
        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.renderTemplate(IntegrationRepositoryImpl.kt:177)
        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$renderTemplate$1.invokeSuspend(Unknown Source:15)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
        at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
        at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
     Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`)
        at [Source: (okhttp3.ResponseBody$BomAwareReader); line: 1, column: 14] (through reference chain: java.util.LinkedHashMap["template"])
        at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1741)
        at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1515)
        at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1420)
        at com.fasterxml.jackson.databind.DeserializationContext.extractScalarFromObject(DeserializationContext.java:932)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:62)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:609)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:437)
        at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:32)
        at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
        at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2051)
        at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1459)
        at retrofit2.converter.jackson.JacksonResponseBodyConverter.convert(JacksonResponseBodyConverter.java:33)
        at retrofit2.converter.jackson.JacksonResponseBodyConverter.convert(JacksonResponseBodyConverter.java:23)
        at retrofit2.OkHttpCall.parseResponse(OkHttpCall.java:243)
        at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:153)
        at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637)
        at java.lang.Thread.run(Thread.java:1012)
```
</details>