### PR TITLE
Add user activity sensor from health services for Wear OS

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -942,4 +942,7 @@
     <string name="sensor_description_theater_mode">Whether theater mode is enabled on the device. For best results enable the interactive sensor.</string>
     <string name="sensor_name_wet_mode">Wet Mode</string>
     <string name="sensor_description_wet_mode">Whether the device has Wet Mode (or Touch Lock) enabled</string>
+    <string name="sensor_name_activity_state">Activity State</string>
+    <string name="sensor_description_activity_state">The state of user activity as determined by Health Services</string>
+    <string name="sensor_name_health_services">Health Services</string>
 </resources>

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -127,4 +127,6 @@ dependencies {
     implementation("androidx.wear.tiles:tiles:1.1.0")
 
     implementation("androidx.wear.watchface:watchface-complications-data-source-ktx:1.1.1")
+
+    implementation("androidx.health:health-services-client:1.0.0-beta01")
 }

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -10,6 +11,8 @@
     <uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
 
     <uses-feature android:name="android.hardware.type.watch" />
+
+    <uses-sdk tools:overrideLibrary="androidx.health.services.client" />
 
     <application
         android:name=".HomeAssistantApplication"

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -60,12 +60,6 @@ class HealthServicesSensorManager : SensorManager {
 
     override fun requestSensorUpdate(context: Context) {
         latestContext = context
-
-        if (healthClient == null) healthClient = HealthServices.getClient(latestContext)
-        if (passiveMonitoringClient == null) passiveMonitoringClient = healthClient?.passiveMonitoringClient
-        passiveListenerConfig = PassiveListenerConfig.builder()
-            .setShouldUserActivityInfoBeRequested(isEnabled(latestContext, userActivityState.id))
-            .build()
         updateUserActivityState()
     }
 
@@ -75,6 +69,12 @@ class HealthServicesSensorManager : SensorManager {
             callBackRegistered = false
             return
         }
+
+        if (healthClient == null) healthClient = HealthServices.getClient(latestContext)
+        if (passiveMonitoringClient == null) passiveMonitoringClient = healthClient?.passiveMonitoringClient
+        passiveListenerConfig = PassiveListenerConfig.builder()
+            .setShouldUserActivityInfoBeRequested(isEnabled(latestContext, userActivityState.id))
+            .build()
 
         val passiveListenerCallback: PassiveListenerCallback = object : PassiveListenerCallback {
             override fun onUserActivityInfoReceived(info: UserActivityInfo) {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -1,0 +1,115 @@
+package io.homeassistant.companion.android.sensors
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.health.services.client.HealthServices
+import androidx.health.services.client.HealthServicesClient
+import androidx.health.services.client.PassiveListenerCallback
+import androidx.health.services.client.PassiveMonitoringClient
+import androidx.health.services.client.data.PassiveListenerConfig
+import androidx.health.services.client.data.UserActivityInfo
+import androidx.health.services.client.data.UserActivityState
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.R as commonR
+
+@RequiresApi(Build.VERSION_CODES.R)
+class HealthServicesSensorManager : SensorManager {
+    companion object {
+
+        private const val TAG = "HealthServices"
+        private val userActivityState = SensorManager.BasicSensor(
+            "activity_state",
+            "sensor",
+            commonR.string.sensor_name_activity_state,
+            commonR.string.sensor_description_activity_state,
+            "mdi:account",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+        )
+    }
+
+    private lateinit var latestContext: Context
+    private var healthClient: HealthServicesClient? = null
+    private var passiveMonitoringClient: PassiveMonitoringClient? = null
+    private var passiveListenerConfig: PassiveListenerConfig? = null
+    private var callBackRegistered = false
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
+    }
+    override val enabledByDefault: Boolean
+        get() = false
+
+    override val name: Int
+        get() = commonR.string.sensor_name_health_services
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(userActivityState)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return arrayOf(Manifest.permission.ACTIVITY_RECOGNITION)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+    }
+
+    override fun requestSensorUpdate(context: Context) {
+        latestContext = context
+
+        if (healthClient == null) healthClient = HealthServices.getClient(latestContext)
+        if (passiveMonitoringClient == null) passiveMonitoringClient = healthClient?.passiveMonitoringClient
+        passiveListenerConfig = PassiveListenerConfig.builder()
+            .setShouldUserActivityInfoBeRequested(isEnabled(latestContext, userActivityState.id))
+            .build()
+        updateUserActivityState()
+    }
+
+    private fun updateUserActivityState() {
+        if (!isEnabled(latestContext, userActivityState.id)) {
+            passiveMonitoringClient?.clearPassiveListenerCallbackAsync()
+            callBackRegistered = false
+            return
+        }
+
+        val passiveListenerCallback: PassiveListenerCallback = object : PassiveListenerCallback {
+            override fun onUserActivityInfoReceived(info: UserActivityInfo) {
+                Log.d(TAG, "User activity state: ${info.userActivityState.name}")
+                onSensorUpdated(
+                    latestContext,
+                    userActivityState,
+                    when (info.userActivityState) {
+                        UserActivityState.USER_ACTIVITY_ASLEEP -> "asleep"
+                        UserActivityState.USER_ACTIVITY_PASSIVE -> "passive"
+                        UserActivityState.USER_ACTIVITY_EXERCISE -> "exercise"
+                        else -> "unknown"
+                    },
+                    when (info.userActivityState) {
+                        UserActivityState.USER_ACTIVITY_EXERCISE -> "mdi:run"
+                        UserActivityState.USER_ACTIVITY_ASLEEP -> "mdi:sleep"
+                        UserActivityState.USER_ACTIVITY_PASSIVE -> "mdi:walk"
+                        else -> userActivityState.statelessIcon
+                    },
+                    mapOf(
+                        "time" to info.stateChangeTime,
+                        "exercise_type" to info.exerciseInfo?.exerciseType?.name
+                    )
+                )
+
+                SensorWorker.start(latestContext)
+            }
+        }
+
+        if (!callBackRegistered) {
+            passiveMonitoringClient?.setPassiveListenerCallback(
+                passiveListenerConfig!!,
+                passiveListenerCallback
+            )
+        }
+        callBackRegistered = true
+    }
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -13,6 +13,8 @@ import androidx.health.services.client.data.PassiveListenerConfig
 import androidx.health.services.client.data.UserActivityInfo
 import androidx.health.services.client.data.UserActivityState
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.database.AppDatabase
+import kotlinx.coroutines.runBlocking
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -91,7 +93,7 @@ class HealthServicesSensorManager : SensorManager {
                     when (info.userActivityState) {
                         UserActivityState.USER_ACTIVITY_EXERCISE -> "mdi:run"
                         UserActivityState.USER_ACTIVITY_ASLEEP -> "mdi:sleep"
-                        UserActivityState.USER_ACTIVITY_PASSIVE -> "mdi:walk"
+                        UserActivityState.USER_ACTIVITY_PASSIVE -> "mdi:human-handsdown"
                         else -> userActivityState.statelessIcon
                     },
                     mapOf(
@@ -101,6 +103,18 @@ class HealthServicesSensorManager : SensorManager {
                 )
 
                 SensorWorker.start(latestContext)
+            }
+
+            override fun onPermissionLost() {
+                val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
+                runBlocking {
+                    sensorDao.setSensorsEnabled(listOf(userActivityState.id), false)
+                }
+            }
+
+            override fun onRegistrationFailed(throwable: Throwable) {
+                Log.e(TAG, "onRegistrationFailed: ", throwable)
+                callBackRegistered = false
             }
         }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -41,6 +41,7 @@ class SensorReceiver : SensorReceiverBase() {
             BatterySensorManager(),
             BedtimeModeSensorManager(),
             DNDSensorManager(),
+            HealthServicesSensorManager(),
             LastUpdateManager(),
             NetworkSensorManager(),
             NextAlarmManager(),

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import android.os.PowerManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
@@ -35,13 +36,12 @@ class SensorReceiver : SensorReceiverBase() {
 
     companion object {
         const val TAG = "SensorReceiver"
-        val MANAGERS = listOf(
+        private val allManager = listOf(
             AppSensorManager(),
             AudioSensorManager(),
             BatterySensorManager(),
             BedtimeModeSensorManager(),
             DNDSensorManager(),
-            HealthServicesSensorManager(),
             LastUpdateManager(),
             NetworkSensorManager(),
             NextAlarmManager(),
@@ -51,6 +51,10 @@ class SensorReceiver : SensorReceiverBase() {
             TheaterModeSensorManager(),
             WetModeSensorManager()
         )
+        val MANAGERS = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+            allManager.plus(HealthServicesSensorManager())
+        else
+            allManager
 
         const val ACTION_REQUEST_SENSORS_UPDATE =
             "io.homeassistant.companion.android.background.REQUEST_SENSORS_UPDATE"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds the first of [many](https://developer.android.com/reference/kotlin/androidx/health/services/client/data/DataType#public-companion-properties_1) sensors for the new Health Services API. For this first sensor I chose activity state as I know a lot of users want to know when they fall asleep so hopefully this works fast enough for them.  I ran some tests using the synthetic method Google [recommended](https://developer.android.com/training/wearables/health-services/synthetic-data#enable) and the state updates as expected. Will need to consider a good way to register and unregister for updates as a user enables or disables the various sensors they can have from this manager.

This sensor has 4 possible states: asleep, exercise, passive or unknown

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/197689342-ebb607ee-9da2-445d-8f62-908c68d147ea.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#846

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->