### PR TITLE
Reduce usage of job scheduling to avoid throttling

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -135,7 +135,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
                 )
 
                 // Send the update immediately
-                SensorWorker.start(context)
+                SensorReceiver.updateAllSensors(context)
             }
         }
         if (SleepSegmentEvent.hasEvents(intent) && isEnabled(context, sleepSegment.id)) {

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -350,7 +350,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             highAccuracyUpdateInterval.statelessIcon,
             mapOf()
         )
-        SensorWorker.start(latestContext)
+        SensorReceiver.updateAllSensors(latestContext)
         HighAccuracyLocationService.restartService(latestContext, intervalInSeconds)
     }
 
@@ -369,7 +369,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             highAccuracyUpdateInterval.statelessIcon,
             mapOf()
         )
-        SensorWorker.start(latestContext)
+        SensorReceiver.updateAllSensors(latestContext)
         HighAccuracyLocationService.startService(latestContext, intervalInSeconds)
     }
 
@@ -381,7 +381,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             highAccuracyMode.statelessIcon,
             mapOf()
         )
-        SensorWorker.start(latestContext)
+        SensorReceiver.updateAllSensors(latestContext)
         HighAccuracyLocationService.stopService(latestContext)
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,6 +97,7 @@
                 <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />
                 <action android:name="android.bluetooth.device.action.ACL_CONNECTED" />
                 <action android:name="android.bluetooth.device.action.ACL_DISCONNECTED" />
+                <action android:name="io.homeassistant.companion.android.UPDATE_SENSORS" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/bluetooth/ble/IBeaconMonitor.kt
@@ -2,7 +2,7 @@ package io.homeassistant.companion.android.bluetooth.ble
 
 import android.content.Context
 import io.homeassistant.companion.android.sensors.BluetoothSensorManager
-import io.homeassistant.companion.android.sensors.SensorWorker
+import io.homeassistant.companion.android.sensors.SensorReceiver
 import org.altbeacon.beacon.Beacon
 import kotlin.math.abs
 import kotlin.math.round
@@ -80,6 +80,6 @@ class IBeaconMonitor {
     private fun sendUpdate(context: Context, tmp: List<IBeacon>) {
         beacons = tmp
         sensorManager.updateBeaconMonitoringSensor(context)
-        SensorWorker.start(context)
+        SensorReceiver.updateAllSensors(context)
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -63,7 +63,7 @@ import io.homeassistant.companion.android.database.settings.WebsocketSetting
 import io.homeassistant.companion.android.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.sensors.NotificationSensorManager
-import io.homeassistant.companion.android.sensors.SensorWorker
+import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.util.UrlHandler
 import io.homeassistant.companion.android.websocket.WebsocketManager
@@ -537,7 +537,7 @@ class MessagingManager @Inject constructor(
                             }
                         }
                     }
-                    COMMAND_UPDATE_SENSORS -> SensorWorker.start(context)
+                    COMMAND_UPDATE_SENSORS -> SensorReceiver.updateAllSensors(context)
                     COMMAND_LAUNCH_APP -> {
                         if (!jsonData[PACKAGE_NAME].isNullOrEmpty()) {
                             handleDeviceCommands(jsonData)
@@ -867,7 +867,7 @@ class MessagingManager @Inject constructor(
                         )
                     }
                     BluetoothSensorManager().requestSensorUpdate(context)
-                    SensorWorker.start(context)
+                    SensorReceiver.updateAllSensors(context)
                 }
             }
             COMMAND_BEACON_MONITOR -> {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -159,7 +159,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         )
 
         // Need to send update!
-        SensorWorker.start(applicationContext)
+        SensorReceiver.updateAllSensors(applicationContext)
     }
 
     override fun onNotificationRemoved(sbn: StatusBarNotification) {
@@ -217,7 +217,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         )
 
         // Need to send update!
-        SensorWorker.start(applicationContext)
+        SensorReceiver.updateAllSensors(applicationContext)
     }
 
     private fun updateActiveNotificationCount() {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -71,6 +71,12 @@ class SensorReceiver : SensorReceiverBase() {
 
         const val ACTION_REQUEST_SENSORS_UPDATE =
             "io.homeassistant.companion.android.background.REQUEST_SENSORS_UPDATE"
+
+        fun updateAllSensors(context: Context) {
+            val intent = Intent(context, SensorReceiver::class.java)
+            intent.action = ACTION_UPDATE_SENSORS
+            context.sendBroadcast(intent)
+        }
     }
 
     // Suppress Lint because we only register for the receiver if the android version matches the intent

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -27,7 +27,6 @@ import io.homeassistant.companion.android.database.settings.SensorUpdateFrequenc
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.sensors.LastAppSensorManager
 import io.homeassistant.companion.android.sensors.SensorReceiver
-import io.homeassistant.companion.android.sensors.SensorWorker
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -232,7 +231,7 @@ class SensorDetailViewModel @Inject constructor(
     }
 
     private fun refreshSensorData() {
-        SensorWorker.start(getApplication())
+        SensorReceiver.updateAllSensors(getApplication())
     }
 
     fun getSettingTranslatedTitle(key: String): String {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -718,7 +718,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
     override fun onPause() {
         super.onPause()
-        SensorWorker.start(this)
+        SensorReceiver.updateAllSensors(this)
         presenter.setAppActive(false)
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
@@ -31,6 +31,7 @@ import javax.inject.Inject
 abstract class SensorReceiverBase : BroadcastReceiver() {
     companion object {
         const val ACTION_UPDATE_SENSOR = "io.homeassistant.companion.android.UPDATE_SENSOR"
+        const val ACTION_UPDATE_SENSORS = "io.homeassistant.companion.android.UPDATE_SENSORS"
         const val EXTRA_SENSOR_ID = "sensorId"
 
         fun shouldDoFastUpdates(context: Context): Boolean {

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="com.htc.intent.action.QUICKBOOT_POWERON" />
                 <action android:name="android.app.action.NEXT_ALARM_CLOCK_CHANGED" />
+                <action android:name="io.homeassistant.companion.android.UPDATE_SENSORS" />
             </intent-filter>
         </receiver>
         <uses-library

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.home.views.LoadHomePage
 import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationActivity
+import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -64,7 +65,7 @@ class HomeActivity : ComponentActivity(), HomeView {
 
     override fun onPause() {
         super.onPause()
-        SensorWorker.start(this)
+        SensorReceiver.updateAllSensors(this)
     }
 
     override fun onDestroy() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -25,7 +25,6 @@ import io.homeassistant.companion.android.database.wear.FavoriteCachesDao
 import io.homeassistant.companion.android.database.wear.FavoritesDao
 import io.homeassistant.companion.android.database.wear.getAllFlow
 import io.homeassistant.companion.android.sensors.SensorReceiver
-import io.homeassistant.companion.android.sensors.SensorWorker
 import io.homeassistant.companion.android.util.RegistriesDataHandler
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
@@ -302,7 +301,7 @@ class MainViewModel @Inject constructor(
         isEnabled: Boolean
     ) {
         sensorDao.setSensorsEnabled(listOf(basicSensor.id), isEnabled)
-        SensorWorker.start(getApplication())
+        SensorReceiver.updateAllSensors(getApplication())
     }
 
     fun updateAllSensors(sensorManager: SensorManager) {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -197,7 +197,7 @@ class HealthServicesSensorManager : SensorManager {
                     forceUpdate = info.userActivityState == UserActivityState.USER_ACTIVITY_EXERCISE
                 )
 
-                SensorWorker.start(latestContext)
+                SensorReceiver.updateAllSensors(latestContext)
             }
 
             override fun onNewDataPointsReceived(dataPoints: DataPointContainer) {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
@@ -93,6 +93,6 @@ class OnBodySensorManager : SensorManager, SensorEventListener {
         }
 
         // Send update immediately
-        SensorWorker.start(latestContext)
+        SensorReceiver.updateAllSensors(latestContext)
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -59,6 +59,12 @@ class SensorReceiver : SensorReceiverBase() {
 
         const val ACTION_REQUEST_SENSORS_UPDATE =
             "io.homeassistant.companion.android.background.REQUEST_SENSORS_UPDATE"
+
+        fun updateAllSensors(context: Context) {
+            val intent = Intent(context, SensorReceiver::class.java)
+            intent.action = ACTION_UPDATE_SENSORS
+            context.sendBroadcast(intent)
+        }
     }
 
     // Suppress Lint because we only register for the receiver if the android version matches the intent


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I have been noticing at times when the app is not on the doze whitelist that sometimes the sensor worker will not start/update, even when we open the app.

WorkManagers `doWork()` function calls `JobScheduler.schedule()` I noticed the following note in the docs:

`
Note: Scheduling a job can have a high cost, even if it's rescheduling the same job and the job didn't execute, especially on platform versions before version [Build.VERSION_CODES.Q](https://developer.android.com/reference/android/os/Build.VERSION_CODES#Q). As such, the system may throttle calls to this API if calls are made too frequently in a short amount of time.
`

Sure enough when the issue was happening on my Pixel Watch the worker calls were always immediately being canceled up until I would force stop the app.  I believe on a wearable device this issue may be more prominent  as this throttling probably happens at a faster interval.

So in this PR I am looking at all of our usage of `SensorWorker.start()` and replacing it with an intent based update so we don't `schedule` our job so often so we can respect the limit imposed above.

- Any sensor that causes an update will use this new method.
- We will start the worker upon app launch `onResume` but when we exit the app we will call the new method. This is to prevent possible throttling if the app were open and put in the background several times causing too many schedules.
- When we enable sensors we will also call this new method to prevent throttling in case many sensors were added back to back.

I don't really know what qualifies the throttling but in my opinion we should really just schedule the job and let it do its thing, instead of constantly rescheduling it. We probably never noticed the above issue as we always keep the app on the whitelist, especially if using location tracking.

I have tested the phone side and updates still happen as expected. I am in the process of testing on my Pixel Watch to see if there are any issues so leaving as a draft to get feedback.  Please let me know if you think I have removed too many instances, my idea was to use the worker sparingly so we never get throttled.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->