### PR TITLE
Only show not supported error after support check is complete and design tweaks

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -36,6 +36,9 @@ class ConversationViewModel @Inject constructor(
     var isRegistered by mutableStateOf(false)
         private set
 
+    var checkSupportProgress by mutableStateOf(true)
+        private set
+
     fun getConversation() {
         viewModelScope.launch {
             conversationResult = integrationUseCase.getConversation(speechResult) ?: ""
@@ -43,11 +46,13 @@ class ConversationViewModel @Inject constructor(
     }
 
     suspend fun isSupportConversation() {
+        checkSupportProgress = true
         isRegistered = integrationUseCase.isRegistered()
         supportsConversation =
             integrationUseCase.isHomeAssistantVersionAtLeast(2023, 1, 0) &&
             webSocketRepository.getConfig()?.components?.contains("conversation") == true
         isHapticEnabled.value = wearPrefsRepository.getWearHapticFeedback()
+        checkSupportProgress = false
     }
 
     fun updateSpeechResult(result: String) {

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -57,8 +57,9 @@ fun ConversationResultView(
                             text = conversationViewModel.speechResult.ifEmpty {
                                 when {
                                     (conversationViewModel.supportsConversation) -> stringResource(R.string.no_results)
+                                    (!conversationViewModel.supportsConversation && !conversationViewModel.checkSupportProgress) -> stringResource(R.string.no_conversation_support)
                                     (!conversationViewModel.isRegistered) -> stringResource(R.string.not_registered)
-                                    else -> stringResource(R.string.no_conversation_support)
+                                    else -> "..."
                                 }
                             },
                             false

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -52,7 +52,7 @@ fun ConversationResultView(
             ) {
                 item {
                     Column {
-                        Spacer(Modifier.padding(24.dp))
+                        Spacer(Modifier.padding(12.dp))
                         SpeechBubble(
                             text = conversationViewModel.speechResult.ifEmpty {
                                 when {
@@ -64,7 +64,7 @@ fun ConversationResultView(
                             },
                             false
                         )
-                        Spacer(Modifier.padding(8.dp))
+                        Spacer(Modifier.padding(4.dp))
                     }
                 }
                 if (conversationViewModel.conversationResult.isNotEmpty())
@@ -106,10 +106,10 @@ fun SpeechBubble(text: String, isResponse: Boolean) {
                     else
                         colorResource(R.color.colorSpeechText),
                     AbsoluteRoundedCornerShape(
-                        topLeftPercent = 40,
-                        topRightPercent = 40,
-                        bottomLeftPercent = if (isResponse) 0 else 40,
-                        bottomRightPercent = if (isResponse) 40 else 0
+                        topLeftPercent = 30,
+                        topRightPercent = 30,
+                        bottomLeftPercent = if (isResponse) 0 else 30,
+                        bottomRightPercent = if (isResponse) 30 else 0
                     )
                 )
                 .padding(4.dp)
@@ -121,7 +121,7 @@ fun SpeechBubble(text: String, isResponse: Boolean) {
                 else
                     Color.Black,
                 modifier = Modifier
-                    .padding(4.dp)
+                    .padding(2.dp)
             )
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Sometimes upon initial launch when the device is running slow the error message for not supported setup shows up briefly. This is due to the condition. Adding in a variable to keep track of the support check so we only show the error when we have completed the check. The default message when starting up should now be `...`.

Some design tweaks based on feedback around spacing to reduce scrolling to see the full response

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/214899947-3e19ae6b-6267-4dbd-9c2e-299266fbb47a.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->