### PR TITLE
Send sensor state as `null` if not set or blank

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -541,7 +541,9 @@ class IntegrationRepositoryImpl @Inject constructor(
             "register_sensor",
             SensorRequest(
                 sensorRegistration.uniqueId,
-                if (canRegisterEntityDisabledState && sensorRegistration.disabled) null else sensorRegistration.state,
+                if (canRegisterEntityDisabledState && sensorRegistration.disabled) null
+                else if (sensorRegistration.state is String) sensorRegistration.state.ifBlank { null }
+                else sensorRegistration.state,
                 sensorRegistration.type,
                 sensorRegistration.icon,
                 sensorRegistration.attributes,
@@ -581,7 +583,7 @@ class IntegrationRepositoryImpl @Inject constructor(
             sensors.map {
                 SensorRequest(
                     it.uniqueId,
-                    it.state,
+                    if (it.state is String) it.state.ifBlank { null } else it.state,
                     it.type,
                     it.icon,
                     it.attributes

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class SensorRequest<T>(
     val uniqueId: String,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     val state: T,
     val type: String,
     val icon: String,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3265, fix home-assistant/core#86875 by sending `null` when the state is not set or a blank string. This will prevent core errors about invalid state types because of the device class/state class/unit.

Tested with 2023.1 and 2023.2, and based on a quick check of the integration code `None` (in Python, so `null` in JSON) has always been accepted as a state.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->