### PR TITLE
Add new option to only show favorites on home screen

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepository.kt
@@ -13,4 +13,6 @@ interface WearPrefsRepository {
     suspend fun setWearHapticFeedback(enabled: Boolean)
     suspend fun getWearToastConfirmation(): Boolean
     suspend fun setWearToastConfirmation(enabled: Boolean)
+    suspend fun getWearFavoritesOnly(): Boolean
+    suspend fun setWearFavoritesOnly(enabled: Boolean)
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
@@ -21,6 +21,7 @@ class WearPrefsRepositoryImpl @Inject constructor(
         private const val PREF_TILE_TEMPLATE_REFRESH_INTERVAL = "tile_template_refresh_interval"
         private const val PREF_WEAR_HAPTIC_FEEDBACK = "wear_haptic_feedback"
         private const val PREF_WEAR_TOAST_CONFIRMATION = "wear_toast_confirmation"
+        private const val PREF_WEAR_FAVORITES_ONLY = "wear_favorites_only"
     }
 
     init {
@@ -44,6 +45,9 @@ class WearPrefsRepositoryImpl @Inject constructor(
                 }
                 integrationStorage.getBooleanOrNull(PREF_WEAR_TOAST_CONFIRMATION)?.let {
                     localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, it)
+                }
+                integrationStorage.getBooleanOrNull(PREF_WEAR_FAVORITES_ONLY)?.let {
+                    localStorage.putBoolean(PREF_WEAR_FAVORITES_ONLY, it)
                 }
 
                 localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
@@ -100,5 +104,13 @@ class WearPrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setWearToastConfirmation(enabled: Boolean) {
         localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, enabled)
+    }
+
+    override suspend fun getWearFavoritesOnly(): Boolean {
+        return localStorage.getBoolean(PREF_WEAR_FAVORITES_ONLY)
+    }
+
+    override suspend fun setWearFavoritesOnly(enabled: Boolean) {
+        localStorage.putBoolean(PREF_WEAR_FAVORITES_ONLY, enabled)
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1015,4 +1015,5 @@
     <string name="assist">Assist</string>
     <string name="not_registered">Please launch the Home Assistant app and login before you can use the assist feature.</string>
     <string name="ha_assist">HA: Assist</string>
+    <string name="only_favorites">Only Show Favorites</string>
 </resources>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -57,9 +57,11 @@ class HomeActivity : ComponentActivity(), HomeView {
                         entityUpdateJob = launch { mainViewModel.entityUpdates() }
                     }
                 }
-                launch { mainViewModel.areaUpdates() }
-                launch { mainViewModel.deviceUpdates() }
-                launch { mainViewModel.entityRegistryUpdates() }
+                if (!mainViewModel.isFavoritesOnly.value) {
+                    launch { mainViewModel.areaUpdates() }
+                    launch { mainViewModel.deviceUpdates() }
+                    launch { mainViewModel.entityRegistryUpdates() }
+                }
             }
         }
     }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -50,4 +50,6 @@ interface HomePresenter {
     suspend fun setTemplateTileContent(content: String)
     suspend fun getTemplateTileRefreshInterval(): Int
     suspend fun setTemplateTileRefreshInterval(interval: Int)
+    suspend fun getWearFavoritesOnly(): Boolean
+    suspend fun setWearFavoritesOnly(enabled: Boolean)
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -271,4 +271,12 @@ class HomePresenterImpl @Inject constructor(
     override suspend fun setTemplateTileRefreshInterval(interval: Int) {
         wearPrefsRepository.setTemplateTileRefreshInterval(interval)
     }
+
+    override suspend fun getWearFavoritesOnly(): Boolean {
+        return wearPrefsRepository.getWearFavoritesOnly()
+    }
+
+    override suspend fun setWearFavoritesOnly(enabled: Boolean) {
+        wearPrefsRepository.setWearFavoritesOnly(enabled)
+    }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -68,8 +68,7 @@ fun LoadHomePage(
                         swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                     },
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
-                    isToastEnabled = mainViewModel.isToastEnabled.value,
-                    deleteFavorite = { id -> mainViewModel.removeFavoriteEntity(id) }
+                    isToastEnabled = mainViewModel.isToastEnabled.value
                 )
             }
             composable("$SCREEN_ENTITY_DETAIL/{entityId}") {
@@ -141,8 +140,10 @@ fun LoadHomePage(
                     onClickLogout = { mainViewModel.logout() },
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
                     isToastEnabled = mainViewModel.isToastEnabled.value,
+                    isFavoritesOnly = mainViewModel.isFavoritesOnly.value,
                     onHapticEnabled = { mainViewModel.setHapticEnabled(it) },
-                    onToastEnabled = { mainViewModel.setToastEnabled(it) }
+                    onToastEnabled = { mainViewModel.setToastEnabled(it) },
+                    setFavoritesOnly = { mainViewModel.setWearFavoritesOnly(it) }
                 ) { swipeDismissableNavController.navigate(SCREEN_SET_TILE_TEMPLATE) }
             }
             composable(SCREEN_SET_FAVORITES) {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
@@ -68,8 +68,10 @@ fun SettingsView(
     onClickLogout: () -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
+    isFavoritesOnly: Boolean,
     onHapticEnabled: (Boolean) -> Unit,
     onToastEnabled: (Boolean) -> Unit,
+    setFavoritesOnly: (Boolean) -> Unit,
     onClickTemplateTile: () -> Unit
 ) {
     val scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState()
@@ -103,6 +105,29 @@ fun SettingsView(
                         secondaryLabel = stringResource(commonR.string.irreversible),
                         enabled = favorites.isNotEmpty(),
                         onClick = onClearFavorites
+                    )
+                }
+                item {
+                    ToggleChip(
+                        modifier = Modifier.fillMaxWidth(),
+                        checked = isFavoritesOnly,
+                        onCheckedChange = { setFavoritesOnly(it) },
+                        label = { Text(stringResource(commonR.string.only_favorites)) },
+                        toggleControl = {
+                            Icon(
+                                imageVector = ToggleChipDefaults.checkboxIcon(isFavoritesOnly),
+                                contentDescription = if (isFavoritesOnly)
+                                    stringResource(commonR.string.enabled)
+                                else
+                                    stringResource(commonR.string.disabled)
+                            )
+                        },
+                        appIcon = {
+                            Image(
+                                asset = CommunityMaterial.Icon2.cmd_home_heart,
+                                colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+                            )
+                        }
                     )
                 }
                 item {
@@ -245,7 +270,9 @@ private fun PreviewSettingsView() {
         onClickLogout = {},
         isHapticEnabled = true,
         isToastEnabled = false,
+        isFavoritesOnly = false,
         onHapticEnabled = {},
-        onToastEnabled = {}
+        onToastEnabled = {},
+        setFavoritesOnly = {}
     ) {}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Based on some feedback that I have seen from users only wanting to see their selected entities. I am adding a new setting to only show favorites on the home screen in the Wear OS app. The hope is that needing to load less data will make things feel faster for people who only want to control a certain set of entities from the app.

This also contains a different approach to #3269 as I have seen that favorites are not really removed, they actually get added back almost immediately. So here instead of creating a cached favorite, just let the app recreate the chip.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/215014877-1cb32a3b-75fb-44d6-8581-e0c0b095fa56.png)

![image](https://user-images.githubusercontent.com/1634145/215014894-f75ed9cd-b634-4286-8a50-0f78b6e4e673.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->