### PR TITLE
Only use internal URL when data is also using Wi-Fi

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
@@ -46,6 +46,7 @@ class SsidFragment : Fragment() {
                     SsidView(
                         wifiSsids = viewModel.wifiSsids,
                         prioritizeInternal = viewModel.prioritizeInternal,
+                        usingWifi = viewModel.usingWifi,
                         activeSsid = viewModel.activeSsid,
                         activeBssid = viewModel.activeBssid,
                         onAddWifiSsid = viewModel::addHomeWifiSsid,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
@@ -26,6 +26,9 @@ class SsidViewModel @Inject constructor(
     var prioritizeInternal by mutableStateOf(false)
         private set
 
+    var usingWifi by mutableStateOf(false)
+        private set
+
     var activeSsid by mutableStateOf<String?>(null)
         private set
 
@@ -37,6 +40,7 @@ class SsidViewModel @Inject constructor(
             wifiSsids.clear()
             wifiSsids.addAll(urlRepository.getHomeWifiSsids())
             prioritizeInternal = urlRepository.isPrioritizeInternal()
+            usingWifi = wifiHelper.isUsingWifi()
             activeSsid = wifiHelper.getWifiSsid()?.removeSurrounding("\"")
             activeBssid = wifiHelper.getWifiBssid()
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
@@ -63,6 +63,7 @@ import io.homeassistant.companion.android.common.R as commonR
 fun SsidView(
     wifiSsids: List<String>,
     prioritizeInternal: Boolean,
+    usingWifi: Boolean,
     activeSsid: String?,
     activeBssid: String?,
     onAddWifiSsid: (String) -> Boolean,
@@ -150,8 +151,12 @@ fun SsidView(
             }
         }
         items(wifiSsids, key = { "ssid.item.$it" }) {
-            val connected = remember(it, activeSsid, activeBssid) {
-                it == activeSsid || (it.startsWith(UrlRepository.BSSID_PREFIX) && it.removePrefix(UrlRepository.BSSID_PREFIX).equals(activeBssid, ignoreCase = true))
+            val connected = remember(it, activeSsid, activeBssid, usingWifi) {
+                usingWifi &&
+                    (
+                        it == activeSsid ||
+                            (it.startsWith(UrlRepository.BSSID_PREFIX) && it.removePrefix(UrlRepository.BSSID_PREFIX).equals(activeBssid, ignoreCase = true))
+                        )
             }
             Row(
                 modifier = Modifier
@@ -251,6 +256,7 @@ private fun PreviewSsidViewEmpty() {
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
         activeBssid = "02:00:00:00:00:00",
+        usingWifi = true,
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
         onSetPrioritize = {}
@@ -265,6 +271,7 @@ private fun PreviewSsidViewItems() {
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
         activeBssid = "02:00:00:00:00:00",
+        usingWifi = true,
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
         onSetPrioritize = {}

--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
 </manifest>

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.data
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.net.ConnectivityManager
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.provider.Settings
@@ -120,6 +121,10 @@ abstract class DataModule {
             appContext.contentResolver,
             Settings.Secure.ANDROID_ID
         )
+
+        @Provides
+        @Singleton
+        fun connectivityManager(@ApplicationContext appContext: Context) = appContext.getSystemService<ConnectivityManager>()!!
 
         @Provides
         @Singleton

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -171,8 +171,9 @@ class UrlRepositoryImpl @Inject constructor(
 
     override suspend fun isInternal(): Boolean {
         val usesInternalSsid = isHomeWifiSsid()
+        val usesWifi = wifiHelper.isUsingWifi()
         val localUrl = localStorage.getString(PREF_LOCAL_URL)
-        Log.d(TAG, "localUrl is: ${!localUrl.isNullOrBlank()} and usesInternalSsid is: $usesInternalSsid")
-        return !localUrl.isNullOrBlank() && usesInternalSsid
+        Log.d(TAG, "localUrl is: ${!localUrl.isNullOrBlank()}, usesInternalSsid is: $usesInternalSsid, usesWifi is: $usesWifi")
+        return !localUrl.isNullOrBlank() && usesInternalSsid && usesWifi
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
@@ -1,6 +1,8 @@
 package io.homeassistant.companion.android.common.data.wifi
 
 interface WifiHelper {
+    /** Returns if the active data connection is using Wi-Fi */
+    fun isUsingWifi(): Boolean
     fun getWifiSsid(): String?
     fun getWifiBssid(): String?
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -1,12 +1,28 @@
 package io.homeassistant.companion.android.common.data.wifi
 
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.wifi.WifiManager
+import android.os.Build
 import javax.inject.Inject
 
 @Suppress("DEPRECATION")
 class WifiHelperImpl @Inject constructor(
+    private val connectivityManager: ConnectivityManager,
     private val wifiManager: WifiManager
 ) : WifiHelper {
+    override fun isUsingWifi(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            connectivityManager.activeNetwork?.let {
+                connectivityManager
+                    .getNetworkCapabilities(it)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) == true
+            } ?: false
+        } else {
+            connectivityManager.activeNetworkInfo?.isConnected == true &&
+                connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_WIFI
+        }
+
     override fun getWifiSsid(): String? =
         wifiManager.connectionInfo.ssid
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add a check to the external/internal URL logic to make sure that the device is not only connected to a Home Wi-Fi network, but is also using that network for data for using the internal URL. This better matches the expected behavior. Inspired by #3006. 

A device can be connected to Wi-Fi but may be using a different (usually mobile) network for data for example if the internet is down or the network is considered "low quality". Expected log output in these situations is something like:
```
2022-10-29 15:32:21.317 11938-12081 UrlRepository           io....stant.companion.android.debug  D  localUrl is: true, usesInternalSsid is: true, usesWifi is: false
2022-10-29 15:32:21.318 11938-12081 UrlRepository           io....stant.companion.android.debug  D  Using external URL
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing note: my Pixel on Android 13 simply hides the Wi-Fi icon from the status bar / shows the 4G data icon when Wi-Fi is not used for data, even though it may be connected. Check the system settings app to be sure.