### PR TITLE
Fix navigation bar color on OnboardingActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -289,7 +289,8 @@
 
         <activity
             android:name=".onboarding.OnboardingActivity"
-            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation" />
+            android:configChanges="orientation|screenSize|keyboard|keyboardHidden|navigation"
+            android:theme="@style/Theme.HomeAssistant.Config" />
 
         <activity
             android:name=".settings.wear.SettingsWearActivity"


### PR DESCRIPTION
## Summary
On the Onboarding activity change the status and navigation bar color to white to match the rest of the app. This screen wasn't using `Theme.HomeAssistant.Config` like most of the activities.

## Screenshots
Before & After (light mode)
<img width="300" alt="Screen Shot 2022-10-23 at 12 50 18 AM" src="https://user-images.githubusercontent.com/6628497/197374524-3c1537fb-1d66-420d-bdc1-ba07c15fce66.png"> <img width="300" alt="Screen Shot 2022-10-23 at 12 49 58 AM" src="https://user-images.githubusercontent.com/6628497/197374531-c773fad8-e05e-430f-a700-b7082ab7cff1.png">

Before & After (dark mode) No difference
<img width="300" alt="Screen Shot 2022-10-23 at 12 53 57 AM" src="https://user-images.githubusercontent.com/6628497/197374549-6d3d7755-1209-4d66-9eec-02a4e7ddad9b.png"> <img width="300" alt="Screen Shot 2022-10-23 at 12 56 05 AM" src="https://user-images.githubusercontent.com/6628497/197374551-b86fa04b-24e1-4d3e-94ad-52f0deb084d7.png">