### PR TITLE
Only resume once for websocket message responses

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -418,7 +418,9 @@ class WebSocketRepositoryImpl @Inject constructor(
     private fun handleMessage(response: SocketResponse) {
         val id = response.id!!
         activeMessages[id]?.let {
-            it.onResponse!!.resumeWith(Result.success(response))
+            it.onResponse?.let { cont ->
+                if (cont.isActive) cont.resumeWith(Result.success(response))
+            }
             if (it.eventFlow == null) {
                 activeMessages.remove(id)
             }
@@ -505,7 +507,9 @@ class WebSocketRepositoryImpl @Inject constructor(
                 activeMessages
                     .filterValues { it.eventFlow == null }
                     .forEach {
-                        it.value.onResponse?.resumeWith(Result.failure(IOException()))
+                        it.value.onResponse?.let { cont ->
+                            if (cont.isActive) cont.resumeWith(Result.failure(IOException()))
+                        }
                         activeMessages.remove(it.key)
                     }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3018 by checking if the continuation can be resumed before trying to resume it. If it was already resumed, the app isn't waiting for another message so discarding it should be OK.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->