### PR TITLE
Show settings chip while loading Wear app

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -117,6 +117,7 @@ fun LoadHomePage(
             }
             composable(SCREEN_SETTINGS) {
                 SettingsView(
+                    loadingState = mainViewModel.loadingState.value,
                     favorites = mainViewModel.favoriteEntityIds.value,
                     onClickSetFavorites = {
                         swipeDismissableNavController.navigate(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.stringResource
@@ -128,9 +130,19 @@ fun MainView(
 
                 when (mainViewModel.loadingState.value) {
                     MainViewModel.LoadingState.LOADING -> {
+                        if (favoriteEntityIds.isEmpty()) {
+                            // Add a Spacer to prevent settings being pushed to the screen center
+                            item { Spacer(modifier = Modifier.fillMaxWidth()) }
+                        }
                         item {
+                            val minHeight =
+                                if (favoriteEntityIds.isEmpty()) LocalConfiguration.current.screenHeightDp - 64
+                                else 0
                             Column(
-                                modifier = Modifier.fillMaxSize(),
+                                modifier = Modifier
+                                    .heightIn(min = minHeight.dp)
+                                    .fillMaxSize()
+                                    .padding(vertical = if (favoriteEntityIds.isEmpty()) 0.dp else 32.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally,
                                 verticalArrangement = Arrangement.Center
                             ) {
@@ -299,27 +311,25 @@ fun MainView(
                     }
                 }
 
-                if (mainViewModel.loadingState.value != MainViewModel.LoadingState.LOADING) {
-                    // Settings
-                    item {
-                        Chip(
-                            modifier = Modifier
-                                .fillMaxWidth(),
-                            icon = {
-                                Image(
-                                    asset = CommunityMaterial.Icon.cmd_cog,
-                                    colorFilter = ColorFilter.tint(Color.White)
-                                )
-                            },
-                            label = {
-                                Text(
-                                    text = stringResource(id = commonR.string.settings)
-                                )
-                            },
-                            onClick = onSettingsClicked,
-                            colors = ChipDefaults.secondaryChipColors()
-                        )
-                    }
+                // Settings
+                item {
+                    Chip(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        icon = {
+                            Image(
+                                asset = CommunityMaterial.Icon.cmd_cog,
+                                colorFilter = ColorFilter.tint(Color.White)
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(id = commonR.string.settings)
+                            )
+                        },
+                        onClick = onSettingsClicked,
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
                 }
             }
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
@@ -22,6 +22,7 @@ import androidx.wear.compose.material.rememberScalingLazyListState
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.previewFavoritesList
@@ -57,6 +58,7 @@ fun SecondarySettingsChip(
 
 @Composable
 fun SettingsView(
+    loadingState: MainViewModel.LoadingState,
     favorites: List<String>,
     onClickSetFavorites: () -> Unit,
     onClearFavorites: () -> Unit,
@@ -89,6 +91,7 @@ fun SettingsView(
                     SecondarySettingsChip(
                         icon = CommunityMaterial.Icon3.cmd_star,
                         label = stringResource(commonR.string.favorite),
+                        enabled = loadingState == MainViewModel.LoadingState.READY,
                         onClick = onClickSetFavorites
                     )
                 }
@@ -232,6 +235,7 @@ fun SettingsView(
 @Composable
 private fun PreviewSettingsView() {
     SettingsView(
+        loadingState = MainViewModel.LoadingState.READY,
         favorites = previewFavoritesList,
         onClickSetFavorites = { /*TODO*/ },
         onClearFavorites = {},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implements #2850: the settings chip is now visible in the Wear app while loading, in addition to when the app is ready or loading failed.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The aim is to have settings accessible, but not as a primary action. I have added an artificial delay to loading data for these videos.

With a favorite:

https://user-images.githubusercontent.com/8148535/195820324-3c8b51b2-1d77-4da1-8269-d30f138b7749.mp4

Without favorites:

https://user-images.githubusercontent.com/8148535/195820347-4af47d2f-5d21-4a35-a094-23df483cb70d.mp4

If you open the settings while the app is still loading, favorite editing is disabled to prevent the app showing an empty list (all other settings should be fine while still loading):
![Wear settings showing a disabled option 'Set Favorite Entities'](https://user-images.githubusercontent.com/8148535/195825214-336ccbe1-823a-49e8-97a7-54e21802329f.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->