### PR TITLE
Use compressed entity changes for device controls

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.data.websocket
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryUpdatedEvent
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedStateChangedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DomainResponse
@@ -25,6 +26,8 @@ interface WebSocketRepository {
     suspend fun getServices(): List<DomainResponse>?
     suspend fun getStateChanges(): Flow<StateChangedEvent>?
     suspend fun getStateChanges(entityIds: List<String>): Flow<TriggerEvent>?
+    suspend fun getCompressedStateAndChanges(): Flow<CompressedStateChangedEvent>?
+    suspend fun getCompressedStateAndChanges(entityIds: List<String>): Flow<CompressedStateChangedEvent>?
     suspend fun getAreaRegistryUpdates(): Flow<AreaRegistryUpdatedEvent>?
     suspend fun getDeviceRegistryUpdates(): Flow<DeviceRegistryUpdatedEvent>?
     suspend fun getEntityRegistryUpdates(): Flow<EntityRegistryUpdatedEvent>?

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
@@ -1,0 +1,82 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.homeassistant.companion.android.common.data.integration.Entity
+import java.util.Calendar
+import kotlin.math.round
+
+/**
+ * Represents a single event emitted in a `subscribe_entities` websocket subscription. One event can
+ * contain state changes for multiple entities; properties map them as entity id -> state.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CompressedStateChangedEvent(
+    @JsonProperty("a")
+    val added: Map<String, CompressedEntityState>?,
+    @JsonProperty("c")
+    val changed: Map<String, CompressedStateDiff>?,
+    @JsonProperty("r")
+    val removed: List<String>?
+)
+
+/**
+ * Describes the difference in an [Entity] state in a `subscribe_entities` websocket subscription.
+ * It will only include properties that have been changed, values that haven't changed will not be
+ * set (in Kotlin: `null`). Apply it to an existing Entity to get the new state.
+ */
+data class CompressedStateDiff(
+    @JsonProperty("+")
+    val plus: CompressedEntityState?,
+    @JsonProperty("-")
+    val minus: CompressedEntityRemoved?
+)
+
+/**
+ * A compressed version of [Entity] used for additions or changes in the entity's state in a
+ * `subscribe_entities` websocket subscription.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CompressedEntityState(
+    @JsonProperty("s")
+    val state: String?,
+    @JsonProperty("a")
+    val attributes: Map<String, Any>?,
+    @JsonProperty("lc")
+    val lastChanged: Double?,
+    @JsonProperty("lu")
+    val lastUpdated: Double?,
+    @JsonProperty("c")
+    val context: Any?
+) {
+    /**
+     * Convert a compressed entity state to a normal [Entity]. This function can be used for new
+     * entities that are delivered in a compressed format.
+     */
+    fun toEntity(entityId: String): Entity<Map<String, Any>> {
+        return Entity(
+            entityId = entityId,
+            state = state!!,
+            attributes = attributes ?: mapOf(),
+            lastChanged = Calendar.getInstance().apply { timeInMillis = round(lastChanged!! * 1000).toLong() },
+            lastUpdated = Calendar.getInstance().apply {
+                timeInMillis =
+                    if (lastUpdated != null) round(lastUpdated * 1000).toLong()
+                    else round(lastChanged!! * 1000).toLong()
+            },
+            context =
+            if (context is String) mapOf("id" to context, "parent_id" to null, "user_id" to null)
+            else context as? Map<String, Any?>
+        )
+    }
+}
+
+/**
+ * A compressed version of [Entity] used for removed properties from the entity's state in a
+ * `subscribe_entities` websocket subscription. Only attributes are expected to be removed.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class CompressedEntityRemoved(
+    @JsonProperty("a")
+    val attributes: List<String>?
+)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support for the `subscribe_entities` websocket subscription which delivers state + changes in a compressed format to reduce data usage, supposedly [by 35-90% depending on the message](https://github.com/home-assistant/core/pull/67891).

Device controls have been updated to use the new subscription on supported Home Assistant versions. 

Because `subscribe_entities` combines initial states + state changes in a single subscription, it is **not** a drop-in replacement for existing entity state changes subscribers, as those only deliver changes. Because the app re-uses subscriptions with the same request message users also have to be mindful of potential re-use, as they may not get the initial states if they are not the first subscriber.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing note: I don't think the limitations mentioned in the last paragraph above apply here; the code has been updated to handle initial states and changes in one subscription, and there should only be one subscription active at a time. During testing I was only able to get it to stop working once, but that was before the recent changes to subscriptions that use a Channel to buffer messages. Still, please do try getting it into weird states!