### PR TITLE
Fix websocket stays subscribed after widget edit due to multiple instances

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.os.Bundle
 import android.util.Log
 import android.widget.RemoteViews
@@ -77,6 +78,11 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
                 }
                 updateAllWidgets(context)
                 if (getAllWidgetIds(context).isNotEmpty()) {
+                    context.applicationContext.registerReceiver(
+                        this@BaseWidgetProvider,
+                        IntentFilter(Intent.ACTION_SCREEN_OFF)
+                    )
+
                     entityUpdates = integrationUseCase.getEntityUpdates()
                     entityUpdates?.collect {
                         onEntityStateChanged(context, it)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -71,7 +71,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
 
     fun onScreenOn(context: Context) {
         mainScope = CoroutineScope(Dispatchers.Main + Job())
-        if (entityUpdates == null) {
+        if (!isSubscribed()) {
             mainScope.launch {
                 if (!integrationUseCase.isRegistered()) {
                     return@launch
@@ -84,6 +84,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
                     )
 
                     entityUpdates = integrationUseCase.getEntityUpdates()
+                    setSubscribed(entityUpdates != null)
                     entityUpdates?.collect {
                         onEntityStateChanged(context, it)
                     }
@@ -95,6 +96,7 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
     private fun onScreenOff() {
         mainScope.cancel()
         entityUpdates = null
+        setSubscribed(false)
     }
 
     private suspend fun updateAllWidgets(
@@ -131,6 +133,8 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
         }
     }
 
+    abstract fun isSubscribed(): Boolean
+    abstract fun setSubscribed(subscribed: Boolean)
     abstract fun getWidgetProvider(context: Context): ComponentName
     abstract suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>? = null): RemoteViews
     abstract suspend fun getAllWidgetIds(context: Context): List<Int>

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -42,10 +42,18 @@ class EntityWidget : BaseWidgetProvider() {
         internal const val EXTRA_TEXT_COLOR = "EXTRA_TEXT_COLOR"
 
         private data class ResolvedText(val text: CharSequence?, val exception: Boolean = false)
+
+        private var isSubscribed = false
     }
 
     @Inject
     lateinit var staticWidgetDao: StaticWidgetDao
+
+    override fun isSubscribed(): Boolean = isSubscribed
+
+    override fun setSubscribed(subscribed: Boolean) {
+        isSubscribed = subscribed
+    }
 
     override fun getWidgetProvider(context: Context): ComponentName =
         ComponentName(context, EntityWidget::class.java)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/media_player_controls/MediaPlayerControlsWidget.kt
@@ -64,6 +64,8 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
         internal const val EXTRA_SHOW_SKIP = "EXTRA_INCLUDE_SKIP"
         internal const val EXTRA_SHOW_SEEK = "EXTRA_INCLUDE_SEEK"
         internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
+
+        private var isSubscribed = false
     }
 
     @Inject
@@ -71,6 +73,12 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
 
     @Inject
     lateinit var mediaPlayCtrlWidgetDao: MediaPlayerControlsWidgetDao
+
+    override fun isSubscribed(): Boolean = isSubscribed
+
+    override fun setSubscribed(subscribed: Boolean) {
+        isSubscribed = subscribed
+    }
 
     override fun getWidgetProvider(context: Context): ComponentName =
         ComponentName(context, MediaPlayerControlsWidget::class.java)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -35,6 +35,8 @@ class TemplateWidget : BaseWidgetProvider() {
         internal const val EXTRA_TEXT_SIZE = "EXTRA_TEXT_SIZE"
         internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
         internal const val EXTRA_TEXT_COLOR = "EXTRA_TEXT_COLOR"
+
+        private var isSubscribed = false
     }
 
     @Inject
@@ -45,6 +47,12 @@ class TemplateWidget : BaseWidgetProvider() {
         mainScope.launch {
             templateWidgetDao.deleteAll(appWidgetIds)
         }
+    }
+
+    override fun isSubscribed(): Boolean = isSubscribed
+
+    override fun setSubscribed(subscribed: Boolean) {
+        isSubscribed = subscribed
     }
 
     override fun getWidgetProvider(context: Context): ComponentName =


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When a widget is added or edited, the system will send a broadcast to _a new instance_ of the widget class (this is easy to spot when debugging or adding additional logging). Because there is a websocket connection to keep widgets updated, we should use a singleton variable to only start a subscription in one of these instances + subscribe for screen off broadcasts in that instance. This will stop the connection from staying active after the screen is turned off due to multiple instances of the class listening and only one receiving screen off events.

When the screen is turned on, only one instance of the widget provider is needed to update all existing widgets and created by the [initial broadcast receiver in the app class](https://github.com/home-assistant/android/blob/90a9a27e5e371445f75481e7a93609528357d3ff/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt#L202-L214).

Fixes #2750

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
[Discussion](https://discord.com/channels/330944238910963714/377667559303938050/1004437013828751370)