### PR TITLE
Add a screen off timeout sensor and command for control

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -169,6 +169,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND_STOP_TTS = "command_stop_tts"
         const val COMMAND_AUTO_SCREEN_BRIGHTNESS = "command_auto_screen_brightness"
         const val COMMAND_SCREEN_BRIGHTNESS_LEVEL = "command_screen_brightness_level"
+        const val COMMAND_SCREEN_OFF_TIMEOUT = "command_screen_off_timeout"
 
         // DND commands
         const val DND_PRIORITY_ONLY = "priority_only"
@@ -249,7 +250,8 @@ class MessagingManager @Inject constructor(
             COMMAND_PERSISTENT_CONNECTION,
             COMMAND_STOP_TTS,
             COMMAND_AUTO_SCREEN_BRIGHTNESS,
-            COMMAND_SCREEN_BRIGHTNESS_LEVEL
+            COMMAND_SCREEN_BRIGHTNESS_LEVEL,
+            COMMAND_SCREEN_OFF_TIMEOUT
         )
         val DND_COMMANDS = listOf(DND_ALARMS_ONLY, DND_ALL, DND_NONE, DND_PRIORITY_ONLY)
         val RM_COMMANDS = listOf(RM_NORMAL, RM_SILENT, RM_VIBRATE)
@@ -545,7 +547,7 @@ class MessagingManager @Inject constructor(
                                 sendNotification(jsonData)
                             }
                     }
-                    COMMAND_SCREEN_BRIGHTNESS_LEVEL -> {
+                    COMMAND_SCREEN_BRIGHTNESS_LEVEL, COMMAND_SCREEN_OFF_TIMEOUT -> {
                         if (!jsonData[COMMAND].isNullOrEmpty() && jsonData[COMMAND]?.toIntOrNull() != null)
                             handleDeviceCommands(jsonData)
                         else
@@ -919,14 +921,14 @@ class MessagingManager @Inject constructor(
             COMMAND_STOP_TTS -> {
                 stopTTS()
             }
-            COMMAND_AUTO_SCREEN_BRIGHTNESS, COMMAND_SCREEN_BRIGHTNESS_LEVEL -> {
+            COMMAND_AUTO_SCREEN_BRIGHTNESS, COMMAND_SCREEN_BRIGHTNESS_LEVEL, COMMAND_SCREEN_OFF_TIMEOUT -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (Settings.System.canWrite(context)) {
-                        if (!processScreenBrightness(data))
+                        if (!processScreenCommands(data))
                             mainScope.launch { sendNotification(data) }
                     } else
                         notifyMissingPermission(data[MESSAGE].toString())
-                } else if (!processScreenBrightness(data))
+                } else if (!processScreenCommands(data))
                     mainScope.launch { sendNotification(data) }
             }
             else -> Log.d(TAG, "No command received")
@@ -2042,22 +2044,25 @@ class MessagingManager @Inject constructor(
         WebsocketManager.start(context)
     }
 
-    private fun processScreenBrightness(data: Map<String, String>): Boolean {
+    private fun processScreenCommands(data: Map<String, String>): Boolean {
         val command = data[COMMAND]
         val contentResolver = context.contentResolver
         val success = Settings.System.putInt(
             contentResolver,
-            if (data[MESSAGE].toString() == COMMAND_SCREEN_BRIGHTNESS_LEVEL)
-                Settings.System.SCREEN_BRIGHTNESS
-            else
-                Settings.System.SCREEN_BRIGHTNESS_MODE,
-            if (data[MESSAGE].toString() == COMMAND_SCREEN_BRIGHTNESS_LEVEL)
-                command!!.toInt().coerceIn(0, 255)
-            else {
-                if (command == TURN_ON)
-                    Settings.System.SCREEN_BRIGHTNESS_MODE_AUTOMATIC
-                else
-                    Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL
+            when (data[MESSAGE].toString()) {
+                COMMAND_SCREEN_BRIGHTNESS_LEVEL -> Settings.System.SCREEN_BRIGHTNESS
+                COMMAND_AUTO_SCREEN_BRIGHTNESS -> Settings.System.SCREEN_BRIGHTNESS_MODE
+                else -> Settings.System.SCREEN_OFF_TIMEOUT
+            },
+            when (data[MESSAGE].toString()) {
+                COMMAND_SCREEN_BRIGHTNESS_LEVEL -> command!!.toInt().coerceIn(0, 255)
+                COMMAND_AUTO_SCREEN_BRIGHTNESS -> {
+                    if (command == TURN_ON)
+                        Settings.System.SCREEN_BRIGHTNESS_MODE_AUTOMATIC
+                    else
+                        Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL
+                }
+                else -> command!!.toInt()
             }
         )
         return success

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DisplaySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DisplaySensorManager.kt
@@ -15,12 +15,18 @@ class DisplaySensorManager : SensorManager {
             "sensor",
             commonR.string.basic_sensor_name_screen_brightness,
             commonR.string.sensor_description_screen_brightness,
-            statelessIcon = "mdi:brightness-6"
+            statelessIcon = "mdi:brightness-6",
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-brightness-sensor"
         )
-    }
 
-    override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#screen-brightness-sensor"
+        val screenOffTimeout = SensorManager.BasicSensor(
+            "screen_off_timeout",
+            "sensor",
+            commonR.string.sensor_name_screen_off_timeout,
+            commonR.string.sensor_description_screen_off_timeout,
+            "mdi:cellphone-off",
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-off-timeout-sensor"
+        )
     }
 
     override val enabledByDefault: Boolean
@@ -29,7 +35,7 @@ class DisplaySensorManager : SensorManager {
         get() = commonR.string.sensor_name_display_sensors
 
     override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(screenBrightness)
+        return listOf(screenBrightness, screenOffTimeout)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -40,6 +46,7 @@ class DisplaySensorManager : SensorManager {
         context: Context
     ) {
         updateScreenBrightness(context)
+        updateScreenTimeout(context)
     }
 
     private fun updateScreenBrightness(context: Context) {
@@ -69,6 +76,28 @@ class DisplaySensorManager : SensorManager {
             mapOf(
                 "automatic" to auto
             )
+        )
+    }
+
+    private fun updateScreenTimeout(context: Context) {
+        if (!isEnabled(context, screenOffTimeout.id))
+            return
+
+        var timeout = 0
+
+        try {
+            timeout =
+                Settings.System.getInt(context.contentResolver, Settings.System.SCREEN_OFF_TIMEOUT)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get screen off timeout setting", e)
+        }
+
+        onSensorUpdated(
+            context,
+            screenOffTimeout,
+            timeout,
+            screenOffTimeout.statelessIcon,
+            mapOf()
         )
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -921,4 +921,6 @@
     <string name="basic_sensor_name_screen_brightness">Screen Brightness</string>
     <string name="sensor_description_screen_brightness">The current screen brightness on the device, an attribute also indicates if auto-brightness is enabled</string>
     <string name="sensor_name_display_sensors">Display Sensors</string>
+    <string name="sensor_name_screen_off_timeout">Screen Off Timeout</string>
+    <string name="sensor_description_screen_off_timeout">The current duration of idle time before the screen turns off in milliseconds</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2948 by providing a new Screen Off Timeout sensor as well as a command to control its value. During testing I noticed that any value below 10000 was still treated as such, I imagine other devices may have a different limit. I also don't see a way to detect the limit so made sure to mention in the docs.

```
service: notify.mobile_app
data:
  message: command_screen_off_timeout
  data:
    command: 15000
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/194731412-a45c6f03-70a1-41e6-8e11-e2b9039b51e2.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#835

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM: https://github.com/home-assistant/mobile-apps-fcm-push/pull/94