### PR TITLE
Skip heart rate value updates when below 0

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -101,7 +101,10 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
-        if (event?.sensor?.type == Sensor.TYPE_HEART_RATE && event.accuracy !in skipAccuracy) {
+        if (
+            event?.sensor?.type == Sensor.TYPE_HEART_RATE && event.accuracy !in skipAccuracy &&
+            event.values[0].roundToInt() >= 0
+        ) {
             onSensorUpdated(
                 latestContext,
                 heartRate,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had a user mention on [discord](https://discord.com/channels/330944238910963714/562408603345092636/1042882512789176320) that their heart rate sensor will show a value of `-1` so lets skip any value below `0` as we are measuring in `bpm` so `0` will be the lowest acceptable value.

Hopefully we don't have to account for a crazy high value 😆 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->