### PR TITLE
Don't notify about cancellations in WebsocketManager

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.database.settings.WebsocketSetting
 import io.homeassistant.companion.android.notifications.MessagingManager
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -226,6 +227,8 @@ class WebsocketManager(
             setForeground(ForegroundInfo(NOTIFICATION_ID, notification))
             true
         } catch (e: IllegalStateException) {
+            if (e is CancellationException) return false
+
             Log.e(TAG, "Unable to setForeground due to restrictions", e)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 if (notificationManager.getNotificationChannel(websocketIssuesChannel) == null) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix useless "Unable to open connection to Home Assistant" notifications caused by cancelled jobs for the WebsocketManager; fixes #2830.

(What the app really wants to catch is `ForegroundServiceStartNotAllowedException`s, but that was added in API 31 which is why it is using the closest exception class that is available on all supported API levels.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->