### PR TITLE
Button Widget: Uniform Spacing

### DIFF
--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -14,6 +14,7 @@
         android:id="@+id/widgetImageButtonLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingVertical="4dp"
         android:orientation="vertical">
 
         <ImageView
@@ -31,18 +32,17 @@
             android:id="@+id/widgetLabelLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="2dp"
-            android:minHeight="32sp">
+            android:layout_margin="2dp">
 
             <TextView
                 android:id="@+id/widgetLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
+                android:layout_gravity="bottom|center_horizontal"
                 android:text="@string/widget_label_placeholder_text_button"
                 android:textSize="12sp"
                 android:textAlignment="center"
-                android:gravity="center"
+                android:gravity="top|center_horizontal"
                 android:textColor="?colorWidgetOnBackground"
                 android:minLines="1"
                 android:maxLines="2" />

--- a/app/src/main/res/layout/widget_button.xml
+++ b/app/src/main/res/layout/widget_button.xml
@@ -38,11 +38,11 @@
                 android:id="@+id/widgetLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="bottom|center_horizontal"
+                android:layout_gravity="center"
                 android:text="@string/widget_label_placeholder_text_button"
                 android:textSize="12sp"
                 android:textAlignment="center"
-                android:gravity="top|center_horizontal"
+                android:gravity="center"
                 android:textColor="?colorWidgetOnBackground"
                 android:minLines="1"
                 android:maxLines="2" />

--- a/app/src/main/res/layout/widget_static.xml
+++ b/app/src/main/res/layout/widget_static.xml
@@ -46,12 +46,12 @@
                 android:id="@+id/widgetLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="bottom|center_horizontal"
+                android:layout_gravity="center"
                 android:text="@string/widget_label_placeholder_text_static_label"
                 android:textSize="12sp"
                 android:textAlignment="center"
                 android:textColor="?colorWidgetOnBackground"
-                android:gravity="top|center_horizontal"
+                android:gravity="center"
                 android:minLines="1"
                 android:maxLines="2" />
         </LinearLayout>

--- a/app/src/main/res/layout/widget_static.xml
+++ b/app/src/main/res/layout/widget_static.xml
@@ -12,6 +12,7 @@
         android:id="@+id/widgetTextLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:paddingVertical="4dp"
         android:orientation="vertical">
 
         <TextView
@@ -30,8 +31,7 @@
             android:id="@+id/widgetLabelLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="2dp"
-            android:minHeight="32sp">
+            android:layout_margin="2dp">
 
             <ImageView
                 android:id="@+id/widgetStaticError"
@@ -46,12 +46,12 @@
                 android:id="@+id/widgetLabel"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
+                android:layout_gravity="bottom|center_horizontal"
                 android:text="@string/widget_label_placeholder_text_static_label"
                 android:textSize="12sp"
                 android:textAlignment="center"
                 android:textColor="?colorWidgetOnBackground"
-                android:gravity="center"
+                android:gravity="top|center_horizontal"
                 android:minLines="1"
                 android:maxLines="2" />
         </LinearLayout>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Button widget had asymmetrical top and bottom spacing. This PR tries to fix that.
Related issue: https://github.com/home-assistant/android/issues/3093

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Portrait:
![image](https://user-images.githubusercontent.com/40914272/203931684-1a2e5c6b-c626-4338-bd56-e9bba7006ef2.png)

Landscape:
![image](https://user-images.githubusercontent.com/40914272/203931837-fbb5ef55-4cd2-4d83-8857-1d2c8dff5268.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
- The icon named old is from stock Home Assistant App kept for comparison with the newer ones.
- The only small downside of this approach is that on multiline text the icon becomes slightly smaller as compared to stock multi line icon (BTW stock multiline widget is not present in the screenshots above)

In order to fully solve this only downside with even better but complex approach is to use multiple layouts:
https://developer.android.com/develop/ui/views/appwidgets/layouts#provide-responsive-layouts