### PR TITLE
Add a heart rate sensor to Wear OS

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -945,4 +945,6 @@
     <string name="sensor_name_activity_state">Activity State</string>
     <string name="sensor_description_activity_state">The state of user activity as determined by Health Services</string>
     <string name="sensor_name_health_services">Health Services</string>
+    <string name="sensor_name_heart_rate">Heart Rate</string>
+    <string name="sensor_description_heart_rate">Current heart rate in beats per minute, an attribute also exists for the reported accuracy from the sensor</string>
 </resources>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.BODY_SENSORS" />
     <uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
 
     <uses-feature android:name="android.hardware.type.watch" />

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -1,0 +1,120 @@
+package io.homeassistant.companion.android.sensors
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
+import android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_HIGH
+import android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_LOW
+import android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM
+import android.hardware.SensorManager.SENSOR_STATUS_NO_CONTACT
+import android.hardware.SensorManager.SENSOR_STATUS_UNRELIABLE
+import android.util.Log
+import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import kotlin.math.roundToInt
+import io.homeassistant.companion.android.common.R as commonR
+
+class HeartRateSensorManager : SensorManager, SensorEventListener {
+    companion object {
+
+        private const val TAG = "HRSensor"
+        private var isListenerRegistered = false
+        private val skipAccuracy = listOf(
+            SENSOR_STATUS_UNRELIABLE,
+            SENSOR_STATUS_NO_CONTACT
+        )
+        private val heartRate = SensorManager.BasicSensor(
+            "heart_rate",
+            "sensor",
+            commonR.string.sensor_name_heart_rate,
+            commonR.string.sensor_description_heart_rate,
+            "mdi:heart-pulse",
+            unitOfMeasurement = "bpm",
+            stateClass = SensorManager.STATE_CLASS_MEASUREMENT
+        )
+    }
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/wear-os/#sensors"
+    }
+    override val enabledByDefault: Boolean
+        get() = false
+
+    override val name: Int
+        get() = commonR.string.sensor_name_heart_rate
+
+    override fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(heartRate)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return arrayOf(Manifest.permission.BODY_SENSORS)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        val packageManager: PackageManager = context.packageManager
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_HEART_RATE)
+    }
+
+    private lateinit var latestContext: Context
+    private lateinit var mySensorManager: android.hardware.SensorManager
+
+    override fun requestSensorUpdate(
+        context: Context
+    ) {
+        latestContext = context
+        updateHeartRate()
+    }
+
+    private fun updateHeartRate() {
+        if (!isEnabled(latestContext, heartRate.id))
+            return
+
+        mySensorManager = latestContext.getSystemService()!!
+
+        val heartRateSensor = mySensorManager.getDefaultSensor(Sensor.TYPE_HEART_RATE)
+        if (heartRateSensor != null && !isListenerRegistered) {
+            mySensorManager.registerListener(
+                this,
+                heartRateSensor,
+                SENSOR_DELAY_NORMAL
+            )
+            Log.d(TAG, "Heart Rate sensor listener registered")
+            isListenerRegistered = true
+        }
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // Nothing happening here but we are required to call onAccuracyChanged for sensor events
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type == Sensor.TYPE_HEART_RATE && event.accuracy !in skipAccuracy) {
+            onSensorUpdated(
+                latestContext,
+                heartRate,
+                event.values[0].roundToInt().toString(),
+                heartRate.statelessIcon,
+                mapOf(
+                    "accuracy" to getAccuracy(event.accuracy)
+                )
+            )
+        }
+        mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Heart Rate sensor listener unregistered")
+        isListenerRegistered = false
+    }
+
+    private fun getAccuracy(accuracy: Int): String {
+        return when (accuracy) {
+            SENSOR_STATUS_ACCURACY_HIGH -> "high"
+            SENSOR_STATUS_ACCURACY_MEDIUM -> "medium"
+            SENSOR_STATUS_ACCURACY_LOW -> "low"
+            else -> "unknown"
+        }
+    }
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -42,6 +42,7 @@ class SensorReceiver : SensorReceiverBase() {
             BatterySensorManager(),
             BedtimeModeSensorManager(),
             DNDSensorManager(),
+            HeartRateSensorManager(),
             LastUpdateManager(),
             NetworkSensorManager(),
             NextAlarmManager(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds a hardware sensor to get the current heart rate. I think if we stream the heart rate data that may be really bad on battery life. With health services we do get heart rate updates however we have no control over how often they show up and from what I saw on my Pixel Watch it was a non-stop stream. Its better to use a hardware sensor here where we have more control over when the updates happen.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/198343473-6ae81a5e-d0a4-46b8-a31e-1457842a8584.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#852

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->