### PR TITLE
Breaking Change: Only update geocoded sensor with location if the setting is turned on

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -18,6 +18,7 @@ class GeocodeSensorManager : SensorManager {
 
     companion object {
         private const val SETTING_ACCURACY = "geocode_minimum_accuracy"
+        const val SETTINGS_INCLUDE_LOCATION = "geocode_include_location_updates"
         private const val DEFAULT_MINIMUM_ACCURACY = 200
         private const val TAG = "GeocodeSM"
         val geocodedLocation = SensorManager.BasicSensor(

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -766,16 +766,29 @@ class LocationSensorManager : LocationSensorManagerBase() {
         lastLocationSend = now
         lastUpdateLocation = updateLocation.gps.contentToString()
 
+        val geocodeIncludeLocation = getSetting(
+            latestContext,
+            GeocodeSensorManager.geocodedLocation,
+            GeocodeSensorManager.SETTINGS_INCLUDE_LOCATION,
+            SensorSettingType.TOGGLE,
+            "false"
+        ).toBoolean()
+
         ioScope.launch {
             try {
                 integrationUseCase.updateLocation(updateLocation)
                 Log.d(TAG, "Location update sent successfully")
 
                 // Update Geocoded Location Sensor
-                val intent = Intent(latestContext, SensorReceiver::class.java)
-                intent.action = SensorReceiverBase.ACTION_UPDATE_SENSOR
-                intent.putExtra(SensorReceiverBase.EXTRA_SENSOR_ID, GeocodeSensorManager.geocodedLocation.id)
-                latestContext.sendBroadcast(intent)
+                if (geocodeIncludeLocation) {
+                    val intent = Intent(latestContext, SensorReceiver::class.java)
+                    intent.action = SensorReceiverBase.ACTION_UPDATE_SENSOR
+                    intent.putExtra(
+                        SensorReceiverBase.EXTRA_SENSOR_ID,
+                        GeocodeSensorManager.geocodedLocation.id
+                    )
+                    latestContext.sendBroadcast(intent)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Could not update location.", e)
             }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -482,7 +482,7 @@
     <string name="sensor_description_dnd_sensor">The current state of Do Not Disturb</string>
     <string name="sensor_description_doze">Whether the device is in Doze mode</string>
     <string name="sensor_description_external_storage">Information about the total and available storage space externally</string>
-    <string name="sensor_description_geocoded_location">Calculated address based on GPS data using Googles Location API</string>
+    <string name="sensor_description_geocoded_location">Calculated address based on GPS data using Googles Location API. The minimum accuracy setting determines if a location update is accurate enough to be updated, the default is 200 meters. A setting also exists to send a sensor update anytime the location sensors update, by default this off.</string>
     <string name="sensor_description_headphone">Whether headphones are plugged into the device</string>
     <string name="sensor_description_headset_mounted">Whether the headset is currently in use</string>
     <string name="sensor_description_high_accuracy_mode">Whether high accuracy mode is active on the device</string>
@@ -595,7 +595,7 @@
     <string name="sensor_setting_beacon_monitor_filter_iterations_title">Filter Iterations</string>
     <string name="sensor_setting_beacon_monitor_filter_rssi_multiplier_title">Filter RSSI Multiplier</string>
     <string name="sensor_setting_geocode_minimum_accuracy_title">Minimum Accuracy</string>
-    <string name="sensor_setting_geocode_include_location_updates_title">Update sensor with device tracker</string>
+    <string name="sensor_setting_geocode_include_location_updates_title">Update sensor with location sensors</string>
     <string name="sensor_setting_lastreboot_deadband_title">Deadband</string>
     <string name="sensor_setting_lastupdate_add_new_intent_title">Add New Intent</string>
     <string name="sensor_setting_lastupdate_intent_title" translatable="false">Intent %1$1s</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -595,6 +595,7 @@
     <string name="sensor_setting_beacon_monitor_filter_iterations_title">Filter Iterations</string>
     <string name="sensor_setting_beacon_monitor_filter_rssi_multiplier_title">Filter RSSI Multiplier</string>
     <string name="sensor_setting_geocode_minimum_accuracy_title">Minimum Accuracy</string>
+    <string name="sensor_setting_geocode_include_location_updates_title">Update sensor with device tracker</string>
     <string name="sensor_setting_lastreboot_deadband_title">Deadband</string>
     <string name="sensor_setting_lastupdate_add_new_intent_title">Add New Intent</string>
     <string name="sensor_setting_lastupdate_intent_title" translatable="false">Intent %1$1s</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

To cut down on the amount of updates the app sends by default I am adding a setting for keeping the geocoded sensor update with location updates. This setting defaults to `off` which is previous app before behavior 2022.8.

Marking as a breaking change as the behavior is changing.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#823

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->