### PR TITLE
Wi-Fi sensor improvements

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -182,20 +182,27 @@ class NetworkSensorManager : SensorManager {
 
         var conInfo: WifiInfo? = null
         var ssid = "Unknown"
+        var connected = false
 
         if (checkPermission(context, wifiConnection.id)) {
             val wifiManager =
                 context.applicationContext.getSystemService<WifiManager>()!!
             conInfo = wifiManager.connectionInfo
 
-            ssid = if (conInfo.networkId == -1) {
-                "<not connected>"
+            if (conInfo.networkId == -1) {
+                if (conInfo.linkSpeed == -1) {
+                    ssid = "<not connected>"
+                } else {
+                    ssid = "<unknown>"
+                    connected = true
+                }
             } else {
-                conInfo.ssid.removePrefix("\"").removeSuffix("\"")
+                ssid = conInfo.ssid.removePrefix("\"").removeSuffix("\"")
+                connected = true
             }
         }
 
-        val icon = if (ssid != "<not connected>") "mdi:wifi" else "mdi:wifi-off"
+        val icon = if (connected) "mdi:wifi" else "mdi:wifi-off"
 
         val attributes = conInfo?.let {
             mapOf("is_hidden" to conInfo.hiddenSSID)
@@ -264,7 +271,7 @@ class NetworkSensorManager : SensorManager {
                 context.applicationContext.getSystemService<WifiManager>()!!
             val conInfo = wifiManager.connectionInfo
 
-            deviceIp = if (conInfo.networkId == -1) {
+            deviceIp = if (conInfo.networkId == -1 && conInfo.linkSpeed == -1) {
                 "<not connected>"
             } else {
                 getIpAddress(conInfo.ipAddress)
@@ -285,27 +292,27 @@ class NetworkSensorManager : SensorManager {
             return
 
         var linkSpeed = 0
-        var lastScanStrength = -1
+        var rssi = -1
 
         if (checkPermission(context, wifiLinkSpeed.id)) {
             val wifiManager =
                 context.applicationContext.getSystemService<WifiManager>()!!
             val conInfo = wifiManager.connectionInfo
 
-            linkSpeed = if (conInfo.networkId == -1) {
+            linkSpeed = if (conInfo.linkSpeed == -1) {
                 0
             } else {
                 conInfo.linkSpeed
             }
 
-            lastScanStrength = wifiManager.scanResults.firstOrNull {
-                it.BSSID == conInfo.bssid
-            }?.level ?: -1
+            if (conInfo.networkId != -1 || conInfo.linkSpeed != -1) {
+                rssi = conInfo.rssi
+            }
         }
 
         var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
+        if (rssi != -1) {
+            signalStrength = WifiManager.calculateSignalLevel(rssi, 4)
         }
 
         val icon = "mdi:wifi-strength-" + when (signalStrength) {
@@ -357,7 +364,7 @@ class NetworkSensorManager : SensorManager {
                 context.applicationContext.getSystemService<WifiManager>()!!
             val conInfo = wifiManager.connectionInfo
 
-            frequency = if (conInfo.networkId == -1) {
+            frequency = if (conInfo.networkId == -1 && conInfo.linkSpeed == -1) {
                 0
             } else {
                 conInfo.frequency
@@ -377,21 +384,21 @@ class NetworkSensorManager : SensorManager {
         if (!isEnabled(context, wifiSignalStrength.id))
             return
 
-        var lastScanStrength = -1
+        var rssi = -1
 
         if (checkPermission(context, wifiSignalStrength.id)) {
             val wifiManager =
                 context.applicationContext.getSystemService<WifiManager>()!!
             val conInfo = wifiManager.connectionInfo
 
-            lastScanStrength = wifiManager.scanResults.firstOrNull {
-                it.BSSID == conInfo.bssid
-            }?.level ?: -1
+            if (conInfo.networkId != -1 || conInfo.linkSpeed != -1) {
+                rssi = conInfo.rssi
+            }
         }
 
         var signalStrength = -1
-        if (lastScanStrength != -1) {
-            signalStrength = WifiManager.calculateSignalLevel(lastScanStrength, 4)
+        if (rssi != -1) {
+            signalStrength = WifiManager.calculateSignalLevel(rssi, 4)
         }
 
         val icon = "mdi:wifi-strength-" + when (signalStrength) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
This request addresses 2 issues at once, because they are interconnected:

1) Using wifiManager.scanResults to get signal strength is very unreliable. I often see "-1" on some devices even if Wi-Fi is connected. Use conInfo.rssi for a reliable result.

Also, wifiManager.scanResults is not available if Location is disabled on a device, but conInfo.rssi is available in such case.

2) There is an issue on devices running Android 10+ (tested on various Android 10 and Android 11 devices). If Wi-Fi is connected, but Location is disabled on a device,  getNetworkId() returns -1 and Home Assistant app thinks that we are not connected. But some information - IP address, link speed, frequency, signal strength (via getRssi()) is actually still available. If NetworkId == -1, we can additionally check LinkSpeed to determine that we are connected and provide IP address, link speed, frequency and signal strength.

Please note that if Location is disabled on a device, wifiManager.scanResults is not available, but conInfo.rssi is available, that's why I've merged this into one commit.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->