### PR TITLE
Fix unable to Toast on QS tiles being clicked error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Icon
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import android.util.Log
@@ -151,7 +149,7 @@ abstract class TileExtensions : TileService() {
                     Log.d(TAG, "Service call sent for tile ID: $tileId")
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to call service for tile ID: $tileId", e)
-                    Handler(Looper.getMainLooper()).post {
+                    withContext(Dispatchers.Main) {
                         Toast.makeText(
                             context,
                             commonR.string.service_call_failure,
@@ -167,7 +165,7 @@ abstract class TileExtensions : TileService() {
             tile.state = Tile.STATE_UNAVAILABLE
             tile.updateTile()
             Log.d(TAG, "No tile data found for tile ID: $tileId")
-            Handler(Looper.getMainLooper()).post {
+            withContext(Dispatchers.Main) {
                 Toast.makeText(
                     context,
                     commonR.string.tile_data_missing,

--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.Icon
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.service.quicksettings.Tile
 import android.service.quicksettings.TileService
 import android.util.Log
@@ -149,8 +151,14 @@ abstract class TileExtensions : TileService() {
                     Log.d(TAG, "Service call sent for tile ID: $tileId")
                 } catch (e: Exception) {
                     Log.e(TAG, "Unable to call service for tile ID: $tileId", e)
-                    Toast.makeText(context, commonR.string.service_call_failure, Toast.LENGTH_SHORT)
-                        .show()
+                    Handler(Looper.getMainLooper()).post {
+                        Toast.makeText(
+                            context,
+                            commonR.string.service_call_failure,
+                            Toast.LENGTH_SHORT
+                        )
+                            .show()
+                    }
                 }
             }
             tile.state = Tile.STATE_INACTIVE
@@ -159,7 +167,14 @@ abstract class TileExtensions : TileService() {
             tile.state = Tile.STATE_UNAVAILABLE
             tile.updateTile()
             Log.d(TAG, "No tile data found for tile ID: $tileId")
-            Toast.makeText(context, commonR.string.tile_data_missing, Toast.LENGTH_SHORT).show()
+            Handler(Looper.getMainLooper()).post {
+                Toast.makeText(
+                    context,
+                    commonR.string.tile_data_missing,
+                    Toast.LENGTH_SHORT
+                )
+                    .show()
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the following sentry errors:

```
java.lang.NullPointerException: Can't toast on a thread that has not called Looper.prepare()
    at com.android.internal.util.Preconditions.checkNotNull(Preconditions.java:167)
    at android.widget.Toast.getLooper(Toast.java:265)
    at android.widget.Toast.<init>(Toast.java:250)
    at android.widget.Toast.makeText(Toast.java:865)
    at android.widget.Toast.makeText(Toast.java:853)
    at android.widget.Toast.makeText(Toast.java:892)
    at io.homeassistant.companion.android.qs.TileExtensions$tileClicked$2.invokeSuspend(TileExtensions.kt:152)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```

and

```
java.lang.RuntimeException: Can't toast on a thread that has not called Looper.prepare()
    at android.widget.Toast$TN.<init>(Toast.java:474)
    at android.widget.Toast.<init>(Toast.java:142)
    at android.widget.Toast.makeText(Toast.java:333)
    at android.widget.Toast.makeText(Toast.java:323)
    at android.widget.Toast.makeText(Toast.java:370)
    at io.homeassistant.companion.android.qs.TileExtensions$tileClicked$2.invokeSuspend(TileExtensions.kt:152)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->