### PR TITLE
Fix monochrome icon on Android 13+

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/colorPrimary" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
Signed-off-by: Tamás Nagy (T-bond) <tbondvagyok@gmail.com>

Closes: #3130


<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix monochrome icon not showing on supported launcher and OS, according to Android Developers documentation:
[Adaptive icons](https://developer.android.com/develop/ui/views/launch/icon_design_adaptive)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![SmartSelect_20221202_185726_One UI Home](https://user-images.githubusercontent.com/3778556/205356433-0f1a3da1-70bd-450e-b23d-ad0b82d7a8b5.jpg)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Not relevant

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I did not update the debug icon with the same change, for it to be easily differentiable from the normal application.
(Maybe an updated icon for example with a `DEV` label on it would be sufficent?)