### PR TITLE
Update deprecated onBackPressed, support predictive back gesture

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
@@ -52,9 +52,8 @@ class SettingsWearMainView : AppCompatActivity() {
             LoadSettingsHomeView(
                 settingsWearViewModel,
                 currentNodes.firstOrNull()?.displayName ?: "unknown",
-                this::loginWearOs,
-                this::onBackPressed
-            )
+                this::loginWearOs
+            ) { onBackPressedDispatcher.onBackPressed() }
         }
 
         if (registerUrl != null) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.HomeAssistant"
         android:networkSecurityConfig="@xml/network_security_config"
+        android:enableOnBackInvokedCallback="true"
         tools:ignore="GoogleAppIndexingWarning">
 
         <!-- Start things like SensorWorker on device boot -->

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.onboarding
 import android.os.Build
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
@@ -58,13 +59,15 @@ class OnboardingActivity : AppCompatActivity() {
                 }
             }
         }
-    }
 
-    override fun onBackPressed() {
-        if (supportFragmentManager.backStackEntryCount > 0) {
-            supportFragmentManager.popBackStack()
-        } else {
-            super.onBackPressed()
+        val onBackPressed = object : OnBackPressedCallback(supportFragmentManager.backStackEntryCount > 0) {
+            override fun handleOnBackPressed() {
+                supportFragmentManager.popBackStack()
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
+        supportFragmentManager.addOnBackStackChangedListener {
+            onBackPressed.isEnabled = supportFragmentManager.backStackEntryCount > 0
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -80,7 +80,7 @@ class SettingsActivity : BaseActivity() {
                 if (supportFragmentManager.backStackEntryCount > 0) {
                     supportFragmentManager.popBackStack()
                 } else {
-                    onBackPressed()
+                    onBackPressedDispatcher.onBackPressed()
                 }
                 true
             }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -42,6 +42,7 @@ import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.Toast
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
@@ -247,6 +248,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         decor = window.decorView as FrameLayout
 
         webView = binding.webview
+
+        val onBackPressed = object : OnBackPressedCallback(webView.canGoBack()) {
+            override fun handleOnBackPressed() {
+                if (webView.canGoBack()) webView.goBack()
+            }
+        }
+        onBackPressedDispatcher.addCallback(this, onBackPressed)
+
         webView.apply {
             // TODO This quick bar workaround only works on Home Assistant core versions <2022.7
             // If not 'fixed' or officially supported: should be removed in Android 2023.1 (GitHub: #2690)
@@ -405,6 +414,15 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                         }
                     }
                     return false
+                }
+
+                override fun doUpdateVisitedHistory(
+                    view: WebView?,
+                    url: String?,
+                    isReload: Boolean
+                ) {
+                    super.doUpdateVisitedHistory(view, url, isReload)
+                    onBackPressed.isEnabled = canGoBack()
                 }
             }
 
@@ -1007,14 +1025,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     override fun relaunchApp() {
         startActivity(Intent(this, LaunchActivity::class.java))
         finish()
-    }
-
-    override fun onBackPressed() {
-        if (webView.canGoBack()) {
-            webView.goBack()
-        } else {
-            super.onBackPressed()
-        }
     }
 
     override fun loadUrl(url: String) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Update the use of `onBackPressed` functions which have been deprecated to use the new `OnBackPressedDispatcher` and `OnBackPressedCallback`. This also makes it possible for the app to support the upcoming [predictive back gesture](https://developer.android.com/guide/navigation/predictive-back-gesture?hl=en).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visible change, unless you have enabled support for the predictive back gesture in developer settings in which case you can see the home screen when there is no more going back in the app:

https://user-images.githubusercontent.com/8148535/194703057-583366c6-6da5-454c-a0eb-9ac36db1db86.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->