### PR TITLE
Only add next subscription if control is not null

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -165,7 +165,8 @@ class HaControlsProviderService : ControlsProviderService() {
                                         RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry),
                                         baseUrl
                                     )
-                                    subscriber.onNext(control)
+                                    if (control != null)
+                                        subscriber.onNext(control)
                                 }
                             }
                         }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -255,7 +255,8 @@ class HaControlsProviderService : ControlsProviderService() {
                     baseUrl
                 )
             }
-            subscriber.onNext(control)
+            if (control != null)
+                subscriber.onNext(control)
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed the following sentry error generating about 10k events, not really sure what triggers it as I could not reproduce but I also don't think we should be passing a `null` control over.  Assuming of course the `control` in this case is null. Ran some tests in the emulator and was able to add controls so probably just a sane null check is all that is needed 😃 

FWIW this error was first discovered in 2022.1.1

```
android.os.DeadObjectException: null
    at android.os.BinderProxy.transactNative(BinderProxy.java)
    at android.os.BinderProxy.transact(BinderProxy.java:584)
    at android.service.controls.IControlsSubscriber$Stub$Proxy.onNext(IControlsSubscriber.java:183)
    at android.service.controls.ControlsProviderService$SubscriberProxy.onNext(ControlsProviderService.java:292)
    at android.service.controls.ControlsProviderService$SubscriberProxy.onNext(ControlsProviderService.java:256)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherFor$1$1$request$1$2$1.emit(HaControlsProviderService.kt:168)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherFor$1$1$request$1$2$1.emit(HaControlsProviderService.kt:160)
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$getEntityUpdates$$inlined$map$1$2.emit(Emitters.kt:224)
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$getEntityUpdates$$inlined$filter$1$2.emit(Emitters.kt:224)
    at kotlinx.coroutines.flow.SharedFlowImpl.collect$suspendImpl(SharedFlow.kt:383)
    at kotlinx.coroutines.flow.SharedFlowImpl$collect$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
java.lang.RuntimeException: android.os.DeadObjectException
    at android.service.controls.ControlsProviderService$SubscriberProxy.onNext(ControlsProviderService.java:294)
    at android.service.controls.ControlsProviderService$SubscriberProxy.onNext(ControlsProviderService.java:256)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherFor$1$1$request$1$2$1.emit(HaControlsProviderService.kt:168)
    at io.homeassistant.companion.android.controls.HaControlsProviderService$createPublisherFor$1$1$request$1$2$1.emit(HaControlsProviderService.kt:160)
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$getEntityUpdates$$inlined$map$1$2.emit(Emitters.kt:224)
    at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl$getEntityUpdates$$inlined$filter$1$2.emit(Emitters.kt:224)
    at kotlinx.coroutines.flow.SharedFlowImpl.collect$suspendImpl(SharedFlow.kt:383)
    at kotlinx.coroutines.flow.SharedFlowImpl$collect$1.invokeSuspend
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
    at kotlinx.coroutines.internal.LimitedDispatcher.run(LimitedDispatcher.kt:42)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:95)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:570)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:750)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:677)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:664)
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->