### PR TITLE
Don't delete favorites instead show cached entity

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/CachedFavorite.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/CachedFavorite.kt
@@ -1,0 +1,52 @@
+package io.homeassistant.companion.android.home.views
+
+import android.content.Context
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Text
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.database.wear.FavoriteCaches
+import io.homeassistant.companion.android.theme.wearColorPalette
+import io.homeassistant.companion.android.util.getIcon
+import io.homeassistant.companion.android.util.onEntityClickedFeedback
+
+@Composable
+fun CachedFavorite(
+    cached: FavoriteCaches?,
+    favoriteEntityID: String,
+    context: Context,
+    onEntityClicked: (String, String) -> Unit,
+    isHapticEnabled: Boolean,
+    isToastEnabled: Boolean,
+) {
+    val haptic = LocalHapticFeedback.current
+    Chip(
+        modifier = Modifier
+            .fillMaxWidth(),
+        icon = {
+            Image(
+                asset = getIcon(cached?.icon, favoriteEntityID.split(".")[0], context) ?: CommunityMaterial.Icon.cmd_bookmark,
+                colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+            )
+        },
+        label = {
+            Text(
+                text = cached?.friendlyName ?: favoriteEntityID,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
+        onClick = {
+            onEntityClicked(favoriteEntityID, "unknown")
+            onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, favoriteEntityID, haptic)
+        },
+        colors = ChipDefaults.secondaryChipColors()
+    )
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -68,8 +68,7 @@ fun LoadHomePage(
                         swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                     },
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
-                    isToastEnabled = mainViewModel.isToastEnabled.value,
-                    deleteFavorite = { id -> mainViewModel.removeFavoriteEntity(id) }
+                    isToastEnabled = mainViewModel.isToastEnabled.value
                 )
             }
             composable("$SCREEN_ENTITY_DETAIL/{entityId}") {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3243 by defaulting to a cached favorite entity chip instead of deleting a favorite. While I am not sure what the actual cause of the loss of favorites is, we can at least not delete the favorite and for the time being keep the removal in the hands of the user. I think it is a better user experience to keep the favorites so users do not need to continue to add them back. Asides from the one user report I have seen mentions on Discord and Reddit so this issue seems to impact quite a bit of users that use this feature.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->