### PR TITLE
Switch to non-deprecated method to get FCM token during registration resync

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/launch/LaunchPresenterImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/launch/LaunchPresenterImpl.kt
@@ -2,14 +2,13 @@ package io.homeassistant.companion.android.launch
 
 import android.content.Context
 import android.util.Log
-import com.google.android.gms.tasks.Tasks
-import com.google.firebase.iid.FirebaseInstanceId
 import dagger.hilt.android.qualifiers.ActivityContext
 import dagger.hilt.android.scopes.ActivityScoped
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.onboarding.getMessagingToken
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -26,7 +25,7 @@ class LaunchPresenterImpl @Inject constructor(
                     DeviceRegistration(
                         "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})",
                         null,
-                        Tasks.await(FirebaseInstanceId.getInstance().instanceId).token
+                        getMessagingToken()
                     )
                 )
             } catch (e: Exception) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Minor clean up to stop using a deprecated method and inappropriate blocking call. We already had a proper method in place so using that here.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->