### PR TITLE
Don't attempt to unsubscribe from event when the ID is null

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -198,20 +198,17 @@ class WebSocketRepositoryImpl @Inject constructor(
                 eventSubscriptionFlow[eventType] = callbackFlow<T> {
                     eventSubscriptionProducerScope[eventType] = this as ProducerScope<Any>
                     awaitClose {
-                        if (lastResponseID[eventType] == null) {
-                            eventSubscriptionProducerScope.remove(eventType)
-                            eventSubscriptionFlow.remove(eventType)
-                            return@awaitClose
-                        }
-                        Log.d(TAG, "Unsubscribing from $eventType")
-                        ioScope.launch {
-                            sendMessage(
-                                mapOf(
-                                    "type" to "unsubscribe_events",
-                                    "subscription" to lastResponseID[eventType]!!
+                        if (lastResponseID[eventType] != null) {
+                            Log.d(TAG, "Unsubscribing from $eventType")
+                            ioScope.launch {
+                                sendMessage(
+                                    mapOf(
+                                        "type" to "unsubscribe_events",
+                                        "subscription" to lastResponseID[eventType]
+                                    )
                                 )
-                            )
-                            lastResponseID.remove(eventType)
+                                lastResponseID.remove(eventType)
+                            }
                         }
                         eventSubscriptionProducerScope.remove(eventType)
                         eventSubscriptionFlow.remove(eventType)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -198,6 +198,7 @@ class WebSocketRepositoryImpl @Inject constructor(
                 eventSubscriptionFlow[eventType] = callbackFlow<T> {
                     eventSubscriptionProducerScope[eventType] = this as ProducerScope<Any>
                     awaitClose {
+                        if (lastResponseID[eventType] == null) return@awaitClose
                         Log.d(TAG, "Unsubscribing from $eventType")
                         ioScope.launch {
                             sendMessage(

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -198,7 +198,11 @@ class WebSocketRepositoryImpl @Inject constructor(
                 eventSubscriptionFlow[eventType] = callbackFlow<T> {
                     eventSubscriptionProducerScope[eventType] = this as ProducerScope<Any>
                     awaitClose {
-                        if (lastResponseID[eventType] == null) return@awaitClose
+                        if (lastResponseID[eventType] == null) {
+                            eventSubscriptionProducerScope.remove(eventType)
+                            eventSubscriptionFlow.remove(eventType)
+                            return@awaitClose
+                        }
                         Log.d(TAG, "Unsubscribing from $eventType")
                         ioScope.launch {
                             sendMessage(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Found the following sentry error so avoiding the unsubscription when the ID is null

```
java.lang.NullPointerException: null
    at io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl$subscribeToEventsForType$2$1$1$1.invokeSuspend(WebSocketRepositoryImpl.kt:206)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->