### PR TITLE
Update quick setting tiles with state updates

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -25,8 +25,8 @@ import io.homeassistant.companion.android.database.qs.TileDao
 import io.homeassistant.companion.android.database.qs.TileEntity
 import io.homeassistant.companion.android.database.qs.isSetup
 import io.homeassistant.companion.android.settings.SettingsActivity
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -50,7 +50,7 @@ abstract class TileExtensions : TileService() {
 
     private val mainScope = MainScope()
 
-    private var stateUpdateJob: CoroutineScope? = null
+    private var stateUpdateJob: Job? = null
 
     override fun onClick() {
         super.onClick()
@@ -88,12 +88,11 @@ abstract class TileExtensions : TileService() {
     override fun onStartListening() {
         super.onStartListening()
         Log.d(TAG, "Tile: ${getTileId()} is in view")
-        stateUpdateJob = MainScope()
         getTile()?.let { tile ->
             mainScope.launch {
                 setTileData(getTileId(), tile)
             }
-            stateUpdateJob?.launch {
+            stateUpdateJob = mainScope.launch {
                 val tileData = tileDao.get(getTileId())
                 if (tileData != null && tileData.isSetup && tileData.entityId.split('.')[0] in toggleDomainsWithLock)
                     integrationUseCase.getEntityUpdates(listOf(tileData.entityId))?.collect {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3120 by switching to state change trigger subscription for the tile. We are still doing an initial state update to make sure the state is current when the tile is first in view.  These tiles will now always have its active state in sync with the state of the entity, even when interacting with them.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->