### PR TITLE
Remove NFC tag sample YAML for 'scanned by this device' on 2022.12+

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/nfc/NfcViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/NfcViewModel.kt
@@ -30,6 +30,8 @@ class NfcViewModel @Inject constructor(
 
     var isNfcEnabled by mutableStateOf(false)
         private set
+    var usesAndroidDeviceId by mutableStateOf(false)
+        private set
     var nfcTagIdentifier by mutableStateOf<String?>(null)
         private set
     var nfcIdentifierIsEditable by mutableStateOf(true)
@@ -41,6 +43,12 @@ class NfcViewModel @Inject constructor(
 
     private val _nfcResultSnackbar = MutableSharedFlow<Int>()
     var nfcResultSnackbar = _nfcResultSnackbar.asSharedFlow()
+
+    init {
+        viewModelScope.launch {
+            usesAndroidDeviceId = !integrationUseCase.isHomeAssistantVersionAtLeast(2022, 12, 0)
+        }
+    }
 
     fun setDestination(destination: String?) {
         nfcEventShouldWrite = nfcTagIdentifier != null && destination == NfcSetupActivity.NAV_WRITE

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/views/NfcEditView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/views/NfcEditView.kt
@@ -32,6 +32,7 @@ import io.homeassistant.companion.android.common.R as commonR
 @Composable
 fun NfcEditView(
     identifier: String?,
+    showDeviceSample: Boolean,
     onDuplicateClicked: () -> Unit,
     onFireEventClicked: () -> Unit
 ) {
@@ -79,15 +80,17 @@ fun NfcEditView(
         item {
             NfcTriggerExample(
                 modifier = Modifier.padding(bottom = 8.dp),
-                description = stringResource(commonR.string.nfc_trigger_any),
+                description = if (showDeviceSample) stringResource(commonR.string.nfc_trigger_any) else "",
                 example = tagTriggerExample
             )
         }
-        item {
-            NfcTriggerExample(
-                description = stringResource(commonR.string.nfc_trigger_device),
-                example = deviceTriggerExample
-            )
+        if (showDeviceSample) {
+            item {
+                NfcTriggerExample(
+                    description = stringResource(commonR.string.nfc_trigger_device),
+                    example = deviceTriggerExample
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.nfc.views
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
@@ -93,11 +94,11 @@ fun LoadNfcView(
                 contentColor = colorResource(commonR.color.colorOnBackground)
             )
         }
-    ) {
+    ) { contentPadding ->
         NavHost(
             navController = navController,
             startDestination = startDestination,
-            modifier = Modifier
+            modifier = Modifier.padding(contentPadding)
         ) {
             composable(NfcSetupActivity.NAV_WELCOME) {
                 NfcWelcomeView(
@@ -121,6 +122,7 @@ fun LoadNfcView(
             composable(NfcSetupActivity.NAV_EDIT) {
                 NfcEditView(
                     identifier = viewModel.nfcTagIdentifier,
+                    showDeviceSample = viewModel.usesAndroidDeviceId,
                     onDuplicateClicked = { viewModel.duplicateNfcTag() },
                     onFireEventClicked = { viewModel.fireNfcTagEvent() }
                 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Due to the bugfix in home-assistant/core#82820, tag scanned events will now use HA's device ID instead of the Android's device ID. The in-app NFC settings show sample YAML code for when a tag is scanned, including the device ID. As Home Assistant's device ID only appears to be exposed via the device registry `identifiers` which is a [minefield](https://github.com/home-assistant/android/issues/2123#issuecomment-1007439106) I propose removing this sample on core >= 2022.12. 

Users that want to automate based on device can still get this ID from the developer tools or URL, as mentioned in the general tag docs.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![NFC tag settings in the Android app showing only one YAML sample, light mode](https://user-images.githubusercontent.com/8148535/204380135-e816a6d1-a905-4810-accd-9cee7d7384c0.png)|![NFC tag settings in the Android app showing only one YAML sample, light mode](https://user-images.githubusercontent.com/8148535/204380161-c899d1c4-3609-4029-be4a-71bee5852dad.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->