### PR TITLE
Improve settings when using Home Assistant Cloud

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -608,7 +608,7 @@ class SettingsFragment constructor(
         super.onResume()
         activity?.title = getString(commonR.string.companion_app)
 
-        presenter.updateInternalUrlStatus()
         presenter.updateExternalUrlStatus()
+        presenter.updateInternalUrlStatus()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -43,6 +43,7 @@ import io.homeassistant.companion.android.settings.sensor.SensorSettingsFragment
 import io.homeassistant.companion.android.settings.sensor.SensorUpdateFrequencyFragment
 import io.homeassistant.companion.android.settings.shortcuts.ManageShortcutsSettingsFragment
 import io.homeassistant.companion.android.settings.ssid.SsidFragment
+import io.homeassistant.companion.android.settings.url.ExternalUrlFragment
 import io.homeassistant.companion.android.settings.wear.SettingsWearActivity
 import io.homeassistant.companion.android.settings.websocket.WebsocketSettingFragment
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
@@ -146,8 +147,14 @@ class SettingsFragment constructor(
                 onChangeUrlValidator
         }
 
-        findPreference<EditTextPreference>("connection_external")?.onPreferenceChangeListener =
-            onChangeUrlValidator
+        findPreference<Preference>("connection_external")?.setOnPreferenceClickListener {
+            parentFragmentManager
+                .beginTransaction()
+                .replace(R.id.content, ExternalUrlFragment::class.java, null)
+                .addToBackStack(getString(commonR.string.input_url))
+                .commit()
+            return@setOnPreferenceClickListener true
+        }
 
         findPreference<Preference>("connection_internal_ssids")?.let {
             it.setOnPreferenceClickListener {
@@ -412,6 +419,14 @@ class SettingsFragment constructor(
         }
     }
 
+    override fun updateExternalUrl(url: String, useCloud: Boolean) {
+        findPreference<Preference>("connection_external")?.let {
+            it.summary =
+                if (useCloud) getString(commonR.string.input_cloud)
+                else url
+        }
+    }
+
     override fun updateSsids(ssids: Set<String>) {
         findPreference<Preference>("connection_internal_ssids")?.let {
             it.summary =
@@ -594,5 +609,6 @@ class SettingsFragment constructor(
         activity?.title = getString(commonR.string.companion_app)
 
         presenter.updateInternalUrlStatus()
+        presenter.updateExternalUrlStatus()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -9,6 +9,7 @@ interface SettingsPresenter {
     fun getPreferenceDataStore(): PreferenceDataStore
     fun onCreate()
     fun onFinish()
+    fun updateExternalUrlStatus()
     fun updateInternalUrlStatus()
     fun isLockEnabled(): Boolean
     fun sessionTimeOut(): Int

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -77,7 +77,7 @@ class SettingsPresenterImpl @Inject constructor(
     override fun getString(key: String, defValue: String?): String? {
         return runBlocking {
             when (key) {
-                "connection_internal" -> (urlUseCase.getUrl(true) ?: "").toString()
+                "connection_internal" -> (urlUseCase.getUrl(isInternal = true, force = true) ?: "").toString()
                 "registration_name" -> integrationUseCase.getRegistration().deviceName
                 "session_timeout" -> integrationUseCase.getSessionTimeOut().toString()
                 "themes" -> themesManager.getCurrentTheme()

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -78,7 +78,6 @@ class SettingsPresenterImpl @Inject constructor(
         return runBlocking {
             when (key) {
                 "connection_internal" -> (urlUseCase.getUrl(true) ?: "").toString()
-                "connection_external" -> (urlUseCase.getUrl(false) ?: "").toString()
                 "registration_name" -> integrationUseCase.getRegistration().deviceName
                 "session_timeout" -> integrationUseCase.getSessionTimeOut().toString()
                 "themes" -> themesManager.getCurrentTheme()
@@ -92,7 +91,6 @@ class SettingsPresenterImpl @Inject constructor(
         mainScope.launch {
             when (key) {
                 "connection_internal" -> urlUseCase.saveUrl(value ?: "", true)
-                "connection_external" -> urlUseCase.saveUrl(value ?: "", false)
                 "session_timeout" -> {
                     try {
                         integrationUseCase.sessionTimeOut(value.toString().toInt())
@@ -142,11 +140,21 @@ class SettingsPresenterImpl @Inject constructor(
     override fun onCreate() {
         mainScope.launch {
             handleInternalUrlStatus(urlUseCase.getHomeWifiSsids())
+            updateExternalUrlStatus()
         }
     }
 
     override fun onFinish() {
         mainScope.cancel()
+    }
+
+    override fun updateExternalUrlStatus() {
+        mainScope.launch {
+            settingsView.updateExternalUrl(
+                urlUseCase.getUrl(false)?.toString() ?: "",
+                urlUseCase.shouldUseCloud() && urlUseCase.canUseCloud()
+            )
+        }
     }
 
     override fun updateInternalUrlStatus() {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsView.kt
@@ -6,6 +6,8 @@ interface SettingsView {
 
     fun enableInternalConnection()
 
+    fun updateExternalUrl(url: String, useCloud: Boolean)
+
     fun updateSsids(ssids: Set<String>)
 
     fun onLangSettingsChanged()

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlFragment.kt
@@ -1,0 +1,49 @@
+package io.homeassistant.companion.android.settings.url
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import com.google.android.material.composethemeadapter.MdcTheme
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.settings.url.views.ExternalUrlView
+import io.homeassistant.companion.android.common.R as commonR
+
+@AndroidEntryPoint
+class ExternalUrlFragment : Fragment() {
+
+    val viewModel by viewModels<ExternalUrlViewModel>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(false)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MdcTheme {
+                    ExternalUrlView(
+                        canUseCloud = viewModel.canUseCloud,
+                        useCloud = viewModel.useCloud,
+                        externalUrl = viewModel.externalUrl,
+                        onUseCloudToggle = { viewModel.toggleCloud(it) },
+                        onExternalUrlSaved = { viewModel.updateExternalUrl(it) }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.title = getString(commonR.string.input_url)
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlViewModel.kt
@@ -30,7 +30,7 @@ class ExternalUrlViewModel @Inject constructor(
         viewModelScope.launch {
             canUseCloud = urlRepository.canUseCloud()
             useCloud = urlRepository.shouldUseCloud()
-            externalUrl = urlRepository.getUrl(isInternal = false, ignoreCloud = true).toString()
+            externalUrl = urlRepository.getUrl(isInternal = false, force = true).toString()
         }
     }
 
@@ -49,7 +49,7 @@ class ExternalUrlViewModel @Inject constructor(
     fun updateExternalUrl(url: String) {
         viewModelScope.launch {
             urlRepository.saveUrl(url, false)
-            externalUrl = urlRepository.getUrl(isInternal = false, ignoreCloud = true)?.toString() ?: ""
+            externalUrl = urlRepository.getUrl(isInternal = false, force = true)?.toString() ?: ""
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlViewModel.kt
@@ -1,0 +1,55 @@
+package io.homeassistant.companion.android.settings.url
+
+import android.app.Application
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.homeassistant.companion.android.common.data.url.UrlRepository
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ExternalUrlViewModel @Inject constructor(
+    private val urlRepository: UrlRepository,
+    application: Application
+) : AndroidViewModel(application) {
+
+    var canUseCloud by mutableStateOf(false)
+        private set
+
+    var useCloud by mutableStateOf(false)
+        private set
+
+    var externalUrl by mutableStateOf("")
+        private set
+
+    init {
+        viewModelScope.launch {
+            canUseCloud = urlRepository.canUseCloud()
+            useCloud = urlRepository.shouldUseCloud()
+            externalUrl = urlRepository.getUrl(isInternal = false, ignoreCloud = true).toString()
+        }
+    }
+
+    fun toggleCloud(use: Boolean) {
+        viewModelScope.launch {
+            useCloud = if (use && canUseCloud) {
+                urlRepository.setUseCloud(true)
+                true
+            } else {
+                urlRepository.setUseCloud(false)
+                false
+            }
+        }
+    }
+
+    fun updateExternalUrl(url: String) {
+        viewModelScope.launch {
+            urlRepository.saveUrl(url, false)
+            externalUrl = urlRepository.getUrl(isInternal = false, ignoreCloud = true)?.toString() ?: ""
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlInputView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlInputView.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
@@ -30,9 +32,9 @@ import io.homeassistant.companion.android.common.R as commonR
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun UrlInputView(
+fun ExternalUrlInputView(
     url: String?,
-    allowBlank: Boolean,
+    focusRequester: FocusRequester,
     onSaveUrl: (String) -> Unit
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -54,13 +56,14 @@ fun UrlInputView(
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    urlError = !performUrlUpdate(urlInput?.trim(), url, allowBlank, onSaveUrl)
+                    urlError = !performUrlUpdate(urlInput?.trim(), url, onSaveUrl)
                     if (!urlError) {
                         keyboardController?.hide()
                         focusManager.clearFocus()
                     }
                 }
             ),
+            placeholder = { Text(stringResource(commonR.string.input_url)) },
             isError = urlError,
             trailingIcon = if (urlError) {
                 {
@@ -71,6 +74,7 @@ fun UrlInputView(
                 }
             } else null,
             modifier = Modifier
+                .focusRequester(focusRequester)
                 .fillMaxWidth()
                 .padding(bottom = 8.dp)
         )
@@ -88,7 +92,7 @@ fun UrlInputView(
             TextButton(
                 modifier = Modifier.align(Alignment.End),
                 onClick = {
-                    urlError = !performUrlUpdate(urlInput?.trim(), url, allowBlank, onSaveUrl)
+                    urlError = !performUrlUpdate(urlInput?.trim(), url, onSaveUrl)
                     if (!urlError) {
                         keyboardController?.hide()
                         focusManager.clearFocus()
@@ -108,17 +112,13 @@ fun UrlInputView(
 private fun performUrlUpdate(
     input: String?,
     current: String?,
-    allowBlank: Boolean,
     onSaveUrl: (String) -> Unit
 ): Boolean {
     return if (input != current && input?.toHttpUrlOrNull()?.toString() != current) {
         val urlValue = input?.toHttpUrlOrNull()
-        val isValid = (allowBlank && input.isNullOrBlank()) || urlValue != null
+        val isValid = urlValue != null
         if (isValid) {
-            onSaveUrl(
-                if (allowBlank && input.isNullOrBlank()) ""
-                else urlValue.toString()
-            )
+            onSaveUrl(urlValue.toString())
         }
         isValid
     } else {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlView.kt
@@ -11,8 +11,11 @@ import androidx.compose.material.Switch
 import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,6 +30,8 @@ fun ExternalUrlView(
     onUseCloudToggle: (Boolean) -> Unit,
     onExternalUrlSaved: (String) -> Unit
 ) {
+    val focusRequester = remember { FocusRequester() }
+
     Column(
         modifier = Modifier.padding(vertical = 16.dp)
     ) {
@@ -35,16 +40,20 @@ fun ExternalUrlView(
                 useCloud = useCloud,
                 onUseCloudToggle = onUseCloudToggle
             )
-            Spacer(modifier = Modifier.height(36.dp))
+            Spacer(modifier = Modifier.height(24.dp))
         }
 
         if (!canUseCloud || !useCloud) {
-            UrlInputView(
+            ExternalUrlInputView(
                 url = externalUrl,
-                allowBlank = false,
+                focusRequester = focusRequester,
                 onSaveUrl = onExternalUrlSaved
             )
         }
+    }
+
+    LaunchedEffect(Unit) {
+        if (!canUseCloud) focusRequester.requestFocus()
     }
 }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlView.kt
@@ -1,0 +1,111 @@
+package io.homeassistant.companion.android.settings.url.views
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.R as commonR
+
+@Composable
+fun ExternalUrlView(
+    canUseCloud: Boolean,
+    useCloud: Boolean,
+    externalUrl: String?,
+    onUseCloudToggle: (Boolean) -> Unit,
+    onExternalUrlSaved: (String) -> Unit
+) {
+    Column(
+        modifier = Modifier.padding(vertical = 16.dp)
+    ) {
+        if (canUseCloud) {
+            ExternalUrlCloudView(
+                useCloud = useCloud,
+                onUseCloudToggle = onUseCloudToggle
+            )
+            Spacer(modifier = Modifier.height(36.dp))
+        }
+
+        if (!canUseCloud || !useCloud) {
+            UrlInputView(
+                url = externalUrl,
+                allowBlank = false,
+                onSaveUrl = onExternalUrlSaved
+            )
+        }
+    }
+}
+
+@Composable
+fun ExternalUrlCloudView(
+    useCloud: Boolean,
+    onUseCloudToggle: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .clickable { onUseCloudToggle(!useCloud) }
+            .heightIn(min = 56.dp)
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = stringResource(commonR.string.input_cloud),
+            modifier = Modifier
+                .weight(1f)
+                .padding(end = 16.dp)
+        )
+        Switch(
+            checked = useCloud,
+            onCheckedChange = null,
+            colors = SwitchDefaults.colors(uncheckedThumbColor = colorResource(commonR.color.colorSwitchUncheckedThumb))
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewExternalUrlViewCloudOn() {
+    ExternalUrlView(
+        canUseCloud = true,
+        useCloud = true,
+        externalUrl = "https://home.example.com:8123/",
+        onUseCloudToggle = {},
+        onExternalUrlSaved = {}
+    )
+}
+
+@Preview
+@Composable
+fun PreviewExternalUrlViewCloudOff() {
+    ExternalUrlView(
+        canUseCloud = true,
+        useCloud = false,
+        externalUrl = "https://home.example.com:8123/",
+        onUseCloudToggle = {},
+        onExternalUrlSaved = {}
+    )
+}
+
+@Preview
+@Composable
+fun PreviewExternalUrlViewCloudNone() {
+    ExternalUrlView(
+        canUseCloud = false,
+        useCloud = false,
+        externalUrl = "https://home.example.com:8123/",
+        onUseCloudToggle = {},
+        onExternalUrlSaved = {}
+    )
+}

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/views/UrlInputView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/views/UrlInputView.kt
@@ -1,0 +1,127 @@
+package io.homeassistant.companion.android.settings.url.views
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import io.homeassistant.companion.android.common.R as commonR
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun UrlInputView(
+    url: String?,
+    allowBlank: Boolean,
+    onSaveUrl: (String) -> Unit
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
+
+    var urlInput by remember(url) { mutableStateOf(url) }
+    var urlError by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.padding(horizontal = 16.dp)
+    ) {
+        OutlinedTextField(
+            value = urlInput ?: "",
+            singleLine = true,
+            onValueChange = {
+                urlInput = it
+                urlError = false
+            },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    urlError = !performUrlUpdate(urlInput?.trim(), url, allowBlank, onSaveUrl)
+                    if (!urlError) {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                    }
+                }
+            ),
+            isError = urlError,
+            trailingIcon = if (urlError) {
+                {
+                    Icon(
+                        imageVector = Icons.Default.Error,
+                        contentDescription = stringResource(commonR.string.url_invalid)
+                    )
+                }
+            } else null,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 8.dp)
+        )
+
+        if (urlError) {
+            Text(
+                text = stringResource(commonR.string.url_parse_error),
+                color = MaterialTheme.colors.error,
+                style = MaterialTheme.typography.caption,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+        }
+
+        if (urlInput != url && urlInput?.trim()?.toHttpUrlOrNull()?.toString() != url) {
+            TextButton(
+                modifier = Modifier.align(Alignment.End),
+                onClick = {
+                    urlError = !performUrlUpdate(urlInput?.trim(), url, allowBlank, onSaveUrl)
+                    if (!urlError) {
+                        keyboardController?.hide()
+                        focusManager.clearFocus()
+                    }
+                }
+            ) {
+                Text(stringResource(commonR.string.update))
+            }
+        }
+    }
+}
+
+/**
+ * Try saving the url with the value of the input.
+ * @return boolean indicating if the url was saved successfully
+ */
+private fun performUrlUpdate(
+    input: String?,
+    current: String?,
+    allowBlank: Boolean,
+    onSaveUrl: (String) -> Unit
+): Boolean {
+    return if (input != current && input?.toHttpUrlOrNull()?.toString() != current) {
+        val urlValue = input?.toHttpUrlOrNull()
+        val isValid = (allowBlank && input.isNullOrBlank()) || urlValue != null
+        if (isValid) {
+            onSaveUrl(
+                if (allowBlank && input.isNullOrBlank()) ""
+                else urlValue.toString()
+            )
+        }
+        isValid
+    } else {
+        true
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -129,6 +129,7 @@ class WebViewPresenterImpl @Inject constructor(
         mainScope.launch {
             urlUseCase.saveUrl("", true)
             urlUseCase.saveUrl("", false)
+            urlUseCase.updateCloudUrls(null, null)
         }
     }
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -4,11 +4,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
         android:title="@string/pref_connection_title">
-        <EditTextPreference
+        <Preference
             android:key="connection_external"
             android:icon="@drawable/ic_globe"
-            android:title="@string/pref_connection_url"
-            app:useSimpleSummaryProvider="true"/>
+            android:title="@string/pref_connection_url"/>
         <Preference
             android:key="connection_internal_ssids"
             android:icon="@drawable/ic_wifi"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -77,6 +77,7 @@ class AuthenticationRepositoryImpl @Inject constructor(
         saveSession(null)
         urlRepository.saveUrl("", true)
         urlRepository.saveUrl("", false)
+        urlRepository.updateCloudUrls(null, null)
         urlRepository.saveHomeWifiSsids(emptySet())
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -540,6 +540,7 @@ class IntegrationRepositoryImpl @Inject constructor(
                     PREF_CHECK_SENSOR_REGISTRATION_NEXT,
                     System.currentTimeMillis() + TimeUnit.HOURS.toMillis(4)
                 )
+                urlRepository.updateCloudUrls(response.cloudhookUrl, response.remoteUiUrl)
                 return response
             }
         }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
@@ -17,7 +17,7 @@ interface UrlRepository {
 
     suspend fun updateCloudUrls(cloudhookUrl: String?, remoteUiUrl: String?)
 
-    suspend fun getUrl(isInternal: Boolean? = null, ignoreCloud: Boolean = false): URL?
+    suspend fun getUrl(isInternal: Boolean? = null, force: Boolean = false): URL?
 
     suspend fun saveUrl(url: String, isInternal: Boolean? = null)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
@@ -15,9 +15,15 @@ interface UrlRepository {
 
     suspend fun saveRegistrationUrls(cloudHookUrl: String?, remoteUiUrl: String?, webhookId: String)
 
+    suspend fun updateCloudUrls(cloudhookUrl: String?, remoteUiUrl: String?)
+
     suspend fun getUrl(isInternal: Boolean? = null): URL?
 
     suspend fun saveUrl(url: String, isInternal: Boolean? = null)
+
+    suspend fun shouldUseCloud(): Boolean
+
+    suspend fun setUseCloud(use: Boolean)
 
     suspend fun getHomeWifiSsids(): Set<String>
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepository.kt
@@ -17,9 +17,11 @@ interface UrlRepository {
 
     suspend fun updateCloudUrls(cloudhookUrl: String?, remoteUiUrl: String?)
 
-    suspend fun getUrl(isInternal: Boolean? = null): URL?
+    suspend fun getUrl(isInternal: Boolean? = null, ignoreCloud: Boolean = false): URL?
 
     suspend fun saveUrl(url: String, isInternal: Boolean? = null)
+
+    suspend fun canUseCloud(): Boolean
 
     suspend fun shouldUseCloud(): Boolean
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -90,15 +90,15 @@ class UrlRepositoryImpl @Inject constructor(
         localStorage.putString(PREF_CLOUD_UI_URL, remoteUiUrl)
     }
 
-    override suspend fun getUrl(isInternal: Boolean?, ignoreCloud: Boolean): URL? {
+    override suspend fun getUrl(isInternal: Boolean?, force: Boolean): URL? {
         val internal = localStorage.getString(PREF_LOCAL_URL)?.toHttpUrlOrNull()?.toUrl()
         val external = localStorage.getString(PREF_REMOTE_URL)?.toHttpUrlOrNull()?.toUrl()
         val cloud = localStorage.getString(PREF_CLOUD_UI_URL)?.toHttpUrlOrNull()?.toUrl()
 
-        return if (isInternal ?: isInternal() && internal != null) {
+        return if (isInternal ?: isInternal() && (internal != null || force)) {
             Log.d(TAG, "Using internal URL")
             internal
-        } else if (!ignoreCloud && shouldUseCloud() && cloud != null) {
+        } else if (!force && shouldUseCloud() && cloud != null) {
             Log.d(TAG, "Using cloud / remote UI URL")
             cloud
         } else {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -20,9 +20,11 @@ class UrlRepositoryImpl @Inject constructor(
 
     companion object {
         private const val PREF_CLOUDHOOK_URL = "cloudhook_url"
+        private const val PREF_CLOUD_UI_URL = "remote_ui_url"
         private const val PREF_REMOTE_URL = "remote_url"
         private const val PREF_WEBHOOK_ID = "webhook_id"
         private const val PREF_LOCAL_URL = "local_url"
+        private const val PREF_USE_CLOUD = "use_cloud"
         private const val PREF_WIFI_SSIDS = "wifi_ssids"
         private const val PREF_PRIORITIZE_INTERNAL = "prioritize_internal"
         private const val TAG = "UrlRepository"
@@ -76,18 +78,32 @@ class UrlRepositoryImpl @Inject constructor(
     ) {
         localStorage.putString(PREF_CLOUDHOOK_URL, cloudHookUrl)
         localStorage.putString(PREF_WEBHOOK_ID, webhookId)
-        remoteUiUrl?.let {
-            localStorage.putString(PREF_REMOTE_URL, it)
+        localStorage.putString(PREF_CLOUD_UI_URL, remoteUiUrl)
+        localStorage.putBoolean(PREF_USE_CLOUD, remoteUiUrl != null)
+    }
+
+    override suspend fun updateCloudUrls(
+        cloudhookUrl: String?,
+        remoteUiUrl: String?
+    ) {
+        localStorage.putString(PREF_CLOUDHOOK_URL, cloudhookUrl)
+        localStorage.putString(PREF_CLOUD_UI_URL, remoteUiUrl)
+        if (remoteUiUrl == null) {
+            localStorage.putBoolean(PREF_USE_CLOUD, false)
         }
     }
 
     override suspend fun getUrl(isInternal: Boolean?): URL? {
         val internal = localStorage.getString(PREF_LOCAL_URL)?.toHttpUrlOrNull()?.toUrl()
         val external = localStorage.getString(PREF_REMOTE_URL)?.toHttpUrlOrNull()?.toUrl()
+        val cloud = localStorage.getString(PREF_CLOUD_UI_URL)?.toHttpUrlOrNull()?.toUrl()
 
         return if (isInternal ?: isInternal() && internal != null) {
             Log.d(TAG, "Using internal URL")
             internal
+        } else if (shouldUseCloud() && cloud != null) {
+            Log.d(TAG, "Using cloud / remote UI URL")
+            cloud
         } else {
             Log.d(TAG, "Using external URL")
             external
@@ -108,6 +124,14 @@ class UrlRepositoryImpl @Inject constructor(
             )
         }
         localStorage.putString(if (isInternal ?: isInternal()) PREF_LOCAL_URL else PREF_REMOTE_URL, trimUrl)
+    }
+
+    override suspend fun shouldUseCloud(): Boolean {
+        return localStorage.getBoolean(PREF_USE_CLOUD)
+    }
+
+    override suspend fun setUseCloud(use: Boolean) {
+        localStorage.putBoolean(PREF_USE_CLOUD, use)
     }
 
     override suspend fun getHomeWifiSsids(): Set<String> {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/GetConfigResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/GetConfigResponse.kt
@@ -12,5 +12,7 @@ data class GetConfigResponse(
     val timeZone: String,
     val components: List<String>,
     val version: String,
+    var cloudhookUrl: String?, // only when using webhook
+    var remoteUiUrl: String?, // only when using webhook
     val entities: Map<String, Map<String, Any>>? // only on core >= 2022.6 when using webhook
 )

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -240,6 +240,7 @@
     <string name="icon">Icon</string>
     <string name="input_booleans">Input Booleans</string>
     <string name="input_buttons">Input Buttons</string>
+    <string name="input_cloud">Use Home Assistant Cloud</string>
     <string name="input_url_hint">https://example.duckdns.org:8123</string>
     <string name="input_url">Home Assistant URL</string>
     <string name="install_app">Install App on Wear Device</string>
@@ -752,7 +753,7 @@
     <string name="update_widget">Update Widget</string>
     <string name="updating_sensors">Updating Sensors</string>
     <string name="url_invalid">Url Invalid</string>
-    <string name="url_parse_error">Unable to parse your Home Assistant URL. It should look like https://example.com</string>
+    <string name="url_parse_error">Unable to parse your URL. It should look like this: https://example.com.</string>
     <string name="username">Username</string>
     <string name="version">Version: %s</string>
     <string name="view_password">View Password</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR aims to improve the app's connection settings when using Home Assistant Cloud by:
- **refreshing Home Assistant Cloud information after registration**; currently information is only retrieved during registration but the `get_config` webhook provides up-to-date information about the cloudhook and remote UI URL, which means the app can now detect if Cloud is added after registration and switch to it without requiring the user to manually copy and paste URLs
- **hiding technical details**; the user doesn't care about their Nabu Casa URL, so hide it behind a simple switch instead to better match how it is (not) presented elsewhere in the frontend UI
- **making it easy to switch it off and go back to local access**; Home Assistant Cloud information is stored separately instead of overwriting the normal URL, so disabling it by choice in the settings or when the instance tells us that there is no longer a subscription is seamless and doesn't require setup or looking up IP addresses

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|The main settings screen now shows 'Use Home Assistant Cloud' when using cloud for the connection|![App connection settings with an item "Home Assistant URL: Use Home Assistant Cloud", light mode.](https://user-images.githubusercontent.com/8148535/195444672-841d1c27-be21-43b7-80e6-4bd7916763d1.png)|![App connection settings with an item "Home Assistant URL: Use Home Assistant Cloud", dark mode.](https://user-images.githubusercontent.com/8148535/195444740-697a7660-0b14-496f-8f58-8f6b5811e514.png)|
|Using Home Assistant Cloud|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" on, light mode.](https://user-images.githubusercontent.com/8148535/195445467-15feb2a1-82fd-46cd-be57-0cbda610cd99.png)|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" on, dark mode.](https://user-images.githubusercontent.com/8148535/195445560-d6279ede-bf59-48a3-84cb-f739a249d955.png)|
|Not using Home Assistant Cloud|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" off and a text input with an IP address below it, light mode.](https://user-images.githubusercontent.com/8148535/195445620-9f12e59d-2170-4384-afdc-f942fda42557.png)|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" off and a text input with an IP address below it, dark mode.](https://user-images.githubusercontent.com/8148535/195445648-482903be-223b-4126-b389-e09844ccf3ba.png)|
|No Home Assistant Cloud on this instance|![A settings screen titled "Home Assistant URL", with only a text input with an IP address, light mode.](https://user-images.githubusercontent.com/8148535/195445774-4962e3fa-b496-473a-af89-b19182e807ea.png)|![A settings screen titled "Home Assistant URL", with only a text input with an IP address, dark mode.](https://user-images.githubusercontent.com/8148535/195445801-b81a9162-cd7c-4d51-8f71-410daab2bff5.png)|
|Input validation|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" off and a text input with an IP address below it, highlighted in red with the error text "Unable to parse your URL. It should look like this: https://example.com.", light mode.](https://user-images.githubusercontent.com/8148535/195445865-5a1d0406-90b1-4899-a6b6-2bf1fb31833a.png)|![A settings screen titled "Home Assistant URL", with a toggle "Use Home Assistant Cloud" off and a text input with an IP address below it, highlighted in red with the error text "Unable to parse your URL. It should look like this: https://example.com.", dark mode.](https://user-images.githubusercontent.com/8148535/195445905-d4adcd2b-9cbf-4b31-96be-c86e8bd2439a.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I originally intended to change up more of the connection settings to unify and simplify it, but in the end decided against it because the home network SSIDs are also used independently in other places (websocket, app lock). This partly explains why there is so much (UI) code for relatively small changes.