### PR TITLE
Update sensor enabled by default logic to be more granular

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -117,7 +117,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
 
     private fun handleSleepUpdate(intent: Intent, context: Context) {
         Log.d(TAG, "Received sleep update")
-        if (SleepClassifyEvent.hasEvents(intent) && isEnabled(context, sleepConfidence.id)) {
+        if (SleepClassifyEvent.hasEvents(intent) && isEnabled(context, sleepConfidence)) {
             Log.d(TAG, "Sleep classify event detected")
             val sleepClassifyEvent = SleepClassifyEvent.extractEvents(intent)
             if (sleepClassifyEvent.size > 0) {
@@ -138,7 +138,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
                 SensorReceiver.updateAllSensors(context)
             }
         }
-        if (SleepSegmentEvent.hasEvents(intent) && isEnabled(context, sleepSegment.id)) {
+        if (SleepSegmentEvent.hasEvents(intent) && isEnabled(context, sleepSegment)) {
             Log.d(TAG, "Sleep segment event detected")
             val sleepSegmentEvent = SleepSegmentEvent.extractEvents(intent)
             if (sleepSegmentEvent.size > 0) {
@@ -191,8 +191,6 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors#activity-sensors"
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_activity
 
@@ -211,7 +209,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     }
 
     override fun requestSensorUpdate(context: Context) {
-        if (isEnabled(context, activity.id)) {
+        if (isEnabled(context, activity)) {
             val actReg = ActivityRecognition.getClient(context)
             val pendingIntent = getActivityPendingIntent(context)
             Log.d(TAG, "Unregistering for activity updates.")
@@ -222,9 +220,9 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             actReg.requestActivityUpdates(TimeUnit.MINUTES.toMillis(if (fastUpdate) 1 else 2), pendingIntent)
         }
         if ((
-            isEnabled(context, sleepConfidence.id) || isEnabled(
+            isEnabled(context, sleepConfidence) || isEnabled(
                     context,
-                    sleepSegment.id
+                    sleepSegment
                 )
             ) && !sleepRegistration
         ) {
@@ -232,9 +230,9 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             Log.d(TAG, "Registering for sleep updates")
             val task = when {
                 (
-                    isEnabled(context, sleepConfidence.id) && !isEnabled(
+                    isEnabled(context, sleepConfidence) && !isEnabled(
                         context,
-                        sleepSegment.id
+                        sleepSegment
                     )
                     ) -> {
                     Log.d(TAG, "Registering for sleep confidence updates only")
@@ -244,9 +242,9 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
                     )
                 }
                 (
-                    !isEnabled(context, sleepConfidence.id) && isEnabled(
+                    !isEnabled(context, sleepConfidence) && isEnabled(
                         context,
-                        sleepSegment.id
+                        sleepSegment
                     )
                     ) -> {
                     Log.d(TAG, "Registering for sleep segment updates only")

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -27,8 +27,6 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
         )
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_android_auto
 
@@ -48,7 +46,7 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
 
     override fun requestSensorUpdate(context: Context) {
         this.context = context
-        if (!isEnabled(context, androidAutoConnected.id)) {
+        if (!isEnabled(context, androidAutoConnected)) {
             return
         }
         CoroutineScope(Dispatchers.Main + Job()).launch {
@@ -60,7 +58,7 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
     }
 
     override fun onChanged(type: Int?) {
-        if (!isEnabled(context, androidAutoConnected.id)) {
+        if (!isEnabled(context, androidAutoConnected)) {
             CoroutineScope(Dispatchers.Main + Job()).launch {
                 carConnection?.type?.removeObserver(this@AndroidAutoSensorManager)
             }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -40,8 +40,6 @@ class GeocodeSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#geocoded-location-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_geolocation
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
@@ -72,7 +70,7 @@ class GeocodeSensorManager : SensorManager {
     }
 
     private suspend fun updateGeocodedLocation(context: Context) {
-        if (!isEnabled(context, geocodedLocation.id) || !checkPermission(context, geocodedLocation.id)) {
+        if (!isEnabled(context, geocodedLocation) || !checkPermission(context, geocodedLocation.id)) {
             return
         }
 

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -234,8 +234,8 @@ class LocationSensorManager : LocationSensorManagerBase() {
             return
         }
 
-        val backgroundEnabled = isEnabled(latestContext, backgroundLocation.id)
-        val zoneEnabled = isEnabled(latestContext, zoneLocation.id)
+        val backgroundEnabled = isEnabled(latestContext, backgroundLocation)
+        val zoneEnabled = isEnabled(latestContext, zoneLocation)
 
         ioScope.launch {
             try {
@@ -285,8 +285,8 @@ class LocationSensorManager : LocationSensorManagerBase() {
     private suspend fun setupBackgroundLocation(backgroundEnabled: Boolean? = null, zoneEnabled: Boolean? = null) {
         var isBackgroundEnabled = backgroundEnabled
         var isZoneEnable = zoneEnabled
-        if (isBackgroundEnabled == null) isBackgroundEnabled = isEnabled(latestContext, backgroundLocation.id)
-        if (isZoneEnable == null) isZoneEnable = isEnabled(latestContext, zoneLocation.id)
+        if (isBackgroundEnabled == null) isBackgroundEnabled = isEnabled(latestContext, backgroundLocation)
+        if (isZoneEnable == null) isZoneEnable = isEnabled(latestContext, zoneLocation)
 
         if (isBackgroundEnabled) {
             val updateIntervalHighAccuracySeconds = getHighAccuracyModeUpdateInterval()
@@ -675,7 +675,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
 
     private fun handleGeoUpdate(intent: Intent) {
         Log.d(TAG, "Received geofence update.")
-        if (!isEnabled(latestContext, zoneLocation.id)) {
+        if (!isEnabled(latestContext, zoneLocation)) {
             isZoneLocationSetup = false
             Log.w(TAG, "Unregistering geofences as zone tracking is disabled and intent was received")
             removeGeofenceUpdateRequests()
@@ -958,7 +958,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun getHighAccuracyModeTriggerRange(): Int {
-        val enabled = isEnabled(latestContext, zoneLocation.id)
+        val enabled = isEnabled(latestContext, zoneLocation)
 
         if (!enabled) return 0
 
@@ -982,7 +982,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
     }
 
     private fun getHighAccuracyModeZones(expandedZones: Boolean): List<String> {
-        val enabled = isEnabled(latestContext, zoneLocation.id)
+        val enabled = isEnabled(latestContext, zoneLocation)
 
         if (!enabled) return emptyList()
 
@@ -1007,7 +1007,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
             Log.w(TAG, "Not getting single accurate location because of permissions.")
             return
         }
-        if (!isEnabled(latestContext, singleAccurateLocation.id)) {
+        if (!isEnabled(latestContext, singleAccurateLocation)) {
             Log.w(TAG, "Requested single accurate location but it is not enabled.")
             return
         }
@@ -1104,8 +1104,6 @@ class LocationSensorManager : LocationSensorManagerBase() {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/location"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_location
@@ -1142,13 +1140,13 @@ class LocationSensorManager : LocationSensorManagerBase() {
         context: Context
     ) {
         latestContext = context
-        if (isEnabled(context, zoneLocation.id) || isEnabled(context, backgroundLocation.id))
+        if (isEnabled(context, zoneLocation) || isEnabled(context, backgroundLocation))
             setupLocationTracking()
         val sensorDao = AppDatabase.getInstance(latestContext).sensorDao()
         val sensorSetting = sensorDao.getSettings(singleAccurateLocation.id)
         val includeSensorUpdate = sensorSetting.firstOrNull { it.name == SETTING_INCLUDE_SENSOR_UPDATE }?.value ?: "false"
         if (includeSensorUpdate == "true") {
-            if (isEnabled(context, singleAccurateLocation.id)) {
+            if (isEnabled(context, singleAccurateLocation)) {
                 context.sendBroadcast(
                     Intent(context, this.javaClass).apply {
                         action = ACTION_REQUEST_ACCURATE_LOCATION_UPDATE

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
@@ -25,8 +25,6 @@ class DevicePolicyManager : SensorManager {
 
     private var isManagedProfileAvailable: Boolean = false
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = R.string.sensor_name_device_policy
 
@@ -55,7 +53,7 @@ class DevicePolicyManager : SensorManager {
 
     private fun updateWorkProfile(context: Context) {
 
-        if (!isEnabled(context, isWorkProfile.id))
+        if (!isEnabled(context, isWorkProfile))
             return
 
         onSensorUpdated(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
@@ -25,8 +25,6 @@ class DynamicColorSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#dynamic-color-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_dynamic_color
 
@@ -48,7 +46,7 @@ class DynamicColorSensorManager : SensorManager {
 
     private fun updateAccentColor(context: Context) {
 
-        if (!isEnabled(context, accentColorSensor.id))
+        if (!isEnabled(context, accentColorSensor))
             return
 
         val dynamicColorContext = DynamicColors.wrapContextIfAvailable(context)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -27,8 +27,6 @@ class LastAppSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#last-used-app-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_last_app
 
@@ -53,7 +51,7 @@ class LastAppSensorManager : SensorManager {
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     private fun updateLastApp(context: Context) {
-        if (!isEnabled(context, last_used.id))
+        if (!isEnabled(context, last_used))
             return
 
         val usageStats = context.getSystemService<UsageStatsManager>()!!

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -77,8 +77,6 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
         return listOf(lastNotification, lastRemovedNotification, activeNotificationCount, mediaSession)
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return arrayOf(Manifest.permission.BIND_NOTIFICATION_LISTENER_SERVICE)
@@ -109,7 +107,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
 
         updateActiveNotificationCount()
 
-        if (!isEnabled(applicationContext, lastNotification.id))
+        if (!isEnabled(applicationContext, lastNotification))
             return
 
         val allowPackages = getSetting(
@@ -167,7 +165,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
 
         updateActiveNotificationCount()
 
-        if (!isEnabled(applicationContext, lastRemovedNotification.id))
+        if (!isEnabled(applicationContext, lastRemovedNotification))
             return
 
         val allowPackages = getSetting(
@@ -221,7 +219,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     }
 
     private fun updateActiveNotificationCount() {
-        if (!isEnabled(applicationContext, activeNotificationCount.id) || !listenerConnected)
+        if (!isEnabled(applicationContext, activeNotificationCount) || !listenerConnected)
             return
 
         try {
@@ -250,7 +248,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     }
 
     private fun updateMediaSession(context: Context) {
-        if (!isEnabled(context, mediaSession.id))
+        if (!isEnabled(context, mediaSession))
             return
 
         val mediaSessionManager = context.getSystemService<MediaSessionManager>()!!

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/QuestSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/QuestSensorManager.kt
@@ -25,9 +25,6 @@ class QuestSensorManager : SensorManager {
         return "https://companion.home-assistant.io/docs/oculus-quest/"
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
-
     override val name: Int
         get() = commonR.string.sensor_name_quest
 
@@ -62,7 +59,7 @@ class QuestSensorManager : SensorManager {
     }
 
     private fun updateHeadsetMount(context: Context, intent: Intent) {
-        if (!isEnabled(context, headsetMounted.id))
+        if (!isEnabled(context, headsetMounted))
             return
 
         val state: Boolean = getHeadsetState(intent)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorSettingsViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorSettingsViewModel.kt
@@ -78,8 +78,8 @@ class SensorSettingsViewModel @Inject constructor(
                             ) &&
                             (
                                 sensorFilter == SensorFilter.ALL ||
-                                    (sensorFilter == SensorFilter.ENABLED && manager.isEnabled(app.applicationContext, sensor.id)) ||
-                                    (sensorFilter == SensorFilter.DISABLED && !manager.isEnabled(app.applicationContext, sensor.id))
+                                    (sensorFilter == SensorFilter.ENABLED && manager.isEnabled(app.applicationContext, sensor)) ||
+                                    (sensorFilter == SensorFilter.DISABLED && !manager.isEnabled(app.applicationContext, sensor))
                                 )
                     }
                     .mapNotNull { sensor -> sensorsList.firstOrNull { it.id == sensor.id } }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -93,8 +93,7 @@ fun SensorDetailView(
 
     val sensorEnabled = viewModel.sensor?.sensor?.enabled
         ?: (
-            viewModel.basicSensor != null && viewModel.sensorManager?.enabledByDefault == true &&
-                viewModel.sensorManager.checkPermission(context, viewModel.basicSensor.id)
+            viewModel.basicSensor != null && viewModel.basicSensor.enabledByDefault && viewModel.sensorManager?.checkPermission(context, viewModel.basicSensor.id) == true
             )
 
     val scaffoldState = rememberScaffoldState()

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -777,7 +777,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
         for (manager in SensorReceiver.MANAGERS) {
             for (basicSensor in manager.getAvailableSensors(this)) {
-                if (manager.isEnabled(this, basicSensor.id)) {
+                if (manager.isEnabled(this, basicSensor)) {
                     var permissions = manager.requiredPermissions(basicSensor.id)
 
                     val fineLocation = DisabledLocationHandler.containsLocationPermission(permissions, true)

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -11,9 +11,6 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
     override fun onReceive(context: Context, intent: Intent) {
         // Noop
     }
-
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_activity
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -6,8 +6,6 @@ import io.homeassistant.companion.android.common.R as commonR
 
 class AndroidAutoSensorManager : SensorManager {
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_android_auto
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -17,8 +17,6 @@ class GeocodeSensorManager : SensorManager {
         )
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_geolocation
 

--- a/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -56,8 +56,6 @@ class LocationSensorManager : LocationSensorManagerBase(), SensorManager {
         // Noop
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_location
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/AppSensorManagerBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/AppSensorManagerBase.kt
@@ -94,8 +94,6 @@ abstract class AppSensorManagerBase : SensorManager {
         )
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_app_sensor
 
@@ -140,7 +138,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     private fun updateCurrentVersion(context: Context) {
 
-        if (!isEnabled(context, currentVersion.id))
+        if (!isEnabled(context, currentVersion))
             return
 
         val state = getCurrentVersion()
@@ -156,7 +154,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     private fun updateAppRxGb(context: Context, appUid: Int) {
 
-        if (!isEnabled(context, app_rx_gb.id))
+        if (!isEnabled(context, app_rx_gb))
             return
 
         val appRx = try {
@@ -177,7 +175,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     private fun updateAppTxGb(context: Context, appUid: Int) {
 
-        if (!isEnabled(context, app_tx_gb.id))
+        if (!isEnabled(context, app_tx_gb))
             return
 
         val appTx = try {
@@ -198,7 +196,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     private fun updateAppMemory(context: Context) {
 
-        if (!isEnabled(context, app_memory.id))
+        if (!isEnabled(context, app_memory))
             return
 
         val runTime = Runtime.getRuntime()
@@ -220,7 +218,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     @RequiresApi(Build.VERSION_CODES.M)
     private fun updateAppInactive(context: Context, usageStatsManager: UsageStatsManager) {
-        if (!isEnabled(context, app_inactive.id))
+        if (!isEnabled(context, app_inactive))
             return
 
         val isAppInactive = usageStatsManager.isAppInactive(context.packageName)
@@ -238,7 +236,7 @@ abstract class AppSensorManagerBase : SensorManager {
 
     @RequiresApi(Build.VERSION_CODES.P)
     private fun updateAppStandbyBucket(context: Context, usageStatsManager: UsageStatsManager) {
-        if (!isEnabled(context, app_standby_bucket.id))
+        if (!isEnabled(context, app_standby_bucket))
             return
 
         val appStandbyBucket = when (usageStatsManager.appStandbyBucket) {
@@ -260,7 +258,7 @@ abstract class AppSensorManagerBase : SensorManager {
     }
 
     private fun updateImportanceCheck(context: Context) {
-        if (!isEnabled(context, app_importance.id))
+        if (!isEnabled(context, app_importance))
             return
 
         val appManager = context.getSystemService<ActivityManager>()!!

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/AudioSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/AudioSensorManager.kt
@@ -132,9 +132,6 @@ class AudioSensorManager : SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors#audio-sensors"
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
-
     override val name: Int
         get() = commonR.string.sensor_name_audio
 
@@ -174,7 +171,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateAudioSensor(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, audioSensor.id))
+        if (!isEnabled(context, audioSensor))
             return
 
         val ringerMode = when (audioManager.ringerMode) {
@@ -201,7 +198,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateAudioState(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, audioState.id))
+        if (!isEnabled(context, audioState))
             return
         val audioMode = when (audioManager.mode) {
             AudioManager.MODE_NORMAL -> "normal"
@@ -231,7 +228,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateHeadphoneState(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, headphoneState.id))
+        if (!isEnabled(context, headphoneState))
             return
 
         var isHeadphones = false
@@ -258,7 +255,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateMicMuted(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, micMuted.id))
+        if (!isEnabled(context, micMuted))
             return
 
         val isMicMuted = audioManager.isMicrophoneMute
@@ -275,7 +272,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateMusicActive(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, musicActive.id))
+        if (!isEnabled(context, musicActive))
             return
 
         val isMusicActive = audioManager.isMusicActive
@@ -292,7 +289,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateSpeakerphoneState(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, speakerphoneState.id))
+        if (!isEnabled(context, speakerphoneState))
             return
 
         val isSpeakerOn = audioManager.isSpeakerphoneOn
@@ -309,7 +306,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeAlarm(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volAlarm.id))
+        if (!isEnabled(context, volAlarm))
             return
         val volumeLevelAlarm = audioManager.getStreamVolume(AudioManager.STREAM_ALARM)
 
@@ -323,7 +320,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeCall(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volCall.id))
+        if (!isEnabled(context, volCall))
             return
 
         val volumeLevelCall = audioManager.getStreamVolume(AudioManager.STREAM_VOICE_CALL)
@@ -338,7 +335,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeMusic(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volMusic.id))
+        if (!isEnabled(context, volMusic))
             return
 
         val volumeLevelMusic = audioManager.getStreamVolume(AudioManager.STREAM_MUSIC)
@@ -353,7 +350,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeRing(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volRing.id))
+        if (!isEnabled(context, volRing))
             return
 
         val volumeLevelRing = audioManager.getStreamVolume(AudioManager.STREAM_RING)
@@ -368,7 +365,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeNotification(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volNotification.id))
+        if (!isEnabled(context, volNotification))
             return
 
         val volumeLevelNotification = audioManager.getStreamVolume(AudioManager.STREAM_NOTIFICATION)
@@ -383,7 +380,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeSystem(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volSystem.id))
+        if (!isEnabled(context, volSystem))
             return
 
         val volumeLevelSystem = audioManager.getStreamVolume(AudioManager.STREAM_SYSTEM)
@@ -399,7 +396,7 @@ class AudioSensorManager : SensorManager {
 
     @RequiresApi(Build.VERSION_CODES.O)
     private fun updateVolumeAccessibility(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volAccessibility.id))
+        if (!isEnabled(context, volAccessibility))
             return
 
         val volumeLevelAccessibility = audioManager.getStreamVolume(AudioManager.STREAM_ACCESSIBILITY)
@@ -414,7 +411,7 @@ class AudioSensorManager : SensorManager {
     }
 
     private fun updateVolumeDTMF(context: Context, audioManager: AudioManager) {
-        if (!isEnabled(context, volDTMF.id))
+        if (!isEnabled(context, volDTMF))
             return
 
         val volumeLevelDTMF = audioManager.getStreamVolume(AudioManager.STREAM_DTMF)

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -22,7 +22,8 @@ class BatterySensorManager : SensorManager {
             deviceClass = "battery",
             unitOfMeasurement = "%",
             stateClass = SensorManager.STATE_CLASS_MEASUREMENT,
-            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            enabledByDefault = true
         )
         private val batteryState = SensorManager.BasicSensor(
             "battery_state",
@@ -31,7 +32,8 @@ class BatterySensorManager : SensorManager {
             commonR.string.sensor_description_battery_state,
             "mdi:battery-charging",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT,
+            enabledByDefault = true
         )
         val isChargingState = SensorManager.BasicSensor(
             "is_charging",
@@ -50,7 +52,8 @@ class BatterySensorManager : SensorManager {
             commonR.string.sensor_description_charger_type,
             "mdi:power-plug",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT,
+            enabledByDefault = true
         )
         private val batteryHealthState = SensorManager.BasicSensor(
             "battery_health",
@@ -97,9 +100,6 @@ class BatterySensorManager : SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors#battery-sensors"
     }
 
-    override val enabledByDefault: Boolean
-        get() = true
-
     override val name: Int
         get() = commonR.string.sensor_name_battery
 
@@ -141,7 +141,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateBatteryLevel(context: Context, intent: Intent) {
-        if (!isEnabled(context, batteryLevel.id))
+        if (!isEnabled(context, batteryLevel))
             return
 
         val percentage = getBatteryPercentage(intent)
@@ -172,7 +172,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateBatteryState(context: Context, intent: Intent) {
-        if (!isEnabled(context, batteryState.id))
+        if (!isEnabled(context, batteryState))
             return
 
         val chargingStatus = getChargingStatus(intent)
@@ -194,7 +194,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateIsCharging(context: Context, intent: Intent) {
-        if (!isEnabled(context, isChargingState.id))
+        if (!isEnabled(context, isChargingState))
             return
 
         val isCharging = getIsCharging(intent)
@@ -210,7 +210,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateChargerType(context: Context, intent: Intent) {
-        if (!isEnabled(context, chargerTypeState.id))
+        if (!isEnabled(context, chargerTypeState))
             return
 
         val chargerType = getChargerType(intent)
@@ -231,7 +231,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateBatteryHealth(context: Context, intent: Intent) {
-        if (!isEnabled(context, batteryHealthState.id))
+        if (!isEnabled(context, batteryHealthState))
             return
 
         val batteryHealth = getBatteryHealth(intent)
@@ -250,7 +250,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateBatteryTemperature(context: Context, intent: Intent) {
-        if (!isEnabled(context, batteryTemperature.id))
+        if (!isEnabled(context, batteryTemperature))
             return
 
         val batteryTemp = getBatteryTemperature(intent)
@@ -265,7 +265,7 @@ class BatterySensorManager : SensorManager {
     }
 
     private fun updateBatteryPower(context: Context, intent: Intent) {
-        if (!isEnabled(context, batteryPower.id))
+        if (!isEnabled(context, batteryPower))
             return
 
         val voltage = getBatteryVolts(intent)

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -135,8 +135,6 @@ class BluetoothSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#bluetooth-sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_bluetooth
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
@@ -197,7 +195,7 @@ class BluetoothSensorManager : SensorManager {
     }
 
     private fun updateBluetoothConnectionSensor(context: Context) {
-        if (!isEnabled(context, bluetoothConnection.id))
+        if (!isEnabled(context, bluetoothConnection))
             return
 
         var totalConnectedDevices = 0
@@ -235,7 +233,7 @@ class BluetoothSensorManager : SensorManager {
     }
 
     private fun updateBluetoothState(context: Context) {
-        if (!isEnabled(context, bluetoothState.id))
+        if (!isEnabled(context, bluetoothState))
             return
         val icon = if (isBtOn(context)) "mdi:bluetooth" else "mdi:bluetooth-off"
         onSensorUpdated(
@@ -295,7 +293,7 @@ class BluetoothSensorManager : SensorManager {
     }
 
     private fun updateBeaconMonitoringDevice(context: Context) {
-        if (!isEnabled(context, beaconMonitor.id)) {
+        if (!isEnabled(context, beaconMonitor)) {
             return
         }
 
@@ -321,7 +319,7 @@ class BluetoothSensorManager : SensorManager {
         monitoringManager.scanPeriod = scanPeriod
         monitoringManager.scanInterval = scanInterval
 
-        if (!isEnabled(context, beaconMonitor.id) || ! monitoringActive || restart) {
+        if (!isEnabled(context, beaconMonitor) || ! monitoringActive || restart) {
             monitoringManager.stopMonitoring(context, beaconMonitoringDevice)
         } else {
             monitoringManager.startMonitoring(context, beaconMonitoringDevice)
@@ -333,7 +331,7 @@ class BluetoothSensorManager : SensorManager {
         updateBLEDevice(context)
 
         // sensor disabled, stop transmitting if we have been
-        if (!isEnabled(context, bleTransmitter.id)) {
+        if (!isEnabled(context, bleTransmitter)) {
             TransmitterManager.stopTransmitting(bleTransmitterDevice)
             return
         }
@@ -368,7 +366,7 @@ class BluetoothSensorManager : SensorManager {
     }
 
     fun updateBeaconMonitoringSensor(context: Context) {
-        if (!isEnabled(context, beaconMonitor.id)) {
+        if (!isEnabled(context, beaconMonitor)) {
             return
         }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
@@ -27,8 +27,6 @@ class DNDSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#do-not-disturb-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_dnd
 
@@ -52,7 +50,7 @@ class DNDSensorManager : SensorManager {
 
     private fun updateDNDState(context: Context) {
 
-        if (!isEnabled(context, dndSensor.id))
+        if (!isEnabled(context, dndSensor))
             return
 
         val notificationManager =

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
@@ -27,9 +27,6 @@ class DisplaySensorManager : SensorManager {
             docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-off-timeout-sensor"
         )
     }
-
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_display_sensors
 
@@ -49,7 +46,7 @@ class DisplaySensorManager : SensorManager {
     }
 
     private fun updateScreenBrightness(context: Context) {
-        if (!isEnabled(context, screenBrightness.id))
+        if (!isEnabled(context, screenBrightness))
             return
 
         var brightness = 0
@@ -79,7 +76,7 @@ class DisplaySensorManager : SensorManager {
     }
 
     private fun updateScreenTimeout(context: Context) {
-        if (!isEnabled(context, screenOffTimeout.id))
+        if (!isEnabled(context, screenOffTimeout))
             return
 
         var timeout = 0

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/KeyguardSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/KeyguardSensorManager.kt
@@ -48,8 +48,6 @@ class KeyguardSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#keyguard-sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_keyguard
 
@@ -81,7 +79,7 @@ class KeyguardSensorManager : SensorManager {
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     private fun updateDeviceLocked(context: Context, km: KeyguardManager) {
 
-        if (!isEnabled(context, deviceLocked.id))
+        if (!isEnabled(context, deviceLocked))
             return
 
         val isLocked = km.isDeviceLocked
@@ -99,7 +97,7 @@ class KeyguardSensorManager : SensorManager {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun updateDeviceSecure(context: Context, km: KeyguardManager) {
 
-        if (!isEnabled(context, deviceSecure.id))
+        if (!isEnabled(context, deviceSecure))
             return
 
         val isSecure = km.isDeviceSecure
@@ -116,7 +114,7 @@ class KeyguardSensorManager : SensorManager {
 
     private fun updateKeyguardLocked(context: Context, km: KeyguardManager) {
 
-        if (!isEnabled(context, keyguardLocked.id))
+        if (!isEnabled(context, keyguardLocked))
             return
 
         val isLocked = km.isKeyguardLocked
@@ -133,7 +131,7 @@ class KeyguardSensorManager : SensorManager {
 
     private fun updateKeyguardSecure(context: Context, km: KeyguardManager) {
 
-        if (!isEnabled(context, keyguardSecure.id))
+        if (!isEnabled(context, keyguardSecure))
             return
 
         val isSecure = km.isKeyguardSecure

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastRebootSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastRebootSensorManager.kt
@@ -37,8 +37,6 @@ class LastRebootSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#last-reboot-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_last_reboot
 
@@ -58,7 +56,7 @@ class LastRebootSensorManager : SensorManager {
 
     @SuppressLint("SimpleDateFormat")
     private fun updateLastReboot(context: Context) {
-        if (!isEnabled(context, lastRebootSensor.id))
+        if (!isEnabled(context, lastRebootSensor))
             return
 
         var timeInMillis = 0L

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastUpdateManager.kt
@@ -27,8 +27,6 @@ class LastUpdateManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#last-update-trigger-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_last_update
 
@@ -48,7 +46,7 @@ class LastUpdateManager : SensorManager {
 
     fun sendLastUpdate(context: Context, intentAction: String?) {
 
-        if (!isEnabled(context, lastUpdate.id))
+        if (!isEnabled(context, lastUpdate))
             return
 
         if (intentAction.isNullOrEmpty())

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LightSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LightSensorManager.kt
@@ -32,9 +32,6 @@ class LightSensorManager : SensorManager, SensorEventListener {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#light-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
-
     override val name: Int
         get() = commonR.string.sensor_name_light
 
@@ -62,7 +59,7 @@ class LightSensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateLightSensor() {
-        if (!isEnabled(latestContext, lightSensor.id))
+        if (!isEnabled(latestContext, lightSensor))
             return
 
         val now = System.currentTimeMillis()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/MobileDataManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/MobileDataManager.kt
@@ -34,8 +34,6 @@ class MobileDataManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#mobile-data-sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_mobile_data
 
@@ -66,7 +64,7 @@ class MobileDataManager : SensorManager {
         settingKey: String,
         icon: String
     ) {
-        if (!isEnabled(context, sensor.id))
+        if (!isEnabled(context, sensor))
             return
 
         var enabled = false

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -122,8 +122,6 @@ class NetworkSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#connection-type-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_network
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
@@ -177,7 +175,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiConnectionSensor(context: Context) {
-        if (!isEnabled(context, wifiConnection.id))
+        if (!isEnabled(context, wifiConnection))
             return
 
         var conInfo: WifiInfo? = null
@@ -218,7 +216,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateBSSIDSensor(context: Context) {
-        if (!isEnabled(context, bssidState.id))
+        if (!isEnabled(context, bssidState))
             return
 
         var conInfo: WifiInfo? = null
@@ -261,7 +259,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiIPSensor(context: Context) {
-        if (!isEnabled(context, wifiIp.id))
+        if (!isEnabled(context, wifiIp))
             return
 
         var deviceIp = "Unknown"
@@ -288,7 +286,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiLinkSpeedSensor(context: Context) {
-        if (!isEnabled(context, wifiLinkSpeed.id))
+        if (!isEnabled(context, wifiLinkSpeed))
             return
 
         var linkSpeed = 0
@@ -331,7 +329,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiSensor(context: Context) {
-        if (!isEnabled(context, wifiState.id))
+        if (!isEnabled(context, wifiState))
             return
 
         var wifiEnabled = false
@@ -354,7 +352,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiFrequencySensor(context: Context) {
-        if (!isEnabled(context, wifiFrequency.id))
+        if (!isEnabled(context, wifiFrequency))
             return
 
         var frequency = 0
@@ -381,7 +379,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiSignalStrengthSensor(context: Context) {
-        if (!isEnabled(context, wifiSignalStrength.id))
+        if (!isEnabled(context, wifiSignalStrength))
             return
 
         var rssi = -1
@@ -424,7 +422,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updatePublicIpSensor(context: Context) {
-        if (!isEnabled(context, publicIp.id))
+        if (!isEnabled(context, publicIp))
             return
 
         var ip = "unknown"
@@ -459,7 +457,7 @@ class NetworkSensorManager : SensorManager {
     @SuppressLint("MissingPermission")
     @RequiresApi(Build.VERSION_CODES.M)
     private fun updateNetworkType(context: Context) {
-        if (!isEnabled(context, networkType.id))
+        if (!isEnabled(context, networkType))
             return
 
         val connectivityManager = context.getSystemService<ConnectivityManager>()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
@@ -33,8 +33,6 @@ class NextAlarmManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#next-alarm-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_alarm
 
@@ -54,7 +52,7 @@ class NextAlarmManager : SensorManager {
 
     private fun updateNextAlarm(context: Context) {
 
-        if (!isEnabled(context, nextAlarm.id))
+        if (!isEnabled(context, nextAlarm))
             return
 
         var triggerTime = 0L

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -49,8 +49,6 @@ class PhoneStateSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#cellular-provider-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_phone
     override fun hasSensor(context: Context): Boolean {
@@ -75,7 +73,7 @@ class PhoneStateSensorManager : SensorManager {
     }
 
     private fun checkPhoneState(context: Context) {
-        if (isEnabled(context, phoneState.id)) {
+        if (isEnabled(context, phoneState)) {
             var currentPhoneState = "unknown"
 
             if (checkPermission(context, phoneState.id)) {
@@ -114,7 +112,7 @@ class PhoneStateSensorManager : SensorManager {
             1 -> sim_2
             else -> throw IllegalArgumentException("Invalid sim slot: $slotIndex")
         }
-        if (!isEnabled(context, basicSimSensor.id))
+        if (!isEnabled(context, basicSimSensor))
             return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             var displayName = "Unavailable"

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PowerSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PowerSensorManager.kt
@@ -44,8 +44,6 @@ class PowerSensorManager : SensorManager {
         )
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_power
 
@@ -74,7 +72,7 @@ class PowerSensorManager : SensorManager {
 
     private fun updateInteractive(context: Context, powerManager: PowerManager) {
 
-        if (!isEnabled(context, interactiveDevice.id))
+        if (!isEnabled(context, interactiveDevice))
             return
 
         val interactiveState = powerManager.isInteractive
@@ -92,7 +90,7 @@ class PowerSensorManager : SensorManager {
     @RequiresApi(Build.VERSION_CODES.M)
     private fun updateDoze(context: Context, powerManager: PowerManager) {
 
-        if (!isEnabled(context, doze.id))
+        if (!isEnabled(context, doze))
             return
 
         val dozeState = powerManager.isDeviceIdleMode
@@ -113,7 +111,7 @@ class PowerSensorManager : SensorManager {
 
     private fun updatePowerSave(context: Context, powerManager: PowerManager) {
 
-        if (!isEnabled(context, powerSave.id))
+        if (!isEnabled(context, powerSave))
             return
 
         val powerSaveState = powerManager.isPowerSaveMode

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PressureSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PressureSensorManager.kt
@@ -35,8 +35,6 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#pressure-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_pressure
@@ -60,7 +58,7 @@ class PressureSensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updatePressureSensor() {
-        if (!isEnabled(latestContext, pressureSensor.id))
+        if (!isEnabled(latestContext, pressureSensor))
             return
 
         val now = System.currentTimeMillis()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/ProximitySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/ProximitySensorManager.kt
@@ -34,8 +34,6 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#proximity-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_proximity
@@ -59,7 +57,7 @@ class ProximitySensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateProximitySensor() {
-        if (!isEnabled(latestContext, proximitySensor.id))
+        if (!isEnabled(latestContext, proximitySensor))
             return
 
         val now = System.currentTimeMillis()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -32,7 +32,6 @@ interface SensorManager {
     }
 
     val name: Int
-    val enabledByDefault: Boolean
 
     data class BasicSensor(
         val id: String,
@@ -45,7 +44,8 @@ interface SensorManager {
         val docsLink: String? = null,
         val stateClass: String? = null,
         val entityCategory: String? = null,
-        val updateType: UpdateType = UpdateType.WORKER
+        val updateType: UpdateType = UpdateType.WORKER,
+        val enabledByDefault: Boolean = false
     ) {
         enum class UpdateType {
             INTENT, WORKER, LOCATION, CUSTOM
@@ -82,14 +82,14 @@ interface SensorManager {
         return mode == AppOpsManager.MODE_ALLOWED
     }
 
-    fun isEnabled(context: Context, sensorId: String): Boolean {
+    fun isEnabled(context: Context, basicSensor: BasicSensor): Boolean {
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
-        val permission = checkPermission(context, sensorId)
+        val permission = checkPermission(context, basicSensor.id)
         return sensorDao.getAnyIsEnabled(
-            sensorId,
+            basicSensor.id,
             serverManager(context).defaultServers.map { it.id },
             permission,
-            enabledByDefault
+            basicSensor.enabledByDefault
         )
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/StepsSensorManager.kt
@@ -34,9 +34,6 @@ class StepsSensorManager : SensorManager, SensorEventListener {
         return "https://companion.home-assistant.io/docs/core/sensors#pedometer-sensors"
     }
 
-    override val enabledByDefault: Boolean
-        get() = false
-
     override val name: Int
         get() = commonR.string.sensor_name_steps
 
@@ -68,7 +65,7 @@ class StepsSensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateStepsSensor() {
-        if (!isEnabled(latestContext, stepsSensor.id))
+        if (!isEnabled(latestContext, stepsSensor))
             return
 
         if (checkPermission(latestContext, stepsSensor.id)) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/StorageSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/StorageSensorManager.kt
@@ -61,8 +61,6 @@ class StorageSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#storage-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_storage
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
@@ -81,7 +79,7 @@ class StorageSensorManager : SensorManager {
     }
 
     private fun updateInternalStorageSensor(context: Context) {
-        if (!isEnabled(context, storageSensor.id))
+        if (!isEnabled(context, storageSensor))
             return
 
         val path = Environment.getDataDirectory()
@@ -100,7 +98,7 @@ class StorageSensorManager : SensorManager {
     }
 
     private fun updateExternalStorageSensor(context: Context) {
-        if (!isEnabled(context, externalStorage.id))
+        if (!isEnabled(context, externalStorage))
             return
 
         val externalStoragePath = getExternalStoragePathIfAvailable(context)

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/TimeZoneManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/TimeZoneManager.kt
@@ -23,8 +23,6 @@ class TimeZoneManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#current-time-zone-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_time_zone
 
@@ -44,7 +42,7 @@ class TimeZoneManager : SensorManager {
 
     private fun updateTimeZone(context: Context) {
 
-        if (!isEnabled(context, currentTimeZone.id))
+        if (!isEnabled(context, currentTimeZone))
             return
 
         val timeZone: TimeZone = TimeZone.getDefault()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/TrafficStatsManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/TrafficStatsManager.kt
@@ -61,8 +61,6 @@ class TrafficStatsManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#traffic-stats-sensor"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_traffic_stats
 
@@ -98,7 +96,7 @@ class TrafficStatsManager : SensorManager {
 
     private fun updateMobileRxBytes(context: Context) {
 
-        if (!isEnabled(context, rxBytesMobile.id))
+        if (!isEnabled(context, rxBytesMobile))
             return
 
         val mobileRx = try {
@@ -119,7 +117,7 @@ class TrafficStatsManager : SensorManager {
 
     private fun updateMobileTxBytes(context: Context) {
 
-        if (!isEnabled(context, txBytesMobile.id))
+        if (!isEnabled(context, txBytesMobile))
             return
 
         val mobileTx = try {
@@ -139,7 +137,7 @@ class TrafficStatsManager : SensorManager {
     }
     private fun updateTotalRxBytes(context: Context) {
 
-        if (!isEnabled(context, rxBytesTotal.id))
+        if (!isEnabled(context, rxBytesTotal))
             return
 
         val totalRx = try {
@@ -160,7 +158,7 @@ class TrafficStatsManager : SensorManager {
 
     private fun updateTotalTxBytes(context: Context) {
 
-        if (!isEnabled(context, txBytesTotal.id))
+        if (!isEnabled(context, txBytesTotal))
             return
 
         val totalTx = try {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -352,7 +352,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             for (manager in SensorReceiver.MANAGERS) {
                 for (basicSensor in manager.getAvailableSensors(getApplication())) {
-                    manager.isEnabled(getApplication(), basicSensor.id)
+                    manager.isEnabled(getApplication(), basicSensor)
                 }
             }
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -58,7 +58,7 @@ fun SensorUi(
 
     val perm = manager.checkPermission(LocalContext.current, basicSensor.id)
     ToggleChip(
-        checked = (sensor == null && manager.enabledByDefault) ||
+        checked = (sensor == null && basicSensor.enabledByDefault) ||
             (sensor?.enabled == true && perm),
         onCheckedChange = { enabled ->
             val permissions = manager.requiredPermissions(basicSensor.id)

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/BedtimeModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/BedtimeModeSensorManager.kt
@@ -25,8 +25,6 @@ class BedtimeModeSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/wear-os/sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_bedtime_mode
 
@@ -48,7 +46,7 @@ class BedtimeModeSensorManager : SensorManager {
 
     private fun updateBedtimeMode(context: Context) {
 
-        if (!isEnabled(context, bedtimeMode.id))
+        if (!isEnabled(context, bedtimeMode))
             return
 
         val state = try {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -96,8 +96,6 @@ class HealthServicesSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/wear-os/sensors#health-services"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_health_services
@@ -140,11 +138,11 @@ class HealthServicesSensorManager : SensorManager {
     }
 
     private fun updateHealthServices() {
-        val activityStateEnabled = isEnabled(latestContext, userActivityState.id)
-        val dailyFloorEnabled = isEnabled(latestContext, dailyFloors.id)
-        val dailyDistanceEnabled = isEnabled(latestContext, dailyDistance.id)
-        val dailyCaloriesEnabled = isEnabled(latestContext, dailyCalories.id)
-        val dailyStepsEnabled = isEnabled(latestContext, dailySteps.id)
+        val activityStateEnabled = isEnabled(latestContext, userActivityState)
+        val dailyFloorEnabled = isEnabled(latestContext, dailyFloors)
+        val dailyDistanceEnabled = isEnabled(latestContext, dailyDistance)
+        val dailyCaloriesEnabled = isEnabled(latestContext, dailyCalories)
+        val dailyStepsEnabled = isEnabled(latestContext, dailySteps)
 
         if (
             !activityStateEnabled && !dailyFloorEnabled && !dailyDistanceEnabled &&

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -43,8 +43,6 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/wear-os/sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_heart_rate
@@ -73,7 +71,7 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateHeartRate() {
-        if (!isEnabled(latestContext, heartRate.id))
+        if (!isEnabled(latestContext, heartRate))
             return
 
         val now = System.currentTimeMillis()

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/OnBodySensorManager.kt
@@ -33,8 +33,6 @@ class OnBodySensorManager : SensorManager, SensorEventListener {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/wear-os/sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
 
     override val name: Int
         get() = commonR.string.sensor_name_on_body
@@ -58,7 +56,7 @@ class OnBodySensorManager : SensorManager, SensorEventListener {
     }
 
     private fun updateOnBodySensor() {
-        if (!isEnabled(latestContext, onBodySensor.id))
+        if (!isEnabled(latestContext, onBodySensor))
             return
 
         mySensorManager = latestContext.getSystemService()!!

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/TheaterModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/TheaterModeSensorManager.kt
@@ -25,8 +25,6 @@ class TheaterModeSensorManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/wear-os/sensors"
     }
-    override val enabledByDefault: Boolean
-        get() = false
     override val name: Int
         get() = commonR.string.sensor_name_theater_mode
 
@@ -44,7 +42,7 @@ class TheaterModeSensorManager : SensorManager {
 
     private fun updateTheaterMode(context: Context) {
 
-        if (!isEnabled(context, theaterMode.id))
+        if (!isEnabled(context, theaterMode))
             return
 
         val state = try {

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
@@ -26,9 +26,6 @@ class WetModeSensorManager : SensorManager {
 
     private var wetModeEnabled: Boolean = false
 
-    override val enabledByDefault: Boolean
-        get() = false
-
     override val name: Int
         get() = commonR.string.sensor_name_wet_mode
 
@@ -60,7 +57,7 @@ class WetModeSensorManager : SensorManager {
     }
 
     private fun updateWetMode(context: Context) {
-        if (!isEnabled(context, wetModeSensor.id))
+        if (!isEnabled(context, wetModeSensor))
             return
 
         onSensorUpdated(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

As we have had more battery sensors get added the amount of sensors enabled by default has grown. Some of the battery sensors were created based on requests and probably not used by majority of users.  Updating the logic to move from disabled at the manager level to be enabled at the individual sensor level. Default is still `false`

So now the new default sensors will be:

- `battery_level`
- `battery_state`
- `charger_type`


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://user-images.githubusercontent.com/1634145/217370499-ddf2661d-e45c-4e89-b0d3-10ae57e718f2.png)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#907

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Not sure if this should be marked as a breaking change since this only impacts new installs.

If you are planning on testing this PR make sure to use a device name never used in your HA instance otherwise you will see the old sensors enabled by default.