### PR TITLE
Set focus for onboarding activity to support rotary input

### DIFF
--- a/wear/src/main/res/layout/activity_onboarding.xml
+++ b/wear/src/main/res/layout/activity_onboarding.xml
@@ -6,12 +6,15 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <androidx.wear.widget.WearableRecyclerView
         android:id="@+id/server_list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="vertical"
         tools:listitem="@layout/listitem_instance">
+
+        <requestFocus />
     </androidx.wear.widget.WearableRecyclerView>
 
     <io.homeassistant.companion.android.util.LoadingView


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This sets focus to the `WearableRecyclerView`. This makes the view scrollable on a rotary input (like the crown for the pixel watch). See [here](https://developer.android.com/training/wearables/user-input/rotary-input) for reference

Tested that on my own device, scrolling via crown worked afterwards