### PR TITLE
Skip showing connection prompt when loaded URL is local or api path

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -109,6 +109,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.withContext
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.chromium.net.CronetEngine
 import org.json.JSONObject
 import java.util.concurrent.Executors
@@ -1321,7 +1322,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private fun waitForConnection() {
         Handler(Looper.getMainLooper()).postDelayed(
             {
-                if (!isConnected) {
+                if (
+                    !isConnected &&
+                    !loadedUrl.toHttpUrl().pathSegments.contains("api") &&
+                    !loadedUrl.toHttpUrl().pathSegments.contains("local")
+                ) {
                     showError()
                 }
             },

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1324,8 +1324,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             {
                 if (
                     !isConnected &&
-                    !loadedUrl.toHttpUrl().pathSegments.contains("api") &&
-                    !loadedUrl.toHttpUrl().pathSegments.contains("local")
+                    !loadedUrl.toHttpUrl().pathSegments.first().contains("api") &&
+                    !loadedUrl.toHttpUrl().pathSegments.first().contains("local")
                 ) {
                     showError()
                 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2684 by skipping the connection prompt when the loaded URL is either `local` or `api` as these pages will not have external bus communication.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->