### PR TITLE
Tweak camera control active state: true if not unavailable

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.net.URL
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -39,7 +40,7 @@ object CameraControl : HaControl {
                 "idle" -> context.getString(commonR.string.state_idle)
                 "recording" -> context.getString(commonR.string.state_recording)
                 "streaming" -> context.getString(commonR.string.state_streaming)
-                else -> entity.state
+                else -> entity.state.capitalize(Locale.getDefault())
             }
         )
 
@@ -54,7 +55,7 @@ object CameraControl : HaControl {
         control.setControlTemplate(
             ThumbnailTemplate(
                 entity.entityId,
-                entity.state != "idle",
+                entity.state != "unavailable" && image != null,
                 icon,
                 context.getString(commonR.string.widget_camera_contentdescription)
             )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Resolves #2870 by seting the thumbnail template for the camera control to active as long as the camera isn't `unavailable` and the app was able to download an image. This change aims to show the camera image more often and better match the frontend.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
It depends on the device how controls are shown, this is on the Android 13 emulator.

Note the idle 'camera' that is now visible (showing [a weather map](https://www.home-assistant.io/integrations/buienradar/)). In the current version of the app both of these tiles would look like the unavailable camera in the screenshot.
![Android device controls showing two cameras, one is 'Unavailable' with a grey background and another one is 'Inactive' with a weather map image as the background](https://user-images.githubusercontent.com/8148535/189448455-4bfc2be5-ede8-4bff-92db-eb5ce6cdaace.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->