### PR TITLE
Store health services updates and send them with worker updates

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -48,7 +48,7 @@ class HealthServicesSensorManager : SensorManager {
             "mdi:stairs",
             unitOfMeasurement = "floors",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.CUSTOM
         )
         private val dailyDistance = SensorManager.BasicSensor(
             "daily_distance",
@@ -58,7 +58,7 @@ class HealthServicesSensorManager : SensorManager {
             "mdi:map-marker-distance",
             unitOfMeasurement = "m",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.CUSTOM
         )
         private val dailyCalories = SensorManager.BasicSensor(
             "daily_calories",
@@ -68,7 +68,7 @@ class HealthServicesSensorManager : SensorManager {
             "mdi:fire",
             unitOfMeasurement = "kcal",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.CUSTOM
         )
         private val dailySteps = SensorManager.BasicSensor(
             "daily_steps",
@@ -78,7 +78,7 @@ class HealthServicesSensorManager : SensorManager {
             "mdi:shoe-print",
             unitOfMeasurement = "steps",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.CUSTOM
         )
     }
 
@@ -225,13 +225,10 @@ class HealthServicesSensorManager : SensorManager {
                     }
                 }
 
-                val hasFloorData = processDataPoint(floorsDaily, dailyFloors)
-                val hasDistanceData = processDataPoint(distanceDaily, dailyDistance)
-                val hasCalorieData = processDataPoint(caloriesDaily, dailyCalories)
-                val hasStepData = processDataPoint(stepsDaily, dailySteps)
-
-                if (hasFloorData || hasDistanceData || hasCalorieData || hasStepData)
-                    SensorWorker.start(latestContext)
+                processDataPoint(floorsDaily, dailyFloors)
+                processDataPoint(distanceDaily, dailyDistance)
+                processDataPoint(caloriesDaily, dailyCalories)
+                processDataPoint(stepsDaily, dailySteps)
             }
 
             override fun onPermissionLost() {
@@ -319,8 +316,7 @@ class HealthServicesSensorManager : SensorManager {
     private fun processDataPoint(
         dataPoints: List<IntervalDataPoint<*>>,
         basicSensor: SensorManager.BasicSensor
-    ): Boolean {
-        var sendUpdate = false
+    ) {
         var latest = 0
         var lastIndex = 0
         val bootInstant =
@@ -333,7 +329,6 @@ class HealthServicesSensorManager : SensorManager {
                 if (endTime.toEpochMilli() > latest) {
                     latest = endTime.toEpochMilli().toInt()
                     lastIndex = index
-                    sendUpdate = true
                 }
             }
             onSensorUpdated(
@@ -344,6 +339,5 @@ class HealthServicesSensorManager : SensorManager {
                 mapOf()
             )
         }
-        return sendUpdate
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This is a different approach compared to #3069 where instead of pushing data point updates every 15 minutes, we just send them along with our worker updates.

I ran a test for 24 hours and while the worker did not stop during the day, it seemed to have stopped shortly after enabling bedtime mode. What actually happens is that Android starts to throttle our jobs for an undetermined length of time, updates from intents are still coming through. The jobs end up getting canceled as soon as they are created.  Placing the app in the whitelist does prevent this behavior and in my testing is decent on battery life.

Its going to be difficult to find a happy medium here and this behavior will vary from user to user.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->