### PR TITLE
Revert "Bump actions/setup-java from 3.6.0 to 3.7.0"

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -76,7 +76,7 @@ jobs:
         fi
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v3.7.0
+      uses: actions/setup-java@v3.6.0
       with:
         distribution: 'adopt'
         java-version: '11'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'
@@ -146,7 +146,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'

--- a/.github/workflows/weekly.yaml
+++ b/.github/workflows/weekly.yaml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: 'adopt'
           java-version: '11'


### PR DESCRIPTION
Reverts home-assistant/android#3129

This is fun...
https://github.com/actions/setup-java/issues/422