### PR TITLE
Add and Android Auto sensor!

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -1,0 +1,89 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import androidx.car.app.connection.CarConnection
+import androidx.lifecycle.Observer
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import io.homeassistant.companion.android.common.R as commonR
+
+class AndroidAutoSensorManager : SensorManager, Observer<Int> {
+
+    companion object {
+
+        internal const val TAG = "AndroidAutoSM"
+
+        private val androidAutoConnected = SensorManager.BasicSensor(
+            "android_auto",
+            "binary_sensor",
+            commonR.string.basic_sensor_name_android_auto,
+            commonR.string.sensor_description_android_auto,
+            "mdi:car",
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+        )
+    }
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = commonR.string.sensor_name_android_auto
+
+    override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(androidAutoConnected)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    private lateinit var context: Context
+    private var carConnection: CarConnection? = null
+
+    override fun requestSensorUpdate(context: Context) {
+        this.context = context
+        if (!isEnabled(context, androidAutoConnected.id)) {
+            return
+        }
+        CoroutineScope(Dispatchers.Main + Job()).launch {
+            if (carConnection == null) {
+                carConnection = CarConnection(context)
+            }
+            carConnection?.type?.observeForever(this@AndroidAutoSensorManager)
+        }
+    }
+
+    override fun onChanged(type: Int?) {
+        if (!isEnabled(context, androidAutoConnected.id)) {
+            CoroutineScope(Dispatchers.Main + Job()).launch {
+                carConnection?.type?.removeObserver(this@AndroidAutoSensorManager)
+            }
+            return
+        }
+        val (connected, typeString) = when (type) {
+            CarConnection.CONNECTION_TYPE_NOT_CONNECTED -> {
+                false to "Disconnected"
+            }
+            CarConnection.CONNECTION_TYPE_PROJECTION -> {
+                true to "Projection"
+            }
+            CarConnection.CONNECTION_TYPE_NATIVE -> {
+                true to "Native"
+            }
+            else -> {
+                false to "Unknown($type)"
+            }
+        }
+        onSensorUpdated(
+            context,
+            androidAutoConnected,
+            connected,
+            androidAutoConnected.statelessIcon,
+            mapOf(
+                "connection_type" to typeString
+            ),
+        )
+    }
+}

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.os.Build
 import androidx.car.app.connection.CarConnection
 import androidx.lifecycle.Observer
 import io.homeassistant.companion.android.common.sensors.SensorManager
@@ -32,7 +33,10 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
         get() = commonR.string.sensor_name_android_auto
 
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(androidAutoConnected)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+            listOf(androidAutoConnected)
+        else
+            emptyList()
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -170,6 +170,11 @@ open class HomeAssistantApplication : Application() {
             )
         }
 
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter("androidx.car.app.connection.action.CAR_CONNECTION_UPDATED")
+        )
+
         // Add a receiver for the shutdown event to attempt to send 1 final sensor update
         registerReceiver(
             sensorReceiver,

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -51,6 +51,7 @@ class SensorReceiver : SensorReceiverBase() {
         const val TAG = "SensorReceiver"
         val MANAGERS = listOf(
             ActivitySensorManager(),
+            AndroidAutoSensorManager(),
             AppSensorManager(),
             AudioSensorManager(),
             BatterySensorManager(),

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -1,3 +1,5 @@
+package io.homeassistant.companion.android.sensors
+
 import android.content.Context
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.R as commonR

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="basic_sensor_name_active_notification_count">Active Notification Count</string>
     <string name="basic_sensor_name_activity">Detected Activity</string>
     <string name="basic_sensor_name_alarm">Next Alarm</string>
+    <string name="basic_sensor_name_android_auto">Android Auto</string>
     <string name="basic_sensor_name_app_importance">App Importance</string>
     <string name="basic_sensor_name_app_inactive">App Inactive</string>
     <string name="basic_sensor_name_app_memory">App Memory</string>
@@ -477,6 +478,7 @@
     <string name="select_instance">Select your Home Assistant server</string>
     <string name="sensor_description_active_notification_count">Total count of active notifications that are visible to the user including silent, persistent and the Sensor Worker notifications.</string>
     <string name="sensor_description_app_importance">If the app is in the foreground, background or any other state it can be.</string>
+    <string name="sensor_description_android_auto">If the phone is currently connected to an Android Auto head unit.</string>
     <string name="sensor_description_app_inactive">Whether the app is currently considered inactive by the system</string>
     <string name="sensor_description_app_memory">Total used and available memory for the app</string>
     <string name="sensor_description_app_rx_gb">App Rx GB since last device reboot</string>
@@ -556,6 +558,7 @@
     <string name="sensor_description_work_profile">Whether the work profile is currently active on the device</string>
     <string name="sensor_name_activity">Activity Sensors</string>
     <string name="sensor_name_alarm">Alarm Sensor</string>
+    <string name="sensor_name_android_auto">Android Auto Sensors</string>
     <string name="sensor_name_app_sensor">App Sensors</string>
     <string name="sensor_name_audio_mode">Audio Mode</string>
     <string name="sensor_name_audio">Audio Sensors</string>

--- a/wear/src/main/java/AndroidAutoSensorManager.kt
+++ b/wear/src/main/java/AndroidAutoSensorManager.kt
@@ -1,0 +1,23 @@
+import android.content.Context
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.R as commonR
+
+class AndroidAutoSensorManager : SensorManager {
+
+    override val enabledByDefault: Boolean
+        get() = false
+    override val name: Int
+        get() = commonR.string.sensor_name_android_auto
+
+    override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf()
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray()
+    }
+
+    override fun requestSensorUpdate(context: Context) {
+        // Noop
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add a binary sensor indicating if the device is connected to Android Auto.
Fixes: https://github.com/home-assistant/android/issues/2367
Fixes: https://github.com/home-assistant/android/issues/1516

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Screenshot_20230114_170753](https://user-images.githubusercontent.com/1051414/212499197-41a55b33-05e6-4e75-a764-855924c988c2.png)



## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: https://github.com/home-assistant/companion.home-assistant/pull/885

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->