### PR TITLE
Invalidate cache before updating camera widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -151,10 +151,12 @@ class CameraWidget : AppWidgetProvider() {
                     )
                     Log.d(TAG, "Fetching camera image")
                     Handler(Looper.getMainLooper()).post {
+                        val picasso = Picasso.get()
                         if (BuildConfig.DEBUG)
-                            Picasso.get().isLoggingEnabled = true
+                            picasso.isLoggingEnabled = true
                         try {
-                            Picasso.get().load(url).resize(1024, 600).into(
+                            picasso.invalidate(url)
+                            picasso.load(url).resize(1024, 600).into(
                                 this,
                                 R.id.widgetCameraImage,
                                 intArrayOf(appWidgetId)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3280 by invalidating the URL before updating the image

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->