### PR TITLE
Mark Wear OS app as non-standalone since we use phone for sign in now

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
         <!-- The app can run without a connected phone -->
         <meta-data
             android:name="com.google.android.wearable.standalone"
-            android:value="true" />
+            android:value="false" />
 
         <activity android:name=".home.HomeActivity" />
         <activity android:name=".splash.SplashActivity"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Now that #2838 has been merged we need to update our manifest to mark the app as non-standalone since we no longer conform to the requirements.

https://developer.android.com/docs/quality-guidelines/wear-app-quality#best

`If the app is identified as standalone, it must be functional without requiring a phone for authentication or operation.`

https://developer.android.com/training/wearables/overlays/standalone-apps#identify

```
Standalone: completely independent app that does not require a phone app for core features including authentication; a phone app would provide only optional features.
Non-standalone: dependent app that requires a phone app or another device for core features including authentication.
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->