### PR TITLE
Fix opening my.home-assistant.io links

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/my/MyActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/my/MyActivity.kt
@@ -7,18 +7,13 @@ import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
+import android.webkit.WebViewClient
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.BuildConfig
-import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.databinding.ActivityMyBinding
-import io.homeassistant.companion.android.util.TLSWebViewClient
 import io.homeassistant.companion.android.webview.WebViewActivity
-import javax.inject.Inject
 
 class MyActivity : BaseActivity() {
-
-    @Inject
-    lateinit var keyChainRepository: KeyChainRepository
 
     companion object {
         val EXTRA_URI = "EXTRA_URI"
@@ -50,7 +45,7 @@ class MyActivity : BaseActivity() {
 
             binding.webview.apply {
                 settings.javaScriptEnabled = true
-                webViewClient = object : TLSWebViewClient(keyChainRepository) {
+                webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(
                         view: WebView?,
                         request: WebResourceRequest?


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #2778 by going back to the default webview instead of the app's version. my.home-assistant.io doesn't need certificate authentication so instead of adding `@AndroidEntryPoint`, it is better to remove the dependency to keep this as fast as possible.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->