### PR TITLE
Support device controls on locked Android 13 device

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
 
     ndkVersion = "21.3.6528147"
 

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -79,7 +79,7 @@ class GeocodeSensorManager : SensorManager {
                 if (location.accuracy <= minAccuracy) {
                     address = Geocoder(context)
                         .getFromLocation(location.latitude, location.longitude, 1)
-                        .firstOrNull()
+                        ?.firstOrNull()
                 } else {
                     Log.w(TAG, "Skipping geocoded update as accuracy was not met: ${location.accuracy}")
                     return@addOnSuccessListener

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -32,6 +32,7 @@ import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.settings.wear.SettingsWearViewModel
+import io.homeassistant.companion.android.util.compose.getEntityDomainString
 import org.burnoutcrew.reorderable.ReorderableItem
 import org.burnoutcrew.reorderable.ReorderableLazyListState
 import org.burnoutcrew.reorderable.detectReorderAfterLongPress
@@ -161,7 +162,7 @@ fun WearFavoriteEntityRow(
             ) {
                 Text(text = entityName, style = MaterialTheme.typography.body1)
                 CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                    Text(text = getDomainString(entityDomain), style = MaterialTheme.typography.body2)
+                    Text(text = getEntityDomainString(entityDomain), style = MaterialTheme.typography.body2)
                 }
             }
             if (draggable) {
@@ -178,22 +179,5 @@ fun WearFavoriteEntityRow(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun getDomainString(domain: String): String {
-    return when (domain) {
-        "button" -> stringResource(commonR.string.domain_button)
-        "cover" -> stringResource(commonR.string.domain_cover)
-        "fan" -> stringResource(commonR.string.domain_fan)
-        "input_boolean" -> stringResource(commonR.string.domain_input_boolean)
-        "input_button" -> stringResource(commonR.string.domain_input_button)
-        "light" -> stringResource(commonR.string.domain_light)
-        "lock" -> stringResource(commonR.string.domain_lock)
-        "scene" -> stringResource(commonR.string.domain_scene)
-        "script" -> stringResource(commonR.string.domain_script)
-        "switch" -> stringResource(commonR.string.domain_switch)
-        else -> ""
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -20,6 +20,7 @@ interface HaControl {
         context: Context,
         entity: Entity<Map<String, Any>>,
         area: AreaRegistryResponse?,
+        authRequired: Boolean,
         baseUrl: String?
     ): Control {
         val controlPath = "entityId:${entity.entityId}"
@@ -45,6 +46,9 @@ interface HaControl {
                 else -> context.getString(R.string.state_unknown)
             }
         )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            control.setAuthRequired(authRequired)
+        }
 
         return provideControlFeatures(context, control, entity, area, baseUrl).build()
     }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -7,6 +7,7 @@ import android.service.controls.actions.ControlAction
 import android.util.Log
 import androidx.annotation.RequiresApi
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
@@ -34,6 +35,39 @@ class HaControlsProviderService : ControlsProviderService() {
 
     companion object {
         private const val TAG = "HaConProService"
+
+        private val domainToHaControl = mapOf(
+            "automation" to DefaultSwitchControl,
+            "button" to DefaultButtonControl,
+            "camera" to CameraControl,
+            "climate" to ClimateControl,
+            "cover" to CoverControl,
+            "fan" to FanControl,
+            "ha_failed" to HaFailedControl,
+            "input_boolean" to DefaultSwitchControl,
+            "input_button" to DefaultButtonControl,
+            "input_number" to DefaultSliderControl,
+            "light" to LightControl,
+            "lock" to LockControl,
+            "media_player" to null,
+            "remote" to null,
+            "scene" to DefaultButtonControl,
+            "script" to DefaultButtonControl,
+            "switch" to DefaultSwitchControl,
+            "vacuum" to VacuumControl
+        )
+        private val domainToMinimumApi = mapOf(
+            "camera" to Build.VERSION_CODES.S
+        )
+
+        fun getSupportedDomains(): List<String> =
+            domainToHaControl
+                .filter { it.value != null }
+                .map { it.key }
+                .filter {
+                    domainToMinimumApi[it] == null ||
+                        Build.VERSION.SDK_INT >= domainToMinimumApi[it]!!
+                }
     }
 
     @Inject
@@ -46,30 +80,6 @@ class HaControlsProviderService : ControlsProviderService() {
     lateinit var urlRepository: UrlRepository
 
     private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
-
-    private val domainToHaControl = mapOf(
-        "automation" to DefaultSwitchControl,
-        "button" to DefaultButtonControl,
-        "camera" to CameraControl,
-        "climate" to ClimateControl,
-        "cover" to CoverControl,
-        "fan" to FanControl,
-        "ha_failed" to HaFailedControl,
-        "input_boolean" to DefaultSwitchControl,
-        "input_button" to DefaultButtonControl,
-        "input_number" to DefaultSliderControl,
-        "light" to LightControl,
-        "lock" to LockControl,
-        "media_player" to null,
-        "remote" to null,
-        "scene" to DefaultButtonControl,
-        "script" to DefaultButtonControl,
-        "switch" to DefaultSwitchControl,
-        "vacuum" to VacuumControl
-    )
-    private val domainToMinimumApi = mapOf(
-        "camera" to Build.VERSION_CODES.S
-    )
 
     override fun createPublisherForAllAvailable(): Flow.Publisher<Control> {
         return Flow.Publisher { subscriber ->
@@ -101,6 +111,7 @@ class HaControlsProviderService : ControlsProviderService() {
                                     applicationContext,
                                     it as Entity<Map<String, Any>>,
                                     areaForEntity[it.entityId],
+                                    false, // Auth not required for preview
                                     null // Prevent downloading camera images
                                 )
                             } catch (e: Exception) {
@@ -163,6 +174,7 @@ class HaControlsProviderService : ControlsProviderService() {
                                         applicationContext,
                                         it as Entity<Map<String, Any>>,
                                         RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry),
+                                        entityRequiresAuth(it.entityId),
                                         baseUrl
                                     )
                                     subscriber.onNext(control)
@@ -229,7 +241,7 @@ class HaControlsProviderService : ControlsProviderService() {
         }
     }
 
-    private fun sendEntitiesToSubscriber(
+    private suspend fun sendEntitiesToSubscriber(
         subscriber: Flow.Subscriber<in Control>,
         entities: Map<String, Entity<Map<String, Any>>>,
         areaRegistry: List<AreaRegistryResponse>?,
@@ -243,6 +255,7 @@ class HaControlsProviderService : ControlsProviderService() {
                     applicationContext,
                     it.value,
                     RegistriesDataHandler.getAreaForEntity(it.value.entityId, areaRegistry, deviceRegistry, entityRegistry),
+                    entityRequiresAuth(it.value.entityId),
                     baseUrl
                 )
             } catch (e: Exception) {
@@ -251,6 +264,7 @@ class HaControlsProviderService : ControlsProviderService() {
                     applicationContext,
                     getFailedEntity(it.value.entityId, e),
                     RegistriesDataHandler.getAreaForEntity(it.value.entityId, areaRegistry, deviceRegistry, entityRegistry),
+                    entityRequiresAuth(it.value.entityId),
                     baseUrl
                 )
             }
@@ -270,5 +284,17 @@ class HaControlsProviderService : ControlsProviderService() {
             lastUpdated = Calendar.getInstance(),
             context = null
         )
+    }
+
+    private suspend fun entityRequiresAuth(entityId: String): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val setting = integrationRepository.getControlsAuthRequired()
+            if (setting == ControlsAuthRequiredSetting.SELECTION) {
+                val includeList = integrationRepository.getControlsAuthEntities()
+                includeList.contains(entityId)
+            } else {
+                setting == ControlsAuthRequiredSetting.ALL
+            }
+        } else false
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.common.util.LocationPermissionInfoHandler
 import io.homeassistant.companion.android.nfc.NfcSetupActivity
+import io.homeassistant.companion.android.settings.controls.ManageControlsSettingsFragment
 import io.homeassistant.companion.android.settings.language.LanguagesProvider
 import io.homeassistant.companion.android.settings.log.LogFragment
 import io.homeassistant.companion.android.settings.notification.NotificationChannelFragment
@@ -204,6 +205,20 @@ class SettingsFragment constructor(
                         .beginTransaction()
                         .replace(R.id.content, ManageTilesFragment::class.java, null)
                         .addToBackStack(getString(commonR.string.tiles))
+                        .commit()
+                    return@setOnPreferenceClickListener true
+                }
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                findPreference<PreferenceCategory>("device_controls")?.let {
+                    it.isVisible = true
+                }
+                findPreference<Preference>("manage_device_controls")?.setOnPreferenceClickListener {
+                    parentFragmentManager
+                        .beginTransaction()
+                        .replace(R.id.content, ManageControlsSettingsFragment::class.java, null)
+                        .addToBackStack(getString(commonR.string.controls_setting_title))
                         .commit()
                     return@setOnPreferenceClickListener true
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
@@ -1,0 +1,68 @@
+package io.homeassistant.companion.android.settings.controls
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.RequiresApi
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
+import io.homeassistant.companion.android.settings.controls.views.ManageControlsView
+import io.homeassistant.companion.android.common.R as commonR
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@AndroidEntryPoint
+class ManageControlsSettingsFragment : Fragment() {
+
+    val viewModel: ManageControlsViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+
+        menu.findItem(R.id.get_help)?.let {
+            it.isVisible = true
+            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://companion.home-assistant.io/docs/integrations/android-device-controls"))
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MdcTheme {
+                    ManageControlsView(
+                        authSetting = viewModel.authRequired,
+                        authRequiredList = viewModel.authRequiredList,
+                        entitiesLoaded = viewModel.entitiesLoaded,
+                        entitiesList = viewModel.entitiesList,
+                        onSelectAll = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.NONE) },
+                        onSelectNone = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.ALL) },
+                        onSelectEntity = { viewModel.toggleAuthForEntity(it) }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.title = getString(commonR.string.controls_setting_title)
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsViewModel.kt
@@ -1,0 +1,96 @@
+package io.homeassistant.companion.android.settings.controls
+
+import android.app.Application
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.controls.HaControlsProviderService
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@RequiresApi(Build.VERSION_CODES.TIRAMISU)
+@HiltViewModel
+class ManageControlsViewModel @Inject constructor(
+    private val integrationUseCase: IntegrationRepository,
+    application: Application
+) : AndroidViewModel(application) {
+
+    var authRequired by mutableStateOf(ControlsAuthRequiredSetting.NONE)
+        private set
+
+    val authRequiredList = mutableStateListOf<String>()
+
+    var entitiesLoaded by mutableStateOf(false)
+        private set
+
+    val entitiesList = mutableStateListOf<Entity<*>>()
+
+    init {
+        viewModelScope.launch {
+            authRequired = integrationUseCase.getControlsAuthRequired()
+            authRequiredList.addAll(integrationUseCase.getControlsAuthEntities())
+
+            val entities = integrationUseCase.getEntities()
+                ?.filter { it.domain in HaControlsProviderService.getSupportedDomains() }
+                ?.sortedWith(
+                    compareBy(String.CASE_INSENSITIVE_ORDER) {
+                        (it.attributes as Map<String, Any>)["friendly_name"].toString()
+                    }
+                )
+            if (entities != null) {
+                entitiesList.addAll(entities)
+            }
+            entitiesLoaded = true
+        }
+    }
+
+    fun setAuthSetting(setting: ControlsAuthRequiredSetting) {
+        viewModelScope.launch {
+            authRequired = setting
+            if (authRequired != ControlsAuthRequiredSetting.SELECTION) authRequiredList.clear()
+
+            integrationUseCase.setControlsAuthRequired(setting)
+            integrationUseCase.setControlsAuthEntities(authRequiredList.toList())
+        }
+    }
+
+    fun toggleAuthForEntity(entityId: String) {
+        viewModelScope.launch {
+            var newAuthRequired = ControlsAuthRequiredSetting.SELECTION
+
+            if (authRequired == ControlsAuthRequiredSetting.ALL) {
+                // User wants this accessible, so add everything except selected
+                authRequiredList.addAll(
+                    entitiesList.map { it.entityId }.filter { it != entityId }
+                )
+            } else if (authRequiredList.contains(entityId)) {
+                authRequiredList.remove(entityId)
+            } else {
+                authRequiredList.add(entityId)
+            }
+
+            // If none or all are selected, clean up
+            if (authRequiredList.isEmpty()) {
+                newAuthRequired = ControlsAuthRequiredSetting.NONE
+            } else if (entitiesList.all { authRequiredList.contains(it.entityId) }) {
+                newAuthRequired = ControlsAuthRequiredSetting.ALL
+            }
+
+            // Set values for update
+            authRequired = newAuthRequired
+            if (newAuthRequired != ControlsAuthRequiredSetting.SELECTION) authRequiredList.clear()
+            integrationUseCase.setControlsAuthRequired(newAuthRequired)
+            integrationUseCase.setControlsAuthEntities(authRequiredList.toList())
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
@@ -1,0 +1,140 @@
+package io.homeassistant.companion.android.settings.controls.views
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.Checkbox
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.util.compose.getEntityDomainString
+import io.homeassistant.companion.android.common.R as commonR
+
+@Composable
+fun ManageControlsView(
+    authSetting: ControlsAuthRequiredSetting,
+    authRequiredList: List<String>,
+    entitiesLoaded: Boolean,
+    entitiesList: List<Entity<*>>,
+    onSelectAll: () -> Unit,
+    onSelectNone: () -> Unit,
+    onSelectEntity: (String) -> Unit
+) {
+    LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
+        item {
+            Text(
+                text = stringResource(commonR.string.controls_setting_choose_setting),
+                modifier = Modifier.padding(horizontal = 16.dp)
+            )
+        }
+        if (entitiesLoaded) {
+            if (entitiesList.isNotEmpty()) {
+                item {
+                    Row(modifier = Modifier.padding(all = 16.dp)) {
+                        OutlinedButton(
+                            onClick = onSelectAll,
+                            enabled = authSetting !== ControlsAuthRequiredSetting.NONE,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(commonR.string.controls_setting_choose_all))
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
+                        OutlinedButton(
+                            onClick = onSelectNone,
+                            enabled = authSetting !== ControlsAuthRequiredSetting.ALL,
+                            modifier = Modifier.weight(1f)
+                        ) {
+                            Text(stringResource(commonR.string.controls_setting_choose_none))
+                        }
+                    }
+                }
+                items(entitiesList.size, key = { entitiesList[it].entityId }) { index ->
+                    val entity = entitiesList[index] as Entity<Map<String, Any>>
+                    ManageControlsEntity(
+                        entityName = (
+                            entity.attributes["friendly_name"]
+                                ?: entity.entityId
+                            ) as String,
+                        entityDomain = entity.domain,
+                        selected = (
+                            authSetting == ControlsAuthRequiredSetting.NONE ||
+                                (
+                                    authSetting == ControlsAuthRequiredSetting.SELECTION &&
+                                        !authRequiredList.contains(entity.entityId)
+                                    )
+                            ),
+                        onClick = { onSelectEntity(entity.entityId) }
+                    )
+                }
+            } else {
+                item {
+                    Text(
+                        text = stringResource(commonR.string.controls_setting_choose_empty),
+                        modifier = Modifier.padding(all = 16.dp),
+                        fontStyle = FontStyle.Italic
+                    )
+                }
+            }
+        } else {
+            item {
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ManageControlsEntity(
+    entityName: String,
+    entityDomain: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .clickable { onClick() }
+            .fillMaxWidth()
+            .padding(all = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
+            checked = selected,
+            modifier = Modifier.padding(end = 16.dp),
+            onCheckedChange = null // Handled by parent Row clickable modifier
+        )
+        Column(
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(text = entityName, style = MaterialTheme.typography.body1)
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                Text(
+                    text = getEntityDomainString(entityDomain),
+                    style = MaterialTheme.typography.body2
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/EntityInfo.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/EntityInfo.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.util.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import io.homeassistant.companion.android.common.R as commonR
+
+@Composable
+fun getEntityDomainString(domain: String): String {
+    return when (domain) {
+        "automation" -> stringResource(commonR.string.domain_automation)
+        "button" -> stringResource(commonR.string.domain_button)
+        "camera" -> stringResource(commonR.string.domain_camera)
+        "climate" -> stringResource(commonR.string.domain_climate)
+        "cover" -> stringResource(commonR.string.domain_cover)
+        "fan" -> stringResource(commonR.string.domain_fan)
+        "input_boolean" -> stringResource(commonR.string.domain_input_boolean)
+        "input_button" -> stringResource(commonR.string.domain_input_button)
+        "input_number" -> stringResource(commonR.string.domain_input_number)
+        "light" -> stringResource(commonR.string.domain_light)
+        "lock" -> stringResource(commonR.string.domain_lock)
+        "scene" -> stringResource(commonR.string.domain_scene)
+        "script" -> stringResource(commonR.string.domain_script)
+        "switch" -> stringResource(commonR.string.domain_switch)
+        "vacuum" -> stringResource(commonR.string.domain_vacuum)
+        else -> ""
+    }
+}

--- a/app/src/main/res/drawable/ic_home_variant_outline.xml
+++ b/app/src/main/res/drawable/ic_home_variant_outline.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="@color/colorAccent" android:pathData="M9,13H15V19H18V10L12,5.5L6,10V19H9V13M4,21V9L12,3L20,9V21H4Z" />
+</vector>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -145,6 +145,16 @@
             android:summary="@string/rate_limit_summary"/>
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="device_controls"
+        android:title="@string/controls_setting_category"
+        app:isPreferenceVisible="false">
+        <Preference
+            android:key="manage_device_controls"
+            android:icon="@drawable/ic_home_variant_outline"
+            android:title="@string/controls_setting_title"
+            android:summary="@string/controls_setting_summary" />
+    </PreferenceCategory>
+    <PreferenceCategory
         android:key="quick_settings"
         android:title="@string/quick_settings"
         app:isPreferenceVisible="false">

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,7 +13,7 @@ val versionName = System.getenv("VERSION") ?: "LOCAL"
 val versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
 
 android {
-    compileSdk = 32
+    compileSdk = 33
 
     defaultConfig {
         minSdk = 21

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ControlsAuthRequiredSetting.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/ControlsAuthRequiredSetting.kt
@@ -1,0 +1,7 @@
+package io.homeassistant.companion.android.common.data.integration
+
+enum class ControlsAuthRequiredSetting {
+    ALL,
+    SELECTION,
+    NONE
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -41,6 +41,11 @@ interface IntegrationRepository {
     suspend fun setSessionExpireMillis(value: Long)
     suspend fun getSessionExpireMillis(): Long
 
+    suspend fun setControlsAuthRequired(setting: ControlsAuthRequiredSetting)
+    suspend fun getControlsAuthRequired(): ControlsAuthRequiredSetting
+    suspend fun setControlsAuthEntities(entities: List<String>)
+    suspend fun getControlsAuthEntities(): List<String>
+
     suspend fun getTileShortcuts(): List<String>
     suspend fun setTileShortcuts(entities: List<String>)
     suspend fun getTemplateTileContent(): String

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
+import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationException
@@ -74,6 +75,8 @@ class IntegrationRepositoryImpl @Inject constructor(
         private const val PREF_WEBVIEW_DEBUG_ENABLED = "webview_debug_enabled"
         private const val PREF_SESSION_TIMEOUT = "session_timeout"
         private const val PREF_SESSION_EXPIRE = "session_expire"
+        private const val PREF_CONTROLS_AUTH_REQUIRED = "controls_auth_required"
+        private const val PREF_CONTROLS_AUTH_ENTITIES = "controls_auth_entities"
         private const val PREF_SEC_WARNING_NEXT = "sec_warning_last"
         private const val TAG = "IntegrationRepository"
         private const val RATE_LIMIT_URL = BuildConfig.RATE_LIMIT_URL
@@ -379,6 +382,25 @@ class IntegrationRepositoryImpl @Inject constructor(
 
     override suspend fun getSessionExpireMillis(): Long {
         return localStorage.getLong(PREF_SESSION_EXPIRE) ?: 0
+    }
+
+    override suspend fun setControlsAuthRequired(setting: ControlsAuthRequiredSetting) {
+        localStorage.putString(PREF_CONTROLS_AUTH_REQUIRED, setting.name)
+    }
+
+    override suspend fun getControlsAuthRequired(): ControlsAuthRequiredSetting {
+        val current = localStorage.getString(PREF_CONTROLS_AUTH_REQUIRED)
+        return ControlsAuthRequiredSetting.values().firstOrNull {
+            it.name == current
+        } ?: ControlsAuthRequiredSetting.NONE
+    }
+
+    override suspend fun setControlsAuthEntities(entities: List<String>) {
+        localStorage.putStringSet(PREF_CONTROLS_AUTH_ENTITIES, entities.toSet())
+    }
+
+    override suspend fun getControlsAuthEntities(): List<String> {
+        return localStorage.getStringSet(PREF_CONTROLS_AUTH_ENTITIES)?.toList() ?: emptyList()
     }
 
     override suspend fun getTileShortcuts(): List<String> {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -128,6 +128,13 @@
     <string name="connect">Connect</string>
     <string name="connected_to_home_assistant">Connected to Home Assistant</string>
     <string name="continue_connect">Continue</string>
+    <string name="controls_setting_category">Device Controls</string>
+    <string name="controls_setting_title">Manage Device Controls</string>
+    <string name="controls_setting_summary">Choose if quick access device controls can be used when this device is locked</string>
+    <string name="controls_setting_choose_setting">Choose which entities you want to be able to control using the built-in device controls option when this device is locked:</string>
+    <string name="controls_setting_choose_all">Select all</string>
+    <string name="controls_setting_choose_none">Select none</string>
+    <string name="controls_setting_choose_empty">No entities available</string>
     <string name="covers">Covers</string>
     <string name="crash_reporting_summary">Help the developers fix bugs and crashes by leaving this enabled. If the application crashes this will automatically generate and send a report. If you notice a crash also create an issue on Github!</string>
     <string name="crash_reporting">Crash Reporting</string>

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
 
     defaultConfig {
         applicationId = "io.homeassistant.companion.android"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add support for using device controls while the device is locked on Android 13. By default this is enabled, as I feel like this is what most users expect and the system level setting for this was enabled by default on upgrade for me.

Because this is Home Assistant, users can enable/disable it for all entities or control the setting for individual entities. When enable/disable all has been used new entities will follow this setting, when individual entities have been adjusted new entities are enabled by default.

To make this possible this PR bumps the `compileSdk` to `33` (Android 13). The change in `GeocodeSensorManager` is because of this, as the function that is used was changed to be nullable.

Fixes #2381

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
A demo of the functionality, showing a locked device where you can use one control without entering the PIN and another that does require entering the PIN:

https://user-images.githubusercontent.com/8148535/186732084-e5133e50-f9b2-4268-a418-5438dbe53cc4.mp4

A new setting was added to Settings > Companion app when using Android 13, using the same icon and name as the tile in quick settings:
|Light|Dark|
|-----|-----|
|![A snippet of the app settings, showing an option titled 'Manage Device Controls', description 'Choose if quick access device controls can be used when this device is locked', icon of a home that matches the quick settings panel, light mode.](https://user-images.githubusercontent.com/8148535/186732336-8d40867f-fb86-4cdd-ac20-806d4a9e4ee0.png)|![A snippet of the app settings, showing an option titled 'Manage Device Controls', description 'Choose if quick access device controls can be used when this device is locked', icon of a home that matches the quick settings panel, dark mode.](https://user-images.githubusercontent.com/8148535/186732359-4aaf83b2-6c40-4d26-b130-3398d613af43.png)|

The 'Manage Device Controls' screen includes a short description of the functionality, buttons to enable/disable all entities, a list of entities with checkboxes, and a help icon in the toolbar that links to the documentation:
|Light|Dark|
|-----|-----|
|![The 'Manage Device Controls' screen as described, light mode.](https://user-images.githubusercontent.com/8148535/186733101-42e801bb-ef0d-4b7d-968a-9c1b5988c74a.png)|![The 'Manage Device Controls' screen as described, dark mode.](https://user-images.githubusercontent.com/8148535/186733157-0a63299f-65bb-4fcf-b139-fd4d4b7f9898.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#799

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->