### PR TITLE
Update Wear OS companion app packages

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -286,9 +286,13 @@ class SettingsFragment constructor(
         }
 
         val pm = requireContext().packageManager
-        val hasWearApp = pm.getLaunchIntentForPackage("com.google.android.wearable.app")
-        val hasSamsungApp = pm.getLaunchIntentForPackage("com.samsung.android.app.watchmanager")
-        findPreference<PreferenceCategory>("wear_category")?.isVisible = BuildConfig.FLAVOR == "full" && (hasWearApp != null || hasSamsungApp != null)
+        val wearCompanionApps = listOf(
+            "com.google.android.wearable.app",
+            "com.samsung.android.app.watchmanager",
+            "com.montblanc.summit.companion.android"
+        )
+        findPreference<PreferenceCategory>("wear_category")?.isVisible =
+            BuildConfig.FLAVOR == "full" && wearCompanionApps.any { pm.getLaunchIntentForPackage(it) != null }
         findPreference<Preference>("wear_settings")?.setOnPreferenceClickListener {
             startActivity(SettingsWearActivity.newInstance(requireContext()))
             return@setOnPreferenceClickListener true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Wear OS 3 devices use a dedicated companion app instead of one app by Google (like Wear OS 1/2). Due to how the HA app is setup, it only queries for packages at first to show the settings item. This PR updates the list of packages for the first non-Samsung, very expensive Wear OS 3 smartwatch.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->