### PR TITLE
Add a setting to battery power sensor to convert current when it is not in microamps

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -11,6 +11,8 @@ class BatterySensorManager : SensorManager {
 
     companion object {
         private const val TAG = "BatterySensor"
+        private const val SETTING_BATTERY_CURRENT_DIVISOR = "battery_current_divisor"
+        private const val DEFAULT_BATTERY_CURRENT_DIVISOR = 1000000
         private val batteryLevel = SensorManager.BasicSensor(
             "battery_level",
             "sensor",
@@ -268,7 +270,7 @@ class BatterySensorManager : SensorManager {
 
         val voltage = getBatteryVolts(intent)
         val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
-        val current = getBatteryCurrent(batteryManager)
+        val current = getBatteryCurrent(context, batteryManager)
         val wattage = voltage * current
         val icon = if (wattage > 0) batteryPower.statelessIcon else "mdi:battery-minus"
 
@@ -319,8 +321,14 @@ class BatterySensorManager : SensorManager {
         return intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0) / 10f
     }
 
-    private fun getBatteryCurrent(batteryManager: BatteryManager): Float {
-        return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW) / 1000000f
+    private fun getBatteryCurrent(context: Context, batteryManager: BatteryManager): Float {
+        val dividerSetting = getNumberSetting(
+            context,
+            batteryPower,
+            SETTING_BATTERY_CURRENT_DIVISOR,
+            DEFAULT_BATTERY_CURRENT_DIVISOR
+        )
+        return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW) / dividerSetting.toFloat()
     }
 
     private fun getBatteryVolts(intent: Intent): Float {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -612,6 +612,7 @@
     <string name="sensor_setting_nextalarm_allow_list_title">Allow List</string>
     <string name="sensor_setting_notification_allow_list_title">Allow List</string>
     <string name="sensor_setting_notification_disable_allow_list_title">Disable Allow List Requirement</string>
+    <string name="sensor_setting_battery_current_divisor_title">Battery Current Divisor</string>
     <string name="sensor_settings">Sensor Settings</string>
     <string name="sensor_summary">Use this to manage what sensors are enabled/disabled.</string>
     <string name="sensor_title">Manage Sensors</string>
@@ -915,7 +916,7 @@
     <string name="tls_cert_not_found_message">The remote site requires a client certificate.\nPlease install the required credential on your phone and try again.</string>
     <string name="tls_cert_expired_message">The certificate is not yet or no longer valid.\nPlease install a new credential on your phone and try again.</string>
     <string name="basic_sensor_name_battery_power">Battery Power</string>
-    <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting.</string>
     <string name="widget_checkbox_require_authentication">Require Authentication</string>
     <string name="widget_error_authenticating">Error authenticating - is an authentication method configured?</string>
+    <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting. If your values are not as expected you may need to adjust the \"Battery Current Divisor\" setting to get a proper unit of amperes for the \"current\" attribute. Android is supposed to report microamperes however, some devices may report a different unit. The default will convert microamperes to amperes.</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2846 by adding a setting so the user can adjust the divisor for the units their device supplies. Seems we have may have at least 3 different units even though android documentation says the value will be in micoramps.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#804

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->