### PR TITLE
Fix potential client certificate crashes

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.data.keychain
 
 import android.content.Context
 import android.security.KeyChain
+import android.util.Log
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -12,6 +13,10 @@ import javax.inject.Inject
 class KeyChainRepositoryImpl @Inject constructor(
     private val prefsRepository: PrefsRepository
 ) : KeyChainRepository {
+
+    companion object {
+        private const val TAG = "KeyChainRepository"
+    }
 
     private var alias: String? = null
     private var key: PrivateKey? = null
@@ -51,10 +56,20 @@ class KeyChainRepositoryImpl @Inject constructor(
     private fun doLoad(context: Context) {
         if (alias != null && alias?.isNotEmpty() == true) {
             if (chain == null) {
-                chain = KeyChain.getCertificateChain(context, alias!!)
+                chain = try {
+                    KeyChain.getCertificateChain(context, alias!!)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Exception getting certificate chain", e)
+                    null
+                }
             }
             if (key == null) {
-                key = KeyChain.getPrivateKey(context, alias!!)
+                key = try {
+                    KeyChain.getPrivateKey(context, alias!!)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Exception getting private key", e)
+                    null
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2707 by returning `null` when unable to load the certificate chain or private key. This will result in a system prompt to select a valid, available certificate that is installed, instead of a crash. The error will also be logged.

Both of these functions specify `throws InterruptedException, KeyChainException`. Although I wasn't able to manually trigger them for testing purposes (the system returned `null` each time), the linked issue suggests it can happen.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->