### PR TITLE
Add Wet Mode Sensor

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -941,5 +941,5 @@
     <string name="sensor_name_theater_mode">Theater Mode</string>
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
 	<string name="sensor_name_wet_mode">Wet Mode</string>
-	<string name="sensor_description_wet_mode">Wether the device is currently in Wet Mode (or Touch Lock)</string>
+	<string name="sensor_description_wet_mode">Wether the device has Wet Mode (or Touch Lock) enabled</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -940,4 +940,6 @@
     <string name="sensor_description_bedtime_mode">Whether bedtime mode is enabled on the device. For best results enable either Do Not Disturb or Interactive sensor.</string>
     <string name="sensor_name_theater_mode">Theater Mode</string>
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
+	<string name="sensor_name_wet_mode">Wet Mode</string>
+	<string name="sensor_description_wet_mode">Wether the device is currently in Wet Mode</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -940,6 +940,6 @@
     <string name="sensor_description_bedtime_mode">Whether bedtime mode is enabled on the device. For best results enable either Do Not Disturb or Interactive sensor.</string>
     <string name="sensor_name_theater_mode">Theater Mode</string>
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
-	<string name="sensor_name_wet_mode">Wet Mode</string>
-	<string name="sensor_description_wet_mode">Whether the device has Wet Mode (or Touch Lock) enabled</string>
+    <string name="sensor_name_wet_mode">Wet Mode</string>
+    <string name="sensor_description_wet_mode">Whether the device has Wet Mode (or Touch Lock) enabled</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -941,5 +941,5 @@
     <string name="sensor_name_theater_mode">Theater Mode</string>
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
 	<string name="sensor_name_wet_mode">Wet Mode</string>
-	<string name="sensor_description_wet_mode">Wether the device is currently in Wet Mode</string>
+	<string name="sensor_description_wet_mode">Wether the device is currently in Wet Mode (or Touch Lock)</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -941,5 +941,5 @@
     <string name="sensor_name_theater_mode">Theater Mode</string>
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
 	<string name="sensor_name_wet_mode">Wet Mode</string>
-	<string name="sensor_description_wet_mode">Wether the device has Wet Mode (or Touch Lock) enabled</string>
+	<string name="sensor_description_wet_mode">Whether the device has Wet Mode (or Touch Lock) enabled</string>
 </resources>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+	<uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
-	<uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
+    <uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
 
     <uses-feature android:name="android.hardware.type.watch" />
 

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -83,6 +83,15 @@ open class HomeAssistantApplication : Application() {
                 addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED)
             }
         )
+
+		// Listen to changes to Wet Mode State
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter().apply {
+                addAction("com.google.android.clockwork.actions.WET_MODE_STARTED")
+                addAction("com.google.android.clockwork.actions.WET_MODE_ENDED")
+            }
+        )
         // Update complications when the screen is on
         val complicationReceiver = ComplicationReceiver()
 

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -84,7 +84,7 @@ open class HomeAssistantApplication : Application() {
             }
         )
 
-		// Listen to changes to Wet Mode State
+        // Listen to changes to Wet Mode State
         registerReceiver(
             sensorReceiver,
             IntentFilter().apply {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -48,7 +48,7 @@ class SensorReceiver : SensorReceiverBase() {
             PowerSensorManager(),
             StepsSensorManager(),
             TheaterModeSensorManager(),
-			WetModeSensorManager()
+            WetModeSensorManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =
@@ -68,7 +68,7 @@ class SensorReceiver : SensorReceiverBase() {
         AudioManager.ACTION_MICROPHONE_MUTE_CHANGED to AudioSensorManager.micMuted.id,
         AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED to AudioSensorManager.speakerphoneState.id,
         AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
-		"com.google.android.clockwork.actions.WET_MODE_STARTED" to WetModeSensorManager.wetModeSensor.id,
+        "com.google.android.clockwork.actions.WET_MODE_STARTED" to WetModeSensorManager.wetModeSensor.id,
         "com.google.android.clockwork.actions.WET_MODE_ENDED" to WetModeSensorManager.wetModeSensor.id
     )
 

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -47,7 +47,8 @@ class SensorReceiver : SensorReceiverBase() {
             OnBodySensorManager(),
             PowerSensorManager(),
             StepsSensorManager(),
-            TheaterModeSensorManager()
+            TheaterModeSensorManager(),
+			WetModeSensorManager()
         )
 
         const val ACTION_REQUEST_SENSORS_UPDATE =
@@ -67,6 +68,8 @@ class SensorReceiver : SensorReceiverBase() {
         AudioManager.ACTION_MICROPHONE_MUTE_CHANGED to AudioSensorManager.micMuted.id,
         AudioManager.ACTION_SPEAKERPHONE_STATE_CHANGED to AudioSensorManager.speakerphoneState.id,
         AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
+		"com.google.android.clockwork.actions.WET_MODE_STARTED" to WetModeSensorManager.wetModeSensor.id,
+        "com.google.android.clockwork.actions.WET_MODE_ENDED" to WetModeSensorManager.wetModeSensor.id
     )
 
     override fun getSensorSettingsIntent(context: Context, id: String): Intent? = null

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
@@ -12,7 +12,7 @@ class WetModeSensorManager : SensorManager {
             "wet_mode",
             "binary_sensor",
             commonR.string.sensor_name_wet_mode,
-            commonR.string.sensor_description_wet_mod,
+            commonR.string.sensor_description_wet_mode,
             "mdi:water-off",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
@@ -1,0 +1,74 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.content.Intent
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.R as commonR
+
+class WetModeSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "WetModeSensor"
+        val wetModeSensor = SensorManager.BasicSensor(
+            "wet_mode",
+            "binary_sensor",
+            commonR.string.sensor_name_wet_mode,
+            commonR.string.sensor_description_wet_mod,
+            "mdi:water-off",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+
+        )
+    }
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
+    }
+
+    private var wetModeEnabled: Boolean = false
+
+    override val enabledByDefault: Boolean
+        get() = false
+
+    override val name: Int
+        get() = commonR.string.sensor_name_wet_mode
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(
+            wetModeSensor
+        )
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(
+        context: Context,
+        intent: Intent?
+    ) {
+        if (intent?.action == "com.google.android.clockwork.actions.WET_MODE_STARTED") {
+            wetModeEnabled = true
+        } else if (intent?.action == "com.google.android.clockwork.actions.WET_MODE_ENDED") {
+            wetModeEnabled = false
+        }
+
+        updateWetMode(context)
+    }
+
+    override fun requestSensorUpdate(context: Context) {
+        // No Op
+    }
+
+    private fun updateWetMode(context: Context) {
+        if (!isEnabled(context, wetModeSensor.id))
+            return
+
+        onSensorUpdated(
+            context,
+            wetModeSensor,
+            wetModeEnabled,
+            if (wetModeEnabled) "mdi:water" else wetModeSensor.statelessIcon,
+            mapOf()
+        )
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a Wet Mode sensor to Wear. This is a special mode where the user must press and hold the crown/power button for 2 seconds to re-enable touch. May also be referred as Touch Lock or Water Lock.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://user-images.githubusercontent.com/37350695/197655716-7f9b2926-87c3-41da-a2a7-00eeb7d7c7fc.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#845

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->