### PR TITLE
Calculate fan speed step count

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -99,7 +99,7 @@ fun <T> Entity<T>.getFanSteps(): Int? {
 
         return calculateNumStep(((attributes as Map<*, *>)["percentage_step"] as? Double)?.toDouble() ?: 1.0) - 1
     } catch (e: Exception) {
-        Log.e(EntityExt.TAG, "Unable to get getFanPercentageStep")
+        Log.e(EntityExt.TAG, "Unable to get getFanSteps")
         null
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -93,8 +93,8 @@ fun <T> Entity<T>.getFanSteps(): Int? {
         fun calculateNumStep(percentageStep: Double): Int {
             val numSteps = round(100 / percentageStep).toInt()
             if (numSteps <= 10) return numSteps
-            if (numSteps % 10 == 0) return  10
-            return calculateNumStep(percentageStep * 2);
+            if (numSteps % 10 == 0) return 10
+            return calculateNumStep(percentageStep * 2)
         }
 
         return calculateNumStep(((attributes as Map<*, *>)["percentage_step"] as? Double)?.toDouble() ?: 1.0) - 1

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.data.integration
 import android.graphics.Color
 import android.util.Log
 import java.util.Calendar
+import kotlin.math.round
 
 data class Entity<T>(
     val entityId: String,
@@ -80,7 +81,25 @@ fun <T> Entity<T>.getFanSpeed(): EntityPosition? {
             max = maxValue
         )
     } catch (e: Exception) {
-        Log.e(EntityExt.TAG, "Unable to get getLightBrightness", e)
+        Log.e(EntityExt.TAG, "Unable to get getFanSpeed", e)
+        null
+    }
+}
+
+fun <T> Entity<T>.getFanSteps(): Int? {
+    return try {
+        if (!supportsFanSetSpeed()) return null
+
+        fun calculateNumStep(percentageStep: Double): Int {
+            val numSteps = round(100 / percentageStep).toInt()
+            if (numSteps <= 10) return numSteps
+            if (numSteps % 10 == 0) return  10
+            return calculateNumStep(percentageStep * 2);
+        }
+
+        return calculateNumStep(((attributes as Map<*, *>)["percentage_step"] as? Double)?.toDouble() ?: 1.0) - 1
+    } catch (e: Exception) {
+        Log.e(EntityExt.TAG, "Unable to get getFanPercentageStep")
         null
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -30,6 +30,7 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.getFanSpeed
+import io.homeassistant.companion.android.common.data.integration.getFanSteps
 import io.homeassistant.companion.android.common.data.integration.getLightBrightness
 import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
@@ -42,6 +43,7 @@ import io.homeassistant.companion.android.util.onEntityFeedback
 import io.homeassistant.companion.android.views.ListHeader
 import io.homeassistant.companion.android.views.ThemeLazyColumn
 import java.text.DateFormat
+import kotlin.math.round
 
 @Composable
 fun DetailsPanelView(
@@ -169,6 +171,7 @@ fun FanSpeedSlider(
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
     val position = entity.getFanSpeed() ?: return
+    val steps = entity.getFanSteps() ?: return
 
     Column {
         Text(
@@ -190,7 +193,7 @@ fun FanSpeedSlider(
                     haptic
                 )
             },
-            steps = 9,
+            steps = steps,
             valueRange = position.min..position.max,
             decreaseIcon = {
                 Image(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -43,7 +43,6 @@ import io.homeassistant.companion.android.util.onEntityFeedback
 import io.homeassistant.companion.android.views.ListHeader
 import io.homeassistant.companion.android.views.ThemeLazyColumn
 import java.text.DateFormat
-import kotlin.math.round
 
 @Composable
 fun DetailsPanelView(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR changes the number of steps shown on the detail page of a fan entity because the default number of nine steps wouldn't work for fan entities with some percentage step size. This new function will calculate an optimal number of steps based on the percentage step size of the fan with a maximum of nine steps.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

**Before**:
![Screenshot_20220825_115230_android](https://user-images.githubusercontent.com/33957974/186634310-4c6932c9-1747-4733-b0a7-14ae2ff58e17.png)

**After**:
![image](https://user-images.githubusercontent.com/33957974/186634378-d2898e2c-730b-438f-997b-39a9add7e67e.png)

**Before:**
![Screenshot_20220825_115444_android](https://user-images.githubusercontent.com/33957974/186634813-5089cc8f-6479-4d64-9374-c83bd4da13af.png)

**After:**
![image](https://user-images.githubusercontent.com/33957974/186634878-e0d7e013-cdaf-4ec4-9c0f-c360502fb30e.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This fixes #2815 