### PR TITLE
Restart health services if no updates received in 30 minutes

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -31,6 +31,7 @@ class HealthServicesSensorManager : SensorManager {
     companion object {
 
         private const val TAG = "HealthServices"
+        private var callbackLastUpdated = 0L
         private val userActivityState = SensorManager.BasicSensor(
             "activity_state",
             "sensor",
@@ -171,7 +172,7 @@ class HealthServicesSensorManager : SensorManager {
             .setDataTypes(dataTypes)
             .build()
 
-        if (dataTypesRegistered != dataTypes || activityStateRegistered != activityStateEnabled) {
+        if (dataTypesRegistered != dataTypes || activityStateRegistered != activityStateEnabled || callbackLastUpdated + 1800000 < System.currentTimeMillis()) {
             clearHealthServicesCallBack()
         }
 
@@ -181,6 +182,7 @@ class HealthServicesSensorManager : SensorManager {
         val passiveListenerCallback: PassiveListenerCallback = object : PassiveListenerCallback {
             override fun onUserActivityInfoReceived(info: UserActivityInfo) {
                 Log.d(TAG, "User activity state: ${info.userActivityState.name}")
+                callbackLastUpdated = System.currentTimeMillis()
                 onSensorUpdated(
                     latestContext,
                     userActivityState,
@@ -203,6 +205,7 @@ class HealthServicesSensorManager : SensorManager {
 
             override fun onNewDataPointsReceived(dataPoints: DataPointContainer) {
                 Log.d(TAG, "New data point received: ${dataPoints.dataTypes}")
+                callbackLastUpdated = System.currentTimeMillis()
                 val floorsDaily = dataPoints.getData(DataType.FLOORS_DAILY)
                 val distanceDaily = dataPoints.getData(DataType.DISTANCE_DAILY)
                 val caloriesDaily = dataPoints.getData(DataType.CALORIES_DAILY)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This is an attempt to fix #3112 by keeping track of the last update received and restarting health services if its been 30 minutes since an update. I feel 30 minutes will be a good time period as there are really no other ways to detect the updates stopping. More than likely if a user only has User Activity State they will probably see the callback registering more frequently as a result of this change. I suspect when this issue occurs it impacts all things registered with the callback so best to include activity state.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->