### PR TITLE
Don't include session in backup/transfer

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -2,4 +2,5 @@
 <full-backup-content>
     <include domain="database" path="." />
     <include domain="sharedpref" path="." />
+    <exclude domain="sharedpref" path="session_0.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/backup_rules_android12.xml
+++ b/app/src/main/res/xml/backup_rules_android12.xml
@@ -3,9 +3,11 @@
     <cloud-backup>
         <include domain="database" path="." />
         <include domain="sharedpref" path="." />
+        <exclude domain="sharedpref" path="session_0.xml" />
     </cloud-backup>
     <device-transfer>
         <include domain="database" path="." />
         <include domain="sharedpref" path="." />
+        <exclude domain="sharedpref" path="session_0.xml" />
     </device-transfer>
 </data-extraction-rules>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/Theme.HomeAssistant"
-        android:fullBackupContent="@xml/backup_rules">
+        android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/backup_rules_android12">
         <!-- Start things like SensorWorker on device boot -->
         <receiver android:name=".sensors.SensorReceiver"
             android:exported="true">

--- a/wear/src/main/res/xml/backup_rules.xml
+++ b/wear/src/main/res/xml/backup_rules.xml
@@ -2,4 +2,5 @@
 <full-backup-content>
     <include domain="database" path="." />
     <include domain="sharedpref" path="." />
+    <exclude domain="sharedpref" path="session_0.xml" />
 </full-backup-content>

--- a/wear/src/main/res/xml/backup_rules_android12.xml
+++ b/wear/src/main/res/xml/backup_rules_android12.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules>
+    <cloud-backup>
+        <include domain="database" path="." />
+        <include domain="sharedpref" path="." />
+        <exclude domain="sharedpref" path="session_0.xml" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="database" path="." />
+        <include domain="sharedpref" path="." />
+        <exclude domain="sharedpref" path="session_0.xml" />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A user on Discord mentioned that [they were automatically logged in on a new device](https://discord.com/channels/330944238910963714/562408603345092636/1003940648157708288) which surprised them. Session data is device specific and shouldn't be restored or transferred, so this PR excludes session data from the automatic backup/transfer.

Not including the session data will also show onboarding on start, which prevents issues with re-using the mobile app integration registration.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->