### PR TITLE
use custom user-agent in websocket requests

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -372,7 +372,7 @@ class WebSocketRepositoryImpl @Inject constructor(
 
             try {
                 connection = okHttpClient.newWebSocket(
-                    Request.Builder().url(urlString).build(),
+                    Request.Builder().url(urlString).header(USER_AGENT, USER_AGENT_STRING).build(),
                     this
                 ).also {
                     // Preemptively send auth


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix user-agent in websocket requests (such as device controls tile in quick settings), use custom values insteadof `okhttp/4.10.0`  
pretty much the same reason as in #1364 and #1418

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Sorry, I dont have development env, I hope github actions build will work