### PR TITLE
Handle foreground service restrictions for persistent connection

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
@@ -5,6 +5,8 @@ import android.content.res.Configuration
 import android.os.Build
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -20,13 +22,16 @@ import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.util.websocketChannel
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import io.homeassistant.companion.android.util.compose.HaAlertWarning
 import io.homeassistant.companion.android.util.compose.InfoNotification
 import io.homeassistant.companion.android.util.compose.RadioButtonRow
 
 @Composable
 fun WebsocketSettingView(
     websocketSetting: WebsocketSetting,
-    onSettingChanged: (WebsocketSetting) -> Unit
+    unrestrictedBackgroundAccess: Boolean,
+    onSettingChanged: (WebsocketSetting) -> Unit,
+    onBackgroundAccessTapped: () -> Unit
 ) {
     val scrollState = rememberScrollState()
     val context = LocalContext.current
@@ -36,6 +41,14 @@ fun WebsocketSettingView(
                 text = stringResource(R.string.websocket_setting_description),
                 modifier = Modifier.padding(bottom = 16.dp)
             )
+            if (!unrestrictedBackgroundAccess && websocketSetting != WebsocketSetting.NEVER) {
+                HaAlertWarning(
+                    message = stringResource(R.string.websocket_notification_backgroundaccess),
+                    action = stringResource(R.string.allow),
+                    onActionClicked = onBackgroundAccessTapped
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
             Divider()
             RadioButtonRow(
                 text = stringResource(if (BuildConfig.FLAVOR == "full") R.string.websocket_setting_never else R.string.websocket_setting_never_minimal),

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/HaAlert.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/HaAlert.kt
@@ -1,0 +1,46 @@
+package io.homeassistant.companion.android.util.compose
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.R as commonR
+
+@Composable
+fun HaAlertWarning(
+    message: String,
+    action: String?,
+    onActionClicked: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(colorResource(commonR.color.colorAlertWarning), MaterialTheme.shapes.medium)
+            .padding(all = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = message,
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = if (action != null) 8.dp else 0.dp)
+        )
+        if (action != null) {
+            TextButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = colorResource(commonR.color.colorOnAlertWarning)),
+                onClick = onActionClicked
+            ) {
+                Text(action)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -27,6 +27,7 @@ import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.util.websocketChannel
+import io.homeassistant.companion.android.common.util.websocketIssuesChannel
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
 import io.homeassistant.companion.android.notifications.MessagingManager
@@ -37,6 +38,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.lang.IllegalStateException
 import java.util.concurrent.TimeUnit
 
 class WebsocketManager(
@@ -48,6 +50,7 @@ class WebsocketManager(
         private const val TAG = "WebSockManager"
         private const val SOURCE = "Websocket"
         private const val NOTIFICATION_ID = 65423
+        private const val NOTIFICATION_RESTRICTED_ID = 65424
         private val DEFAULT_WEBSOCKET_SETTING = if (BuildConfig.FLAVOR == "full") WebsocketSetting.NEVER else WebsocketSetting.ALWAYS
 
         fun start(context: Context) {
@@ -99,7 +102,7 @@ class WebsocketManager(
         }
 
         Log.d(TAG, "Starting to listen to Websocket")
-        createNotification()
+        if (!createNotification()) return@withContext Result.success()
 
         // Start listening for notifications
         val job = launch { collectNotifications() }
@@ -163,7 +166,12 @@ class WebsocketManager(
         }
     }
 
-    private suspend fun createNotification() {
+    /**
+     * Create a notification to start the service as a foreground service.
+     *
+     * @return `true` if the foreground service was started
+     */
+    private suspend fun createNotification(): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             var notificationChannel =
                 notificationManager.getNotificationChannel(websocketChannel)
@@ -210,6 +218,31 @@ class WebsocketManager(
                 settingPendingIntent
             )
             .build()
-        setForeground(ForegroundInfo(NOTIFICATION_ID, notification))
+        return try {
+            setForeground(ForegroundInfo(NOTIFICATION_ID, notification))
+            true
+        } catch (e: IllegalStateException) {
+            Log.e(TAG, "Unable to setForeground due to restrictions", e)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                if (notificationManager.getNotificationChannel(websocketIssuesChannel) == null) {
+                    val restrictedNotificationChannel = NotificationChannel(
+                        websocketIssuesChannel,
+                        applicationContext.getString(R.string.websocket_notification_issues),
+                        NotificationManager.IMPORTANCE_DEFAULT
+                    )
+                    notificationManager.createNotificationChannel(restrictedNotificationChannel)
+                }
+            }
+            val restrictedNotification = NotificationCompat.Builder(applicationContext, websocketIssuesChannel)
+                .setSmallIcon(R.drawable.ic_stat_ic_notification)
+                .setContentTitle(applicationContext.getString(R.string.websocket_restricted_title))
+                .setContentText(applicationContext.getString(R.string.websocket_restricted_fix))
+                .setContentIntent(settingPendingIntent)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setAutoCancel(true)
+                .build()
+            notificationManager.notify(NOTIFICATION_RESTRICTED_ID, restrictedNotification)
+            false
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -101,10 +101,12 @@ class WebsocketManager(
             return@withContext Result.success()
         }
 
-        Log.d(TAG, "Starting to listen to Websocket")
-        if (!createNotification()) return@withContext Result.success()
+        if (!createNotification()) {
+            return@withContext Result.success()
+        }
 
         // Start listening for notifications
+        Log.d(TAG, "Starting to listen to Websocket")
         val job = launch { collectNotifications() }
 
         // play ping pong to ensure we have a connection.

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.util
 const val sensorWorkerChannel = "Sensor Worker"
 const val sensorCoreSyncChannel = "Sensor Sync"
 const val websocketChannel = "Websocket"
+const val websocketIssuesChannel = "Websocket Issues"
 const val highAccuracyChannel = "High accuracy location"
 const val databaseChannel = "App Database"
 const val locationDisabledChannel = "Location disabled"
@@ -13,6 +14,7 @@ val appCreatedChannels = listOf(
     sensorWorkerChannel,
     sensorCoreSyncChannel,
     websocketChannel,
+    websocketIssuesChannel,
     highAccuracyChannel,
     databaseChannel,
     locationDisabledChannel,

--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -25,4 +25,6 @@
     <color name="colorActionBarPopupBackground">@android:color/white</color>
     <color name="colorLaunchScreenBackground">#fafafa</color>
     <color name="colorCodeBackground">#f5f5f5</color>
+    <color name="colorAlertWarning">#1fffa600</color>
+    <color name="colorOnAlertWarning">#ffa600</color>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="add_ssid_name_suggestion">Add %1$s</string>
     <string name="add_widget">Add widget</string>
     <string name="all_entities">All entities</string>
+    <string name="allow">Allow</string>
     <string name="app_name">Home Assistant</string>
     <string name="app_version_info">App Version Info</string>
     <string name="application_version">Application Version</string>
@@ -748,6 +749,8 @@
     <string name="wear_set_favorites">Select your favorite entities to appear at the top of the Wear home screen. You can also drag and drop to change the order in which they appear.</string>
     <string name="wear_settings">Wear Device Settings</string>
     <string name="websocket_listening">Connected to Home Assistant</string>
+    <string name="websocket_restricted_title">Unable to open connection to Home Assistant</string>
+    <string name="websocket_restricted_fix">Update settings to fix or disable</string>
     <string name="webview_error_AUTH_SCHEME">Unsupported authentication scheme (not basic or digest), please check network settings.</string>
     <string name="webview_error_AUTHENTICATION">User authentication failed on server, please check server settings.</string>
     <string name="webview_error_description">Encountered error :</string>
@@ -829,7 +832,9 @@
     <string name="websocket_setting_always">Always</string>
     <string name="websocket_setting_always_minimal">Always\n\nRequired to always receive notifications</string>
     <string name="websocket_persistent_notification">In order to maintain the persistent connection the app will need to create a persistent notification. You may use the button below to manage the appearance of this notification. It is recommended to minimize the notification to hide the icon.</string>
+    <string name="websocket_notification_backgroundaccess">To reliably connect your server, allow Home Assistant to keep running in the background.</string>
     <string name="websocket_notification_channel">Manage Persistent Connection Notification</string>
+    <string name="websocket_notification_issues">Persistent Connection Issues</string>
     <string name="notification_channels">Notification Channels</string>
     <string name="notification_channels_summary">Manage all notification channels configured on the device. Channels control the behavior of its notifications including visibility and sound.</string>
     <string name="info">Information</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Resolves #2164, part 1: Persistent Connection.

When trying to start the `WebsocketManager` as a foreground service, catch a `ForegroundServiceStartNotAllowedException` that may be thrown due to restrictions and show the user a notification to fix it. Tapping it will open the settings in the app, where a new alert is shown when the websocket is enabled but the app is not exempt from background restrictions (same colors as frontend alerts).

While the connection can technically be established without being a foreground service, it is unreliable so to offer a good experience it will stop trying to set up a connection when this exception is caught.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Example of notification posted:
![A notification titled 'Unable to open connection to Home Assistant', with the text 'Update settings to fix or disable'](https://user-images.githubusercontent.com/8148535/184238415-f1aaf84e-34f9-479e-bd0b-864839630ff4.png)

Updated settings screen:
|Light|Dark|
|-----|-----|
|![The Persistent Connection settings screen, showing an alert on a yellow background with the text 'To reliably connect your server, allow Home Assistant to keep running in the background.', and a button titled 'Allow'. Light mode.](https://user-images.githubusercontent.com/8148535/184238683-6c74aade-b375-4519-b031-ef797814a2a7.png)|![The Persistent Connection settings screen, showing an alert on a yellow background with the text 'To reliably connect your server, allow Home Assistant to keep running in the background.', and a button titled 'Allow'. Dark mode.](https://user-images.githubusercontent.com/8148535/184238698-c36c084a-bdf9-4a63-82ad-e912667c23a5.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Part 2 will be a smaller change to [check the battery restriction status in the `SensorWorker` on Android 12 before starting](https://github.com/home-assistant/android/issues/2164#issuecomment-1212371722), instead of always trying to run it as a foreground service. I'm not including it in this PR to keep the review easier.