### PR TITLE
Fix beacon monitor not updating after move to common

### DIFF
--- a/common/src/main/AndroidManifest.xml
+++ b/common/src/main/AndroidManifest.xml
@@ -3,4 +3,14 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+
+    <application>
+        <receiver android:name=".sensors.SensorUpdateReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="io.homeassistant.companion.android.UPDATE_SENSORS" />
+            </intent-filter>
+        </receiver>
+    </application>
+
 </manifest>

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
@@ -1,9 +1,8 @@
 package io.homeassistant.companion.android.common.bluetooth.ble
 
 import android.content.Context
-import android.content.Intent
 import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
-import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
+import io.homeassistant.companion.android.common.sensors.SensorUpdateReceiver
 import org.altbeacon.beacon.Beacon
 import kotlin.math.abs
 import kotlin.math.round
@@ -81,8 +80,6 @@ class IBeaconMonitor {
     private fun sendUpdate(context: Context, tmp: List<IBeacon>) {
         beacons = tmp
         sensorManager.updateBeaconMonitoringSensor(context)
-        val intent = Intent(context, SensorReceiverBase::class.java)
-        intent.action = SensorReceiverBase.ACTION_UPDATE_SENSORS
-        context.sendBroadcast(intent)
+        SensorUpdateReceiver.updateSensors(context)
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -123,6 +123,7 @@ class BluetoothSensorManager : SensorManager {
                 monitoringManager.stopMonitoring(context, beaconMonitoringDevice)
             }
             sensorDao.add(SensorSetting(beaconMonitor.id, SETTING_BEACON_MONITOR_ENABLED, monitorEnabled.toString(), SensorSettingType.TOGGLE))
+            SensorUpdateReceiver.updateSensors(context)
         }
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorUpdateReceiver.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorUpdateReceiver.kt
@@ -1,0 +1,40 @@
+package io.homeassistant.companion.android.common.sensors
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.BuildConfig
+
+@AndroidEntryPoint
+class SensorUpdateReceiver : SensorReceiverBase() {
+
+    companion object {
+        fun updateSensors(context: Context) {
+            val intent = Intent(context, SensorUpdateReceiver::class.java)
+            intent.action = ACTION_UPDATE_SENSORS
+            context.sendBroadcast(intent)
+        }
+    }
+
+    override val tag: String
+        get() = "SensorReceiver"
+
+    override val currentAppVersion: String
+        get() = BuildConfig.VERSION_NAME
+
+    override val managers: List<SensorManager>
+        get() = listOf(BluetoothSensorManager())
+
+    override val skippableActions: Map<String, String>
+        get() = emptyMap()
+
+    override fun getSensorSettingsIntent(
+        context: Context,
+        sensorId: String,
+        sensorManagerId: String,
+        notificationId: Int
+    ): PendingIntent? {
+        return null
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3215 which was introduced after #3168 created a new class in `common` so we can actually send updates as it was not being sent before as `SensorReceiverBase` is abstract and cannot be instantiated. I am not sure if I should include all sensor managers in common here or only bluetooth as it is the only method using this type of update.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->