### PR TITLE
Revert jackson-module-kotlin bump to fix compatibility on older Android version

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -158,7 +158,7 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.5.4")
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
     implementation("com.squareup.picasso:picasso:2.8")
 

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -72,6 +72,6 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-jackson:2.9.0")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.10.0")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
     implementation("org.altbeacon:android-beacon-library:2.19.4")
 }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -103,7 +103,7 @@ dependencies {
     implementation("com.google.dagger:hilt-android:2.44")
     kapt("com.google.dagger:hilt-android-compiler:2.44")
 
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.4")
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
 
     implementation("com.mikepenz:iconics-core:5.4.0")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Revert #3048 as Jackson 2.14 [increases the minimum SDK version to 26](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14#compatibility-min-android-sdk), while the app has a minimum of 21 and this will currently result in crashes on versions <26.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
[Short discussion with two crash logs on Discord](https://discord.com/channels/330944238910963714/377667559303938050/1042478429607579728)