### PR TITLE
Breaking Change: Only send notification received event if a notification wants the confirmation

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -134,6 +134,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND = "command"
         const val TTS_TEXT = "tts_text"
         const val CHANNEL = "channel"
+        const val CONFIRMATION = "confirmation"
 
         // special intent constants
         const val INTENT_PACKAGE_NAME = "intent_package_name"
@@ -280,13 +281,17 @@ class MessagingManager @Inject constructor(
             NotificationItem(0, now, jsonData[MESSAGE].toString(), jsonObject.toString(), source)
         notificationDao.add(notificationRow)
 
-        mainScope.launch {
-            try {
-                integrationUseCase.fireEvent("mobile_app_notification_received", jsonData)
-            } catch (e: Exception) {
-                Log.e(TAG, "Unable to send notification received event", e)
+        val confirmation = jsonData[CONFIRMATION]?.toBoolean() ?: false
+        if (confirmation) {
+            mainScope.launch {
+                try {
+                    integrationUseCase.fireEvent("mobile_app_notification_received", jsonData)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Unable to send notification received event", e)
+                }
             }
         }
+
         when {
             jsonData[MESSAGE] == REQUEST_LOCATION_UPDATE -> {
                 Log.d(TAG, "Request location update")

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -4,6 +4,7 @@
     <release version="2022.9 - Phone" versioncode="2">
         <change>&lt;b&gt;Breaking Change:&lt;/b&gt; Geocoded Location sensor attributes for latitude and longitude have been combined into location, the sensor will no longer show on the map. Additional attributes also added to the sensor.</change>
         <change>&lt;b&gt;Breaking Change:&lt;/b&gt; Template widgets will only update when the template detects a change. If you are not seeing frequent updates then you are hit by rate limiting and will need to readjust the template.</change>
+        <change>&lt;b&gt;Breaking Change:&lt;/b&gt; Notification Received event will only be sent if a notification contains "confirmation: true" in the service call.</change>
         <change>Add beacon monitor sensor</change>
         <change>Add authentication option to button widget</change>
         <change>Add option to bypass locking the app when on home WiFi</change>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

There has been a large increase in data traffic from the app to HA since the last release. This PR now requires a new notification parameter to be set so the app can send the received event. Users will need to set `confirmation: true` for the notification they wish to get confirmation the notification was received. This will allow us to cut down on traffic and let the user specify which notifications they actually want the event for.

example:

```
message: Test
data:
  confirmation: true
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#818

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM: https://github.com/home-assistant/mobile-apps-fcm-push/pull/92