### PR TITLE
Don't check Wifi SSID when home wifi list is empty

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/url/UrlRepositoryImpl.kt
@@ -152,9 +152,11 @@ class UrlRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isHomeWifiSsid(): Boolean {
+        val wifiSsids = getHomeWifiSsids()
+        if (wifiSsids.isEmpty())
+            return false
         val formattedSsid = wifiHelper.getWifiSsid()?.removeSurrounding("\"")
         val formattedBssid = wifiHelper.getWifiBssid()
-        val wifiSsids = getHomeWifiSsids()
         return (
             formattedSsid != null &&
                 (Build.VERSION.SDK_INT < Build.VERSION_CODES.R || formattedSsid !== WifiManager.UNKNOWN_SSID) &&


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

If home wifi SSID is empty then do not bother checking the connected SSID or BSSID as we don't need to access the data.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Ref: https://discord.com/channels/330944238910963714/562408603345092636/1036401886842064956