### PR TITLE
Support multiple subscriptions of same type in websocket and use in template widget

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -161,7 +161,7 @@
                 <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
                 <action android:name="io.homeassistant.companion.android.background.REQUEST_SENSORS_UPDATE" />
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
-                <action android:name="io.homeassistant.companion.android.widgets.template.BaseWidgetProvider.RECEIVE_DATA" />
+                <action android:name="io.homeassistant.companion.android.widgets.template.TemplateWidget.RECEIVE_DATA" />
             </intent-filter>
 
             <meta-data

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -2,9 +2,11 @@ package io.homeassistant.companion.android.widgets.template
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.graphics.Color
 import android.os.Bundle
 import android.text.Html.fromHtml
@@ -17,52 +19,184 @@ import androidx.core.graphics.toColorInt
 import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
-import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.database.widget.TemplateWidgetDao
 import io.homeassistant.companion.android.database.widget.TemplateWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import io.homeassistant.companion.android.util.getAttribute
-import io.homeassistant.companion.android.widgets.BaseWidgetProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
-class TemplateWidget : BaseWidgetProvider() {
+class TemplateWidget : AppWidgetProvider() {
     companion object {
         private const val TAG = "TemplateWidget"
+
+        const val UPDATE_VIEW =
+            "io.homeassistant.companion.android.widgets.template.TemplateWidget.UPDATE_VIEW"
+        const val RECEIVE_DATA =
+            "io.homeassistant.companion.android.widgets.template.TemplateWidget.RECEIVE_DATA"
+
         internal const val EXTRA_TEMPLATE = "extra_template"
         internal const val EXTRA_TEXT_SIZE = "EXTRA_TEXT_SIZE"
         internal const val EXTRA_BACKGROUND_TYPE = "EXTRA_BACKGROUND_TYPE"
         internal const val EXTRA_TEXT_COLOR = "EXTRA_TEXT_COLOR"
 
-        private var isSubscribed = false
+        private var widgetScope: CoroutineScope? = null
+        private val widgetTemplates = mutableMapOf<Int, String>()
+        private val widgetJobs = mutableMapOf<Int, Job>()
     }
+
+    @Inject
+    lateinit var integrationUseCase: IntegrationRepository
 
     @Inject
     lateinit var templateWidgetDao: TemplateWidgetDao
 
-    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
-        // When the user deletes the widget, delete the preference associated with it.
-        mainScope.launch {
-            templateWidgetDao.deleteAll(appWidgetIds)
+    private var thisSetScope = false
+    private var lastIntent = ""
+
+    init {
+        setupWidgetScope()
+    }
+
+    private fun setupWidgetScope() {
+        if (widgetScope == null || !widgetScope!!.isActive) {
+            widgetScope = CoroutineScope(Dispatchers.Main + Job())
+            thisSetScope = true
         }
     }
 
-    override fun isSubscribed(): Boolean = isSubscribed
-
-    override fun setSubscribed(subscribed: Boolean) {
-        isSubscribed = subscribed
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        // There may be multiple widgets active, so update all of them
+        for (appWidgetId in appWidgetIds) {
+            widgetScope?.launch {
+                val views = getWidgetRemoteViews(context, appWidgetId)
+                appWidgetManager.updateAppWidget(appWidgetId, views)
+            }
+        }
     }
 
-    override fun getWidgetProvider(context: Context): ComponentName =
-        ComponentName(context, TemplateWidget::class.java)
-
-    override suspend fun getAllWidgetIds(context: Context): List<Int> {
-        return templateWidgetDao.getAll().map { it.id }
+    override fun onDeleted(context: Context, appWidgetIds: IntArray) {
+        // When the user deletes the widget, delete the preference associated with it.
+        widgetScope?.launch {
+            templateWidgetDao.deleteAll(appWidgetIds)
+            appWidgetIds.forEach {
+                widgetTemplates.remove(it)
+                widgetJobs[it]?.cancel()
+                widgetJobs.remove(it)
+            }
+        }
     }
 
-    override suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedEntity: Entity<Map<String, Any>>?): RemoteViews {
+    override fun onReceive(context: Context, intent: Intent) {
+        lastIntent = intent.action.toString()
+        val appWidgetId = intent.getIntExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, -1)
+
+        super.onReceive(context, intent)
+        when (lastIntent) {
+            UPDATE_VIEW -> updateView(context, appWidgetId)
+            RECEIVE_DATA -> {
+                saveEntityConfiguration(
+                    context,
+                    intent.extras,
+                    appWidgetId
+                )
+                onScreenOn(context)
+            }
+            Intent.ACTION_SCREEN_ON -> onScreenOn(context)
+            Intent.ACTION_SCREEN_OFF -> onScreenOff()
+        }
+    }
+
+    private fun onScreenOn(context: Context) {
+        setupWidgetScope()
+        widgetScope!!.launch {
+            if (!integrationUseCase.isRegistered()) {
+                return@launch
+            }
+            updateAllWidgets(context)
+
+            val allWidgets = templateWidgetDao.getAll()
+            val widgetsWithDifferentTemplate = allWidgets.filter { it.template != widgetTemplates[it.id] }
+            if (widgetsWithDifferentTemplate.isNotEmpty()) {
+                if (thisSetScope) {
+                    context.applicationContext.registerReceiver(
+                        this@TemplateWidget,
+                        IntentFilter(Intent.ACTION_SCREEN_OFF)
+                    )
+                }
+
+                widgetsWithDifferentTemplate.forEach { widget ->
+                    widgetJobs[widget.id]?.cancel()
+
+                    val templateUpdates = integrationUseCase.getTemplateUpdates(widget.template)
+                    if (templateUpdates != null) {
+                        widgetTemplates[widget.id] = widget.template
+                        widgetJobs[widget.id] = widgetScope!!.launch {
+                            templateUpdates.collect {
+                                onTemplateChanged(context, widget.id, it)
+                            }
+                        }
+                    } else { // Remove data to make it retry on the next update
+                        widgetTemplates.remove(widget.id)
+                        widgetJobs.remove(widget.id)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun onScreenOff() {
+        if (thisSetScope) {
+            widgetScope?.cancel()
+            thisSetScope = false
+            widgetTemplates.clear()
+            widgetJobs.clear()
+        }
+    }
+
+    private suspend fun updateAllWidgets(
+        context: Context
+    ) {
+        val systemWidgetIds = AppWidgetManager.getInstance(context)
+            .getAppWidgetIds(ComponentName(context, TemplateWidget::class.java))
+            .toSet()
+        val dbWidgetIds = templateWidgetDao.getAll().map { it.id }
+
+        val invalidWidgetIds = dbWidgetIds.minus(systemWidgetIds)
+        if (invalidWidgetIds.isNotEmpty()) {
+            Log.i(TAG, "Found widgets $invalidWidgetIds in database, but not in AppWidgetManager - sending onDeleted")
+            onDeleted(context, invalidWidgetIds.toIntArray())
+        }
+
+        dbWidgetIds.filter { systemWidgetIds.contains(it) }.forEach {
+            updateView(context, it)
+        }
+    }
+
+    private fun updateView(
+        context: Context,
+        appWidgetId: Int,
+        appWidgetManager: AppWidgetManager = AppWidgetManager.getInstance(context)
+    ) {
+        widgetScope?.launch {
+            val views = getWidgetRemoteViews(context, appWidgetId)
+            appWidgetManager.updateAppWidget(appWidgetId, views)
+        }
+    }
+
+    private suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int, suggestedTemplate: String? = null): RemoteViews {
         // Every time AppWidgetManager.updateAppWidget(...) is called, the button listener
         // and label need to be re-assigned, or the next time the layout updates
         // (e.g home screen rotation) the widget will fall back on its default layout
@@ -97,9 +231,9 @@ class TemplateWidget : BaseWidgetProvider() {
                 }
 
                 // Content
-                var renderedTemplate: String? = templateWidgetDao.get(appWidgetId)?.lastUpdate ?: "Loading"
+                var renderedTemplate: String? = templateWidgetDao.get(appWidgetId)?.lastUpdate ?: context.getString(commonR.string.loading)
                 try {
-                    renderedTemplate = integrationUseCase.renderTemplate(widget.template, mapOf()).toString()
+                    renderedTemplate = suggestedTemplate ?: integrationUseCase.renderTemplate(widget.template, mapOf()).toString()
                     templateWidgetDao.updateTemplateWidgetLastUpdate(
                         appWidgetId,
                         renderedTemplate
@@ -124,7 +258,7 @@ class TemplateWidget : BaseWidgetProvider() {
         }
     }
 
-    override fun saveEntityConfiguration(context: Context, extras: Bundle?, appWidgetId: Int) {
+    private fun saveEntityConfiguration(context: Context, extras: Bundle?, appWidgetId: Int) {
         if (extras == null) return
 
         val template: String? = extras.getString(EXTRA_TEMPLATE)
@@ -137,7 +271,7 @@ class TemplateWidget : BaseWidgetProvider() {
             return
         }
 
-        mainScope.launch {
+        widgetScope?.launch {
             templateWidgetDao.add(
                 TemplateWidgetEntity(
                     appWidgetId,
@@ -152,13 +286,10 @@ class TemplateWidget : BaseWidgetProvider() {
         }
     }
 
-    override suspend fun onEntityStateChanged(context: Context, entity: Entity<*>) {
-        getAllWidgetIds(context).forEach { appWidgetId ->
-            val intent = Intent(context, TemplateWidget::class.java).apply {
-                action = UPDATE_VIEW
-                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
-            }
-            context.sendBroadcast(intent)
+    private fun onTemplateChanged(context: Context, appWidgetId: Int, template: String) {
+        widgetScope?.launch {
+            val views = getWidgetRemoteViews(context, appWidgetId, template)
+            AppWidgetManager.getInstance(context).updateAppWidget(appWidgetId, views)
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -27,7 +27,6 @@ import io.homeassistant.companion.android.databinding.WidgetTemplateConfigureBin
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.util.getHexForColor
 import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
-import io.homeassistant.companion.android.widgets.BaseWidgetProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -170,7 +169,7 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
         }
 
         val createIntent = Intent().apply {
-            action = BaseWidgetProvider.RECEIVE_DATA
+            action = TemplateWidget.RECEIVE_DATA
             component = ComponentName(applicationContext, TemplateWidget::class.java)
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             putExtra(TemplateWidget.EXTRA_TEMPLATE, binding.templateText.text.toString())

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -15,6 +15,7 @@ interface IntegrationRepository {
     suspend fun getNotificationRateLimits(): RateLimitResponse
 
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String?
+    suspend fun getTemplateUpdates(template: String): Flow<String>?
 
     suspend fun updateLocation(updateLocation: UpdateLocation)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -178,6 +178,13 @@ class IntegrationRepositoryImpl @Inject constructor(
         else throw IntegrationException("Error calling integration request render_template")
     }
 
+    override suspend fun getTemplateUpdates(template: String): Flow<String>? {
+        return webSocketRepository.getTemplateUpdates(template)
+            ?.map {
+                it.result
+            }
+    }
+
     override suspend fun updateLocation(updateLocation: UpdateLocation) {
         val updateLocationRequest = createUpdateLocation(updateLocation)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -10,6 +10,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.En
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.TemplateUpdatedEvent
 import kotlinx.coroutines.flow.Flow
 
 interface WebSocketRepository {
@@ -25,6 +26,7 @@ interface WebSocketRepository {
     suspend fun getAreaRegistryUpdates(): Flow<AreaRegistryUpdatedEvent>?
     suspend fun getDeviceRegistryUpdates(): Flow<DeviceRegistryUpdatedEvent>?
     suspend fun getEntityRegistryUpdates(): Flow<EntityRegistryUpdatedEvent>?
+    suspend fun getTemplateUpdates(template: String): Flow<TemplateUpdatedEvent>?
     suspend fun getNotifications(): Flow<Map<String, Any>>?
     suspend fun ackNotification(confirmId: String): Boolean
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -219,15 +219,17 @@ class WebSocketRepositoryImpl @Inject constructor(
                 eventSubscriptionFlow[subscribeMessage] = callbackFlow<T> {
                     eventSubscriptionProducerScope[subscribeMessage] = this as ProducerScope<Any>
                     awaitClose {
-                        Log.d(TAG, "Unsubscribing from $type with data $data")
-                        ioScope.launch {
-                            sendMessage(
-                                mapOf(
-                                    "type" to "unsubscribe_events",
-                                    "subscription" to eventSubscriptionId[subscribeMessage]!!
+                        if (eventSubscriptionId[subscribeMessage] != null) {
+                            Log.d(TAG, "Unsubscribing from $type with data $data")
+                            ioScope.launch {
+                                sendMessage(
+                                    mapOf(
+                                        "type" to "unsubscribe_events",
+                                        "subscription" to eventSubscriptionId[subscribeMessage]!!
+                                    )
                                 )
-                            )
-                            eventSubscriptionId.remove(subscribeMessage)
+                                eventSubscriptionId.remove(subscribeMessage)
+                            }
                         }
                         eventSubscriptionProducerScope.remove(subscribeMessage)
                         eventSubscriptionFlow.remove(subscribeMessage)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -208,10 +208,11 @@ class WebSocketRepositoryImpl @Inject constructor(
             if (eventSubscriptionId[subscribeMessage] == null) {
 
                 val response = sendMessage(subscribeMessage)
-                eventSubscriptionId[subscribeMessage] = response?.id
-                if (response == null) {
+                if (response == null || response.success != true) {
                     Log.e(TAG, "Unable to subscribe to $type with data $data")
                     return null
+                } else {
+                    eventSubscriptionId[subscribeMessage] = response.id
                 }
 
                 // Subscriptions are stored by subscribe message instead of ID, because the ID will
@@ -441,9 +442,11 @@ class WebSocketRepositoryImpl @Inject constructor(
                 if (connect()) {
                     eventSubscriptionFlow.forEach { (subscribeMessage, _) ->
                         val response = sendMessage(subscribeMessage)
-                        eventSubscriptionId[subscribeMessage] = response?.id
-                        if (response == null) {
+                        if (response == null || response.success != true) {
                             Log.e(TAG, "Issue re-registering subscription with $subscribeMessage")
+                            eventSubscriptionId[subscribeMessage] = null
+                        } else {
+                            eventSubscriptionId[subscribeMessage] = response.id
                         }
                     }
                     if (notificationFlow != null) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/TemplateUpdatedEvent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/TemplateUpdatedEvent.kt
@@ -1,0 +1,9 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TemplateUpdatedEvent(
+    val result: String,
+    val listeners: Map<String, Any>
+)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR updates the app's websocket implementation to support multiple subscriptions of the same type, and partially implements #2769.

**1. Websocket update**

The app will now not only track the `type` of a subscription but also any additional data, in order to support multiple subscriptions where the type is the same but the data is not (like templates, or specific entity updates). 

The logic for these subscriptions is the same as before: if an identical subscription already exists, it will return the existing Flow instead of starting another subscription.

**2. Template widget update**

The changes mentioned above are used to implement the first part of #2769: template widgets now use a subscription for the template instead of refreshing on any state change. Because there might be multiple instances of the widget which start subscriptions, a single `CoroutineScope` is stored in the companion object to tie these subscriptions to - based on my understanding this should be fine but please let me know if it is not!

As a result the `TemplateWidget` no longer implements `BaseWidgetProvider`, and some duplicate code had to be added.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, no visual changes

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#796

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I opted to combine changes 1 and 2 in this PR, because without change 2 nothing will actually use the new subscription support. Change 2 is all included in commit 4bcf375ef5316ff5c460e5ddabab053f2ca5c884 though.