### PR TITLE
Add a watchface complication for Assist

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -162,6 +162,24 @@
                 android:name="android.support.wearable.complications.PROVIDER_CONFIG_ACTION"
                 android:value="io.homeassistant.companion.android.ENTITY_STATE_COMPLICATION_CONFIG" />
         </service>
+
+        <service android:name=".complications.AssistDataSourceService"
+            android:exported="true"
+            android:icon="@mipmap/ic_assist_launcher"
+            android:label="@string/assist"
+            android:permission="com.google.android.wearable.permission.BIND_COMPLICATION_PROVIDER">
+            <intent-filter>
+                <action android:name="android.support.wearable.complications.ACTION_COMPLICATION_UPDATE_REQUEST" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.support.wearable.complications.SUPPORTED_TYPES"
+                android:value="ICON" />
+            <meta-data
+                android:name="android.support.wearable.complications.UPDATE_PERIOD_SECONDS"
+                android:value="0" />
+        </service>
+
         <receiver android:name=".complications.ComplicationReceiver" />
 
         <service android:name=".phone.PhoneSettingsListener" android:exported="true">

--- a/wear/src/main/java/io/homeassistant/companion/android/complications/AssistDataSourceService.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/complications/AssistDataSourceService.kt
@@ -1,0 +1,52 @@
+package io.homeassistant.companion.android.complications
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.Icon
+import androidx.wear.watchface.complications.data.ComplicationData
+import androidx.wear.watchface.complications.data.ComplicationType
+import androidx.wear.watchface.complications.data.MonochromaticImage
+import androidx.wear.watchface.complications.data.MonochromaticImageComplicationData
+import androidx.wear.watchface.complications.data.PlainComplicationText
+import androidx.wear.watchface.complications.datasource.ComplicationDataSourceService
+import androidx.wear.watchface.complications.datasource.ComplicationRequest
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.colorInt
+import io.homeassistant.companion.android.common.R
+
+class AssistDataSourceService : ComplicationDataSourceService() {
+
+    companion object {
+        const val TAG = "AssistDataSourceService"
+    }
+
+    override fun onComplicationRequest(request: ComplicationRequest, listener: ComplicationRequestListener) {
+        if (request.complicationType != ComplicationType.MONOCHROMATIC_IMAGE)
+            return
+
+        listener.onComplicationData(
+            MonochromaticImageComplicationData.Builder(
+                monochromaticImage = MonochromaticImage.Builder(Icon.createWithBitmap(getAssistIcon())).build(),
+                contentDescription = PlainComplicationText.Builder(getText(R.string.assist))
+                    .build()
+            )
+                .setTapAction(ComplicationReceiver.getAssistIntent(this))
+                .build()
+        )
+    }
+
+    private fun getAssistIcon(): Bitmap {
+        val icon = CommunityMaterial.Icon.cmd_comment_processing_outline
+        return IconicsDrawable(this, icon).apply {
+            colorInt = Color.WHITE
+        }.toBitmap()
+    }
+
+    override fun getPreviewData(type: ComplicationType): ComplicationData =
+        MonochromaticImageComplicationData.Builder(
+            monochromaticImage = MonochromaticImage.Builder(Icon.createWithBitmap(getAssistIcon())).build(),
+            contentDescription = PlainComplicationText.Builder(getText(R.string.assist)).build()
+        )
+            .build()
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/complications/ComplicationReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/complications/ComplicationReceiver.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import androidx.wear.watchface.complications.datasource.ComplicationDataSourceUpdateRequester
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.conversation.ConversationActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -90,6 +91,15 @@ class ComplicationReceiver : BroadcastReceiver() {
                 complicationInstanceId,
                 intent,
                 PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        fun getAssistIntent(context: Context): PendingIntent {
+            return PendingIntent.getActivity(
+                context,
+                0,
+                Intent(context, ConversationActivity::class.java),
+                PendingIntent.FLAG_IMMUTABLE
             )
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds a watchface complication for Assist so users can quickly interact with it directly from the watchface.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/215380069-d1d3c87b-dbcd-41db-b6be-cf1d5077d794.png)

![image](https://user-images.githubusercontent.com/1634145/215380091-ed3a5d0c-fd7c-4076-bb2a-72a8229b7678.png)

![image](https://user-images.githubusercontent.com/1634145/215380099-f28b01ff-fe1f-46a1-b0b9-8c92d6f1c2c5.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#898

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->