### PR TITLE
Catch Geocoder exceptions on Android 13

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -158,7 +158,7 @@ class GeocodeSensorManager : SensorManager {
                         }
 
                         override fun onError(errorMessage: String?) {
-                            cont.resumeWithException(Error(errorMessage))
+                            cont.resumeWithException(Exception(errorMessage))
                         }
                     }
                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3019 by switching from `Error` to `Exception` on Geocoder errors which will be caught.

`Error` [directly extends `Throwable`](https://developer.android.com/reference/kotlin/java/lang/Error?hl=en). On older APIs an `IOException` will be thrown.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->