### PR TITLE
Add a dynamic color sensor for accent color

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
@@ -8,9 +8,9 @@ import com.google.android.material.color.DynamicColors
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.R as commonR
 
-class DynamicColorsSensorManager : SensorManager {
+class DynamicColorSensorManager : SensorManager {
     companion object {
-        private const val TAG = "DynamicColors"
+        private const val TAG = "DynamicColor"
 
         val accentColorSensor = SensorManager.BasicSensor(
             "accent_color",
@@ -28,7 +28,7 @@ class DynamicColorsSensorManager : SensorManager {
     override val enabledByDefault: Boolean
         get() = false
     override val name: Int
-        get() = commonR.string.sensor_name_dynamic_colors
+        get() = commonR.string.sensor_name_dynamic_color
 
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
         return listOf(accentColorSensor)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorsSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorsSensorManager.kt
@@ -1,0 +1,73 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import androidx.core.graphics.blue
+import androidx.core.graphics.green
+import androidx.core.graphics.red
+import com.google.android.material.color.DynamicColors
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.R as commonR
+
+class DynamicColorsSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "DynamicColors"
+
+        val accentColorSensor = SensorManager.BasicSensor(
+            "accent_color",
+            "sensor",
+            commonR.string.sensor_name_accent_color_sensor,
+            commonR.string.sensor_description_accent_color_sensor,
+            "mdi:palette",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+        )
+    }
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/core/sensors#dynamic-color-sensor"
+    }
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = commonR.string.sensor_name_dynamic_colors
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(accentColorSensor)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(context: Context) {
+        updateAccentColor(context)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return DynamicColors.isDynamicColorAvailable()
+    }
+
+    private fun updateAccentColor(context: Context) {
+
+        if (!isEnabled(context, accentColorSensor.id))
+            return
+
+        val dynamicColorContext = DynamicColors.wrapContextIfAvailable(context)
+        val attrsToResolve = intArrayOf(
+            android.R.attr.colorAccent, // 0
+        )
+        val test = dynamicColorContext.obtainStyledAttributes(attrsToResolve)
+        val accent = test.getColor(0, 0)
+        val accentHex = java.lang.String.format("#%06X", 0xFFFFFF and accent)
+        test.recycle()
+
+        onSensorUpdated(
+            context,
+            accentColorSensor,
+            accentHex,
+            accentColorSensor.statelessIcon,
+            mapOf(
+                "rgb_color" to listOf(accent.red, accent.green, accent.blue)
+            )
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -38,6 +38,7 @@ class SensorReceiver : SensorReceiverBase() {
             BatterySensorManager(),
             BluetoothSensorManager(),
             DNDSensorManager(),
+            DynamicColorsSensorManager(),
             DevicePolicyManager(),
             GeocodeSensorManager(),
             KeyguardSensorManager(),

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -38,7 +38,7 @@ class SensorReceiver : SensorReceiverBase() {
             BatterySensorManager(),
             BluetoothSensorManager(),
             DNDSensorManager(),
-            DynamicColorsSensorManager(),
+            DynamicColorSensorManager(),
             DevicePolicyManager(),
             GeocodeSensorManager(),
             KeyguardSensorManager(),

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -922,4 +922,7 @@
     <string name="widget_checkbox_require_authentication">Require Authentication</string>
     <string name="widget_error_authenticating">Error authenticating - is an authentication method configured?</string>
     <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting. If your values are not as expected you may need to adjust the \"Battery Current Divisor\" setting to get a proper unit of amperes for the \"current\" attribute. Android is supposed to report microamperes however, some devices may report a different unit. The default will convert microamperes to amperes.</string>
+    <string name="sensor_name_accent_color_sensor">Accent Color</string>
+    <string name="sensor_description_accent_color_sensor">A hexadecimal color value for the dynamic accent color used in the device theme</string>
+    <string name="sensor_name_dynamic_colors">Dynamic Colors</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -924,5 +924,5 @@
     <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting. If your values are not as expected you may need to adjust the \"Battery Current Divisor\" setting to get a proper unit of amperes for the \"current\" attribute. Android is supposed to report microamperes however, some devices may report a different unit. The default will convert microamperes to amperes.</string>
     <string name="sensor_name_accent_color_sensor">Accent Color</string>
     <string name="sensor_description_accent_color_sensor">A hexadecimal color value for the dynamic accent color used in the device theme</string>
-    <string name="sensor_name_dynamic_colors">Dynamic Colors</string>
+    <string name="sensor_name_dynamic_color">Dynamic Color</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2085 by adding a new sensor that gets the accent color from the dynamic color used. The state is in a hexadecimal format and an attribute is also provided for `rgb_color` in case a user wanted to use it for the `light.turn_on` service call. This sensor will only be available for devices that support dynamic color.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/190517879-e75712c7-f30d-4edc-b802-8050bdad1fab.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#814

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->