### PR TITLE
Add deeplinks to Wear OS sensor sync notifications

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.annotation.SuppressLint
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.bluetooth.BluetoothAdapter
 import android.content.Context
 import android.content.Intent
@@ -100,11 +101,17 @@ class SensorReceiver : SensorReceiverBase() {
         WifiManager.WIFI_STATE_CHANGED_ACTION to NetworkSensorManager.wifiState.id,
     )
 
-    override fun getSensorSettingsIntent(context: Context, id: String): Intent? {
-        return SettingsActivity.newInstance(context).apply {
-            putExtra("fragment", "sensors/$id")
+    override fun getSensorSettingsIntent(
+        context: Context,
+        sensorId: String,
+        sensorManagerId: String,
+        notificationId: Int
+    ): PendingIntent? {
+        val intent = SettingsActivity.newInstance(context).apply {
+            putExtra("fragment", "sensors/$sensorId")
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
         }
+        return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_IMMUTABLE)
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
@@ -69,7 +69,12 @@ abstract class SensorReceiverBase : BroadcastReceiver() {
 
     protected abstract val skippableActions: Map<String, String>
 
-    protected abstract fun getSensorSettingsIntent(context: Context, id: String): Intent?
+    protected abstract fun getSensorSettingsIntent(
+        context: Context,
+        sensorId: String,
+        sensorManagerId: String,
+        notificationId: Int
+    ): PendingIntent?
 
     override fun onReceive(context: Context, intent: Intent) {
         Log.d(tag, "Received intent: ${intent.action}")
@@ -244,9 +249,7 @@ abstract class SensorReceiverBase : BroadcastReceiver() {
                                 context.getSystemService<NotificationManager>()?.let { notificationManager ->
                                     createNotificationChannel(context)
                                     val notificationId = "$sensorCoreSyncChannel-${basicSensor.id}".hashCode()
-                                    val notificationIntent = getSensorSettingsIntent(context, basicSensor.id)?.let {
-                                        PendingIntent.getActivity(context, notificationId, it, PendingIntent.FLAG_IMMUTABLE)
-                                    }
+                                    val notificationIntent = getSensorSettingsIntent(context, basicSensor.id, manager.id(), notificationId)
                                     val notification = NotificationCompat.Builder(context, sensorCoreSyncChannel)
                                         .setSmallIcon(R.drawable.ic_stat_ic_notification)
                                         .setContentTitle(context.getString(basicSensor.name))

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
+import androidx.navigation.navDeepLink
 import androidx.wear.compose.navigation.SwipeDismissableNavHost
 import androidx.wear.compose.navigation.composable
 import androidx.wear.compose.navigation.rememberSwipeDismissableNavController
@@ -32,6 +33,8 @@ private const val SCREEN_SET_TILE_SHORTCUTS = "set_tile_shortcuts"
 private const val SCREEN_SELECT_TILE_SHORTCUT = "select_tile_shortcut"
 private const val SCREEN_SET_TILE_TEMPLATE = "set_tile_template"
 private const val SCREEN_SET_TILE_TEMPLATE_REFRESH_INTERVAL = "set_tile_template_refresh_interval"
+
+const val DEEPLINK_SENSOR_MANAGER = "ha_wear://$SCREEN_SINGLE_SENSOR_MANAGER"
 
 @Composable
 fun LoadHomePage(
@@ -215,6 +218,9 @@ fun LoadHomePage(
                     navArgument(name = ARG_SCREEN_SENSOR_MANAGER_ID) {
                         type = NavType.StringType
                     }
+                ),
+                deepLinks = listOf(
+                    navDeepLink { uriPattern = "$DEEPLINK_SENSOR_MANAGER/{$ARG_SCREEN_SENSOR_MANAGER_ID}" }
                 )
             ) { backStackEntry ->
                 val sensorManagerId =

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -2,12 +2,15 @@ package io.homeassistant.companion.android.sensors
 
 import android.annotation.SuppressLint
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.PowerManager
+import androidx.core.app.TaskStackBuilder
+import androidx.core.net.toUri
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.sensors.AppSensorManager
@@ -21,6 +24,8 @@ import io.homeassistant.companion.android.common.sensors.PowerSensorManager
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 import io.homeassistant.companion.android.common.sensors.StepsSensorManager
+import io.homeassistant.companion.android.home.HomeActivity
+import io.homeassistant.companion.android.home.views.DEEPLINK_SENSOR_MANAGER
 
 @AndroidEntryPoint
 class SensorReceiver : SensorReceiverBase() {
@@ -84,5 +89,21 @@ class SensorReceiver : SensorReceiverBase() {
         "com.google.android.clockwork.actions.WET_MODE_ENDED" to WetModeSensorManager.wetModeSensor.id
     )
 
-    override fun getSensorSettingsIntent(context: Context, id: String): Intent? = null
+    override fun getSensorSettingsIntent(
+        context: Context,
+        sensorId: String,
+        sensorManagerId: String,
+        notificationId: Int
+    ): PendingIntent? {
+        val intent = Intent(
+            Intent.ACTION_VIEW,
+            "$DEEPLINK_SENSOR_MANAGER/$sensorManagerId".toUri(),
+            context,
+            HomeActivity::class.java
+        )
+        return TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(notificationId, PendingIntent.FLAG_UPDATE_CURRENT)
+        }
+    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When enabling a sensor on the server that requires additional permissions, the app will post a notification to let you know that it needs to be enabled from the app. The main app added an intent to that notification to open the sensor's settings when tapped, this PR adds a similar intent to the Wear OS app.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The notification that is posted when a sensor requires additional permissions (this isn't new):
![A notification on a watch by the Home Assistant app titled 'WiFi State', description 'To enable this sensor, turn it on in the app set...'](https://user-images.githubusercontent.com/8148535/204091076-e7e2493d-5c38-433a-85c0-ed69d4711f52.png)

It now includes an intent which will show up as a 'Open on watch' button (using the Wear OS 3 emulator):
![A notification on a watch by the Home Assistant app telling the user that the WiFi State sensor needs to be enabled in the app, with buttons labeled 'Clear' and 'Open on watch'](https://user-images.githubusercontent.com/8148535/204091094-51573e2a-e2da-4552-a78a-849d28cb262a.png)

Tapping on it will open the sensor manager's settings screen where the sensor can be enabled and permission(s) can be granted.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing note: after launching the app from the notification, the app in the recents screen seems to use this intent for subsequent launches until launched from the main app list, which is technically correct but might be unexpected.