### PR TITLE
Fix global vars in bedtime and theater mode

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/BedtimeModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/BedtimeModeSensorManager.kt
@@ -23,7 +23,7 @@ class BedtimeModeSensorManager : SensorManager {
     }
 
     override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#bedtime-mode-sensor"
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
     }
     override val enabledByDefault: Boolean
         get() = false
@@ -52,7 +52,7 @@ class BedtimeModeSensorManager : SensorManager {
             return
 
         val state = try {
-            Settings.Global.getInt(context.contentResolver, "bedtime_mode") == 1
+            Settings.Global.getInt(context.contentResolver, if (Build.MANUFACTURER == "samsung") "setting_bedtime_mode_running_state" else "bedtime_mode") == 1
         } catch (e: Exception) {
             Log.e(TAG, "Unable to update bedtime mode sensor", e)
             false

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
@@ -30,7 +30,7 @@ class OnBodySensorManager : SensorManager, SensorEventListener {
     private lateinit var mySensorManager: android.hardware.SensorManager
 
     override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#on-body-sensor"
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
     }
     override val enabledByDefault: Boolean
         get() = false

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/TheaterModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/TheaterModeSensorManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.os.Build
 import android.provider.Settings
 import android.util.Log
 import io.homeassistant.companion.android.common.sensors.SensorManager
@@ -22,7 +23,7 @@ class TheaterModeSensorManager : SensorManager {
     }
 
     override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#theater-mode-sensor"
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
     }
     override val enabledByDefault: Boolean
         get() = false
@@ -47,7 +48,7 @@ class TheaterModeSensorManager : SensorManager {
             return
 
         val state = try {
-            Settings.Global.getInt(context.contentResolver, "theater_mode_on") == 1
+            Settings.Global.getInt(context.contentResolver, if (Build.MANUFACTURER == "samsung") "setting_theater_mode_on" else "theater_mode_on") == 1
         } catch (e: Exception) {
             Log.e(TAG, "Unable to update theater mode sensor", e)
             false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a check in the Theater & Bedtime mode sensors for Samsung as they have different globals for those
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|  ![image](https://user-images.githubusercontent.com/37350695/197905679-94c688d2-7f9f-45a7-92ab-d27c40f29f84.png) | ![image](https://user-images.githubusercontent.com/37350695/197906060-4e4fb5a5-cc0b-4b99-8aee-ba3f33e2c6fe.png) | 
|-----------|-----------|
## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: N/A

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->