### PR TITLE
Default to carrier name when SIM sensor display name is null

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -128,7 +128,7 @@ class PhoneStateSensorManager : SensorManager {
 
                 if (info != null) {
                     try {
-                        displayName = info.displayName?.toString() ?: displayName
+                        displayName = info.displayName?.toString() ?: info.carrierName.toString()
                         attrs["carrier name"] = info.carrierName
                         attrs["iso country code"] = info.countryIso
                         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Had a user point out that their e-SIM was showing `unavailable` despite using a SIM. Turns out there is data but the `displayName` is `null` so now we will default to the `carrierName` instead of showing `unavailable`

We may need to mark this as a breaking change due to this behavior change.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Ref: https://community.home-assistant.io/t/e-sim-support/483806/17?u=dshokouhi