### PR TITLE
Allow device credential for app lock setup

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/authenticator/Authenticator.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/authenticator/Authenticator.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.authenticator
 
 import android.content.Context
 import android.util.Log
+import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricPrompt
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
@@ -11,6 +12,8 @@ class Authenticator(context: Context, fragmentActivity: FragmentActivity, callba
         const val CANCELED = 2
         const val SUCCESS = 1
         const val ERROR = 0
+
+        const val AUTH_TYPES = Authenticators.DEVICE_CREDENTIAL or Authenticators.BIOMETRIC_WEAK
     }
 
     private val executor = ContextCompat.getMainExecutor(context)
@@ -42,7 +45,7 @@ class Authenticator(context: Context, fragmentActivity: FragmentActivity, callba
         val promptDialog = BiometricPrompt.PromptInfo.Builder()
             .setTitle(title)
             .setConfirmationRequired(false)
-            .setDeviceCredentialAllowed(true)
+            .setAllowedAuthenticators(AUTH_TYPES)
             .build()
 
         biometricPrompt.authenticate(promptDialog)

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -41,6 +41,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.notifications.DeviceCommandData
@@ -1701,7 +1702,7 @@ class MessagingManager @Inject constructor(
         val appLockTimeoutValue = data[APP_LOCK_TIMEOUT]?.toIntOrNull()
         val homeBypassEnableValue = data[HOME_BYPASS_ENABLED]?.lowercase()?.toBooleanStrictOrNull()
 
-        val canAuth = (BiometricManager.from(context).canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS)
+        val canAuth = (BiometricManager.from(context).canAuthenticate(Authenticator.AUTH_TYPES) == BiometricManager.BIOMETRIC_SUCCESS)
         val serverId = data[THIS_SERVER_ID]!!.toInt()
         if (canAuth) {
             if (appLockEnableValue != null) {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -204,7 +204,7 @@ class SettingsActivity : BaseActivity() {
     }
 
     fun requestAuthentication(title: String, callback: (Int) -> Boolean): Boolean {
-        return if (BiometricManager.from(this).canAuthenticate() != BiometricManager.BIOMETRIC_SUCCESS) {
+        return if (BiometricManager.from(this).canAuthenticate(Authenticator.AUTH_TYPES) != BiometricManager.BIOMETRIC_SUCCESS) {
             false
         } else {
             externalAuthCallback = callback


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3299 by allowing device credentials in addition to (weak) biometrics when enabling app lock. [`canAuthenticate()`](https://developer.android.com/reference/kotlin/androidx/biometric/BiometricManager?hl=en#canAuthenticate()) has always required biometrics based on what I can find so this issue must not have been noticed before.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->