### PR TITLE
Only subscribe to state changes for added controls

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -168,18 +168,16 @@ class HaControlsProviderService : ControlsProviderService() {
 
                         // Listen for the state changed events.
                         webSocketScope.launch {
-                            integrationRepository.getEntityUpdates()?.collect {
-                                if (controlIds.contains(it.entityId)) {
-                                    val control = domainToHaControl[it.domain]?.createControl(
-                                        applicationContext,
-                                        it as Entity<Map<String, Any>>,
-                                        RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry),
-                                        entityRequiresAuth(it.entityId),
-                                        baseUrl
-                                    )
-                                    if (control != null)
-                                        subscriber.onNext(control)
-                                }
+                            integrationRepository.getEntityUpdates(controlIds)?.collect {
+                                val control = domainToHaControl[it.domain]?.createControl(
+                                    applicationContext,
+                                    it as Entity<Map<String, Any>>,
+                                    RegistriesDataHandler.getAreaForEntity(it.entityId, areaRegistry, deviceRegistry, entityRegistry),
+                                    entityRequiresAuth(it.entityId),
+                                    baseUrl
+                                )
+                                if (control != null)
+                                    subscriber.onNext(control)
                             }
                         }
                         webSocketScope.launch {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Instead of receiving all state changes when the device controls are open, only receive state changes for entities that were added as controls. This potentially reduces the amount of data used while controls are open (mostly saved by no changes for irrelevant entities, the change messages itself are similar in size).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->