### PR TITLE
Only change channel if variable actually provided

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -131,6 +131,7 @@ class MessagingManager @Inject constructor(
         const val PACKAGE_NAME = "package_name"
         const val COMMAND = "command"
         const val TTS_TEXT = "tts_text"
+        const val CHANNEL = "channel"
 
         // special intent constants
         const val INTENT_PACKAGE_NAME = "intent_package_name"
@@ -291,9 +292,9 @@ class MessagingManager @Inject constructor(
                 Log.d(TAG, "Clearing notification with tag: ${jsonData["tag"]}")
                 clearNotification(jsonData["tag"]!!)
             }
-            jsonData[MESSAGE] == REMOVE_CHANNEL && !jsonData["channel"].isNullOrBlank() -> {
-                Log.d(TAG, "Removing Notification channel ${jsonData["channel"]}")
-                removeNotificationChannel(jsonData["channel"]!!)
+            jsonData[MESSAGE] == REMOVE_CHANNEL && !jsonData[CHANNEL].isNullOrBlank() -> {
+                Log.d(TAG, "Removing Notification channel ${jsonData[CHANNEL]}")
+                removeNotificationChannel(jsonData[CHANNEL]!!)
             }
             jsonData[MESSAGE] == TTS -> {
                 Log.d(TAG, "Sending notification title to TTS")
@@ -1117,7 +1118,7 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        if (data["channel"] == ALARM_STREAM) {
+        if (data[CHANNEL] == ALARM_STREAM) {
             builder.setCategory(Notification.CATEGORY_ALARM)
             builder.setSound(
                 RingtoneManager.getActualDefaultRingtoneUri(
@@ -1571,9 +1572,9 @@ class MessagingManager @Inject constructor(
         var channelID = generalChannel
         var channelName = "General"
 
-        if (data.containsKey("channel")) {
-            channelID = createChannelID(data["channel"].toString())
-            channelName = data["channel"].toString().trim()
+        if (!data[CHANNEL].isNullOrEmpty()) {
+            channelID = createChannelID(data[CHANNEL].toString())
+            channelName = data[CHANNEL].toString().trim()
         }
 
         // Since android Oreo notification channel is needed.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry crash that is reproduced by sending `channel: ""` as part of a notification. We now default to `General` if the string is not provided or blank.

```
java.lang.IllegalArgumentException: null
    at android.os.Parcel.createExceptionOrNull(Parcel.java:3027)
    at android.os.Parcel.createException(Parcel.java:3007)
    at android.os.Parcel.readException(Parcel.java:2990)
    at android.os.Parcel.readException(Parcel.java:2932)
    at android.app.INotificationManager$Stub$Proxy.createNotificationChannels(INotificationManager.java:4397)
    at android.app.NotificationManager.createNotificationChannels(NotificationManager.java:960)
    at android.app.NotificationManager.createNotificationChannel(NotificationManager.java:948)
    at androidx.core.app.NotificationManagerCompat.createNotificationChannel(NotificationManagerCompat.java:291)
    at io.homeassistant.companion.android.notifications.MessagingManager.handleChannel(MessagingManager.kt:1562)
    at io.homeassistant.companion.android.notifications.MessagingManager.sendNotification(MessagingManager.kt:923)
    at io.homeassistant.companion.android.notifications.MessagingManager.access$sendNotification(MessagingManager.kt:87)
    at io.homeassistant.companion.android.notifications.MessagingManager$handleMessage$16.invokeSuspend(MessagingManager.kt:504)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at android.app.ActivityThread.main(ActivityThread.java:8650)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:570)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->