### PR TITLE
Support websocket message coalescing

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantVersion.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/HomeAssistantVersion.kt
@@ -1,0 +1,29 @@
+package io.homeassistant.companion.android.common.data
+
+import java.util.regex.Pattern
+
+data class HomeAssistantVersion(
+    val year: Int,
+    val month: Int,
+    val release: Int
+) {
+
+    companion object {
+        private val VERSION_PATTERN = Pattern.compile("([0-9]{4})\\.([0-9]{1,2})\\.([0-9]{1,2}).*")
+
+        fun fromString(versionString: String): HomeAssistantVersion? {
+            val matches = VERSION_PATTERN.matcher(versionString)
+            return if (matches.find() && matches.matches()) {
+                val coreYear = matches.group(1)?.toIntOrNull() ?: 0
+                val coreMonth = matches.group(2)?.toIntOrNull() ?: 0
+                val coreRelease = matches.group(3)?.toIntOrNull() ?: 0
+                HomeAssistantVersion(coreYear, coreMonth, coreRelease)
+            } else { // Invalid version
+                null
+            }
+        }
+    }
+
+    fun isAtLeast(minYear: Int, minMonth: Int, minRelease: Int = 0): Boolean =
+        year > minYear || (year == minYear && (month > minMonth || (month == minMonth && release >= minRelease)))
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/SocketResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/SocketResponse.kt
@@ -9,5 +9,6 @@ data class SocketResponse(
     val type: String,
     val success: Boolean?,
     val result: JsonNode?,
-    val event: JsonNode?
+    val event: JsonNode?,
+    val haVersion: String?
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implement support for home-assistant/core#77238. Core will now combine multiple responses in 1 single websocket message if it's faster. Translation: it might return a JSON array of objects instead of a single object.

The logging for websocket has also been adjusted to handle these changes. To keep the logs readable and better match 'normal' network requests, it will no longer print the entire body on non-debug builds.

Example output (debug):

```
2022-08-27 18:10:52.323 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Sending message 1: {type=supported_features, id=1, features={coalesce_messages=1}}
2022-08-27 18:10:52.332 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Sending message 2: {type=config/device_registry/list, id=2}
2022-08-27 18:10:52.332 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 2 sent
2022-08-27 18:10:52.334 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Sending message 3: {type=config/entity_registry/list, id=3}
2022-08-27 18:10:52.335 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 3 sent
2022-08-27 18:10:52.337 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Sending message 4: {type=get_states, id=4}
2022-08-27 18:10:52.337 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 4 sent
2022-08-27 18:10:52.338 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Sending message 5: {type=config/area_registry/list, id=5}
2022-08-27 18:10:52.339 28760-28760/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 5 sent
2022-08-27 18:10:52.488 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Websocket: onMessage (text: [{"id":1,"type":"result","success":true,"result":null},{"id":2,"type":"result","success":true,"result":[...]},{"id":3,"type":"result","success":true,"result":[...
2022-08-27 18:10:52.598 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 1 received
2022-08-27 18:10:52.599 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 2 received
2022-08-27 18:10:52.599 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 3 received
2022-08-27 18:10:52.599 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 4 received
2022-08-27 18:10:52.600 28760-28796/io.homeassistant.companion.android.debug D/WebSocketRepository: Message number 5 received
```

Non-debug builds will replace the `Websocket: onMessage (text: [response])` log message with `Websocket: onMessage (text)`.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->