### PR TITLE
Actually check the paired state instead of assuming it

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/BluetoothUtils.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.bluetooth
 
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.content.Context
@@ -7,6 +8,7 @@ import androidx.core.content.getSystemService
 import java.lang.reflect.Method
 
 object BluetoothUtils {
+    @SuppressLint("MissingPermission")
     fun getBluetoothDevices(context: Context, allowDuplicates: Boolean = false): List<BluetoothDevice> {
         val devices: MutableList<BluetoothDevice> = ArrayList()
 
@@ -26,7 +28,7 @@ object BluetoothUtils {
                         BluetoothDevice(
                             btDev.address,
                             name,
-                            true,
+                            btDev.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED,
                             isConnected(btDev)
                         )
                     )
@@ -39,7 +41,7 @@ object BluetoothUtils {
                         BluetoothDevice(
                             btDev.address,
                             name,
-                            false,
+                            btDev.bondState == android.bluetooth.BluetoothDevice.BOND_BONDED,
                             isConnected(btDev)
                         )
                     )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2736 by actually checking the bonded state. I am also suppressing the lint message as its not valid in our use case and makes the page look like it won't compile. The main app already requests the proper permission and its not necessary for the Wear app.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->