### PR TITLE
Send external url to Wear discovery

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/onboarding/WearOnboardingListener.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/onboarding/WearOnboardingListener.kt
@@ -33,7 +33,7 @@ class WearOnboardingListener : WearableListenerService() {
     private fun sendHomeAssistantInstance(nodeId: String) = runBlocking {
         Log.d("WearOnboardingListener", "sendHomeAssistantInstance: $nodeId")
         // Retrieve current instance
-        val url = urlUseCase.getUrl()
+        val url = urlUseCase.getUrl(false)
 
         if (url != null) {
             // Put as DataMap in data layer


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Improve onboarding on Wear OS by sending the external url for discovery, even if the app is currently using the internal url. Because Wear doesn't support url switching, suggesting the url that works in more locations is probably a good idea. The internal url can still be used via manual entry.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->