### PR TITLE
Allow navigation to sensors in android auto if they contain proper attributes

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -64,6 +64,7 @@ class MainVehicleScreen(
         private val MAP_DOMAINS = listOf(
             "device_tracker",
             "person",
+            "sensor",
             "zone",
         )
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I originally thought that it was any entity but now I realize we limited the domains. Adding in `sensor` domain in case a user has a sensor or created a template sensor so it can also be navigated to.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#896

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->