### PR TITLE
Add Matter module preferred to manifest

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -60,6 +60,17 @@
                 <category android:name="androidx.car.app.category.IOT"/>
             </intent-filter>
         </service>
+        <service
+            android:name="com.google.android.gms.metadata.ModuleDependencies"
+            android:enabled="false"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
+            </intent-filter>
+            <meta-data
+                android:name="home:-1:preferred"
+                android:value=""/>
+        </service>
     </application>
 
 </manifest>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Indicate to Play Services that the app would like to have Matter support. While Android Studio cannot find the class, I suspect this will allow Matter support to be installed without requiring the user to have the Google Home app installed (but this isn't documented anywhere). [Based on the official sample app.](https://github.com/google-home/sample-app-for-matter-android/blob/264c8404cac2b5d1e4195adb6cea4caf12c812bc/app/src/main/AndroidManifest.xml#L71-L79)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Following a comment in home-assistant/home-assistant.io#26165