### PR TITLE
Clear beacons when the monitor stops

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
@@ -63,6 +63,8 @@ class MonitoringManager {
     }
 
     fun stopMonitoring(context: Context, haMonitor: IBeaconMonitor) {
+        haMonitor.beacons = emptyList()
+        haMonitor.lastSeenBeacons = emptyList()
         if (isMonitoring()) {
             beaconManager.stopRangingBeacons(region)
             haMonitor.sensorManager.updateBeaconMonitoringSensor(context)

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
@@ -48,12 +48,15 @@ class MonitoringManager {
             beaconManager.backgroundBetweenScanPeriod = scanInterval
 
             region = buildRegion()
+            var observerCount = 0
             scope.launch(Dispatchers.Main) {
                 beaconManager.getRegionViewModel(region).rangedBeacons.observeForever { beacons ->
-                    haMonitor.setBeacons(
-                        context,
-                        beacons
-                    )
+                    if (observerCount > 0)
+                        haMonitor.setBeacons(
+                            context,
+                            beacons
+                        )
+                    observerCount++
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3010 by clearing the stored list of `beacons` and `lastSeenBeacons` every time the monitor stops. Also skipping the first observer values as they are cached from live data.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
