### PR TITLE
Conversation tile design changes

### DIFF
--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -32,4 +32,5 @@
     <color name="colorDeviceControlsDefaultOn">#8AB4F8</color>
     <color name="colorDeviceControlsThermostatHeat">#FF8B66</color>
     <color name="colorDeviceControlsCamera">#F1F3F4</color>
+    <color name="colorSpeechText">#B3E5FC</color>
 </resources>

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
@@ -62,9 +62,8 @@ class ConversationActivity : ComponentActivity() {
     override fun onPause() {
         super.onPause()
         val pm = applicationContext.getSystemService<PowerManager>()
-        if (pm != null) {
-            if (!pm.isInteractive)
-                finish()
+        if (pm?.isInteractive == false && conversationViewModel.conversationResult.isNotEmpty()) {
+            finish()
         }
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
@@ -3,11 +3,13 @@ package io.homeassistant.companion.android.conversation
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.os.PowerManager
 import android.speech.RecognizerIntent
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
+import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.conversation.views.ConversationResultView
@@ -54,6 +56,15 @@ class ConversationActivity : ComponentActivity() {
 
         setContent {
             ConversationResultView(conversationViewModel)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        val pm = applicationContext.getSystemService<PowerManager>()
+        if (pm != null) {
+            if (!pm.isInteractive)
+                finish()
         }
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -28,6 +28,9 @@ class ConversationViewModel @Inject constructor(
     var supportsConversation by mutableStateOf(false)
         private set
 
+    var isHapticEnabled = mutableStateOf(false)
+        private set
+
     fun getConversation() {
         viewModelScope.launch {
             conversationResult = integrationUseCase.getConversation(speechResult) ?: ""
@@ -38,6 +41,7 @@ class ConversationViewModel @Inject constructor(
         supportsConversation =
             integrationUseCase.isHomeAssistantVersionAtLeast(2023, 1, 0) &&
             webSocketRepository.getConfig()?.components?.contains("conversation") == true
+        isHapticEnabled.value = integrationUseCase.getWearHapticFeedback()
     }
 
     fun updateSpeechResult(result: String) {

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -89,10 +89,13 @@ fun ConversationResultView(
 fun SpeechBubble(text: String, isResponse: Boolean) {
     Row(
         horizontalArrangement = if (isResponse) Arrangement.Start else Arrangement.End,
-        modifier = Modifier.fillMaxWidth()
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                start = if (isResponse) 0.dp else 24.dp,
+                end = if (isResponse) 24.dp else 0.dp
+            )
     ) {
-        if (!isResponse)
-            Spacer(Modifier.padding(start = 24.dp))
         Box(
             modifier = Modifier
                 .background(

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -51,35 +51,35 @@ fun ConversationResultView(
                 item {
                     Column {
                         Spacer(Modifier.padding(24.dp))
-                        SpeechBubble(
-                            text = conversationViewModel.speechResult.ifEmpty {
-                                if (conversationViewModel.supportsConversation)
-                                    stringResource(R.string.no_results)
-                                else
-                                    stringResource(R.string.no_conversation_support)
-                            },
-                            false
-                        )
+                        Row {
+                            Spacer(Modifier.padding(start = 40.dp))
+                            SpeechBubble(
+                                text = conversationViewModel.speechResult.ifEmpty {
+                                    if (conversationViewModel.supportsConversation)
+                                        stringResource(R.string.no_results)
+                                    else
+                                        stringResource(R.string.no_conversation_support)
+                                },
+                                false
+                            )
+                        }
                         Spacer(Modifier.padding(8.dp))
                     }
                 }
                 if (conversationViewModel.conversationResult.isNotEmpty())
                     item {
-                        Row {
-                            if (conversationViewModel.isHapticEnabled.value) {
-                                val haptic = LocalHapticFeedback.current
-                                LaunchedEffect(key1 = "haptic") {
-                                    haptic.performHapticFeedback(
-                                        HapticFeedbackType.LongPress
-                                    )
-                                }
+                        if (conversationViewModel.isHapticEnabled.value) {
+                            val haptic = LocalHapticFeedback.current
+                            LaunchedEffect(key1 = "haptic") {
+                                haptic.performHapticFeedback(
+                                    HapticFeedbackType.LongPress
+                                )
                             }
-                            Spacer(Modifier.padding(start = 40.dp))
-                            SpeechBubble(
-                                text = conversationViewModel.conversationResult,
-                                true
-                            )
                         }
+                        SpeechBubble(
+                            text = conversationViewModel.conversationResult,
+                            true
+                        )
                     }
             }
         }
@@ -98,8 +98,8 @@ fun SpeechBubble(text: String, isResponse: Boolean) {
                 AbsoluteRoundedCornerShape(
                     topLeftPercent = 40,
                     topRightPercent = 40,
-                    bottomLeftPercent = if (isResponse) 40 else 0,
-                    bottomRightPercent = if (isResponse) 0 else 40
+                    bottomLeftPercent = if (isResponse) 0 else 40,
+                    bottomRightPercent = if (isResponse) 40 else 0
                 )
             )
             .padding(4.dp)

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -1,10 +1,12 @@
 package io.homeassistant.companion.android.conversation.views
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -51,18 +53,15 @@ fun ConversationResultView(
                 item {
                     Column {
                         Spacer(Modifier.padding(24.dp))
-                        Row {
-                            Spacer(Modifier.padding(start = 40.dp))
-                            SpeechBubble(
-                                text = conversationViewModel.speechResult.ifEmpty {
-                                    if (conversationViewModel.supportsConversation)
-                                        stringResource(R.string.no_results)
-                                    else
-                                        stringResource(R.string.no_conversation_support)
-                                },
-                                false
-                            )
-                        }
+                        SpeechBubble(
+                            text = conversationViewModel.speechResult.ifEmpty {
+                                if (conversationViewModel.supportsConversation)
+                                    stringResource(R.string.no_results)
+                                else
+                                    stringResource(R.string.no_conversation_support)
+                            },
+                            false
+                        )
                         Spacer(Modifier.padding(8.dp))
                     }
                 }
@@ -88,31 +87,38 @@ fun ConversationResultView(
 
 @Composable
 fun SpeechBubble(text: String, isResponse: Boolean) {
-    Box(
-        modifier = Modifier
-            .background(
-                if (isResponse)
-                    colorResource(R.color.colorAccent)
-                else
-                    colorResource(R.color.colorSpeechText),
-                AbsoluteRoundedCornerShape(
-                    topLeftPercent = 40,
-                    topRightPercent = 40,
-                    bottomLeftPercent = if (isResponse) 0 else 40,
-                    bottomRightPercent = if (isResponse) 40 else 0
-                )
-            )
-            .padding(4.dp)
+    Row(
+        horizontalArrangement = if (isResponse) Arrangement.Start else Arrangement.End,
+        modifier = Modifier.fillMaxWidth()
     ) {
-        Text(
-            text = text,
-            color = if (isResponse)
-                Color.White
-            else
-                Color.Black,
+        if (!isResponse)
+            Spacer(Modifier.padding(start = 24.dp))
+        Box(
             modifier = Modifier
+                .background(
+                    if (isResponse)
+                        colorResource(R.color.colorAccent)
+                    else
+                        colorResource(R.color.colorSpeechText),
+                    AbsoluteRoundedCornerShape(
+                        topLeftPercent = 40,
+                        topRightPercent = 40,
+                        bottomLeftPercent = if (isResponse) 0 else 40,
+                        bottomRightPercent = if (isResponse) 40 else 0
+                    )
+                )
                 .padding(4.dp)
-        )
+        ) {
+            Text(
+                text = text,
+                color = if (isResponse)
+                    Color.White
+                else
+                    Color.Black,
+                modifier = Modifier
+                    .padding(4.dp)
+            )
+        }
     }
 }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -1,9 +1,16 @@
 package io.homeassistant.companion.android.conversation.views
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
@@ -34,24 +41,59 @@ fun ConversationResultView(
                 state = scrollState
             ) {
                 item {
-                    Text(
+                    Spacer(modifier = Modifier.padding(40.dp))
+                    SpeechBubble(
                         text = conversationViewModel.speechResult.ifEmpty {
                             if (conversationViewModel.supportsConversation)
                                 stringResource(R.string.no_results)
                             else
                                 stringResource(R.string.no_conversation_support)
                         },
-                        modifier = Modifier.padding(40.dp)
+                        false
                     )
                 }
                 if (conversationViewModel.conversationResult.isNotEmpty())
                     item {
-                        Text(
+                        SpeechBubble(
                             text = conversationViewModel.conversationResult,
-                            modifier = Modifier.padding(top = 8.dp, start = 32.dp)
+                            true
                         )
                     }
             }
         }
     }
+}
+
+@Composable
+fun SpeechBubble(text: String, isResponse: Boolean) {
+    Box(
+        modifier = Modifier
+            .background(
+                if (isResponse)
+                    colorResource(R.color.colorAccent)
+                else
+                    Color.White,
+                AbsoluteRoundedCornerShape(
+                    topLeftPercent = 40,
+                    topRightPercent = 40,
+                    bottomLeftPercent = if (isResponse) 40 else 0,
+                    bottomRightPercent = if (isResponse) 0 else 40
+                )
+            )
+            .padding(4.dp)
+    ) {
+        Text(
+            text = text,
+            color = if (isResponse)
+                Color.White
+            else
+                Color.Black
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewSpeechBubble() {
+    SpeechBubble(text = "Testing", isResponse = true)
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -2,25 +2,31 @@ package io.homeassistant.companion.android.conversation.views
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
+import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberScalingLazyListState
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.conversation.ConversationViewModel
 import io.homeassistant.companion.android.home.views.TimeText
 import io.homeassistant.companion.android.theme.WearAppTheme
-import io.homeassistant.companion.android.views.ThemeLazyColumn
 
 @Composable
 fun ConversationResultView(
@@ -37,27 +43,36 @@ fun ConversationResultView(
             },
             timeText = { TimeText(visible = !scrollState.isScrollInProgress) }
         ) {
-            ThemeLazyColumn(
-                state = scrollState
+            ScalingLazyColumn(
+                state = scrollState,
+                horizontalAlignment = Alignment.Start
             ) {
                 item {
-                    Spacer(modifier = Modifier.padding(40.dp))
-                    SpeechBubble(
-                        text = conversationViewModel.speechResult.ifEmpty {
-                            if (conversationViewModel.supportsConversation)
-                                stringResource(R.string.no_results)
-                            else
-                                stringResource(R.string.no_conversation_support)
-                        },
-                        false
-                    )
+                    Column {
+                        Spacer(Modifier.padding(24.dp))
+                        SpeechBubble(
+                            text = conversationViewModel.speechResult.ifEmpty {
+                                if (conversationViewModel.supportsConversation)
+                                    stringResource(R.string.no_results)
+                                else
+                                    stringResource(R.string.no_conversation_support)
+                            },
+                            false
+                        )
+                        Spacer(Modifier.padding(8.dp))
+                    }
                 }
                 if (conversationViewModel.conversationResult.isNotEmpty())
                     item {
-                        SpeechBubble(
-                            text = conversationViewModel.conversationResult,
-                            true
-                        )
+                        Row {
+                            if (conversationViewModel.isHapticEnabled.value)
+                                LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)
+                            Spacer(Modifier.padding(start = 40.dp))
+                            SpeechBubble(
+                                text = conversationViewModel.conversationResult,
+                                true
+                            )
+                        }
                     }
             }
         }
@@ -72,7 +87,7 @@ fun SpeechBubble(text: String, isResponse: Boolean) {
                 if (isResponse)
                     colorResource(R.color.colorAccent)
                 else
-                    Color.White,
+                    colorResource(R.color.colorSpeechText),
                 AbsoluteRoundedCornerShape(
                     topLeftPercent = 40,
                     topRightPercent = 40,
@@ -87,13 +102,22 @@ fun SpeechBubble(text: String, isResponse: Boolean) {
             color = if (isResponse)
                 Color.White
             else
-                Color.Black
+                Color.Black,
+            modifier = Modifier
+                .padding(4.dp)
         )
     }
 }
 
-@Preview
+@Preview(device = Devices.WEAR_OS_SMALL_ROUND)
 @Composable
 fun PreviewSpeechBubble() {
-    SpeechBubble(text = "Testing", isResponse = true)
+    ScalingLazyColumn(horizontalAlignment = Alignment.Start) {
+        item {
+            SpeechBubble(text = "Speech", isResponse = false)
+        }
+        item {
+            SpeechBubble(text = "Response", isResponse = true)
+        }
+    }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.AbsoluteRoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -65,8 +66,14 @@ fun ConversationResultView(
                 if (conversationViewModel.conversationResult.isNotEmpty())
                     item {
                         Row {
-                            if (conversationViewModel.isHapticEnabled.value)
-                                LocalHapticFeedback.current.performHapticFeedback(HapticFeedbackType.LongPress)
+                            if (conversationViewModel.isHapticEnabled.value) {
+                                val haptic = LocalHapticFeedback.current
+                                LaunchedEffect(key1 = "haptic") {
+                                    haptic.performHapticFeedback(
+                                        HapticFeedbackType.LongPress
+                                    )
+                                }
+                            }
                             Spacer(Modifier.padding(start = 40.dp))
                             SpeechBubble(
                                 text = conversationViewModel.conversationResult,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

A few more improvements to the conversation tile.

*  Added speech bubbles to align the text more like a conversation
*  If haptic feedback is enabled we will vibrate upon displaying the response
*  Close the activity when the screen turns off and we have received a response
*  Adds a preview of the speech bubbles

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/213275926-80477b6f-de65-4ffa-90c6-ce6d017711b2.png)

![image](https://user-images.githubusercontent.com/1634145/213275938-c0693eca-285a-4cad-9050-5a4febde32ab.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->