### PR TITLE
Update geocode location sensor with location updates that are sent to HA

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -765,21 +765,21 @@ class LocationSensorManager : LocationSensorManagerBase() {
         lastLocationSend = now
         lastUpdateLocation = updateLocation.gps.contentToString()
 
-        val geoSensor = AppDatabase.getInstance(latestContext).sensorDao().getFull(GeocodeSensorManager.geocodedLocation.id)
         val geoSensorManager = SensorReceiver.MANAGERS.firstOrNull { it.getAvailableSensors(latestContext).any { s -> s.name == commonR.string.basic_sensor_name_geolocation } }
-
         ioScope.launch {
             try {
                 integrationUseCase.updateLocation(updateLocation)
                 Log.d(TAG, "Location update sent successfully")
 
                 // Update Geocoded Location Sensor if enabled and state has changed
+                geoSensorManager?.requestSensorUpdate(latestContext)
+                val geoSensor = AppDatabase.getInstance(latestContext).sensorDao().getFull(GeocodeSensorManager.geocodedLocation.id)
+
                 if (
                     geoSensor != null && geoSensor.sensor.enabled &&
-                    geoSensor.sensor.registered == true && geoSensorManager != null &&
+                    geoSensor.sensor.registered == true &&
                     geoSensor.sensor.state != geoSensor.sensor.lastSentState
                 ) {
-                    geoSensorManager.requestSensorUpdate(latestContext)
                     integrationUseCase.updateSensors(
                         arrayOf(geoSensor.toSensorRegistration(GeocodeSensorManager.geocodedLocation))
                     )

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -599,16 +599,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             if (location.accuracy > minAccuracy) {
                 Log.w(TAG, "Location accuracy didn't meet requirements, disregarding: $location")
             } else {
-                // Update GeoLocation Sensor (if enabled) with new Location
-                val geoSensorManager = SensorReceiver.MANAGERS.firstOrNull { it.getAvailableSensors(latestContext).any { s -> s.name == commonR.string.basic_sensor_name_geolocation } }
-                if (geoSensorManager != null) {
-                    if (geoSensorManager.isEnabled(latestContext, "geocoded_location")) {
-                        geoSensorManager.requestSensorUpdate(latestContext)
-                    } else {
-                        HighAccuracyLocationService.updateNotificationAddress(latestContext, location)
-                    }
-                }
-
+                HighAccuracyLocationService.updateNotificationAddress(latestContext, location)
                 // Send new location to Home Assistant
                 sendLocationUpdate(location)
             }
@@ -774,10 +765,25 @@ class LocationSensorManager : LocationSensorManagerBase() {
         lastLocationSend = now
         lastUpdateLocation = updateLocation.gps.contentToString()
 
+        val geoSensor = AppDatabase.getInstance(latestContext).sensorDao().getFull(GeocodeSensorManager.geocodedLocation.id)
+        val geoSensorManager = SensorReceiver.MANAGERS.firstOrNull { it.getAvailableSensors(latestContext).any { s -> s.name == commonR.string.basic_sensor_name_geolocation } }
+
         ioScope.launch {
             try {
                 integrationUseCase.updateLocation(updateLocation)
                 Log.d(TAG, "Location update sent successfully")
+
+                // Update Geocoded Location Sensor if enabled and state has changed
+                if (
+                    geoSensor != null && geoSensor.sensor.enabled &&
+                    geoSensor.sensor.registered == true && geoSensorManager != null &&
+                    geoSensor.sensor.state != geoSensor.sensor.lastSentState
+                ) {
+                    geoSensorManager.requestSensorUpdate(latestContext)
+                    integrationUseCase.updateSensors(
+                        arrayOf(geoSensor.toSensorRegistration(GeocodeSensorManager.geocodedLocation))
+                    )
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Could not update location.", e)
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
@@ -320,6 +320,31 @@ abstract class SensorReceiverBase : BroadcastReceiver() {
         integrationUseCase.registerSensor(reg)
     }
 
+    suspend fun updateSensor(
+        context: Context,
+        integrationUseCase: IntegrationRepository,
+        fullSensor: SensorWithAttributes?,
+        sensorManager: SensorManager?,
+        basicSensor: SensorManager.BasicSensor
+    ) {
+        sensorManager?.requestSensorUpdate(context)
+        if (
+            fullSensor != null && fullSensor.sensor.enabled &&
+            fullSensor.sensor.registered == true &&
+            (
+                fullSensor.sensor.state != fullSensor.sensor.lastSentState ||
+                    fullSensor.sensor.icon != fullSensor.sensor.lastSentIcon
+                )
+        ) {
+            integrationUseCase.updateSensors(arrayOf(fullSensor.toSensorRegistration(basicSensor)))
+            sensorDao.updateLastSentStateAndIcon(
+                basicSensor.id,
+                fullSensor.sensor.state,
+                fullSensor.sensor.icon
+            )
+        }
+    }
+
     private fun createNotificationChannel(context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val notificationManager = context.getSystemService<NotificationManager>() ?: return


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that we had some code to update the geocoded sensor but it only updated the DB and did not update HA. Moved the logic to only update the sensor if location is being sent to HA instead of when it was just received. Also only sending the state if it has changed since the last update so we don't send too many updates like in high accuracy mode.

As this sensor should be kept updated with location updates it made sense to only update this one sensor. Updating all sensors when high accuracy mode is on does not sound like something that would be battery friendly. Updating 1 sensor since we are awake and sending an update should have minimal impact.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->