### PR TITLE
Set Wear OAuth redirect URI automatically and catch exceptions

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/AuthenticationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/AuthenticationRepository.kt
@@ -13,7 +13,7 @@ interface AuthenticationRepository {
 
     suspend fun getSessionState(): SessionState
 
-    suspend fun buildAuthenticationUrl(baseUrl: String, callbackUrl: String): String
+    suspend fun buildAuthenticationUrl(baseUrl: String): String
 
     suspend fun buildBearerToken(): String
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -89,13 +89,12 @@ class AuthenticationRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun buildAuthenticationUrl(baseUrl: String, callbackUrl: String): String {
+    override suspend fun buildAuthenticationUrl(baseUrl: String): String {
         return baseUrl.toHttpUrlOrNull()!!
             .newBuilder()
             .addPathSegments("auth/authorize")
             .addEncodedQueryParameter("response_type", "code")
             .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
-            .addEncodedQueryParameter("redirect_uri", callbackUrl)
             .build()
             .toString()
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3242 by:
 - allowing the library to insert the redirect URI in the OAuth request automatically, which will allow for using the China version `https://wear.googleapis-cn.com/3p_auth/io.homeassistant.companion.android`
 - catching any exceptions that might be thrown when building the OAuth request instead of crashing

Because the server verifies if the request URI is valid, actually using the China version of the redirect URI requires changes in core (offline) and on the website (online), changes have been submitted which mention this PR (see below).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->