### PR TITLE
Update instead of cancel notification on replies

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -43,6 +43,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat
 import androidx.core.text.isDigitsOnly
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.utils.toAndroidIconCompat
 import com.vdurmont.emoji.EmojiParser
@@ -286,27 +288,44 @@ class MessagingManager @Inject constructor(
         const val VIDEO_START_MICROSECONDS = 100000L
         const val VIDEO_INCREMENT_MICROSECONDS = 750000L
         const val VIDEO_GUESS_MILLISECONDS = 7000L
+
+        // Values for a notification that has been replied to
+        const val SOURCE_REPLY = "REPLY_"
+        const val SOURCE_REPLY_TEXT = "reply_text"
     }
 
     private val mainScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
 
     private var textToSpeech: TextToSpeech? = null
 
-    fun handleMessage(jsonData: Map<String, String>, source: String) {
+    fun handleMessage(notificationData: Map<String, String>, source: String) {
 
-        val jsonObject = JSONObject(jsonData)
-        val now = System.currentTimeMillis()
-        val notificationRow =
-            NotificationItem(0, now, jsonData[MESSAGE].toString(), jsonObject.toString(), source)
-        notificationDao.add(notificationRow)
+        var now = System.currentTimeMillis()
+        var jsonData = notificationData
+        val notificationId: Long
 
-        val confirmation = jsonData[CONFIRMATION]?.toBoolean() ?: false
-        if (confirmation) {
-            mainScope.launch {
-                try {
-                    integrationUseCase.fireEvent("mobile_app_notification_received", jsonData)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Unable to send notification received event", e)
+        if (source.startsWith(SOURCE_REPLY)) {
+            notificationId = source.substringAfter(SOURCE_REPLY).toLong()
+            notificationDao.get(notificationId.toInt())?.let {
+                val dbData: Map<String, String> = jacksonObjectMapper().readValue(it.data)
+
+                now = it.received // Allow for updating the existing notification without a tag
+                jsonData = jsonData + dbData // Add the notificationData, this contains the reply text
+            } ?: return
+        } else {
+            val jsonObject = JSONObject(jsonData)
+            val notificationRow =
+                NotificationItem(0, now, jsonData[MESSAGE].toString(), jsonObject.toString(), source)
+            notificationId = notificationDao.add(notificationRow)
+
+            val confirmation = jsonData[CONFIRMATION]?.toBoolean() ?: false
+            if (confirmation) {
+                mainScope.launch {
+                    try {
+                        integrationUseCase.fireEvent("mobile_app_notification_received", jsonData)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Unable to send notification received event", e)
+                    }
                 }
             }
         }
@@ -598,7 +617,7 @@ class MessagingManager @Inject constructor(
             }
             else -> mainScope.launch {
                 Log.d(TAG, "Creating notification with following data: $jsonData")
-                sendNotification(jsonData)
+                sendNotification(jsonData, notificationId, now)
             }
         }
     }
@@ -1033,11 +1052,11 @@ class MessagingManager @Inject constructor(
      * Create and show a simple notification containing the received FCM message.
      *
      */
-    private suspend fun sendNotification(data: Map<String, String>) {
+    private suspend fun sendNotification(data: Map<String, String>, id: Long? = null, received: Long? = null) {
         val notificationManagerCompat = NotificationManagerCompat.from(context)
 
         val tag = data["tag"]
-        val messageId = tag?.hashCode() ?: System.currentTimeMillis().toInt()
+        val messageId = tag?.hashCode() ?: received?.toInt() ?: System.currentTimeMillis().toInt()
 
         var group = data["group"]
         var groupId = 0
@@ -1087,7 +1106,9 @@ class MessagingManager @Inject constructor(
 
         handleVisibility(notificationBuilder, data)
 
-        handleActions(notificationBuilder, tag, messageId, data)
+        handleActions(notificationBuilder, tag, messageId, id, data)
+
+        handleReplyInput(notificationBuilder, data)
 
         handleDeleteIntent(notificationBuilder, data, messageId, group, groupId)
 
@@ -1599,6 +1620,7 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         tag: String?,
         messageId: Int,
+        databaseId: Long?,
         data: Map<String, String>
     ) {
         for (i in 1..3) {
@@ -1618,6 +1640,10 @@ class MessagingManager @Inject constructor(
                     putExtra(
                         NotificationActionReceiver.EXTRA_NOTIFICATION_ACTION,
                         notificationAction
+                    )
+                    putExtra(
+                        NotificationActionReceiver.EXTRA_NOTIFICATION_DB,
+                        databaseId
                     )
                 }
 
@@ -1733,6 +1759,18 @@ class MessagingManager @Inject constructor(
                 intent,
             PendingIntent.FLAG_IMMUTABLE
         )
+    }
+
+    private fun handleReplyInput(
+        builder: NotificationCompat.Builder,
+        data: Map<String, String>
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            if (data.containsKey(SOURCE_REPLY_TEXT)) {
+                builder.setRemoteInputHistory(arrayOf(data[SOURCE_REPLY_TEXT]))
+                builder.setOnlyAlertOnce(true) // Overwrites user settings to match system defaults
+            }
+        }
     }
 
     private fun handleChannel(

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
@@ -63,9 +63,12 @@ class NotificationActionReceiver : BroadcastReceiver() {
                     .sortedBy { it.key.substringAfter(MessagingManager.SOURCE_REPLY_HISTORY).toInt() }
                     .map { it.value } + replyText
                 messagingManager.handleMessage(
-                    replies.mapIndexed { index, text ->
-                        "${MessagingManager.SOURCE_REPLY_HISTORY}$index" to text!!
-                    }.toMap(),
+                    replies
+                        .takeLast(3)
+                        .mapIndexed { index, text ->
+                            "${MessagingManager.SOURCE_REPLY_HISTORY}$index" to text!!
+                        }
+                        .toMap(),
                     "${MessagingManager.SOURCE_REPLY}$databaseId"
                 )
             } else {

--- a/common/src/main/java/io/homeassistant/companion/android/database/notification/NotificationDao.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/notification/NotificationDao.kt
@@ -9,7 +9,10 @@ import androidx.room.Query
 interface NotificationDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun add(notification: NotificationItem)
+    fun add(notification: NotificationItem): Long
+
+    @Query("SELECT * FROM notification_history WHERE id = :id")
+    fun get(id: Int): NotificationItem?
 
     @Query("SELECT * FROM notification_history ORDER BY received DESC")
     fun getAll(): Array<NotificationItem>?


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3150 by updating notifications with their replies [as documented](https://developer.android.com/develop/ui/views/notifications/build-notification#:~:text=After%20you%E2%80%99ve%20processed%20the%20text%2C%20you%20must%20update%20the%20notification%20by%20calling%20NotificationManagerCompat.notify()%20with%20the%20same%20ID%20and%20tag%20(if%20used).) instead of cancelling them (which the system mostly ignored), allowing users to continue manipulating notifications after a reply. 

To make this possible I've added a new "source" for notifications which reads an existing notification from the database and adds the provided data to it - these 'updated' notifications are not stored in the database.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->