### PR TITLE
Fix BLE monitor new beacon check

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
@@ -38,10 +38,10 @@ class IBeaconMonitor {
             val minor = newBeacon.id3.toString()
             val distance = round(newBeacon.distance * 100) / 100
             val rssi = newBeacon.runningAverageRssi
-            if (!tmp.contains(uuid)) { // we found a new beacon
+            if (!tmp.contains(name(uuid, major, minor))) { // we found a new beacon
                 requireUpdate = true
             }
-            tmp += Pair(uuid, IBeacon(uuid, major, minor, distance, rssi, 0))
+            tmp += Pair(name(uuid, major, minor), IBeacon(uuid, major, minor, distance, rssi, 0))
         }
         val sorted = sort(tmp.values).toMutableList()
         if (requireUpdate) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes a bug introduced in #2909 where the app keeps thinking there are new beacons because it is only checking for the UUID while the app now stores beacons using UUID+major+minor.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->