### PR TITLE
Make sure to fallback to background updates when disable is selected in high accuracy notification

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
@@ -17,6 +17,10 @@ class HighAccuracyLocationReceiver : BroadcastReceiver() {
                 {
                     HighAccuracyLocationService.stopService(context)
                     LocationSensorManager.setHighAccuracyModeSetting(context, false)
+                    LocationSensorManager.isBackgroundLocationSetup = false
+                    val locationIntent = Intent(context, LocationSensorManager::class.java)
+                    locationIntent.action = LocationSensorManager.ACTION_REQUEST_LOCATION_UPDATES
+                    context.sendBroadcast(locationIntent)
                 }
         }
     }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -123,7 +123,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         private var geofencingClient: GeofencingClient? = null
         private var fusedLocationProviderClient: FusedLocationProviderClient? = null
 
-        private var isBackgroundLocationSetup = false
+        var isBackgroundLocationSetup = false
         private var isZoneLocationSetup = false
 
         private var lastLocationSend = 0L


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed during testing of other PRs that the disable action button in the high accuracy notification only stops the service but it never registers for background updates again. This is not the case when high accuracy is automated either in app or controlled via notification command. As the user has location tracking enabled we should make sure to trigger background updates again when disable is selected.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->