### PR TITLE
Add support for using BSSIDs for internal connection

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
@@ -34,6 +34,7 @@ class SsidFragment : Fragment() {
                         wifiSsids = viewModel.wifiSsids,
                         prioritizeInternal = viewModel.prioritizeInternal,
                         activeSsid = viewModel.activeSsid,
+                        activeBssid = viewModel.activeBssid,
                         onAddWifiSsid = viewModel::addHomeWifiSsid,
                         onRemoveWifiSsid = viewModel::removeHomeWifiSsid,
                         onSetPrioritize = viewModel::setPrioritize

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
@@ -1,7 +1,10 @@
 package io.homeassistant.companion.android.settings.ssid
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
@@ -9,6 +12,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.google.android.material.composethemeadapter.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.settings.ssid.views.SsidView
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -19,7 +23,16 @@ class SsidFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setHasOptionsMenu(false)
+        setHasOptionsMenu(true)
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        super.onPrepareOptionsMenu(menu)
+
+        menu.findItem(R.id.get_help)?.let {
+            it.isVisible = true
+            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://companion.home-assistant.io/docs/troubleshooting/networking#setting-up-the-app"))
+        }
     }
 
     override fun onCreateView(

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
@@ -26,7 +26,10 @@ class SsidViewModel @Inject constructor(
     var prioritizeInternal by mutableStateOf(false)
         private set
 
-    var activeSsid by mutableStateOf("")
+    var activeSsid by mutableStateOf<String?>(null)
+        private set
+
+    var activeBssid by mutableStateOf<String?>(null)
         private set
 
     init {
@@ -34,7 +37,8 @@ class SsidViewModel @Inject constructor(
             wifiSsids.clear()
             wifiSsids.addAll(urlRepository.getHomeWifiSsids())
             prioritizeInternal = urlRepository.isPrioritizeInternal()
-            activeSsid = wifiHelper.getWifiSsid().removeSurrounding("\"")
+            activeSsid = wifiHelper.getWifiSsid()?.removeSurrounding("\"")
+            activeBssid = wifiHelper.getWifiBssid()
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
@@ -47,9 +47,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.data.url.UrlRepository
 import io.homeassistant.companion.android.common.R as commonR
 
 @OptIn(
@@ -61,7 +63,8 @@ import io.homeassistant.companion.android.common.R as commonR
 fun SsidView(
     wifiSsids: List<String>,
     prioritizeInternal: Boolean,
-    activeSsid: String,
+    activeSsid: String?,
+    activeBssid: String?,
     onAddWifiSsid: (String) -> Boolean,
     onRemoveWifiSsid: (String) -> Unit,
     onSetPrioritize: (Boolean) -> Unit
@@ -125,7 +128,7 @@ fun SsidView(
         }
 
         if (
-            activeSsid.isNotBlank() &&
+            activeSsid?.isNotBlank() == true &&
             wifiSsids.none { it == activeSsid } &&
             (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || activeSsid !== WifiManager.UNKNOWN_SSID)
         ) {
@@ -147,7 +150,9 @@ fun SsidView(
             }
         }
         items(wifiSsids, key = { "ssid.item.$it" }) {
-            val connected = it == activeSsid
+            val connected = remember(it, activeSsid, activeBssid) {
+                it == activeSsid || (it.startsWith(UrlRepository.BSSID_PREFIX) && it.removePrefix(UrlRepository.BSSID_PREFIX).equals(activeBssid, ignoreCase = true))
+            }
             Row(
                 modifier = Modifier
                     .heightIn(min = 56.dp)
@@ -163,7 +168,12 @@ fun SsidView(
                     else LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
                 )
                 Text(
-                    text = it,
+                    text =
+                    if (it.startsWith(UrlRepository.BSSID_PREFIX)) it.removePrefix(UrlRepository.BSSID_PREFIX)
+                    else it,
+                    fontFamily =
+                    if (it.startsWith(UrlRepository.BSSID_PREFIX)) FontFamily.Monospace
+                    else null,
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
                         .weight(1f)
@@ -240,6 +250,7 @@ private fun PreviewSsidViewEmpty() {
         wifiSsids = emptyList(),
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
+        activeBssid = "02:00:00:00:00:00",
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
         onSetPrioritize = {}
@@ -250,9 +261,10 @@ private fun PreviewSsidViewEmpty() {
 @Composable
 private fun PreviewSsidViewItems() {
     SsidView(
-        wifiSsids = listOf("home-assistant-wifi", "wifi-one", "wifi-two"),
+        wifiSsids = listOf("home-assistant-wifi", "wifi-one", "BSSID:1A:2B:3C:4D:5E:6F"),
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
+        activeBssid = "02:00:00:00:00:00",
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
         onSetPrioritize = {}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
@@ -4,6 +4,11 @@ import java.net.URL
 
 interface UrlRepository {
 
+    companion object {
+        const val BSSID_PREFIX = "BSSID:"
+        const val INVALID_BSSID = "02:00:00:00:00:00"
+    }
+
     suspend fun getWebhookId(): String?
 
     suspend fun getApiUrls(): Array<URL>

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.data.wifi
 
 interface WifiHelper {
-    fun getWifiSsid(): String
+    fun getWifiSsid(): String?
+    fun getWifiBssid(): String?
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -3,10 +3,13 @@ package io.homeassistant.companion.android.common.data.wifi
 import android.net.wifi.WifiManager
 import javax.inject.Inject
 
+@Suppress("DEPRECATION")
 class WifiHelperImpl @Inject constructor(
     private val wifiManager: WifiManager
 ) : WifiHelper {
-    override fun getWifiSsid(): String {
-        return wifiManager.connectionInfo?.ssid.toString()
-    }
+    override fun getWifiSsid(): String? =
+        wifiManager.connectionInfo.ssid
+
+    override fun getWifiBssid(): String? =
+        wifiManager.connectionInfo.bssid
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add support for entering BSSIDs to use for detecting when the internal connection URL should be used. These are entered and saved like any regular SSID, but contain the prefix "BSSID:". The SSID settings screen will recognize the prefix and apply some formatting to make it easier to see that they've been recognized.

Fixes #2880

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The Home Network WiFi SSID screen with a BSSID alongside a regular SSID. It will remove the "BSSID:" prefix and instead shows the value in a monospace font. Active network detection (blue icon) still works.
|Light|Dark|
|-----|-----|
|![The Home Network WiFi SSID screen as described above, light mode.](https://user-images.githubusercontent.com/8148535/190478125-ed3755db-67ea-437d-9f49-280502d7897e.png)|![The Home Network WiFi SSID screen as described above, dark mode.](https://user-images.githubusercontent.com/8148535/190478138-218a45db-e694-4c87-8f95-796692ee436c.png)|

Note that the main screen still shows the raw value, I think this is fine.
|Light|Dark|
|-----|-----|
|![A settings row with the text 'Home Network WiFi SSID', value 'BSSID:1A:2B:3C:4D:5E:6F, home-assistant-wifi', light mode.](https://user-images.githubusercontent.com/8148535/190478326-4d2e4799-d0d0-4b0f-9207-f17aafbc36f3.png)|![A settings row with the text 'Home Network WiFi SSID', value 'BSSID:1A:2B:3C:4D:5E:6F, home-assistant-wifi', dark mode.](https://user-images.githubusercontent.com/8148535/190478337-6f12c2e4-203a-46dd-a92b-55641f6e5569.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#813

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->