### PR TITLE
Migrate bluetooth sensors to common and add to wear OS

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -51,6 +51,7 @@ import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.url.UrlRepository
+import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.common.util.cancel
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
 import io.homeassistant.companion.android.common.util.generalChannel
@@ -60,7 +61,6 @@ import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
-import io.homeassistant.companion.android.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.sensors.NotificationSensorManager
 import io.homeassistant.companion.android.sensors.SensorReceiver

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.sensors.AudioSensorManager
 import io.homeassistant.companion.android.common.sensors.BatterySensorManager
+import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.common.sensors.DNDSensorManager
 import io.homeassistant.companion.android.common.sensors.DisplaySensorManager
 import io.homeassistant.companion.android.common.sensors.KeyguardSensorManager

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
@@ -1,8 +1,9 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 import android.content.Context
-import io.homeassistant.companion.android.sensors.BluetoothSensorManager
-import io.homeassistant.companion.android.sensors.SensorReceiver
+import android.content.Intent
+import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
+import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 import org.altbeacon.beacon.Beacon
 import kotlin.math.abs
 import kotlin.math.round
@@ -80,6 +81,8 @@ class IBeaconMonitor {
     private fun sendUpdate(context: Context, tmp: List<IBeacon>) {
         beacons = tmp
         sensorManager.updateBeaconMonitoringSensor(context)
-        SensorReceiver.updateAllSensors(context)
+        val intent = Intent(context, SensorReceiverBase::class.java)
+        intent.action = SensorReceiverBase.ACTION_UPDATE_SENSORS
+        context.sendBroadcast(intent)
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconNameFormat.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconNameFormat.kt
@@ -1,4 +1,4 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 interface IBeaconNameFormat {
     val uuid: String

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconTransmitter.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconTransmitter.kt
@@ -1,4 +1,4 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 data class IBeaconTransmitter(
     override var uuid: String,

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/KalmanFilter.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/KalmanFilter.kt
@@ -1,4 +1,4 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 import org.altbeacon.beacon.service.RssiFilter
 import kotlin.math.pow

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
@@ -1,4 +1,4 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/TransmitterManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/TransmitterManager.kt
@@ -1,11 +1,11 @@
-package io.homeassistant.companion.android.bluetooth.ble
+package io.homeassistant.companion.android.common.bluetooth.ble
 
 import android.bluetooth.BluetoothManager
 import android.bluetooth.le.AdvertiseCallback
 import android.bluetooth.le.AdvertiseSettings
 import android.content.Context
 import androidx.core.content.getSystemService
-import io.homeassistant.companion.android.sensors.BluetoothSensorManager
+import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import org.altbeacon.beacon.Beacon
 import org.altbeacon.beacon.BeaconParser
 import org.altbeacon.beacon.BeaconTransmitter

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -1,19 +1,18 @@
-package io.homeassistant.companion.android.sensors
+package io.homeassistant.companion.android.common.sensors
 
 import android.Manifest
 import android.content.Context
 import android.os.Build
-import io.homeassistant.companion.android.bluetooth.ble.IBeacon
-import io.homeassistant.companion.android.bluetooth.ble.IBeaconMonitor
-import io.homeassistant.companion.android.bluetooth.ble.IBeaconTransmitter
-import io.homeassistant.companion.android.bluetooth.ble.KalmanFilter
-import io.homeassistant.companion.android.bluetooth.ble.MonitoringManager
-import io.homeassistant.companion.android.bluetooth.ble.TransmitterManager
-import io.homeassistant.companion.android.bluetooth.ble.name
 import io.homeassistant.companion.android.common.bluetooth.BluetoothDevice
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils
 import io.homeassistant.companion.android.common.bluetooth.BluetoothUtils.supportsTransmitter
-import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.bluetooth.ble.IBeacon
+import io.homeassistant.companion.android.common.bluetooth.ble.IBeaconMonitor
+import io.homeassistant.companion.android.common.bluetooth.ble.IBeaconTransmitter
+import io.homeassistant.companion.android.common.bluetooth.ble.KalmanFilter
+import io.homeassistant.companion.android.common.bluetooth.ble.MonitoringManager
+import io.homeassistant.companion.android.common.bluetooth.ble.TransmitterManager
+import io.homeassistant.companion.android.common.bluetooth.ble.name
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.sensors.AudioSensorManager
 import io.homeassistant.companion.android.common.sensors.BatterySensorManager
+import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.common.sensors.DNDSensorManager
 import io.homeassistant.companion.android.common.sensors.DisplaySensorManager
 import io.homeassistant.companion.android.common.sensors.KeyguardSensorManager
@@ -56,6 +57,7 @@ class SensorReceiver : SensorReceiverBase() {
             AudioSensorManager(),
             BatterySensorManager(),
             BedtimeModeSensorManager(),
+            BluetoothSensorManager(),
             DisplaySensorManager(),
             DNDSensorManager(),
             HeartRateSensorManager(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Migrates over the bluetooth sensors so they can be used in Wear OS.

I know that previously I had mentioned we need to have settings and notifications for these sensors to work properly, I came to notice that a lot of users in the request (#2183) just wanted something to work and use it right away. Given the interest I wanted to see if we can get some testers to do some battery life testing.

Its important to note that I have not tested this on my own watch yet (I plan to do so this weekend or next week but maybe sooner), testing was done on the phone but the code should still work on Wear OS so would be good to get some early feedback on this. This will also tell us how badly we would need settings and commands for these sensors or even if a dedicated tile to control the transmitter/monitor will suffice.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->