### PR TITLE
Switch from `viewModelScope` to `lifecycleScope` for external collections

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -6,12 +6,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.home.views.LoadHomePage
 import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationActivity
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -41,6 +45,27 @@ class HomeActivity : ComponentActivity(), HomeView {
         }
 
         mainViewModel.init(presenter)
+
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                mainViewModel.entityUpdates()
+            }
+        }
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                mainViewModel.areaUpdates()
+            }
+        }
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                mainViewModel.deviceUpdates()
+            }
+        }
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                mainViewModel.entityRegistryUpdates()
+            }
+        }
     }
 
     override fun onResume() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -48,22 +48,10 @@ class HomeActivity : ComponentActivity(), HomeView {
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mainViewModel.entityUpdates()
-            }
-        }
-        lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mainViewModel.areaUpdates()
-            }
-        }
-        lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mainViewModel.deviceUpdates()
-            }
-        }
-        lifecycleScope.launch {
-            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                mainViewModel.entityRegistryUpdates()
+                launch { mainViewModel.entityUpdates() }
+                launch { mainViewModel.areaUpdates() }
+                launch { mainViewModel.deviceUpdates() }
+                launch { mainViewModel.entityRegistryUpdates() }
             }
         }
     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -162,41 +162,37 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun entityUpdates() {
-        if (loadingState.value != LoadingState.LOADING)
-            homePresenter.getEntityUpdates()?.collect {
-                if (supportedDomains().contains(it.domain)) {
-                    entities[it.entityId] = it
-                    updateEntityDomains()
-                }
+        homePresenter.getEntityUpdates()?.collect {
+            if (supportedDomains().contains(it.domain)) {
+                entities[it.entityId] = it
+                updateEntityDomains()
             }
+        }
     }
 
     suspend fun areaUpdates() {
-        if (loadingState.value != LoadingState.LOADING)
-            homePresenter.getAreaRegistryUpdates()?.collect {
-                areaRegistry = homePresenter.getAreaRegistry()
-                areas.clear()
-                areaRegistry?.let {
-                    areas.addAll(it)
-                }
-                updateEntityDomains()
+        homePresenter.getAreaRegistryUpdates()?.collect {
+            areaRegistry = homePresenter.getAreaRegistry()
+            areas.clear()
+            areaRegistry?.let {
+                areas.addAll(it)
             }
+            updateEntityDomains()
+        }
     }
 
     suspend fun deviceUpdates() {
-        if (loadingState.value != LoadingState.LOADING)
-            homePresenter.getDeviceRegistryUpdates()?.collect {
-                deviceRegistry = homePresenter.getDeviceRegistry()
-                updateEntityDomains()
-            }
+        homePresenter.getDeviceRegistryUpdates()?.collect {
+            deviceRegistry = homePresenter.getDeviceRegistry()
+            updateEntityDomains()
+        }
     }
 
     suspend fun entityRegistryUpdates() {
-        if (loadingState.value != LoadingState.LOADING)
-            homePresenter.getEntityRegistryUpdates()?.collect {
-                entityRegistry = homePresenter.getEntityRegistry()
-                updateEntityDomains()
-            }
+        homePresenter.getEntityRegistryUpdates()?.collect {
+            entityRegistry = homePresenter.getEntityRegistry()
+            updateEntityDomains()
+        }
     }
 
     fun updateEntityDomains() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -162,6 +162,8 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun entityUpdates() {
+        if (!homePresenter.isConnected())
+            return
         homePresenter.getEntityUpdates()?.collect {
             if (supportedDomains().contains(it.domain)) {
                 entities[it.entityId] = it
@@ -171,6 +173,8 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun areaUpdates() {
+        if (!homePresenter.isConnected())
+            return
         homePresenter.getAreaRegistryUpdates()?.collect {
             areaRegistry = homePresenter.getAreaRegistry()
             areas.clear()
@@ -182,6 +186,8 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun deviceUpdates() {
+        if (!homePresenter.isConnected())
+            return
         homePresenter.getDeviceRegistryUpdates()?.collect {
             deviceRegistry = homePresenter.getDeviceRegistry()
             updateEntityDomains()
@@ -189,6 +195,8 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun entityRegistryUpdates() {
+        if (!homePresenter.isConnected())
+            return
         homePresenter.getEntityRegistryUpdates()?.collect {
             entityRegistry = homePresenter.getEntityRegistry()
             updateEntityDomains()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -162,37 +162,41 @@ class MainViewModel @Inject constructor(
     }
 
     suspend fun entityUpdates() {
-        homePresenter.getEntityUpdates()?.collect {
-            if (supportedDomains().contains(it.domain)) {
-                entities[it.entityId] = it
-                updateEntityDomains()
+        if (loadingState.value != LoadingState.LOADING)
+            homePresenter.getEntityUpdates()?.collect {
+                if (supportedDomains().contains(it.domain)) {
+                    entities[it.entityId] = it
+                    updateEntityDomains()
+                }
             }
-        }
     }
 
     suspend fun areaUpdates() {
-        homePresenter.getAreaRegistryUpdates()?.collect {
-            areaRegistry = homePresenter.getAreaRegistry()
-            areas.clear()
-            areaRegistry?.let {
-                areas.addAll(it)
+        if (loadingState.value != LoadingState.LOADING)
+            homePresenter.getAreaRegistryUpdates()?.collect {
+                areaRegistry = homePresenter.getAreaRegistry()
+                areas.clear()
+                areaRegistry?.let {
+                    areas.addAll(it)
+                }
+                updateEntityDomains()
             }
-            updateEntityDomains()
-        }
     }
 
     suspend fun deviceUpdates() {
-        homePresenter.getDeviceRegistryUpdates()?.collect {
-            deviceRegistry = homePresenter.getDeviceRegistry()
-            updateEntityDomains()
-        }
+        if (loadingState.value != LoadingState.LOADING)
+            homePresenter.getDeviceRegistryUpdates()?.collect {
+                deviceRegistry = homePresenter.getDeviceRegistry()
+                updateEntityDomains()
+            }
     }
 
     suspend fun entityRegistryUpdates() {
-        homePresenter.getEntityRegistryUpdates()?.collect {
-            entityRegistry = homePresenter.getEntityRegistry()
-            updateEntityDomains()
-        }
+        if (loadingState.value != LoadingState.LOADING)
+            homePresenter.getEntityRegistryUpdates()?.collect {
+                entityRegistry = homePresenter.getEntityRegistry()
+                updateEntityDomains()
+            }
     }
 
     fun updateEntityDomains() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -154,42 +154,44 @@ class MainViewModel @Inject constructor(
                 } else {
                     LoadingState.ERROR
                 }
-
-                // Listen for updates
-                viewModelScope.launch {
-                    homePresenter.getEntityUpdates()?.collect {
-                        if (supportedDomains().contains(it.domain)) {
-                            entities[it.entityId] = it
-                            updateEntityDomains()
-                        }
-                    }
-                }
-                viewModelScope.launch {
-                    homePresenter.getAreaRegistryUpdates()?.collect {
-                        areaRegistry = homePresenter.getAreaRegistry()
-                        areas.clear()
-                        areaRegistry?.let {
-                            areas.addAll(it)
-                        }
-                        updateEntityDomains()
-                    }
-                }
-                viewModelScope.launch {
-                    homePresenter.getDeviceRegistryUpdates()?.collect {
-                        deviceRegistry = homePresenter.getDeviceRegistry()
-                        updateEntityDomains()
-                    }
-                }
-                viewModelScope.launch {
-                    homePresenter.getEntityRegistryUpdates()?.collect {
-                        entityRegistry = homePresenter.getEntityRegistry()
-                        updateEntityDomains()
-                    }
-                }
             } catch (e: Exception) {
                 Log.e(TAG, "Exception while loading entities", e)
                 loadingState.value = LoadingState.ERROR
             }
+        }
+    }
+
+    suspend fun entityUpdates() {
+        homePresenter.getEntityUpdates()?.collect {
+            if (supportedDomains().contains(it.domain)) {
+                entities[it.entityId] = it
+                updateEntityDomains()
+            }
+        }
+    }
+
+    suspend fun areaUpdates() {
+        homePresenter.getAreaRegistryUpdates()?.collect {
+            areaRegistry = homePresenter.getAreaRegistry()
+            areas.clear()
+            areaRegistry?.let {
+                areas.addAll(it)
+            }
+            updateEntityDomains()
+        }
+    }
+
+    suspend fun deviceUpdates() {
+        homePresenter.getDeviceRegistryUpdates()?.collect {
+            deviceRegistry = homePresenter.getDeviceRegistry()
+            updateEntityDomains()
+        }
+    }
+
+    suspend fun entityRegistryUpdates() {
+        homePresenter.getEntityRegistryUpdates()?.collect {
+            entityRegistry = homePresenter.getEntityRegistry()
+            updateEntityDomains()
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3014 by converting our external collections (flows) from using `viewModelScope` to `lifecycleScope` and to only run while the state is `RESUMED`

These changes allow for initial data to load just like before but updates will only take place while the screen is on and app is in the foreground. When screen is off or app is in background the flows will stop.

<details>
<summary>Example logs where screen turns on/off and app goes in background/foreground with subscription stopping/starting as expected</summary>

```
---------------------------- PROCESS STARTED (5495) for package io.homeassistant.companion.android.debug ----------------------------
2022-11-07 08:10:43.850  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onOpen
2022-11-07 08:10:43.857  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_required","ha_version":"2022.10.5"})
2022-11-07 08:10:44.848  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:10:44.851  5495-5542  WebSocketRepository     io....stant.companion.android.debug  D  Auth Requested
2022-11-07 08:10:44.855  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_ok","ha_version":"2022.10.5"})
2022-11-07 08:10:44.860  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:10:46.878  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 1: {type=supported_features, id=1, features={coalesce_messages=1}}
2022-11-07 08:10:46.933  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 2: {type=config/device_registry/list, id=2}
2022-11-07 08:10:46.934  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 2 sent
2022-11-07 08:10:46.937  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 3: {type=config/entity_registry/list, id=3}
2022-11-07 08:10:46.939  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 3 sent
2022-11-07 08:10:46.976  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 4: {type=get_states, id=4}
2022-11-07 08:10:46.985  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 4 sent
2022-11-07 08:10:46.995  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 5: {type=config/area_registry/list, id=5}
2022-11-07 08:10:46.996  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 5 sent
2022-11-07 08:10:46.996  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":1,"type":"result","success":true,"result":null})
2022-11-07 08:10:47.018  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 1 received
2022-11-07 08:10:50.126  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":2,"type":"result","success":true,"result":[{"area_id":"100fd512915c49d390df92aaf003cb03","configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"d885c641c6df4f5aac8a043bae84afbd","identifiers":[["cast","2f5745706944ddf8afbb9f09d63fa439"]],"manufacturer":"Google Inc.","model":"Google Home","name_by_user":"Bathroom Home","name":"Bathroom Home","sw_version":null,"via_device_id":null},{"area_id":null,"configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"1026ddc2c21741d9aece245390c2f4f7","identifiers":[["cast","d21dfa02e7ac291b561788b54186a174"]],"manufacturer":"Google Inc.","model":"Chromecast Audio","name_by_user":null,"name":"Outdoor Speakers","sw_version":null,"via_device_id":null},{"area_id":"022a53843b1146b3a21a7be9e68a46d2","configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"f02a3ae2e7f5470d8eec1e74c2450b13","identifiers":[["cast","c24b6d75ac6508aa8221d373ed04e8e6"]],"manufacturer":"Google Inc.","model":"Google Home","name_by_user":null,"name":"Kitchen Home","sw_version":null,"via_device_id":null},{"area_id":"0090703f43b643c48a54ab1b1d656370","configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"d78cebaba4334f3a8f3cd3064191633b","identifiers":[["cast","a77e8b82dbfb1354a6200199e0c5f9a7"]],"manufacturer":"Sony","model":"BRAVIA 4K 2015","name_by_user":null,"name":"Den TV","sw_version":null,"via_device_id":null},{"area_id":"0090703f43b643c48a54ab1b1d656370","configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"b42e8ac56782468b8bfeacf20fe286b4","identifiers":[["cast","1ae648d67fbf25d1d4dd14953039851e"]],"manufacturer":"Unknown manufacturer","model":"Onkyo TX-NR777","name_by_user":null,"name":"Onkyo TX-NR777","sw_version":null,"via_device_id":null},{"area_id":"5ddcf6e766fc4333bf8218256bce368b","configuration_url":null,"config_entries":["22c8f656967a4652b1ec83f7c0fa6f9d"],"connections":[],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"915bf82ded6548bd9136939fcba10d87","identifiers":[["cast","5b30fffc822c060d3643e32f010332ee"]],"manufacturer":"Google Inc.","model":"Google Home","name_by_user":null,"name":"Living Room Home","sw_version":null,"via_device_id":null},{"area_id":"ollie_s","configuration_url":null,"config_entries":["b1dcf07b9e1746acbb8ab0c314d11348"],"connections":[["mac","00:17:88:01:02:83:8d:e7"]],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"b665b1b9c6804efb8d8cd880efbacf73","identifiers":[["hue","d81f6509-44b1-44a0-8bfb-dbc11ad60c2d"]],"manufacturer":"Signify Netherlands B.V.","model":"Hue white lamp (LWB014)","name_by_user":null,"name":"Office Closet","sw_version":"1.88.1","via_device_id":"535855d2bdce4ec5aae29b1f5bd6f5fe"},{"area_id":"5ddcf6e766fc4333bf8218256bce368b","configuration_url":null,"config_entries":["b1dcf07b9e1746acbb8ab0c314d11348"],"connections":[["mac","00:17:88:01:10:57:95:68"]],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"807d37e3eeae437c8257544f506c396b","identifiers":[["hue","6f86d5f7-f5f3-480b-9fcc-2373adde01ea"]],"manufacturer":"Signify Netherlands B.V.","model":"Hue white lamp (LWB006)","name_by_user":null,"name":"Front Door Lamp","sw_version":"130.1.30000","via_device_id":"535855d2bdce4ec5aae29b1f5bd6f5fe"},{"area_id":"patio","configuration_url":null,"config_entries":["b1dcf07b9e1746acbb8ab0c314d11348"],"connections":[["mac","7c:e5:24:00:00:01:44:24"]],"disabled_by":null,"entry_type":null,"hw_version":null,"id":"56d96135d36b4dce918d58e8e01e1fa5","identifiers":[["hue","59889bd2-5365-4fba-839a-98e2a33aa45a"]],"manufacturer":"GE_Appliances","model":"Dimmable 
2022-11-07 08:10:54.947  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 2 received
2022-11-07 08:10:54.949  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 3 received
2022-11-07 08:10:54.954  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 4 received
2022-11-07 08:10:54.958  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":5,"type":"result","success":true,"result":[{"area_id":"0090703f43b643c48a54ab1b1d656370","name":"Den","picture":null},{"area_id":"022a53843b1146b3a21a7be9e68a46d2","name":"Kitchen","picture":null},{"area_id":"5ddcf6e766fc4333bf8218256bce368b","name":"Living Room","picture":null},{"area_id":"73cce5d36e964834bfbda86ff2971fc7","name":"Bedroom","picture":null},{"area_id":"100fd512915c49d390df92aaf003cb03","name":"Bathroom","picture":null},{"area_id":"57aa8b2b82474c8db47661c96a7a5b1b","name":"Garage","picture":null},{"area_id":"patio","name":"Patio","picture":null},{"area_id":"ollie_s","name":"Ollie's","picture":null},{"area_id":"hallway","name":"Hallway","picture":null}]})
2022-11-07 08:10:54.967  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 5 received
2022-11-07 08:11:07.091  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 6: {type=subscribe_events, event_type=state_changed, id=6}
2022-11-07 08:11:07.093  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 sent
2022-11-07 08:11:07.144  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":6,"type":"result","success":true,"result":null})
2022-11-07 08:11:07.150  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:07.626  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.memory_use_percent","old_state":{"entity_id":"sensor.memory_use_percent","state":"75.9","attributes":{"state_class":"measurement","unit_of_measurement":"%","icon":"mdi:memory","friendly_name":"Memory use (percent)"},"last_changed":"2022-11-07T16:10:37.237132+00:00","last_updated":"2022-11-07T16:10:37.237132+00:00","context":{"id":"01GH9DQ99NWDQH25W089X4C0YA","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.memory_use_percent","state":"75.8","attributes":{"state_class":"measurement","unit_of_measurement":"%","icon":"mdi:memory","friendly_name":"Memory use (percent)"},"last_changed":"2022-11-07T16:11:07.238246+00:00","last_updated":"2022-11-07T16:11:07.238246+00:00","context":{"id":"01GH9DR6K6DVHY35P704DEFB18","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:07.238246+00:00","context":{"id":"01GH9DR6K6DVHY35P704DEFB18","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.processor_use","old_state":{"entity_id":"sensor.processor_use","state":"6","attributes":{"state_class":"measurement","unit_of_measurement":"%","icon":"mdi:cpu-64-bit","friendly_name":"Processor use"},"last_changed":"2022-11-07T16:10:52.237759+00:00","last_updated":"2022-11-07T16:10:52.237759+00:00","context":{"id":"01GH9DQQYD65SFZ5PF8BJ0X1H0","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.processor_use","state":"5","attributes":{"state_class":"measurement","unit_of_measurement":"%","icon":"mdi:cpu-64-bit","friendly_name":"Processor use"},"last_changed":"2022-11-07T16:11:07.238563+00:00","last_updated":"2022-11-07T16:11:07.238563+00:00","context":{"id":"01GH9DR6K65YF48QXP6SPTC7R9","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:07.238563+00:00","context":{"id":"01GH9DR6K65YF48QXP6SPTC7R9","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.load_1m","old_state":{"entity_id":"sensor.load_1m","state":"0.14","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (1m)"},"last_changed":"2022-11-07T16:10:52.238030+00:00","last_updated":"2022-11-07T16:10:52.238030+00:00","context":{"id":"01GH9DQQYE2H3SDCSV4Y5AVDBG","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.load_1m","state":"0.18","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (1m)"},"last_changed":"2022-11-07T16:11:07.238814+00:00","last_updated":"2022-11-07T16:11:07.238814+00:00","context":{"id":"01GH9DR6K6JR9ZSEAW0WCC7V2A","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:07.238814+00:00","context":{"id":"01GH9DR6K6JR9ZSEAW0WCC7V2A","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.load_5m","old_state":{"entity_id":"sensor.load_5m","state":"0.15","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (5m)"},"last_changed":"2022-11-07T16:10:52.238194+00:00","last_updated":"2022-11-07T16:10:52.238194+00:00","context":{"id":"01GH9DQQYET7917304JES4SH42","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.load_5m","state":"0.16","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (5m)"},"last_changed":"2022-11-07T16:11:07.238990+00:00","last_updated":"2022-11-07T16:11:07.238990+00:00","context":{"id":"01GH9DR6K6KJJRHPZFE9RAM2X1","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:07.238990+00:00","context":{"id":"01GH9DR6K6KJJRHPZFE9RAM2X1","parent_id":null,"user_id":null}}}])
2022-11-07 08:11:07.751  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:07.882  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:09.761  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 7: {type=subscribe_events, event_type=area_registry_updated, id=7}
2022-11-07 08:11:09.763  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 7 sent
2022-11-07 08:11:10.295  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":7,"type":"result","success":true,"result":null})
2022-11-07 08:11:10.297  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 7 received
2022-11-07 08:11:11.322  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.dannys_pixel_watch_app_memory","old_state":{"entity_id":"sensor.dannys_pixel_watch_app_memory","state":"0.029","attributes":{"state_class":"measurement","free_memory":0.005,"total_memory":0.034,"unit_of_measurement":"GB","icon":"mdi:memory","friendly_name":"Dannys Pixel Watch App Memory"},"last_changed":"2022-11-07T16:09:18.821951+00:00","last_updated":"2022-11-07T16:09:18.821951+00:00","context":{"id":"01GH9DMWQ5A25N7DSTH2WX8BSX","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.dannys_pixel_watch_app_memory","state":"0.031","attributes":{"state_class":"measurement","free_memory":0.003,"total_memory":0.034,"unit_of_measurement":"GB","icon":"mdi:memory","friendly_name":"Dannys Pixel Watch App Memory"},"last_changed":"2022-11-07T16:11:10.883960+00:00","last_updated":"2022-11-07T16:11:10.883960+00:00","context":{"id":"01GH9DRA53F15BMR2PZHZ3Z09N","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:10.883960+00:00","context":{"id":"01GH9DRA53F15BMR2PZHZ3Z09N","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.dannys_pixel_watch_app_importance","old_state":{"entity_id":"sensor.dannys_pixel_watch_app_importance","state":"visible","attributes":{"icon":"mdi:android","friendly_name":"Dannys Pixel Watch App Importance"},"last_changed":"2022-11-07T16:05:34.825155+00:00","last_updated":"2022-11-07T16:05:34.825155+00:00","context":{"id":"01GH9DE1Z9FQKXT7TZ3MZB5DD2","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.dannys_pixel_watch_app_importance","state":"foreground_service","attributes":{"icon":"mdi:android","friendly_name":"Dannys Pixel Watch App Importance"},"last_changed":"2022-11-07T16:11:10.885747+00:00","last_updated":"2022-11-07T16:11:10.885747+00:00","context":{"id":"01GH9DRA55RZB116QFX0XJ25BY","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:10.885747+00:00","context":{"id":"01GH9DRA55RZB116QFX0XJ25BY","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.dannys_pixel_watch_battery_level_2","old_state":{"entity_id":"sensor.dannys_pixel_watch_battery_level_2","state":"37","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-30","friendly_name":"Dannys Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:09:02.010253+00:00","last_updated":"2022-11-07T16:09:18.823567+00:00","context":{"id":"01GH9DMWQ7DAVA6WWNZP50K8X9","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.dannys_pixel_watch_battery_level_2","state":"39","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-charging-wireless-30","friendly_name":"Dannys Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:11:10.887327+00:00","last_updated":"2022-11-07T16:11:10.887327+00:00","context":{"id":"01GH9DRA57XQPMJSHVVX3WHYF7","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:10.887327+00:00","context":{"id":"01GH9DRA57XQPMJSHVVX3WHYF7","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.dannys_pixel_watch_battery_state_2","old_state":{"entity_id":"sensor.dannys_pixel_watch_battery_state_2","state":"discharging","attributes":{"icon":"mdi:battery-minus","friendly_name":"Dannys Pixel Watch Battery State"},"last_changed":"2022-11-07T16:09:18.825089+00:00","last_updated":"2022-11-07T16:09:18.825089+00:00","context":{"id":"01GH9DMWQ9DY0R000X9ZCT2GMW","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.dannys_pixel_watch_battery_state_2","state":"charging","attributes":{"icon":"mdi:battery-plus","friendly_name":"Dannys Pixel Watch Battery State"},"last_changed":"2022-11-07T16:11:10.888998+00:00","last_updated":"2022-
2022-11-07 08:11:11.418  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:11.813  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.living_room_air_purifier_motor_speed","old_state":{"entity_id":"sensor.living_room_air_purifier_motor_speed","state":"347","attributes":{"state_class":"measurement","unit_of_measurement":"rpm","icon":"mdi:fast-forward","friendly_name":"Living Room Air Purifier Motor speed"},"last_changed":"2022-11-07T16:10:26.043238+00:00","last_updated":"2022-11-07T16:10:26.043238+00:00","context":{"id":"01GH9DPYBVQ0R0V0BQV2B0VD30","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.living_room_air_purifier_motor_speed","state":"346","attributes":{"state_class":"measurement","unit_of_measurement":"rpm","icon":"mdi:fast-forward","friendly_name":"Living Room Air Purifier Motor speed"},"last_changed":"2022-11-07T16:11:11.425595+00:00","last_updated":"2022-11-07T16:11:11.425595+00:00","context":{"id":"01GH9DRAP121RG5RP2YKM789SX","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:11.425595+00:00","context":{"id":"01GH9DRAP121RG5RP2YKM789SX","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.living_room_air_purifier_pm2_5","old_state":{"entity_id":"sensor.living_room_air_purifier_pm2_5","state":"26","attributes":{"state_class":"measurement","unit_of_measurement":"µg/m³","device_class":"pm25","friendly_name":"Living Room Air Purifier PM2.5"},"last_changed":"2022-11-07T16:10:56.023718+00:00","last_updated":"2022-11-07T16:10:56.023718+00:00","context":{"id":"01GH9DQVMQANTQFMJ8S5SVEZPX","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.living_room_air_purifier_pm2_5","state":"22","attributes":{"state_class":"measurement","unit_of_measurement":"µg/m³","device_class":"pm25","friendly_name":"Living Room Air Purifier PM2.5"},"last_changed":"2022-11-07T16:11:11.425854+00:00","last_updated":"2022-11-07T16:11:11.425854+00:00","context":{"id":"01GH9DRAP1F02PEH8MPDJW78CB","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:11.425854+00:00","context":{"id":"01GH9DRAP1F02PEH8MPDJW78CB","parent_id":null,"user_id":null}}}])
2022-11-07 08:11:11.822  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:11.838  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:11.943  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 8: {type=subscribe_events, event_type=device_registry_updated, id=8}
2022-11-07 08:11:11.947  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 8 sent
2022-11-07 08:11:11.980  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":8,"type":"result","success":true,"result":null})
2022-11-07 08:11:12.019  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 8 received
2022-11-07 08:11:13.914  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:13.942  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 9: {type=subscribe_events, event_type=entity_registry_updated, id=9}
2022-11-07 08:11:13.944  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 9 sent
2022-11-07 08:11:14.060  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":9,"type":"result","success":true,"result":null})
2022-11-07 08:11:14.064  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 9 received
2022-11-07 08:11:32.508  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:37.617  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.load_1m","old_state":{"entity_id":"sensor.load_1m","state":"0.14","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (1m)"},"last_changed":"2022-11-07T16:11:22.239405+00:00","last_updated":"2022-11-07T16:11:22.239405+00:00","context":{"id":"01GH9DRN7ZT39SQK79R5W6YXJ2","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.load_1m","state":"0.11","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (1m)"},"last_changed":"2022-11-07T16:11:37.240136+00:00","last_updated":"2022-11-07T16:11:37.240136+00:00","context":{"id":"01GH9DS3WR8WC2T5DWPXSKFMBZ","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:37.240136+00:00","context":{"id":"01GH9DS3WR8WC2T5DWPXSKFMBZ","parent_id":null,"user_id":null}}},{"id":6,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.load_5m","old_state":{"entity_id":"sensor.load_5m","state":"0.15","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (5m)"},"last_changed":"2022-11-07T16:11:22.239575+00:00","last_updated":"2022-11-07T16:11:22.239575+00:00","context":{"id":"01GH9DRN7ZBS60VV72JEGE5P3G","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.load_5m","state":"0.14","attributes":{"state_class":"measurement","icon":"mdi:cpu-64-bit","friendly_name":"Load (5m)"},"last_changed":"2022-11-07T16:11:37.240397+00:00","last_updated":"2022-11-07T16:11:37.240397+00:00","context":{"id":"01GH9DS3WRWDNEVD0G5B69AM6S","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:37.240397+00:00","context":{"id":"01GH9DS3WRWDNEVD0G5B69AM6S","parent_id":null,"user_id":null}}}])
2022-11-07 08:11:37.631  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:37.633  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 6 received
2022-11-07 08:11:38.063  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=device_registry_updated}
2022-11-07 08:11:38.070  5495-5555  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=entity_registry_updated}
2022-11-07 08:11:38.071  5495-5555  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 10: {type=unsubscribe_events, subscription=9, id=10}
2022-11-07 08:11:38.073  5495-5646  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=area_registry_updated}
2022-11-07 08:11:38.094  5495-5555  WebSocketRepository     io....stant.companion.android.debug  D  Message number 10 sent
2022-11-07 08:11:38.104  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 11: {type=unsubscribe_events, subscription=8, id=11}
2022-11-07 08:11:38.120  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":10,"type":"result","success":true,"result":null})
2022-11-07 08:11:38.124  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 10 received
2022-11-07 08:11:38.132  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Message number 11 sent
2022-11-07 08:11:38.133  5495-5646  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 12: {type=unsubscribe_events, subscription=7, id=12}
2022-11-07 08:11:38.135  5495-5646  WebSocketRepository     io....stant.companion.android.debug  D  Message number 12 sent
2022-11-07 08:11:38.143  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=state_changed}
2022-11-07 08:11:38.144  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 13: {type=unsubscribe_events, subscription=6, id=13}
2022-11-07 08:11:38.199  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":11,"type":"result","success":true,"result":null})
2022-11-07 08:11:38.216  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 11 received
2022-11-07 08:11:38.222  5495-5625  WebSocketRepository     io....stant.companion.android.debug  D  Message number 13 sent
2022-11-07 08:11:38.283  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":12,"type":"result","success":true,"result":null})
2022-11-07 08:11:38.296  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 12 received
2022-11-07 08:11:38.306  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":13,"type":"result","success":true,"result":null})
2022-11-07 08:11:38.318  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 13 received
2022-11-07 08:11:38.336  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosing code: 1000, reason: 
2022-11-07 08:11:38.338  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosed
2022-11-07 08:11:50.710  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onOpen
2022-11-07 08:11:50.727  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_required","ha_version":"2022.10.5"})
2022-11-07 08:11:50.732  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:11:50.739  5495-5647  WebSocketRepository     io....stant.companion.android.debug  D  Auth Requested
2022-11-07 08:11:50.747  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_ok","ha_version":"2022.10.5"})
2022-11-07 08:11:50.750  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:11:50.755  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 14: {type=supported_features, id=14, features={coalesce_messages=1}}
2022-11-07 08:11:50.758  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 15: {type=subscribe_events, event_type=state_changed, id=15}
2022-11-07 08:11:50.759  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 15 sent
2022-11-07 08:11:50.795  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":14,"type":"result","success":true,"result":null})
2022-11-07 08:11:50.797  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 14 received
2022-11-07 08:11:50.817  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":15,"type":"result","success":true,"result":null})
2022-11-07 08:11:50.818  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 15 received
2022-11-07 08:11:50.824  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 16: {type=subscribe_events, event_type=area_registry_updated, id=16}
2022-11-07 08:11:50.825  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 16 sent
2022-11-07 08:11:50.873  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":16,"type":"result","success":true,"result":null})
2022-11-07 08:11:50.875  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 16 received
2022-11-07 08:11:50.881  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 17: {type=subscribe_events, event_type=device_registry_updated, id=17}
2022-11-07 08:11:50.882  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 17 sent
2022-11-07 08:11:50.900  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":17,"type":"result","success":true,"result":null})
2022-11-07 08:11:50.903  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 17 received
2022-11-07 08:11:50.910  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 18: {type=subscribe_events, event_type=entity_registry_updated, id=18}
2022-11-07 08:11:50.911  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 18 sent
2022-11-07 08:11:50.963  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":18,"type":"result","success":true,"result":null})
2022-11-07 08:11:50.965  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 18 received
2022-11-07 08:11:51.538  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":15,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.oranda_aquarium_temp","old_state":{"entity_id":"sensor.oranda_aquarium_temp","state":"71.6","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:fishbowl-outline","friendly_name":"Oranda Aquarium Temp"},"last_changed":"2022-11-07T16:11:21.085620+00:00","last_updated":"2022-11-07T16:11:21.085620+00:00","context":{"id":"01GH9DRM3XMXM7JC6BXCCFK5ER","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.oranda_aquarium_temp","state":"71.5","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:fishbowl-outline","friendly_name":"Oranda Aquarium Temp"},"last_changed":"2022-11-07T16:11:51.125982+00:00","last_updated":"2022-11-07T16:11:51.125982+00:00","context":{"id":"01GH9DSHEN0Z245QNWP0FABHHR","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:51.125982+00:00","context":{"id":"01GH9DSHEN0Z245QNWP0FABHHR","parent_id":null,"user_id":null}}})
2022-11-07 08:11:51.542  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 15 received
2022-11-07 08:11:51.548  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":15,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_level","old_state":{"entity_id":"sensor.google_pixel_watch_battery_level","state":"39","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-charging-wireless-30","friendly_name":"Google Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:11:12.688899+00:00","last_updated":"2022-11-07T16:11:12.688899+00:00","context":{"id":"01GH9DRBXGR83GKFDKK4ZPSTX0","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_level","state":"40","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-charging-wireless-40","friendly_name":"Google Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:11:51.150979+00:00","last_updated":"2022-11-07T16:11:51.150979+00:00","context":{"id":"01GH9DSHFECT88ZJGYQ31E1437","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:51.150979+00:00","context":{"id":"01GH9DSHFECT88ZJGYQ31E1437","parent_id":null,"user_id":null}}},{"id":15,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_temperature","old_state":{"entity_id":"sensor.google_pixel_watch_battery_temperature","state":"108.7","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:battery","friendly_name":"Google Pixel Watch Battery Temperature"},"last_changed":"2022-11-07T16:11:12.690634+00:00","last_updated":"2022-11-07T16:11:12.690634+00:00","context":{"id":"01GH9DRBXJGWDE5G748W16E70W","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_temperature","state":"109.6","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:battery","friendly_name":"Google Pixel Watch Battery Temperature"},"last_changed":"2022-11-07T16:11:51.152761+00:00","last_updated":"2022-11-07T16:11:51.152761+00:00","context":{"id":"01GH9DSHFGCAE3V4MXVWP6NXA4","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:51.152761+00:00","context":{"id":"01GH9DSHFGCAE3V4MXVWP6NXA4","parent_id":null,"user_id":null}}},{"id":15,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_power","old_state":{"entity_id":"sensor.google_pixel_watch_battery_power","state":"-8446.05","attributes":{"state_class":"measurement","current":-2147.4836,"voltage":3.933,"unit_of_measurement":"W","device_class":"power","icon":"mdi:battery-minus","friendly_name":"Google Pixel Watch Battery Power"},"last_changed":"2022-11-07T16:11:12.692283+00:00","last_updated":"2022-11-07T16:11:12.692283+00:00","context":{"id":"01GH9DRBXMQA6X3NKGEKSGXH43","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_power","state":"-8433.17","attributes":{"state_class":"measurement","current":-2147.4836,"voltage":3.927,"unit_of_measurement":"W","device_class":"power","icon":"mdi:battery-minus","friendly_name":"Google Pixel Watch Battery Power"},"last_changed":"2022-11-07T16:11:51.154327+00:00","last_updated":"2022-11-07T16:11:51.154327+00:00","context":{"id":"01GH9DSHFJMT42AM81BYYZHMGV","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:11:51.154327+00:00","context":{"id":"01GH9DSHFJMT42AM81BYYZHMGV","parent_id":null,"user_id":null}}}])
2022-11-07 08:11:51.562  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 15 received
2022-11-07 08:12:04.207  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":15,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"binary_sensor.kitchen_motion_detected","old_state":{"entity_id":"binary_sensor.kitchen_motion_detected","state":"on","attributes":{"device_class":"motion","friendly_name":"Kitchen Motion Detected"},"last_changed":"2022-11-07T16:11:58.647564+00:00","last_updated":"2022-11-07T16:11:58.647564+00:00","context":{"id":"01GH9DSRSQSNQBTEQ2T1HVCS5A","parent_id":null,"user_id":null}},"new_state":{"entity_id":"binary_sensor.kitchen_motion_detected","state":"off","attributes":{"device_class":"motion","friendly_name":"Kitchen Motion Detected"},"last_changed":"2022-11-07T16:12:03.806337+00:00","last_updated":"2022-11-07T16:12:03.806337+00:00","context":{"id":"01GH9DSXTYNPV2TKWNCMN2D3CB","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:12:03.806337+00:00","context":{"id":"01GH9DSXTYNPV2TKWNCMN2D3CB","parent_id":null,"user_id":null}}})
2022-11-07 08:12:04.218  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 15 received
2022-11-07 08:12:07.210  5495-5624  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=entity_registry_updated}
2022-11-07 08:12:07.211  5495-5624  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 19: {type=unsubscribe_events, subscription=18, id=19}
2022-11-07 08:12:07.212  5495-5624  WebSocketRepository     io....stant.companion.android.debug  D  Message number 19 sent
2022-11-07 08:12:07.215  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=area_registry_updated}
2022-11-07 08:12:07.291  5495-5643  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=device_registry_updated}
2022-11-07 08:12:07.299  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 20: {type=unsubscribe_events, subscription=16, id=20}
2022-11-07 08:12:07.315  5495-5657  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=state_changed}
2022-11-07 08:12:07.397  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Message number 20 sent
2022-11-07 08:12:07.398  5495-5643  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 21: {type=unsubscribe_events, subscription=17, id=21}
2022-11-07 08:12:07.399  5495-5643  WebSocketRepository     io....stant.companion.android.debug  D  Message number 21 sent
2022-11-07 08:12:07.424  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":19,"type":"result","success":true,"result":null})
2022-11-07 08:12:07.427  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 19 received
2022-11-07 08:12:07.488  5495-5657  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 22: {type=unsubscribe_events, subscription=15, id=22}
2022-11-07 08:12:07.490  5495-5657  WebSocketRepository     io....stant.companion.android.debug  D  Message number 22 sent
2022-11-07 08:12:07.560  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":20,"type":"result","success":true,"result":null})
2022-11-07 08:12:07.563  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 20 received
2022-11-07 08:12:07.593  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":21,"type":"result","success":true,"result":null})
2022-11-07 08:12:07.609  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 21 received
2022-11-07 08:12:07.680  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":22,"type":"result","success":true,"result":null})
2022-11-07 08:12:07.683  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Message number 22 received
2022-11-07 08:12:08.075  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosing code: 1000, reason: 
2022-11-07 08:12:08.077  5495-5548  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosed
2022-11-07 08:25:04.833  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onOpen
2022-11-07 08:25:04.845  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_required","ha_version":"2022.10.5"})
2022-11-07 08:25:04.851  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:25:04.857  5495-6430  WebSocketRepository     io....stant.companion.android.debug  D  Auth Requested
2022-11-07 08:25:04.865  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"type":"auth_ok","ha_version":"2022.10.5"})
2022-11-07 08:25:04.869  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number null received
2022-11-07 08:25:04.879  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 23: {type=supported_features, id=23, features={coalesce_messages=1}}
2022-11-07 08:25:04.882  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 24: {type=subscribe_events, event_type=state_changed, id=24}
2022-11-07 08:25:04.883  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 24 sent
2022-11-07 08:25:04.910  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":23,"type":"result","success":true,"result":null})
2022-11-07 08:25:04.912  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 23 received
2022-11-07 08:25:04.928  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":24,"type":"result","success":true,"result":null})
2022-11-07 08:25:04.930  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 24 received
2022-11-07 08:25:04.942  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 25: {type=subscribe_events, event_type=area_registry_updated, id=25}
2022-11-07 08:25:04.944  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 25 sent
2022-11-07 08:25:04.975  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":25,"type":"result","success":true,"result":null})
2022-11-07 08:25:04.978  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 25 received
2022-11-07 08:25:04.983  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 26: {type=subscribe_events, event_type=device_registry_updated, id=26}
2022-11-07 08:25:04.985  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 26 sent
2022-11-07 08:25:05.014  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":26,"type":"result","success":true,"result":null})
2022-11-07 08:25:05.016  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 26 received
2022-11-07 08:25:05.086  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 27: {type=subscribe_events, event_type=entity_registry_updated, id=27}
2022-11-07 08:25:05.087  5495-5495  WebSocketRepository     io....stant.companion.android.debug  D  Message number 27 sent
2022-11-07 08:25:05.099  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":27,"type":"result","success":true,"result":null})
2022-11-07 08:25:05.108  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 27 received
2022-11-07 08:25:06.129  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":24,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_level","old_state":{"entity_id":"sensor.google_pixel_watch_battery_level","state":"40","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-charging-wireless-40","friendly_name":"Google Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:11:51.150979+00:00","last_updated":"2022-11-07T16:11:51.150979+00:00","context":{"id":"01GH9DSHFECT88ZJGYQ31E1437","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_level","state":"57","attributes":{"state_class":"measurement","unit_of_measurement":"%","device_class":"battery","icon":"mdi:battery-charging-wireless-50","friendly_name":"Google Pixel Watch Battery Level"},"last_changed":"2022-11-07T16:25:05.749634+00:00","last_updated":"2022-11-07T16:25:05.749634+00:00","context":{"id":"01GH9EHSENXQ97V4M6KF62TDER","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:25:05.749634+00:00","context":{"id":"01GH9EHSENXQ97V4M6KF62TDER","parent_id":null,"user_id":null}}},{"id":24,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_temperature","old_state":{"entity_id":"sensor.google_pixel_watch_battery_temperature","state":"109.6","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:battery","friendly_name":"Google Pixel Watch Battery Temperature"},"last_changed":"2022-11-07T16:11:51.152761+00:00","last_updated":"2022-11-07T16:11:51.152761+00:00","context":{"id":"01GH9DSHFGCAE3V4MXVWP6NXA4","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_temperature","state":"107.6","attributes":{"state_class":"measurement","unit_of_measurement":"°F","device_class":"temperature","icon":"mdi:battery","friendly_name":"Google Pixel Watch Battery Temperature"},"last_changed":"2022-11-07T16:25:05.751344+00:00","last_updated":"2022-11-07T16:25:05.751344+00:00","context":{"id":"01GH9EHSEQ1HQ4C0G16QTBRP6R","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:25:05.751344+00:00","context":{"id":"01GH9EHSEQ1HQ4C0G16QTBRP6R","parent_id":null,"user_id":null}}},{"id":24,"type":"event","event":{"event_type":"state_changed","data":{"entity_id":"sensor.google_pixel_watch_battery_power","old_state":{"entity_id":"sensor.google_pixel_watch_battery_power","state":"-8433.17","attributes":{"state_class":"measurement","current":-2147.4836,"voltage":3.927,"unit_of_measurement":"W","device_class":"power","icon":"mdi:battery-minus","friendly_name":"Google Pixel Watch Battery Power"},"last_changed":"2022-11-07T16:11:51.154327+00:00","last_updated":"2022-11-07T16:11:51.154327+00:00","context":{"id":"01GH9DSHFJMT42AM81BYYZHMGV","parent_id":null,"user_id":null}},"new_state":{"entity_id":"sensor.google_pixel_watch_battery_power","state":"-8504.04","attributes":{"state_class":"measurement","current":-2147.4836,"voltage":3.96,"unit_of_measurement":"W","device_class":"power","icon":"mdi:battery-minus","friendly_name":"Google Pixel Watch Battery Power"},"last_changed":"2022-11-07T16:25:05.752656+00:00","last_updated":"2022-11-07T16:25:05.752656+00:00","context":{"id":"01GH9EHSERB99VN5HB5AGZWQGP","parent_id":null,"user_id":null}}},"origin":"LOCAL","time_fired":"2022-11-07T16:25:05.752656+00:00","context":{"id":"01GH9EHSERB99VN5HB5AGZWQGP","parent_id":null,"user_id":null}}}])
2022-11-07 08:25:10.961  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 24 received
2022-11-07 08:25:10.964  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 24 received
2022-11-07 08:25:11.800  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=entity_registry_updated}
2022-11-07 08:25:11.801  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 28: {type=unsubscribe_events, subscription=27, id=28}
2022-11-07 08:25:11.803  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Message number 28 sent
2022-11-07 08:25:11.813  5495-6436  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=device_registry_updated}
2022-11-07 08:25:11.814  5495-6436  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 29: {type=unsubscribe_events, subscription=26, id=29}
2022-11-07 08:25:11.816  5495-6436  WebSocketRepository     io....stant.companion.android.debug  D  Message number 29 sent
2022-11-07 08:25:11.842  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=area_registry_updated}
2022-11-07 08:25:11.850  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 30: {type=unsubscribe_events, subscription=25, id=30}
2022-11-07 08:25:11.854  5495-5640  WebSocketRepository     io....stant.companion.android.debug  D  Message number 30 sent
2022-11-07 08:25:11.887  5495-6446  WebSocketRepository     io....stant.companion.android.debug  D  Unsubscribing from subscribe_events with data {event_type=state_changed}
2022-11-07 08:25:11.897  5495-6446  WebSocketRepository     io....stant.companion.android.debug  D  Sending message 31: {type=unsubscribe_events, subscription=24, id=31}
2022-11-07 08:25:11.914  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":28,"type":"result","success":true,"result":null})
2022-11-07 08:25:11.917  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 28 received
2022-11-07 08:25:11.948  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: [{"id":29,"type":"result","success":true,"result":null},{"id":30,"type":"result","success":true,"result":null}])
2022-11-07 08:25:11.950  5495-6446  WebSocketRepository     io....stant.companion.android.debug  D  Message number 31 sent
2022-11-07 08:25:11.965  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 29 received
2022-11-07 08:25:11.970  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 30 received
2022-11-07 08:25:11.977  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onMessage (text: {"id":31,"type":"result","success":true,"result":null})
2022-11-07 08:25:12.032  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Message number 31 received
2022-11-07 08:25:12.070  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosing code: 1000, reason: 
2022-11-07 08:25:12.072  5495-6428  WebSocketRepository     io....stant.companion.android.debug  D  Websocket: onClosed
```

</details>

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Removed a few state changes logs to keep github happy in case you wonder about the gaps :)