### PR TITLE
Fix websocket subscription race/dropping first message

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
@@ -10,6 +10,8 @@ import kotlinx.coroutines.flow.SharedFlow
  * received, or sent for a subscription) on the websocket connection.
  * @param message Map that holds the websocket message contents
  * @param eventFlow Flow (using callbackFlow) that will emit events for a subscription, else `null`
+ * @param eventTimeout timeout in milliseconds for ending the subscription when the flow is no
+ * longer collected
  * @param onEvent Channel that can receive events for a subscription, else `null`
  * @param onResponse Continuation for the initial response to this message. Don't set this when
  * creating this class, it will be set when a message is sent on the websocket.
@@ -17,6 +19,7 @@ import kotlinx.coroutines.flow.SharedFlow
 data class WebSocketRequest(
     val message: Map<*, *>,
     val eventFlow: SharedFlow<Any>? = null,
+    val eventTimeout: Long = 0L,
     val onEvent: Channel<Any>? = null,
     var onResponse: CancellableContinuation<SocketResponse>? = null
 )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.common.data.websocket
+
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.SocketResponse
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * A class that holds information about messages that are currently active (sent and no response
+ * received, or sent for a subscription) on the websocket connection.
+ * @param message Map that holds the websocket message contents
+ * @param eventFlow Flow (using callbackFlow) that will emit events for a subscription, else `null`
+ * @param onEvent Channel that can receive events for a subscription, else `null`
+ * @param onResponse Continuation for the initial response to this message. Don't set this when
+ * creating this class, it will be set when a message is sent on the websocket.
+ */
+data class WebSocketRequest(
+    val message: Map<*, *>,
+    val eventFlow: SharedFlow<Any>? = null,
+    val onEvent: Channel<Any>? = null,
+    var onResponse: CancellableContinuation<SocketResponse>? = null
+)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes a potential race condition for subscriptions on the websocket, where the first message might be dropped if it is delivered very soon after the subscription confirmation because the `eventSubscriptionFlow`/`eventSubscriptionProducerScope` haven't been set up yet. While not new, it is more likely to happen after #2829 because the server can send messages faster.

As this issue also applied to the notification flow, **I've merged the notification subscription logic with the more general subscription logic in this PR** so it can also receive the fix without duplicating code.

Inspired by [home-assistant-js-websocket](https://github.com/home-assistant/home-assistant-js-websocket), the app will now set up the response + subscription handlers immediately after _sending_ the initial message. To make sure no messages are dropped, it'll also use a `Channel` to buffer event messages while not yet ready to receive them. The `Channel` will be collected inside the existing `callbackFlow` that is only active while there are subscribers.

If the app receives events for subscriptions that aren't tracked, it will now send an unsubscribe message.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
The easiest option to reproduce the issue is by introducing a delay [here](https://github.com/home-assistant/android/blob/7ab914a8bb47ad84a62c435d19f2b26fb1171064/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt#L232), for example 10 seconds. Then, do something that will generate an event after subscribing and note that it isn't handled by the app.

You can easily see this in the Wear app by triggering a state change after opening the app. In the stable version of the app the state change won't be reflected, with this PR it will be after the delay.

Re: https://github.com/home-assistant/android/blob/1449ff540938e8823eba6c9b26d86eb8ab20c4b3/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt#L287

Yes, it turns out it works the same as unsubscribing from any other subscription :)