### PR TITLE
Fix template widgets that render null in websocket subscription

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -286,7 +286,7 @@ class TemplateWidget : AppWidgetProvider() {
         }
     }
 
-    private fun onTemplateChanged(context: Context, appWidgetId: Int, template: String) {
+    private fun onTemplateChanged(context: Context, appWidgetId: Int, template: String?) {
         widgetScope?.launch {
             val views = getWidgetRemoteViews(context, appWidgetId, template)
             AppWidgetManager.getInstance(context).updateAppWidget(appWidgetId, views)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -15,7 +15,7 @@ interface IntegrationRepository {
     suspend fun getNotificationRateLimits(): RateLimitResponse
 
     suspend fun renderTemplate(template: String, variables: Map<String, String>): String?
-    suspend fun getTemplateUpdates(template: String): Flow<String>?
+    suspend fun getTemplateUpdates(template: String): Flow<String?>?
 
     suspend fun updateLocation(updateLocation: UpdateLocation)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -179,7 +179,7 @@ class IntegrationRepositoryImpl @Inject constructor(
         else throw IntegrationException("Error calling integration request render_template")
     }
 
-    override suspend fun getTemplateUpdates(template: String): Flow<String>? {
+    override suspend fun getTemplateUpdates(template: String): Flow<String?>? {
         return webSocketRepository.getTemplateUpdates(template)
             ?.map {
                 it.result

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/TemplateUpdatedEvent.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/TemplateUpdatedEvent.kt
@@ -4,6 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class TemplateUpdatedEvent(
-    val result: String,
+    val result: String?,
     val listeners: Map<String, Any>
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #2865 by handling templates that return `null`, which is a valid result. These will, like in the preview and developer tools, show up as the string "null" on the widget.

(A similar change was previously made for the preview, but somehow this wasn't considered for subscriptions 🙃)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->