### PR TITLE
Support automation entities in quick settings tiles

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -228,7 +228,7 @@ abstract class TileExtensions : TileService() {
         private const val TAG = "TileExtensions"
         private var iconPack: IconPack? = null
         private val toggleDomains = listOf(
-            "cover", "fan", "humidifier", "input_boolean", "light",
+            "automation", "cover", "fan", "humidifier", "input_boolean", "light",
             "media_player", "remote", "siren", "switch"
         )
         private val validActiveStates = listOf("on", "open", "locked")

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -26,7 +26,7 @@ class ManageTilesFragment : Fragment(), IconDialog.Callback {
     companion object {
         private const val TAG = "TileFragment"
         val validDomains = listOf(
-            "button", "cover", "fan", "humidifier", "input_boolean", "input_button", "light",
+            "automation", "button", "cover", "fan", "humidifier", "input_boolean", "input_button", "light",
             "lock", "media_player", "remote", "siren", "scene", "script", "switch"
         )
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add support for toggling automations from the quick settings tiles, resolves #3095. The states are `on`/`off` and the service to call is `automation.toggle` so it only needs to be added to the list of supported domains.

(This was already supported in device controls.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Android quick settings shade showing a tile with a droid icon and the label "I'm an automation"](https://user-images.githubusercontent.com/8148535/204023789-4c9d9df2-b3f8-4524-94ba-ba86698386fa.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#864

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->