### PR TITLE
Don't use a hardcoded list of apps for Wear OS detection

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
@@ -1,0 +1,25 @@
+package io.homeassistant.companion.android.settings.wear
+
+import android.content.Context
+import android.util.Log
+import com.google.android.gms.wearable.Wearable
+import kotlinx.coroutines.tasks.await
+
+object SettingsWearDetection {
+
+    private const val TAG = "SettingsWearDetection"
+
+    /**
+     * Returns if there are any Wear OS devices connected to this device. It does **not** indicate
+     * if they have the Home Assistant app installed.
+     */
+    suspend fun hasAnyNodes(context: Context): Boolean {
+        return try {
+            val nodeClient = Wearable.getNodeClient(context)
+            nodeClient.connectedNodes.await().any()
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception while discovering nodes", e)
+            false
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -44,6 +44,7 @@ import io.homeassistant.companion.android.settings.sensor.SensorUpdateFrequencyF
 import io.homeassistant.companion.android.settings.shortcuts.ManageShortcutsSettingsFragment
 import io.homeassistant.companion.android.settings.ssid.SsidFragment
 import io.homeassistant.companion.android.settings.wear.SettingsWearActivity
+import io.homeassistant.companion.android.settings.wear.SettingsWearDetection
 import io.homeassistant.companion.android.settings.websocket.WebsocketSettingFragment
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
 import kotlinx.coroutines.Dispatchers
@@ -305,18 +306,13 @@ class SettingsFragment constructor(
             }
         }
 
-        val pm = requireContext().packageManager
-        val wearCompanionApps = listOf(
-            "com.google.android.wearable.app",
-            "com.google.android.apps.wear.companion",
-            "com.samsung.android.app.watchmanager",
-            "com.montblanc.summit.companion.android"
-        )
-        findPreference<PreferenceCategory>("wear_category")?.isVisible =
-            BuildConfig.FLAVOR == "full" && wearCompanionApps.any { pm.getLaunchIntentForPackage(it) != null }
-        findPreference<Preference>("wear_settings")?.setOnPreferenceClickListener {
-            startActivity(SettingsWearActivity.newInstance(requireContext()))
-            return@setOnPreferenceClickListener true
+        lifecycleScope.launch {
+            findPreference<PreferenceCategory>("wear_category")?.isVisible =
+                SettingsWearDetection.hasAnyNodes(requireContext())
+            findPreference<Preference>("wear_settings")?.setOnPreferenceClickListener {
+                startActivity(SettingsWearActivity.newInstance(requireContext()))
+                return@setOnPreferenceClickListener true
+            }
         }
 
         findPreference<Preference>("changelog_github")?.let {

--- a/app/src/minimal/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
@@ -1,0 +1,15 @@
+package io.homeassistant.companion.android.settings.wear
+
+import android.content.Context
+
+object SettingsWearDetection {
+
+    /**
+     * Returns if there are any Wear OS devices connected to this device. It does **not** indicate
+     * if they have the Home Assistant app installed.
+     */
+    suspend fun hasAnyNodes(context: Context): Boolean {
+        // The minimal version of the app doesn't support Wear OS, so always return false
+        return false
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
As Wear OS 3 watches are going to use an unique app for each brand, the HA app should use the Google APIs for detecting watches instead of hardcoding a list of companion apps to be more future-proof.

I have only tested this with an emulator (and without an emulator, for when there is no watch) which works well, but I'd appreciate it if anyone with a real watch could test it as well.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->