### PR TITLE
Revert "Add Matter module preferred to manifest"

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -60,17 +60,6 @@
                 <category android:name="androidx.car.app.category.IOT"/>
             </intent-filter>
         </service>
-        <service
-            android:name="com.google.android.gms.metadata.ModuleDependencies"
-            android:enabled="false"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
-            </intent-filter>
-            <meta-data
-                android:name="home:-1:preferred"
-                android:value=""/>
-        </service>
     </application>
 
 </manifest>


### PR DESCRIPTION
Reverts home-assistant/android#3319

This caused us to be unable to upload the app to the Play Store or Firebase.