### PR TITLE
Use OkHttpClient to download notification videos

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -79,6 +79,8 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
+import java.io.File
+import java.io.FileOutputStream
 import java.net.URL
 import java.net.URLDecoder
 import java.util.Locale
@@ -1394,17 +1396,29 @@ class MessagingManager @Inject constructor(
             Dispatchers.IO
         ) {
             url ?: return@withContext null
+            val videoFile = File(context.applicationContext.cacheDir.absolutePath + "/notifications/video-${System.currentTimeMillis()}")
             val processingFrames = mutableListOf<Deferred<Bitmap?>>()
 
             try {
                 MediaMetadataRetriever().let { mediaRetriever ->
+                    val request = Request.Builder().apply {
+                        url(url)
+                        if (requiresAuth) {
+                            addHeader("Authorization", authenticationUseCase.buildBearerToken())
+                        }
+                    }.build()
+                    val response = okHttpClient.newCall(request).execute()
 
-                    if (requiresAuth) {
-                        mediaRetriever.setDataSource(url.toString(), mapOf("Authorization" to authenticationUseCase.buildBearerToken()))
-                    } else {
-                        mediaRetriever.setDataSource(url.toString(), hashMapOf())
+                    if (!videoFile.exists()) {
+                        videoFile.parentFile?.mkdirs()
+                        videoFile.createNewFile()
                     }
+                    FileOutputStream(videoFile).use { output ->
+                        response.body?.byteStream()?.copyTo(output)
+                    }
+                    response.close()
 
+                    mediaRetriever.setDataSource(videoFile.absolutePath)
                     val durationInMicroSeconds = ((mediaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: VIDEO_GUESS_MILLISECONDS)) * 1000
 
                     // Start at 100 milliseconds and get frames every 2 seconds until reaching the end
@@ -1426,7 +1440,9 @@ class MessagingManager @Inject constructor(
                 Log.e(TAG, "Couldn't download video for notification", e)
             }
 
-            return@withContext processingFrames.awaitAll().filterNotNull()
+            val frames = processingFrames.awaitAll().filterNotNull()
+            videoFile.delete()
+            return@withContext frames
         }
 
     private fun Bitmap.getCompressedFrame(): Bitmap? {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes downloading notification videos from servers that have enabled TLS client certificate authentication, [a bug reported in a comment on a related bug here](https://github.com/home-assistant/android/issues/2706#issuecomment-1207245382).

The app will now handle the downloading so that it is possible to provide the necessary authentication, instead of asking the system to do it. The file is removed as soon as the frames are extracted.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, notifications will show videos again instead of not including them

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
cc @Rogue136198, as you reported this bug I'd appreciate it if you could also verify that the change works