### PR TITLE
Breaking Change: Add bluetooth connect permission to beacon monitor to prevent log spam from library

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/BluetoothSensorManager.kt
@@ -160,6 +160,7 @@ class BluetoothSensorManager : SensorManager {
             (sensorId == beaconMonitor.id && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) -> {
                 arrayOf(
                     Manifest.permission.BLUETOOTH,
+                    Manifest.permission.BLUETOOTH_CONNECT,
                     Manifest.permission.BLUETOOTH_SCAN,
                     Manifest.permission.ACCESS_FINE_LOCATION,
                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed the following error spamming logcat while testing other PR fixes so adding in the permission to avoid that.

```
2022-09-25 08:59:35.789  2898-3408  BeaconParser            io....stant.companion.android.debug  D  Cannot read device name without Manifest.permission.BLUETOOTH_CONNECT
```

Marking as a breaking change as the sensor may not be enabled if permissions are not granted.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->