### PR TITLE
Add new force_on and force_off options to command_high_accuracy_mode.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -225,6 +225,8 @@ class MessagingManager @Inject constructor(
 
         // High accuracy commands
         const val HIGH_ACCURACY_SET_UPDATE_INTERVAL = "high_accuracy_set_update_interval"
+        const val FORCE_ON = "force_on"
+        const val FORCE_OFF = "force_off"
 
         // Command groups
         val DEVICE_COMMANDS = listOf(
@@ -252,6 +254,7 @@ class MessagingManager @Inject constructor(
             SYSTEM_STREAM, DTMF_STREAM
         )
         val ENABLE_COMMANDS = listOf(TURN_OFF, TURN_ON)
+        val FORCE_COMMANDS = listOf(FORCE_OFF, FORCE_ON)
         val MEDIA_COMMANDS = listOf(
             MEDIA_FAST_FORWARD, MEDIA_NEXT, MEDIA_PAUSE, MEDIA_PLAY,
             MEDIA_PLAY_PAUSE, MEDIA_PREVIOUS, MEDIA_REWIND, MEDIA_STOP
@@ -431,6 +434,7 @@ class MessagingManager @Inject constructor(
                     }
                     COMMAND_HIGH_ACCURACY_MODE -> {
                         if ((!jsonData[COMMAND].isNullOrEmpty() && jsonData[COMMAND] in ENABLE_COMMANDS) ||
+                            (!jsonData[COMMAND].isNullOrEmpty() && jsonData[COMMAND] in FORCE_COMMANDS) ||
                             (
                                 !jsonData[COMMAND].isNullOrEmpty() && jsonData[COMMAND] == HIGH_ACCURACY_SET_UPDATE_INTERVAL &&
                                     jsonData[HIGH_ACCURACY_UPDATE_INTERVAL]?.toIntOrNull() != null && jsonData[HIGH_ACCURACY_UPDATE_INTERVAL]?.toInt()!! >= 5
@@ -815,6 +819,7 @@ class MessagingManager @Inject constructor(
                 when (command) {
                     TURN_OFF -> LocationSensorManager.setHighAccuracyModeSetting(context, false)
                     TURN_ON -> LocationSensorManager.setHighAccuracyModeSetting(context, true)
+                    FORCE_ON -> LocationSensorManager.setHighAccuracyModeSetting(context, true)
                     HIGH_ACCURACY_SET_UPDATE_INTERVAL -> LocationSensorManager.setHighAccuracyModeIntervalSetting(context, data[HIGH_ACCURACY_UPDATE_INTERVAL]!!.toInt())
                 }
                 val intent = Intent(context, LocationSensorManager::class.java)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Following discussion in PR #2906, this PR adds two new options to the command_high_accuracy_mode notification which are useful if there are bluetooth or zone constraints set up.

- force_on: behaves as turn_on does currently; it turns on the highAccuracyModeSetting and sets an internal flag which forces high accuracy mode even if the constraints aren't currently met.  The flag is cleared when a force_off is received, or the constraints act to turn on high accuracy mode anyway.
- force_off: this does not alter the highAccuracyMode setting but sets an internal flag which forces high accuracy mode off even if the constraints are such that it would normally be on.  The flag is cleared if force_on (or turn_on) is receieved, or the constraints are such that high accuracy mode would be off anyway.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#822

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->