### PR TITLE
Track time between hardware sensor updates to restart the listener as needed

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -17,6 +17,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
 
         private const val TAG = "LightSensor"
         private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
         private val lightSensor = SensorManager.BasicSensor(
             "light_sensor",
             "sensor",
@@ -65,6 +66,12 @@ class LightSensorManager : SensorManager, SensorEventListener {
         if (!isEnabled(latestContext, lightSensor.id))
             return
 
+        val now = System.currentTimeMillis()
+        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+            Log.d(TAG, "Re-registering listener as it appears to be stuck")
+            mySensorManager.unregisterListener(this)
+            isListenerRegistered = false
+        }
         mySensorManager = latestContext.getSystemService()!!
 
         val lightSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_LIGHT)
@@ -76,6 +83,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
             )
             Log.d(TAG, "Light sensor listener registered")
             isListenerRegistered = true
+            listenerLastRegistered = now.toInt()
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LightSensorManager.kt
@@ -67,7 +67,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
             return
 
         val now = System.currentTimeMillis()
-        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+        if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
             Log.d(TAG, "Re-registering listener as it appears to be stuck")
             mySensorManager.unregisterListener(this)
             isListenerRegistered = false

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -17,6 +17,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
 
         private const val TAG = "PressureSensor"
         private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
         private val pressureSensor = SensorManager.BasicSensor(
             "pressure_sensor",
             "sensor",
@@ -63,6 +64,13 @@ class PressureSensorManager : SensorManager, SensorEventListener {
         if (!isEnabled(latestContext, pressureSensor.id))
             return
 
+        val now = System.currentTimeMillis()
+        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+            Log.d(TAG, "Re-registering listener as it appears to be stuck")
+            mySensorManager.unregisterListener(this)
+            isListenerRegistered = false
+        }
+
         mySensorManager = latestContext.getSystemService()!!
 
         val pressureSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PRESSURE)
@@ -74,6 +82,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
             )
             Log.d(TAG, "Pressure sensor listener registered")
             isListenerRegistered = true
+            listenerLastRegistered = now.toInt()
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/PressureSensorManager.kt
@@ -65,7 +65,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
             return
 
         val now = System.currentTimeMillis()
-        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+        if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
             Log.d(TAG, "Re-registering listener as it appears to be stuck")
             mySensorManager.unregisterListener(this)
             isListenerRegistered = false

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -17,6 +17,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
 
         private const val TAG = "ProximitySensor"
         private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
         private val proximitySensor = SensorManager.BasicSensor(
             "proximity_sensor",
             "sensor",
@@ -62,6 +63,13 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
         if (!isEnabled(latestContext, proximitySensor.id))
             return
 
+        val now = System.currentTimeMillis()
+        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+            Log.d(TAG, "Re-registering listener as it appears to be stuck")
+            mySensorManager.unregisterListener(this)
+            isListenerRegistered = false
+        }
+
         mySensorManager = latestContext.getSystemService()!!
 
         val proximitySensors = mySensorManager.getDefaultSensor(Sensor.TYPE_PROXIMITY)
@@ -73,6 +81,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
             )
             Log.d(TAG, "Proximity sensor listener registered")
             isListenerRegistered = true
+            listenerLastRegistered = now.toInt()
             maxRange = proximitySensors.maximumRange.roundToInt()
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/ProximitySensorManager.kt
@@ -64,7 +64,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
             return
 
         val now = System.currentTimeMillis()
-        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+        if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
             Log.d(TAG, "Re-registering listener as it appears to be stuck")
             mySensorManager.unregisterListener(this)
             isListenerRegistered = false

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -23,6 +23,7 @@ interface SensorManager {
         const val STATE_CLASS_MEASUREMENT = "measurement"
         const val STATE_CLASS_TOTAL = "total"
         const val STATE_CLASS_TOTAL_INCREASING = "total_increasing"
+        const val SENSOR_LISTENER_TIMEOUT = 60000
     }
 
     val name: Int

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
@@ -18,6 +18,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
 
         private const val TAG = "StepsSensor"
         private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
         private val stepsSensor = SensorManager.BasicSensor(
             "steps_sensor",
             "sensor",
@@ -71,6 +72,12 @@ class StepsSensorManager : SensorManager, SensorEventListener {
             return
 
         if (checkPermission(latestContext, stepsSensor.id)) {
+            val now = System.currentTimeMillis()
+            if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+                Log.d(TAG, "Re-registering listener as it appears to be stuck")
+                mySensorManager.unregisterListener(this)
+                isListenerRegistered = false
+            }
             mySensorManager = latestContext.getSystemService()!!
 
             val stepsSensors = mySensorManager.getDefaultSensor(Sensor.TYPE_STEP_COUNTER)
@@ -82,6 +89,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
                 )
                 Log.d(TAG, "Steps sensor listener registered")
                 isListenerRegistered = true
+                listenerLastRegistered = now.toInt()
             }
         }
     }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
@@ -73,7 +73,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
 
         if (checkPermission(latestContext, stepsSensor.id)) {
             val now = System.currentTimeMillis()
-            if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+            if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
                 Log.d(TAG, "Re-registering listener as it appears to be stuck")
                 mySensorManager.unregisterListener(this)
                 isListenerRegistered = false

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -23,6 +23,7 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
 
         private const val TAG = "HRSensor"
         private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
         private val skipAccuracy = listOf(
             SENSOR_STATUS_UNRELIABLE,
             SENSOR_STATUS_NO_CONTACT
@@ -74,6 +75,12 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
         if (!isEnabled(latestContext, heartRate.id))
             return
 
+        val now = System.currentTimeMillis()
+        if (listenerLastRegistered + 60000 < now && isListenerRegistered) {
+            Log.d(TAG, "Re-registering listener as it appears to be stuck")
+            mySensorManager.unregisterListener(this)
+            isListenerRegistered = false
+        }
         mySensorManager = latestContext.getSystemService()!!
 
         val heartRateSensor = mySensorManager.getDefaultSensor(Sensor.TYPE_HEART_RATE)
@@ -85,6 +92,7 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
             )
             Log.d(TAG, "Heart Rate sensor listener registered")
             isListenerRegistered = true
+            listenerLastRegistered = now.toInt()
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
@@ -22,7 +22,8 @@ class OnBodySensorManager : SensorManager, SensorEventListener {
             commonR.string.sensor_name_on_body,
             commonR.string.sensor_description_on_body,
             "mdi:account",
-            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed at times some hardware sensors would get its state stuck and thus needing a force stop of the app to reset the variable to continue to register for updates. I realized the state is stuck because other sensors were updating its state but these ones were not. So now adding a check where if 1 minute has passed and we are still registered on the next sensor update to reset the variable so we can get new updates.

![image](https://user-images.githubusercontent.com/1634145/199084087-c1e9a922-42b1-4e94-baba-ab5eea63f42b.png)


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->