### PR TITLE
Fix race condition in websocket unsubscribe/resubscribe

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -235,20 +235,20 @@ class WebSocketRepositoryImpl @Inject constructor(
                 eventSubscriptionFlow[subscribeMessage] = callbackFlow<T> {
                     eventSubscriptionProducerScope[subscribeMessage] = this as ProducerScope<Any>
                     awaitClose {
-                        if (eventSubscriptionId[subscribeMessage] != null) {
+                        eventSubscriptionProducerScope.remove(subscribeMessage)
+                        eventSubscriptionFlow.remove(subscribeMessage)
+                        eventSubscriptionId[subscribeMessage]?.let {
+                            eventSubscriptionId.remove(subscribeMessage)
                             Log.d(TAG, "Unsubscribing from $type with data $data")
                             ioScope.launch {
                                 sendMessage(
                                     mapOf(
                                         "type" to "unsubscribe_events",
-                                        "subscription" to eventSubscriptionId[subscribeMessage]!!
+                                        "subscription" to it
                                     )
                                 )
-                                eventSubscriptionId.remove(subscribeMessage)
                             }
                         }
-                        eventSubscriptionProducerScope.remove(subscribeMessage)
-                        eventSubscriptionFlow.remove(subscribeMessage)
                     }
                 }.shareIn(ioScope, SharingStarted.WhileSubscribed())
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If the app tried to start a new websocket subscription before the last one with the same message/data was properly unsubscribed, the app would return a flow that is `null` and crash. To prevent this, change the unsubscribe logic to immediately remove the subscription ID (the confirmation isn't used). This will allow the app to start a new subscription and create a new flow even if the previous unsubscribe hasn't yet fully finished.

More info and reproduction steps in the original issue, which this PR fixes: #2852

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->