### PR TITLE
Improve state for Android Auto: translate, timestamps

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -63,7 +63,7 @@ class EntityGridVehicleScreen(
                 GridItem.Builder()
                     .setLoading(false)
                     .setTitle(entity.friendlyName)
-                    .setText(entity.friendlyState)
+                    .setText(entity.friendlyState(carContext))
                     .setImage(
                         CarIcon.Builder(
                             IconicsDrawable(carContext, icon).apply {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Improve how states for entities are displayed in the Android Auto interface

 - Use string resources for common states to allow for translation
 - Format timestamps to a relative time (if recent) to make it easier to read

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![A screenshot of scenes on Android Auto, with states '3 days ago', 'Jan 7', '5 min. ago', and 'Unknown' several times](https://user-images.githubusercontent.com/8148535/214398068-ed28314c-cf84-48b0-9fd0-bc7f1757e7a1.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->