### PR TITLE
Don't log full exception with no Wear app installed

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
@@ -2,6 +2,8 @@ package io.homeassistant.companion.android.settings.wear
 
 import android.content.Context
 import android.util.Log
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.wearable.Wearable
 import kotlinx.coroutines.tasks.await
 
@@ -18,7 +20,12 @@ object SettingsWearDetection {
             val nodeClient = Wearable.getNodeClient(context)
             nodeClient.connectedNodes.await().any()
         } catch (e: Exception) {
-            Log.e(TAG, "Exception while discovering nodes", e)
+            if (e is ApiException && e.statusCode == CommonStatusCodes.API_NOT_CONNECTED && e.message?.contains("API_UNAVAILABLE") == true) {
+                // Wearable.API is not available on this device.
+                Log.d(TAG, "API unavailable for discovering nodes (no Wear)",)
+            } else {
+                Log.e(TAG, "Exception while discovering nodes", e)
+            }
             false
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If no Wear app is installed on a device, checking for nodes will throw an exception that the API is unavailable. This is an expected error, don't log it so users aren't confused / share an incorrect error for other issues.

```
2022-11-02 21:33:09.626 25472-25472 SettingsWearDetection   io....stant.companion.android.debug  E  Exception while discovering nodes
                                                                                                    com.google.android.gms.common.api.ApiException: 17: API: Wearable.API is not available on this device. Connection failed with: ConnectionResult{statusCode=API_UNAVAILABLE, resolution=null, message=null}
                                                                                                    	at com.google.android.gms.common.internal.ApiExceptionUtil.fromStatus(com.google.android.gms:play-services-base@@18.0.1:3)
                                                                                                    	at com.google.android.gms.common.internal.zap.onComplete(com.google.android.gms:play-services-base@@18.0.1:4)
                                                                                                    	at com.google.android.gms.common.api.internal.BasePendingResult.zab(com.google.android.gms:play-services-base@@18.0.1:7)
                                                                                                    	at com.google.android.gms.common.api.internal.BasePendingResult.setResult(com.google.android.gms:play-services-base@@18.0.1:6)
                                                                                                    	at com.google.android.gms.common.api.internal.BaseImplementation$ApiMethodImpl.setFailedResult(com.google.android.gms:play-services-base@@18.0.1:5)
                                                                                                    	at com.google.android.gms.common.api.internal.zae.zad(com.google.android.gms:play-services-base@@18.0.1:1)
                                                                                                    	at com.google.android.gms.common.api.internal.zabq.zaE(com.google.android.gms:play-services-base@@18.0.1:7)
                                                                                                    	at com.google.android.gms.common.api.internal.zabq.zaD(com.google.android.gms:play-services-base@@18.0.1:2)
                                                                                                    	at com.google.android.gms.common.api.internal.zabq.zar(com.google.android.gms:play-services-base@@18.0.1:24)
                                                                                                    	at com.google.android.gms.common.api.internal.zabq.onConnectionFailed(com.google.android.gms:play-services-base@@18.0.1:1)
                                                                                                    	at com.google.android.gms.common.internal.zai.onConnectionFailed(com.google.android.gms:play-services-base@@18.0.1:1)
                                                                                                    	at com.google.android.gms.common.internal.zzf.zzb(com.google.android.gms:play-services-basement@@18.1.0:2)
                                                                                                    	at com.google.android.gms.common.internal.zza.zza(com.google.android.gms:play-services-basement@@18.1.0:3)
                                                                                                    	at com.google.android.gms.common.internal.zzc.zze(com.google.android.gms:play-services-basement@@18.1.0:3)
                                                                                                    	at com.google.android.gms.common.internal.zzb.handleMessage(com.google.android.gms:play-services-basement@@18.1.0:31)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:106)
                                                                                                    	at android.os.Looper.loop(Looper.java:223)
                                                                                                    	at android.os.HandlerThread.run(HandlerThread.java:67)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->