### PR TITLE
Update Gradle to 7.5.1, Android Gradle plugin to 7.3.0

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,6 +14,8 @@ plugins {
 }
 
 android {
+    namespace = "io.homeassistant.companion.android"
+
     compileSdk = 33
 
     ndkVersion = "21.3.6528147"

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.homeassistant.companion.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:name="io.homeassistant.companion.android.HomeAssistantApplication" >

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.homeassistant.companion.android">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-sdk tools:overrideLibrary="androidx.wear.remote.interactions" />
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.2.2")
+        classpath("com.android.tools.build:gradle:7.3.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
         classpath("com.google.gms:google-services:4.3.14")
         classpath("com.google.firebase:firebase-appdistribution-gradle:3.0.3")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,6 +13,8 @@ val versionName = System.getenv("VERSION") ?: "LOCAL"
 val versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
 
 android {
+    namespace = "io.homeassistant.companion.android.common"
+
     compileSdk = 33
 
     defaultConfig {

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="io.homeassistant.companion.android.common"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 </manifest>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -8,6 +8,8 @@ plugins {
 }
 
 android {
+    namespace = "io.homeassistant.companion.android"
+
     compileSdk = 33
 
     defaultConfig {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.homeassistant.companion.android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Resolves #2886 failing to build

 - Update Gradle to latest version (7.5.1)
 - Update Android Gradle plugin to latest version (7.3.0)
 - Move package out of manifest into gradle build files namespace as recommended (Android Studio: "Move package from Android manifest to build files: Declaration of a project's namespace using the package attribute of the Android manifest is deprecated in favour of a namespace declaration in build files.")

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->