### PR TITLE
Minor Android Auto improvements

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -15,6 +15,7 @@ import androidx.car.app.model.Template
 import androidx.lifecycle.lifecycleScope
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.sizeDp
 import com.mikepenz.iconics.utils.toAndroidIconCompat
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -57,7 +58,11 @@ class EntityGridVehicleScreen(
                     .setTitle(entity.friendlyName)
                     .setText(entity.friendlyState)
                     .setImage(
-                        CarIcon.Builder(IconicsDrawable(carContext, icon).toAndroidIconCompat())
+                        CarIcon.Builder(
+                            IconicsDrawable(carContext, icon).apply {
+                                sizeDp = 64
+                            }.toAndroidIconCompat()
+                        )
                             .setTint(CarColor.DEFAULT)
                             .build()
                     )

--- a/app/src/full/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -11,12 +11,12 @@ import androidx.car.app.model.ListTemplate
 import androidx.car.app.model.Row
 import androidx.car.app.model.Template
 import androidx.lifecycle.lifecycleScope
-import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import kotlinx.coroutines.launch
 import java.util.Locale
+import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.O)
 class MainVehicleScreen(
@@ -27,16 +27,18 @@ class MainVehicleScreen(
     companion object {
         private const val TAG = "MainVehicleScreen"
 
-        private val SUPPORTED_DOMAINS = listOf(
-            "button",
-            "cover",
-            "input_boolean",
-            "light",
-            "lock",
-            "scene",
-            "script",
-            "switch",
+        private val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
+            "button" to commonR.string.buttons,
+            "cover" to commonR.string.covers,
+            "input_boolean" to commonR.string.input_booleans,
+            "input_button" to commonR.string.input_buttons,
+            "light" to commonR.string.lights,
+            "lock" to commonR.string.locks,
+            "scene" to commonR.string.scenes,
+            "script" to commonR.string.scripts,
+            "switch" to commonR.string.switches,
         )
+        private val SUPPORTED_DOMAINS = SUPPORTED_DOMAINS_WITH_STRING.keys
     }
 
     private val domains = mutableSetOf<String>()
@@ -45,7 +47,7 @@ class MainVehicleScreen(
     init {
         lifecycleScope.launch {
             integrationRepository.getEntities()?.forEach { entity ->
-                val domain = entity.entityId.split(".")[0]
+                val domain = entity.domain
                 if (domain in SUPPORTED_DOMAINS) {
                     entities[entity.entityId] = entity
                     domains.add(domain)
@@ -58,11 +60,13 @@ class MainVehicleScreen(
     override fun onGetTemplate(): Template {
         val listBuilder = ItemList.Builder()
         domains.forEach { domain ->
-            val friendlyDomain = domain.split("_").joinToString(" ") { word ->
-                word.replaceFirstChar {
-                    if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-                }
-            }
+            val friendlyDomain =
+                SUPPORTED_DOMAINS_WITH_STRING[domain]?.let { carContext.getString(it) }
+                    ?: domain.split("_").joinToString(" ") { word ->
+                        word.replaceFirstChar {
+                            if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
+                        }
+                    }
             listBuilder.addItem(
                 Row.Builder()
                     .setTitle(friendlyDomain)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -414,9 +414,10 @@ suspend fun <T> Entity<T>.onPressed(
         "cover" -> {
             if (state == "open") "close_cover" else "open_cover"
         }
+        "button",
+        "input_button",
         "scene",
-        "script",
-        "button" -> "press"
+        "script" -> "press"
         "fan",
         "input_boolean",
         "switch" -> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Fix low res entity icons
 - Fix domains not being translated
 - Add support for `input_button`, as `button` was already supported
 - Use domain extension property

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The increased icon resolution is clearly visible:

|Before|After|
|-----|-----|
|![An input button entity with a fuzzy, low resolution icon in the Android Auto emulator](https://user-images.githubusercontent.com/8148535/212158520-00520128-aafb-48a9-814a-3490fe9bb052.png)|![An input button entity with an icon that is as sharp as other icons/text on the Android Auto emulator](https://user-images.githubusercontent.com/8148535/212158393-df66bc4d-1b29-42b4-9eff-b1fcc6a53134.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a (but shouldn't Android Auto support in general be documented?)

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->