### PR TITLE
Only check for beacons if the index is present

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
@@ -60,12 +60,13 @@ class IBeaconMonitor {
         }
         assert(sorted.count() == beacons.count())
         beacons.forEachIndexed foreach@{ i, existingBeacon ->
-
-            if (name(sorted[i].uuid, sorted[i].major, sorted[i].minor) != name(existingBeacon.uuid, existingBeacon.major, existingBeacon.minor) || // the distance order switched
-                kotlin.math.abs(sorted[i].distance - existingBeacon.distance) > 0.5 // the distance difference is greater than 0.5m
-            ) {
-                requireUpdate = true
-                return@foreach
+            if (i <= sorted.size) {
+                if (name(sorted[i].uuid, sorted[i].major, sorted[i].minor) != name(existingBeacon.uuid, existingBeacon.major, existingBeacon.minor) || // the distance order switched
+                    kotlin.math.abs(sorted[i].distance - existingBeacon.distance) > 0.5 // the distance difference is greater than 0.5m
+                ) {
+                    requireUpdate = true
+                    return@foreach
+                }
             }
         }
         if (requireUpdate) {

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
@@ -59,7 +59,7 @@ class IBeaconMonitor {
             return
         }
         beacons.forEachIndexed foreach@{ i, existingBeacon ->
-            if (i <= sorted.size) {
+            if (i < sorted.size) {
                 if (name(sorted[i].uuid, sorted[i].major, sorted[i].minor) != name(existingBeacon.uuid, existingBeacon.major, existingBeacon.minor) || // the distance order switched
                     kotlin.math.abs(sorted[i].distance - existingBeacon.distance) > 0.5 // the distance difference is greater than 0.5m
                 ) {

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
@@ -58,7 +58,6 @@ class IBeaconMonitor {
             sendUpdate(context, sorted)
             return
         }
-        assert(sorted.count() == beacons.count())
         beacons.forEachIndexed foreach@{ i, existingBeacon ->
             if (i <= sorted.size) {
                 if (name(sorted[i].uuid, sorted[i].major, sorted[i].minor) != name(existingBeacon.uuid, existingBeacon.major, existingBeacon.minor) || // the distance order switched


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed the below sentry error in the latest beta so preventing accessing an index that will not exist so the app does not crash. I thought the [`assert()`](https://github.com/home-assistant/android/blob/1fb159999720b6065a3feb8198b344e267765750/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt#L61)  above would take care of this but I guess not? Do we need that check?

```
java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
    at java.util.ArrayList.get(ArrayList.java:437)
    at io.homeassistant.companion.android.bluetooth.ble.IBeaconMonitor.setBeacons(IBeaconMonitor.kt:64)
    at io.homeassistant.companion.android.bluetooth.ble.MonitoringManager$startMonitoring$2.invokeSuspend$lambda-0(MonitoringManager.kt:53)
    at io.homeassistant.companion.android.bluetooth.ble.MonitoringManager$startMonitoring$2.$r8$lambda$a-4DQIY1f5dyfoiXoAHs7lcceLI
    at io.homeassistant.companion.android.bluetooth.ble.MonitoringManager$startMonitoring$2$$ExternalSyntheticLambda0.onChanged
    at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
    at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:151)
    at androidx.lifecycle.LiveData.setValue(LiveData.java:309)
    at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
    at androidx.lifecycle.LiveData$1.run(LiveData.java:93)
    at android.os.Handler.handleCallback(Handler.java:938)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:226)
    at android.os.Looper.loop(Looper.java:313)
    at android.app.ActivityThread.main(ActivityThread.java:8751)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->