### PR TITLE
Add permissions requests to wear OS sensors and add network sensors

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android
 import android.app.Application
 import android.content.Intent
 import android.content.IntentFilter
+import android.net.wifi.WifiManager
 import dagger.hilt.android.HiltAndroidApp
 import io.homeassistant.companion.android.complications.ComplicationReceiver
 import io.homeassistant.companion.android.sensors.SensorReceiver
@@ -23,6 +24,15 @@ open class HomeAssistantApplication : Application() {
                 addAction(Intent.ACTION_BATTERY_OKAY)
                 addAction(Intent.ACTION_POWER_CONNECTED)
                 addAction(Intent.ACTION_POWER_DISCONNECTED)
+            }
+        )
+
+        // This will trigger an update any time the wifi state has changed
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter().apply {
+                addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
+                addAction(WifiManager.WIFI_STATE_CHANGED_ACTION)
             }
         )
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -279,7 +279,6 @@ class MainViewModel @Inject constructor(
         isEnabled: Boolean
     ) {
         sensorDao.setSensorsEnabled(listOf(basicSensor.id), isEnabled)
-        sensorDao.updateLastSentStateAndIcon(basicSensor.id, null, null)
         SensorWorker.start(getApplication())
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -21,6 +21,7 @@ import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.wear.FavoritesDao
 import io.homeassistant.companion.android.database.wear.getAllFlow
+import io.homeassistant.companion.android.sensors.SensorWorker
 import io.homeassistant.companion.android.util.RegistriesDataHandler
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
@@ -278,6 +279,8 @@ class MainViewModel @Inject constructor(
         isEnabled: Boolean
     ) {
         sensorDao.setSensorsEnabled(listOf(basicSensor.id), isEnabled)
+        sensorDao.updateLastSentStateAndIcon(basicSensor.id, null, null)
+        SensorWorker.start(getApplication())
     }
 
     fun getAreaForEntity(entityId: String): AreaRegistryResponse? =

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -25,12 +25,11 @@ fun SensorUi(
     basicSensor: SensorManager.BasicSensor,
     onSensorClicked: (String, Boolean) -> Unit,
 ) {
-    var checked = sensor?.enabled == true
+    val checked = sensor?.enabled == true
 
     val backgroundRequest =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
             onSensorClicked(basicSensor.id, it)
-            checked = sensor?.enabled == true && it
         }
 
     val permissionLaunch = rememberLauncherForActivityResult(
@@ -50,7 +49,6 @@ fun SensorUi(
                 allGranted = false
         }
         onSensorClicked(basicSensor.id, allGranted)
-        checked = sensor?.enabled == true && allGranted
     }
 
     val perm = manager.checkPermission(LocalContext.current, basicSensor.id)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -32,14 +32,17 @@ fun SensorUi(
     val permissionLaunch = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { isGranted ->
+        var allGranted = true
         isGranted.forEach {
             if (manager.requiredPermissions(basicSensor.id)
                 .contains(Manifest.permission.ACCESS_FINE_LOCATION) && manager.requiredPermissions(basicSensor.id)
                     .contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) && it.key == Manifest.permission.ACCESS_FINE_LOCATION
             )
                 backgroundRequest.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
-            checked = sensor?.enabled == true && it.value
+            if (!it.value)
+                allGranted = false
         }
+        checked = sensor?.enabled == true && allGranted
     }
 
     val perm = manager.checkPermission(LocalContext.current, basicSensor.id)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -26,10 +26,20 @@ fun SensorUi(
 ) {
     var checked = sensor?.enabled == true
 
+    val backgroundRequest =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
+
     val permissionLaunch = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { isGranted ->
-        isGranted.forEach { checked = sensor?.enabled == true && it.value }
+        isGranted.forEach {
+            if (manager.requiredPermissions(basicSensor.id)
+                .contains(Manifest.permission.ACCESS_FINE_LOCATION) && manager.requiredPermissions(basicSensor.id)
+                    .contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) && it.key == Manifest.permission.ACCESS_FINE_LOCATION
+            )
+                backgroundRequest.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+            checked = sensor?.enabled == true && it.value
+        }
     }
 
     val perm = manager.checkPermission(LocalContext.current, basicSensor.id)
@@ -45,7 +55,8 @@ fun SensorUi(
                     if (permissions.size == 1 && permissions[0] == Manifest.permission.ACCESS_BACKGROUND_LOCATION)
                         permissions
                     else
-                        permissions.toSet().minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION).toTypedArray()
+                        permissions.toSet().minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                            .toTypedArray()
                 )
         },
         modifier = Modifier

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.home.views
 
 import android.Manifest
+import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -27,16 +28,19 @@ fun SensorUi(
     var checked = sensor?.enabled == true
 
     val backgroundRequest =
-        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {}
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            checked = sensor?.enabled == true && it
+        }
 
     val permissionLaunch = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) { isGranted ->
         var allGranted = true
         isGranted.forEach {
-            if (manager.requiredPermissions(basicSensor.id)
-                .contains(Manifest.permission.ACCESS_FINE_LOCATION) && manager.requiredPermissions(basicSensor.id)
-                    .contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) && it.key == Manifest.permission.ACCESS_FINE_LOCATION
+            if (
+                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_FINE_LOCATION) &&
+                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) &&
+                it.key == Manifest.permission.ACCESS_FINE_LOCATION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
             )
                 backgroundRequest.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
             if (!it.value)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -29,6 +29,7 @@ fun SensorUi(
 
     val backgroundRequest =
         rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            onSensorClicked(basicSensor.id, it)
             checked = sensor?.enabled == true && it
         }
 
@@ -41,11 +42,14 @@ fun SensorUi(
                 manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_FINE_LOCATION) &&
                 manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) &&
                 it.key == Manifest.permission.ACCESS_FINE_LOCATION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
-            )
+            ) {
                 backgroundRequest.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                return@forEach
+            }
             if (!it.value)
                 allGranted = false
         }
+        onSensorClicked(basicSensor.id, allGranted)
         checked = sensor?.enabled == true && allGranted
     }
 
@@ -55,7 +59,7 @@ fun SensorUi(
             (sensor?.enabled == true && perm),
         onCheckedChange = { enabled ->
             val permissions = manager.requiredPermissions(basicSensor.id)
-            if (perm)
+            if (perm || !enabled)
                 onSensorClicked(basicSensor.id, enabled)
             else
                 permissionLaunch.launch(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.home.views
 
+import android.Manifest
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -36,10 +37,16 @@ fun SensorUi(
         checked = (sensor == null && manager.enabledByDefault) ||
             (sensor?.enabled == true && perm),
         onCheckedChange = { enabled ->
+            val permissions = manager.requiredPermissions(basicSensor.id)
             if (perm)
                 onSensorClicked(basicSensor.id, enabled)
             else
-                permissionLaunch.launch(manager.requiredPermissions(basicSensor.id))
+                permissionLaunch.launch(
+                    if (permissions.size == 1 && permissions[0] == Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                        permissions
+                    else
+                        permissions.toSet().minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION).toTypedArray()
+                )
         },
         modifier = Modifier
             .fillMaxWidth(),

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorsView.kt
@@ -44,20 +44,19 @@ fun SensorsView(
                     ListHeader(id = commonR.string.sensors)
                 }
                 items(sensorManagers.size, { sensorManagers[it].name }) { index ->
-                    sensorManagers.forEach { manager ->
-                        Row {
-                            Chip(
-                                modifier = Modifier
-                                    .fillMaxWidth(),
-                                colors = ChipDefaults.secondaryChipColors(),
-                                label = {
-                                    Text(
-                                        text = stringResource(manager.name)
-                                    )
-                                },
-                                onClick = { onClickSensorManager(manager) }
-                            )
-                        }
+                    val manager = sensorManagers[index]
+                    Row {
+                        Chip(
+                            modifier = Modifier
+                                .fillMaxWidth(),
+                            colors = ChipDefaults.secondaryChipColors(),
+                            label = {
+                                Text(
+                                    text = stringResource(manager.name)
+                                )
+                            },
+                            onClick = { onClickSensorManager(manager) }
+                        )
                     }
                 }
             }

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.sensors
 import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
+import android.net.wifi.WifiManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.sensors.BatterySensorManager
@@ -35,7 +36,9 @@ class SensorReceiver : SensorReceiverBase() {
 
     // Suppress Lint because we only register for the receiver if the android version matches the intent
     @SuppressLint("InlinedApi")
-    override val skippableActions = mapOf<String, String>()
+    override val skippableActions = mapOf(
+        WifiManager.WIFI_STATE_CHANGED_ACTION to NetworkSensorManager.wifiState.id
+    )
 
     override fun getSensorSettingsIntent(context: Context, id: String): Intent? = null
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.sensors.BatterySensorManager
+import io.homeassistant.companion.android.common.sensors.NetworkSensorManager
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 
@@ -24,7 +25,8 @@ class SensorReceiver : SensorReceiverBase() {
     companion object {
         const val TAG = "SensorReceiver"
         val MANAGERS = listOf(
-            BatterySensorManager()
+            BatterySensorManager(),
+            NetworkSensorManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds permissions requests to Wear OS when a user enables a sensor, also adds Network Sensors as a start.

WTH: https://community.home-assistant.io/t/wth-dont-we-have-more-sensor-in-wear-os/469354

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/194604934-3a3420b7-77b9-4cb8-a09e-9a2ea5e65c3b.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#834

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

This was a "quick and dirty" approach to just get some more sensors added as permissions is holding up adding some of the sensors.  Some of this code may be stale but wanted to get some extra eyes on this.