### PR TITLE
Increase notification video attachment GIF length

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1540,7 +1540,7 @@ class MessagingManager @Inject constructor(
                     run frameLoop@{
                         for (timeInMicroSeconds in VIDEO_START_MICROSECONDS until durationInMicroSeconds step VIDEO_INCREMENT_MICROSECONDS) {
                             // Max size in bytes for notification GIF
-                            val maxSize = (2500000 - singleFrame)
+                            val maxSize = (5000000 - singleFrame)
                             if (processingFramesSize >= maxSize) {
                                 return@frameLoop
                             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Increase (up to 2x!) the length of the GIF created for video attachments in notifications as the [Android 13 bug that limited this](https://issuetracker.google.com/issues/239945905) has been resolved shortly after release.

(Not sure why `if Android 13 short/else longer` wasn't added for this in #2657, but anyway it is no longer required.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, it's more of the same

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
cc @Rogue136198 