### PR TITLE
Let heart rate sensor get up to 5 events in case first is invalid

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -28,6 +28,7 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
             SENSOR_STATUS_UNRELIABLE,
             SENSOR_STATUS_NO_CONTACT
         )
+        private var eventCount = 0
         private val heartRate = SensorManager.BasicSensor(
             "heart_rate",
             "sensor",
@@ -101,14 +102,14 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun onSensorChanged(event: SensorEvent?) {
+        eventCount++
+        val validReading = event?.sensor?.type == Sensor.TYPE_HEART_RATE && event.accuracy !in skipAccuracy &&
+            event.values[0].roundToInt() >= 0
         if (event?.sensor?.type == Sensor.TYPE_HEART_RATE) {
-            Log.d(TAG, "HR event received with accuracy: ${getAccuracy(event.accuracy)} and value: ${event.values[0]}")
+            Log.d(TAG, "HR event received with accuracy: ${getAccuracy(event.accuracy)} and value: ${event.values[0]} with event count: $eventCount")
         } else
             Log.d(TAG, "No HR event received")
-        if (
-            event?.sensor?.type == Sensor.TYPE_HEART_RATE && event.accuracy !in skipAccuracy &&
-            event.values[0].roundToInt() >= 0
-        ) {
+        if (event != null && validReading) {
             onSensorUpdated(
                 latestContext,
                 heartRate,
@@ -119,9 +120,12 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
                 )
             )
         }
-        mySensorManager.unregisterListener(this)
-        Log.d(TAG, "Heart Rate sensor listener unregistered")
-        isListenerRegistered = false
+        if (validReading || eventCount >= 5) {
+            mySensorManager.unregisterListener(this)
+            Log.d(TAG, "Heart Rate sensor listener unregistered")
+            isListenerRegistered = false
+            eventCount = 0
+        }
     }
 
     private fun getAccuracy(accuracy: Int): String {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

An attempt to fix #3100 

Looking at the logs it looks like sometimes we may get an invalid report for the first event so lets see if one of the first 5 events are valid or not. That should give a good balance between battery life and hopefully a valid reading :)

Apparently the only time this really happens on my Pixel Watch is when moving from charger to wrist which is understandable because it probably cant get reading immediately. Based on teh android docs I do not think we should ignore sensory accuracy but with that said hopefully a device doesn't forever report its accuracy as invalid 😬 

```
2022-11-30 16:34:11.255 20125-20125 HRSensor                io....stant.companion.android.debug  D  HR event received with accuracy: no_contact and value: 77.0 with event count: 2
2022-11-30 16:34:14.034 20125-20125 HRSensor                io....stant.companion.android.debug  D  HR event received with accuracy: no_contact and value: 76.0 with event count: 3
2022-11-30 16:34:17.476 20125-20125 HRSensor                io....stant.companion.android.debug  D  HR event received with accuracy: no_contact and value: 78.0 with event count: 4
2022-11-30 16:34:17.476 20125-20125 HRSensor                io....stant.companion.android.debug  D  HR event received with accuracy: no_contact and value: 77.0 with event count: 5
2022-11-30 16:34:17.487 20125-20125 HRSensor                io....stant.companion.android.debug  D  Heart Rate sensor listener unregistered
```

Here is an example of what a good reading will look like:

```
2022-11-30 16:37:31.762 20125-20865 HRSensor                io....stant.companion.android.debug  D  Heart Rate sensor listener registered
2022-11-30 16:37:31.763 20125-20125 HRSensor                io....stant.companion.android.debug  D  HR event received with accuracy: high and value: 74.0 with event count: 1
2022-11-30 16:37:31.831 20125-20125 HRSensor                io....stant.companion.android.debug  D  Heart Rate sensor listener unregistered
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->