### PR TITLE
Only use the base URL during onboarding if the URL is Nabu Casa

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -165,8 +165,11 @@ class AuthenticationFragment : Fragment() {
     }
 
     private fun buildAuthUrl(base: String): String {
+        val url = base.toHttpUrl().toUrl()
+        val port = if (url.port > 0) ":${url.port}" else ""
+        val baseUrl = "${url.protocol}://${url.host}$port"
         return try {
-            base.toHttpUrl()
+            baseUrl.toHttpUrl()
                 .newBuilder()
                 .addPathSegments("auth/authorize")
                 .addEncodedQueryParameter("response_type", "code")

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -166,8 +166,8 @@ class AuthenticationFragment : Fragment() {
     }
 
     private fun buildAuthUrl(base: String): String {
-        val url = base.toHttpUrl()
         return try {
+            val url = base.toHttpUrl()
             HttpUrl.Builder()
                 .scheme(url.scheme)
                 .host(url.host)

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -168,7 +168,7 @@ class AuthenticationFragment : Fragment() {
     private fun buildAuthUrl(base: String): String {
         return try {
             val url = base.toHttpUrl()
-            if (url.toString().contains("ui.nabu.casa", true)) {
+            if (url.host.endsWith("ui.nabu.casa", true)) {
                 HttpUrl.Builder()
                     .scheme(url.scheme)
                     .host(url.host)

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegr
 import io.homeassistant.companion.android.themes.ThemesManager
 import io.homeassistant.companion.android.util.TLSWebViewClient
 import io.homeassistant.companion.android.util.isStarted
+import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
@@ -165,12 +166,12 @@ class AuthenticationFragment : Fragment() {
     }
 
     private fun buildAuthUrl(base: String): String {
-        val url = base.toHttpUrl().toUrl()
-        val port = if (url.port > 0) ":${url.port}" else ""
-        val baseUrl = "${url.protocol}://${url.host}$port"
+        val url = base.toHttpUrl()
         return try {
-            baseUrl.toHttpUrl()
-                .newBuilder()
+            HttpUrl.Builder()
+                .scheme(url.scheme)
+                .host(url.host)
+                .port(url.port)
                 .addPathSegments("auth/authorize")
                 .addEncodedQueryParameter("response_type", "code")
                 .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -168,16 +168,27 @@ class AuthenticationFragment : Fragment() {
     private fun buildAuthUrl(base: String): String {
         return try {
             val url = base.toHttpUrl()
-            HttpUrl.Builder()
-                .scheme(url.scheme)
-                .host(url.host)
-                .port(url.port)
-                .addPathSegments("auth/authorize")
-                .addEncodedQueryParameter("response_type", "code")
-                .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
-                .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
-                .build()
-                .toString()
+            if (url.toString().contains("ui.nabu.casa", true)) {
+                HttpUrl.Builder()
+                    .scheme(url.scheme)
+                    .host(url.host)
+                    .port(url.port)
+                    .addPathSegments("auth/authorize")
+                    .addEncodedQueryParameter("response_type", "code")
+                    .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
+                    .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
+                    .build()
+                    .toString()
+            } else {
+                url
+                    .newBuilder()
+                    .addPathSegments("auth/authorize")
+                    .addEncodedQueryParameter("response_type", "code")
+                    .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
+                    .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
+                    .build()
+                    .toString()
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Unable to build authentication URL", e)
             Toast.makeText(context, commonR.string.error_connection_failed, Toast.LENGTH_LONG).show()

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -168,27 +168,21 @@ class AuthenticationFragment : Fragment() {
     private fun buildAuthUrl(base: String): String {
         return try {
             val url = base.toHttpUrl()
-            if (url.host.endsWith("ui.nabu.casa", true)) {
+            val builder = if (url.host.endsWith("ui.nabu.casa", true)) {
                 HttpUrl.Builder()
                     .scheme(url.scheme)
                     .host(url.host)
                     .port(url.port)
-                    .addPathSegments("auth/authorize")
-                    .addEncodedQueryParameter("response_type", "code")
-                    .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
-                    .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
-                    .build()
-                    .toString()
             } else {
-                url
-                    .newBuilder()
-                    .addPathSegments("auth/authorize")
-                    .addEncodedQueryParameter("response_type", "code")
-                    .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
-                    .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
-                    .build()
-                    .toString()
+                url.newBuilder()
             }
+            builder
+                .addPathSegments("auth/authorize")
+                .addEncodedQueryParameter("response_type", "code")
+                .addEncodedQueryParameter("client_id", AuthenticationService.CLIENT_ID)
+                .addEncodedQueryParameter("redirect_uri", AUTH_CALLBACK)
+                .build()
+                .toString()
         } catch (e: Exception) {
             Log.e(TAG, "Unable to build authentication URL", e)
             Toast.makeText(context, commonR.string.error_connection_failed, Toast.LENGTH_LONG).show()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that during onboarding if a user enters a URL with say the lovelace path like a dashboard from a bookmark then the frontend will not present the correct login screen. This in turn means the app does not save any data upon exit and the user needs to onboard again. Even the Companion App menu item is missing.

example: `https://example.com/lovelace/home`

![image](https://user-images.githubusercontent.com/1634145/217688273-a1cd9b6f-b18d-4059-8a62-db7cbddbf5c4.png)

With this change we now force the URL to be just the base URL, there may be a better way to construct the actual base URL but this is what I found as of now :)

Fixes: #2220


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Ref: https://community.home-assistant.io/t/new-android-device-does-not-keep-connection-info-between-uses-with-the-companion-app/382766/25?u=dshokouhi

CC: @bramkragten - I am not sure if its correct that the frontend is serving the incorrect login page. Notice in the screenshot how the user is prompted to save the login.

CC:  @home-assistant/ios-developers - in case a similar fix should be applied elsewhere. I am not sure if iOS also looks at the URL to remove everything but the base URL. I imagine its a common use case for users to copy and paste the URL if discovery did not work.