### PR TITLE
Add item ID to active notification attributes to keep them unique

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -227,15 +227,15 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         try {
             val attr: MutableMap<String, Any?> = mutableMapOf()
             for (item in activeNotifications) {
-                attr += mappedBundle(item.notification.extras, "_${item.packageName}").orEmpty()
-                    .plus(item.packageName + "_" + item.id + "_post_time" to item.postTime)
-                    .plus(item.packageName + "_" + item.id + "_is_ongoing" to item.isOngoing)
-                    .plus(item.packageName + "_" + item.id + "_is_clearable" to item.isClearable)
-                    .plus(item.packageName + "_" + item.id + "_group_id" to item.notification.group)
-                    .plus(item.packageName + "_" + item.id + "_category" to item.notification.category)
+                attr += mappedBundle(item.notification.extras, "_${item.packageName}_${item.id}").orEmpty()
+                    .plus("${item.packageName}_${item.id}_post_time" to item.postTime)
+                    .plus("${item.packageName}_${item.id}_is_ongoing" to item.isOngoing)
+                    .plus("${item.packageName}_${item.id}_is_clearable" to item.isClearable)
+                    .plus("${item.packageName}_${item.id}_group_id" to item.notification.group)
+                    .plus("${item.packageName}_${item.id}_category" to item.notification.category)
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    attr[item.packageName + "_" + item.id + "_channel_id"] = item.notification.channelId
+                    attr["${item.packageName}_${item.id}_channel_id"] = item.notification.channelId
             }
             onSensorUpdated(
                 applicationContext,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Was helping a user on discord who mentioned they did not see all notification data in the attributes for active notification sensor, turns out we need to add the ID as well to keep the attributes unique otherwise they will overwrite each other.

Ref: https://discord.com/channels/330944238910963714/562408603345092636/1016456857574985738
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->