### PR TITLE
Don't crash when system is unable to handle download intent

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.webview
 import android.annotation.SuppressLint
 import android.app.DownloadManager
 import android.app.PictureInPictureParams
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -1345,8 +1346,15 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
             else -> {
                 Log.d(TAG, "Received download request for unsupported scheme, forwarding to system")
-                val browserIntent = Intent(Intent.ACTION_VIEW, uri)
-                startActivity(browserIntent)
+                try {
+                    val browserIntent = Intent(Intent.ACTION_VIEW, uri).apply {
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                    }
+                    startActivity(browserIntent)
+                } catch (e: ActivityNotFoundException) {
+                    Log.e(TAG, "Unable to forward download request to system", e)
+                    Toast.makeText(this, commonR.string.failed_unsupported, Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When trying to forward a download intent to the system catch the exception that is thrown if the system can't handle it to prevent a crash.

This should close #3098 as explained in my [comment on the issue](https://github.com/home-assistant/android/issues/3098#issuecomment-1328061532).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The app will show a toast to indicate the download is not supported when an exception is caught, for example when trying to use a blob URL:

https://user-images.githubusercontent.com/8148535/204135215-1ac23461-8cec-456b-91d5-8db46412760e.mp4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->