### PR TITLE
Add exclude recents flag to avoid showing multiple open activities in recents

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1587,6 +1587,7 @@ class MessagingManager @Inject constructor(
             intent.putExtra("fragment", NOTIFICATION_HISTORY)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
 
         return PendingIntent.getActivity(
             context,
@@ -1886,6 +1887,7 @@ class MessagingManager @Inject constructor(
             else
                 WebViewActivity.newInstance(context, title)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
             context.startActivity(intent)
         } catch (e: Exception) {
             Log.e(TAG, "Unable to open webview", e)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
@@ -109,6 +109,7 @@ class ManageShortcutsViewModel @Inject constructor(
         )
         intent.action = shortcutPath
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
         intent.putExtra("iconId", iconId)
 
         val shortcut = ShortcutInfo.Builder(getApplication(), shortcutId)

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -190,6 +190,7 @@ class WebsocketManager(
         val intent = WebViewActivity.newInstance(applicationContext)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
         val pendingIntent = PendingIntent.getActivity(
             applicationContext,
             0,
@@ -201,6 +202,7 @@ class WebsocketManager(
         settingIntent.putExtra("fragment", "websocket")
         settingIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         settingIntent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+        settingIntent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
         val settingPendingIntent = PendingIntent.getActivity(
             applicationContext,
             0,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had a few closed issues and user complaints before and I was just reading the description for this flag and its behavior works well with our webview intents which require a new task to be created in order to properly load and change the URL. I don't think there are any other places to add this. In device controls we use a different flag so it is not impacted by showing multiple activities in recent apps.

I decided against adding this to sensor detail intent as I figured those users may actually need to navigate back to sensor settings faster if they need to make any further changes outside of granting permissions.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->