### PR TITLE
Don't collapse lists by default if there's only one list

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/views/ExpandableListHeader.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ExpandableListHeader.kt
@@ -28,10 +28,13 @@ import io.homeassistant.companion.android.common.R as commonR
 fun <K> rememberExpandedStates(
     initialKeys: Iterable<K>
 ): SnapshotStateMap<K, Boolean> {
+    val defaultExpanded = if (initialKeys is Collection) {
+        initialKeys.size == 1
+    } else false
     return remember {
         mutableStateMapOf<K, Boolean>().apply {
             initialKeys.forEach { key ->
-                put(key, false)
+                put(key, defaultExpanded)
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If there is only one collapsible list, the app shouldn't collapse it by default as the app may not use a collapsible header in that case. Fixes #2858.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
cc @leroyboerefijn somehow we missed this in #2804