### PR TITLE
Fix entity registry change type / crash

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryUpdatedEvent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryUpdatedEvent.kt
@@ -3,6 +3,6 @@ package io.homeassistant.companion.android.common.data.websocket.impl.entities
 data class EntityRegistryUpdatedEvent(
     val action: String,
     val entityId: String,
-    val changes: Map<String, String?>?,
+    val changes: Map<String, Any?>?,
     val oldEntityId: String?
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2853; the type for changes is usually a String but [not always](https://github.com/home-assistant/core/blob/73ba7a989b0cae6fba3564947d819e1eeb423f54/homeassistant/helpers/entity_registry.py#L107). Change the type to `Any` to handle this (even though the app currently never uses the changes).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->