### PR TITLE
Revert/set force dark again for webview

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -66,7 +66,7 @@ class AuthenticationFragment : Fragment() {
                 MdcTheme {
                     AndroidView({
                         WebView(requireContext()).apply {
-                            themesManager.setThemeForWebView()
+                            themesManager.setThemeForWebView(requireContext(), settings)
                             settings.javaScriptEnabled = true
                             settings.domStorageEnabled = true
                             settings.userAgentString = settings.userAgentString + " ${HomeAssistantApis.USER_AGENT_STRING}"

--- a/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/themes/ThemesManager.kt
@@ -1,7 +1,12 @@
 package io.homeassistant.companion.android.themes
 
+import android.content.Context
+import android.content.res.Configuration
 import android.os.Build
+import android.webkit.WebSettings
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.webkit.WebSettingsCompat
+import androidx.webkit.WebViewFeature
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -35,9 +40,40 @@ class ThemesManager @Inject constructor(
         }
     }
 
-    fun setThemeForWebView() {
+    @Suppress("DEPRECATION")
+    fun setThemeForWebView(context: Context, webSettings: WebSettings) {
         val theme = getCurrentTheme()
         setNightModeBasedOnTheme(theme)
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) &&
+            WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)
+        ) {
+            // While an up-to-date official WebView respects the app light/dark theme automatically,
+            // some users are running forks where this doesn't seem to work or are reportedly
+            // unable to update. These deprecated settings are set to preserve compatibility for
+            // those users. Issue: https://github.com/home-assistant/android/issues/2985
+            WebSettingsCompat.setForceDarkStrategy(
+                webSettings, WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
+            )
+            when (theme) {
+                "dark" -> {
+                    WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_ON)
+                }
+                "android", "system" -> {
+                    val nightModeFlags =
+                        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+                    if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES) {
+                        WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_ON)
+                    } else {
+                        WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_OFF)
+                    }
+                }
+                else -> {
+                    WebSettingsCompat.setForceDark(webSettings, WebSettingsCompat.FORCE_DARK_OFF)
+                }
+            }
+        }
     }
 
     private fun setNightModeBasedOnTheme(theme: String?) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -637,7 +637,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         // This enables the ability to have the launch screen behind the WebView until the web frontend gets rendered
         binding.webview.setBackgroundColor(Color.TRANSPARENT)
 
-        themesManager.setThemeForWebView()
+        themesManager.setThemeForWebView(this, webView.settings)
 
         val cookieManager = CookieManager.getInstance()
         cookieManager.setAcceptCookie(true)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Revert some of the changes in #2923 in an attempt to fix #2985. The WebView doesn't use the app's light/dark theme light as expected because users are running a webview version which works differently or are running an outdated/unupdateable version (which IMO is the bigger issue here, but who am I to judge).

Documentation and logs suggest this won't work anymore but as the affected devices don't work correctly in the first place it is worth a shot. There don't appear to be any downsides to adding this code aside from the log statement.

```
2022-10-23 15:51:12.299 18646-18646 cr_SupportWebSettings   io....stant.companion.android.debug  W  setForceDarkBehavior() is a no-op in an app with targetSdkVersion>=T
2022-10-23 15:51:12.300 18646-18646 cr_SupportWebSettings   io....stant.companion.android.debug  W  setForceDark() is a no-op in an app with targetSdkVersion>=T
```

Confirmed 'working' by multiple users in the issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->