### PR TITLE
Simplify themes

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -66,7 +66,7 @@ class AuthenticationFragment : Fragment() {
                 MdcTheme {
                     AndroidView({
                         WebView(requireContext()).apply {
-                            themesManager.setThemeForWebView(requireContext(), settings)
+                            themesManager.setThemeForWebView()
                             settings.javaScriptEnabled = true
                             settings.domStorageEnabled = true
                             settings.userAgentString = settings.userAgentString + " ${HomeAssistantApis.USER_AGENT_STRING}"

--- a/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
@@ -1,12 +1,7 @@
 package io.homeassistant.companion.android.themes
 
-import android.content.Context
-import android.content.res.Configuration
 import android.os.Build
-import android.webkit.WebSettings
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -40,48 +35,9 @@ class ThemesManager @Inject constructor(
         }
     }
 
-    fun setThemeForWebView(context: Context, webSettings: WebSettings) {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY) &&
-            WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)
-        ) {
-            val theme = getCurrentTheme()
-
-            setNightModeBasedOnTheme(theme)
-
-            WebSettingsCompat.setForceDarkStrategy(
-                webSettings,
-                WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
-            )
-            when (theme) {
-                "dark" -> {
-                    WebSettingsCompat.setForceDark(
-                        webSettings,
-                        WebSettingsCompat.FORCE_DARK_ON
-                    )
-                }
-                "android", "system" -> {
-                    val nightModeFlags =
-                        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-                    if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
-                        WebSettingsCompat.setForceDark(
-                            webSettings,
-                            WebSettingsCompat.FORCE_DARK_ON
-                        )
-                    } else {
-                        WebSettingsCompat.setForceDark(
-                            webSettings,
-                            WebSettingsCompat.FORCE_DARK_OFF
-                        )
-                    }
-                }
-                else -> {
-                    WebSettingsCompat.setForceDark(
-                        webSettings,
-                        WebSettingsCompat.FORCE_DARK_OFF
-                    )
-                }
-            }
-        }
+    fun setThemeForWebView() {
+        val theme = getCurrentTheme()
+        setNightModeBasedOnTheme(theme)
     }
 
     private fun setNightModeBasedOnTheme(theme: String?) {

--- a/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
@@ -53,10 +53,6 @@ class ThemesManager @Inject constructor(
                 WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
             )
             when (theme) {
-                "newTheme" -> {
-                    // Just a template for custom themes
-                    // context.setTheme(android.R.style.newTheme);
-                }
                 "dark" -> {
                     WebSettingsCompat.setForceDark(
                         webSettings,

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -621,7 +621,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         // This enables the ability to have the launch screen behind the WebView until the web frontend gets rendered
         binding.webview.setBackgroundColor(Color.TRANSPARENT)
 
-        themesManager.setThemeForWebView(this, webView.settings)
+        themesManager.setThemeForWebView()
 
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -2,13 +2,11 @@
 <resources>
     <string-array name="pref_theme_option_labels">
         <item>@string/themes_option_label_system</item>
-        <item>@string/themes_option_label_android</item>
         <item>@string/themes_option_label_light</item>
         <item>@string/themes_option_label_dark</item>
     </string-array>
     <string-array name="pref_theme_option_values">
         <item>@string/themes_option_value_system</item>
-        <item>@string/themes_option_value_android</item>
         <item>@string/themes_option_value_light</item>
         <item>@string/themes_option_value_dark</item>
     </string-array>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -708,10 +708,9 @@
     <string name="template_widget_default">Enter Template Here</string>
     <string name="template_widget_desc">Render any template with HTML formatting</string>
     <string name="template_widget">Template Widget</string>
-    <string name="themes_option_label_android">Follow System Settings</string>
     <string name="themes_option_label_dark">Dark</string>
     <string name="themes_option_label_light">Light</string>
-    <string name="themes_option_label_system">Follow Home Assistant</string>
+    <string name="themes_option_label_system">Follow System Settings</string>
     <string name="themes_option_value_android">android</string>
     <string name="themes_option_value_dark">dark</string>
     <string name="themes_option_value_light">light</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR simplifies themes by:

 - **Merging the 'Follow Home Assistant' and 'Follow System Settings' theme options**
    This was originally introduced in #1501 to be able to control the system bar colors, but that functionality was removed in #1950. As the two options currently behave identically and there haven't been any complaints, I'm merging them back in to one setting 'Follow System Settings'.
    The merged option will be called 'Follow System Settings' because 'Follow Home Assistant' makes it sound like the app will use the theme setting from the frontend/profile which is not correct.
 - **Removing webview force dark settings**
   While the developer documentation [suggests that you use these 'force' settings](https://developer.android.com/develop/ui/views/layout/webapps/dark-theme), they are no longer required for the app. With the latest version of the webview and all the app's dependencies, the frontend will follow the app's theme setting without the need to set force dark (so dark mode app + auto frontend = dark mode frontend, or dark mode app + light frontend = light mode frontend simply works without any additional settings). I have tested this on Android 8.1 (no system level dark theme), Android 11 and Android 13.
    When the app starts targeting Android 13, the existing setting also wouldn't be possible to set [as it will only allow managing algorithmic darkening](https://developer.android.com/jetpack/androidx/releases/webkit#1.5.0) which was already disabled by setting the strategy to [`DARK_STRATEGY_WEB_THEME_DARKENING_ONLY`](https://developer.android.com/reference/kotlin/androidx/webkit/WebSettingsCompat#DARK_STRATEGY_WEB_THEME_DARKENING_ONLY()).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->