### PR TITLE
Use dagger for icon dialog icon pack

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -77,7 +77,7 @@ class ManageTilesFragment : Fragment(), IconDialog.Callback {
     }
 
     override val iconDialogIconPack: IconPack
-        get() = viewModel.iconPack
+        get() = viewModel.iconPack.get()
 
     override fun onIconDialogIconsSelected(dialog: IconDialog, icons: List<com.maltaisn.icondialog.data.Icon>) {
         Log.d(TAG, "Selected icon: ${icons.firstOrNull()}")

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -17,8 +17,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.maltaisn.icondialog.data.Icon
 import com.maltaisn.icondialog.pack.IconPack
-import com.maltaisn.icondialog.pack.IconPackLoader
-import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -59,7 +57,8 @@ class ManageTilesViewModel @Inject constructor(
         private const val TAG = "ManageTilesViewModel"
     }
 
-    lateinit var iconPack: IconPack
+    @Inject
+    lateinit var iconPack: dagger.Lazy<IconPack>
 
     private val app = application
 
@@ -103,9 +102,7 @@ class ManageTilesViewModel @Inject constructor(
         }
 
         viewModelScope.launch(Dispatchers.IO) {
-            val loader = IconPackLoader(getApplication())
-            iconPack = createMaterialDesignIconPack(loader)
-            iconPack.loadDrawables(loader.drawableLoader)
+            iconPack.get()
             withContext(Dispatchers.Main) {
                 // The icon pack might not have been initialized when the tile data was loaded
                 selectTile(slots.indexOf(selectedTile))
@@ -140,9 +137,8 @@ class ManageTilesViewModel @Inject constructor(
         tileSubtitle = currentTile.subtitle
         selectedEntityId = currentTile.entityId
         selectIcon(
-            currentTile.iconId?.let {
-                if (::iconPack.isInitialized) iconPack.getIcon(it)
-                else null
+            currentTile.iconId?.let { iconId ->
+                iconPack.get().getIcon(iconId)
             }
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -20,15 +20,12 @@ import com.google.android.material.composethemeadapter.MdcTheme
 import com.maltaisn.icondialog.IconDialog
 import com.maltaisn.icondialog.IconDialogSettings
 import com.maltaisn.icondialog.pack.IconPack
-import com.maltaisn.icondialog.pack.IconPackLoader
-import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.settings.shortcuts.views.ManageShortcutsView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -43,18 +40,16 @@ class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
     }
 
     val viewModel: ManageShortcutsViewModel by viewModels()
-    private lateinit var iconPack: IconPack
+
+    @Inject
+    lateinit var iconPack: dagger.Lazy<IconPack>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
 
-        lifecycleScope.launch {
-            withContext(Dispatchers.IO) {
-                val loader = IconPackLoader(requireContext())
-                iconPack = createMaterialDesignIconPack(loader)
-                iconPack.loadDrawables(loader.drawableLoader)
-            }
+        lifecycleScope.launch(Dispatchers.IO) {
+            iconPack.get()
         }
     }
 
@@ -97,7 +92,7 @@ class ManageShortcutsSettingsFragment : Fragment(), IconDialog.Callback {
     }
 
     override val iconDialogIconPack: IconPack
-        get() = iconPack
+        get() = iconPack.get()
 
     override fun onIconDialogIconsSelected(dialog: IconDialog, icons: List<com.maltaisn.icondialog.data.Icon>) {
         Log.d(TAG, "Selected icon: ${icons.firstOrNull()}")

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt
@@ -22,8 +22,6 @@ import androidx.core.graphics.drawable.DrawableCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.maltaisn.icondialog.pack.IconPack
-import com.maltaisn.icondialog.pack.IconPackLoader
-import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -41,8 +39,11 @@ class ManageShortcutsViewModel @Inject constructor(
 
     val app = application
     private val TAG = "ShortcutViewModel"
-    private lateinit var iconPack: IconPack
-    private var shortcutManager = application.applicationContext.getSystemService<ShortcutManager>()!!
+
+    @Inject
+    lateinit var iconPack: dagger.Lazy<IconPack>
+
+    private var shortcutManager = application.getSystemService<ShortcutManager>()!!
     val canPinShortcuts = Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && shortcutManager.isRequestPinShortcutSupported
     var pinnedShortcuts: MutableList<ShortcutInfo> = shortcutManager.pinnedShortcuts
         private set
@@ -191,10 +192,7 @@ class ManageShortcutsViewModel @Inject constructor(
     }
 
     private fun getTileIcon(tileIconId: Int): Drawable? {
-        val loader = IconPackLoader(getApplication())
-        iconPack = createMaterialDesignIconPack(loader)
-        iconPack.loadDrawables(loader.drawableLoader)
-        val iconDrawable = iconPack.icons[tileIconId]?.drawable
+        val iconDrawable = iconPack.get().icons[tileIconId]?.drawable
         if (iconDrawable != null) {
             val icon = DrawableCompat.wrap(iconDrawable)
             icon.setColorFilter(app.resources.getColor(R.color.colorAccent), PorterDuff.Mode.SRC_IN)

--- a/app/src/main/java/io/homeassistant/companion/android/util/IconPackModule.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/IconPackModule.kt
@@ -1,0 +1,23 @@
+package io.homeassistant.companion.android.util
+
+import android.content.Context
+import com.maltaisn.icondialog.pack.IconPack
+import com.maltaisn.icondialog.pack.IconPackLoader
+import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
+import dagger.hilt.android.qualifiers.ActivityContext
+
+@Module
+@InstallIn(ActivityComponent::class)
+object IconPackModule {
+
+    @Provides
+    fun iconPack(@ActivityContext context: Context): IconPack {
+        // Create an icon pack and load all drawables.
+        val loader = IconPackLoader(context)
+        return createMaterialDesignIconPack(loader).apply { loadDrawables(loader.drawableLoader) }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/IconPackModule.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/IconPackModule.kt
@@ -7,11 +7,11 @@ import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.components.SingletonComponent
 
 @Module
-@InstallIn(ActivityComponent::class)
+@InstallIn(SingletonComponent::class)
 object IconPackModule {
 
     @Provides

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.android.material.color.DynamicColors
 import com.maltaisn.icondialog.pack.IconPack
-import com.maltaisn.icondialog.pack.IconPackLoader
-import com.maltaisn.iconpack.mdi.createMaterialDesignIconPack
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -65,12 +63,13 @@ class ButtonWidget : AppWidgetProvider() {
     }
 
     @Inject
+    lateinit var iconPack: dagger.Lazy<IconPack>
+
+    @Inject
     lateinit var integrationUseCase: IntegrationRepository
 
     @Inject
     lateinit var buttonWidgetDao: ButtonWidgetDao
-
-    private var iconPack: IconPack? = null
 
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
@@ -175,12 +174,6 @@ class ButtonWidget : AppWidgetProvider() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
         }
 
-        // Create an icon pack and load all drawables.
-        if (iconPack == null) {
-            val loader = IconPackLoader(context)
-            iconPack = createMaterialDesignIconPack(loader)
-            iconPack!!.loadDrawables(loader.drawableLoader)
-        }
         val useDynamicColors = widget?.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable()
         return RemoteViews(context.packageName, if (useDynamicColors) R.layout.widget_button_wrapper_dynamiccolor else R.layout.widget_button_wrapper_default).apply {
             // Theming
@@ -194,7 +187,7 @@ class ButtonWidget : AppWidgetProvider() {
             // Content
             val iconId = widget?.iconId ?: 988171 // Lightning bolt
 
-            val iconDrawable = iconPack?.icons?.get(iconId)?.drawable
+            val iconDrawable = iconPack.get().icons[iconId]?.drawable
             if (iconDrawable != null) {
                 val icon = DrawableCompat.wrap(iconDrawable)
                 if (widget?.backgroundType == WidgetBackgroundType.TRANSPARENT) {


### PR DESCRIPTION
## Summary
Streamlines the icon pack code by moving it into Dagger. `dagger.Lazy` is used to preserve loading the icon pack on a background thread.

## Screenshots
N/A

## Link to pull request in Documentation repository
N/A
## Any other notes
This is some cleanup to make it easier to migrate off the icon dialog later