### PR TITLE
Sync Thread datasets when starting Matter commissioning

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -168,6 +168,7 @@ dependencies {
 
     "fullImplementation"("com.google.android.gms:play-services-location:21.0.1")
     "fullImplementation"("com.google.android.gms:play-services-home:16.0.0")
+    "fullImplementation"("com.google.android.gms:play-services-threadnetwork:16.0.0-beta02")
     "fullImplementation"(platform("com.google.firebase:firebase-bom:31.1.1"))
     "fullImplementation"("com.google.firebase:firebase-messaging")
     "fullImplementation"("io.sentry:sentry-android:6.14.0")

--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-sdk tools:overrideLibrary="com.google.android.gms.threadnetwork" />
 
     <application
         android:name="io.homeassistant.companion.android.HomeAssistantApplication" >

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -1,0 +1,81 @@
+package io.homeassistant.companion.android.thread
+
+import android.app.Activity
+import android.content.Context
+import android.content.IntentSender
+import android.os.Build
+import android.util.Log
+import androidx.activity.result.ActivityResult
+import com.google.android.gms.threadnetwork.ThreadBorderAgent
+import com.google.android.gms.threadnetwork.ThreadNetwork
+import com.google.android.gms.threadnetwork.ThreadNetworkCredentials
+import io.homeassistant.companion.android.common.data.HomeAssistantVersion
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+import javax.inject.Inject
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+class ThreadManagerImpl @Inject constructor(
+    private val serverManager: ServerManager
+) : ThreadManager {
+    companion object {
+        private const val TAG = "ThreadManagerImpl"
+
+        // ID is a placeholder while we wait for Google to remove the requirement to provide one
+        private const val BORDER_AGENT_ID = "0000000000000001"
+    }
+
+    override fun appSupportsThread(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+
+    override suspend fun coreSupportsThread(serverId: Int): Boolean {
+        if (!serverManager.isRegistered() || serverManager.getServer(serverId) == null) return false
+        val config = serverManager.webSocketRepository(serverId).getConfig()
+        return config != null &&
+            config.components.contains("thread") &&
+            HomeAssistantVersion.fromString(config.version)?.isAtLeast(2023, 3, 0) == true
+    }
+
+    override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? {
+        val datasets = serverManager.webSocketRepository(serverId).getThreadDatasets()
+        return datasets?.firstOrNull { it.preferred }
+    }
+
+    override suspend fun importPreferredDatasetFromServer(context: Context, serverId: Int) {
+        val preferred = getPreferredDatasetFromServer(serverId) ?: return
+        val tlv = serverManager.webSocketRepository(serverId).getThreadDatasetTlv(preferred.datasetId)?.tlvAsByteArray
+        if (tlv != null) {
+            val threadBorderAgent = ThreadBorderAgent.newBuilder(BORDER_AGENT_ID.toByteArray()).build()
+            val threadNetworkCredentials = ThreadNetworkCredentials.fromActiveOperationalDataset(tlv)
+            suspendCoroutine { cont ->
+                ThreadNetwork.getClient(context).addCredentials(threadBorderAgent, threadNetworkCredentials)
+                    .addOnSuccessListener { cont.resume(Unit) }
+                    .addOnFailureListener { cont.resumeWithException(it) }
+            }
+        }
+    }
+
+    override suspend fun getThreadPreferredDatasetExport(context: Context): IntentSender? = suspendCoroutine { cont ->
+        if (appSupportsThread()) {
+            ThreadNetwork.getClient(context)
+                .preferredCredentials
+                .addOnSuccessListener { cont.resume(it.intentSender) }
+                .addOnFailureListener { cont.resumeWithException(it) }
+        } else {
+            cont.resumeWithException(IllegalStateException("Thread is not supported on SDK <27"))
+        }
+    }
+
+    override suspend fun sendThreadDatasetExportResult(result: ActivityResult, serverId: Int) {
+        if (result.resultCode == Activity.RESULT_OK && coreSupportsThread(serverId)) {
+            val threadNetworkCredentials = ThreadNetworkCredentials.fromIntentSenderResultData(result.data!!)
+            try {
+                serverManager.webSocketRepository(serverId).addThreadDataset(threadNetworkCredentials.activeOperationalDataset)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error while executing server new Thread credentials request", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/matter/MatterFrontendCommissioningStatus.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/matter/MatterFrontendCommissioningStatus.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.matter
 enum class MatterFrontendCommissioningStatus {
     NOT_STARTED,
     REQUESTED,
+    THREAD_EXPORT_TO_SERVER,
     IN_PROGRESS,
     ERROR
 }

--- a/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -29,13 +29,13 @@ interface MatterManager {
 
     /**
      * Send a request to the server to add a Matter device to the network and commission it
-     * @return `true` if the request was successful
+     * @return [MatterCommissionResponse], or `null` if it wasn't possible to complete the request
      */
     suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse?
 
     /**
      * Send a request to the server to commission an "on network" Matter device
-     * @return `true` if the request was successful
+     * @return [MatterCommissionResponse], or `null` if it wasn't possible to complete the request
      */
     suspend fun commissionOnNetworkDevice(pin: Long, serverId: Int): MatterCommissionResponse?
 }

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+import kotlinx.coroutines.CoroutineScope
 
 interface ThreadManager {
 
@@ -18,16 +19,30 @@ interface ThreadManager {
     suspend fun coreSupportsThread(serverId: Int): Boolean
 
     /**
+     * Try to sync the preferred Thread dataset with the device and server. If one has a preferred
+     * dataset while the other one doesn't, it will sync. If both have or don't have preferred
+     * datasets, skip syncing.
+     * @return [IntentSender] if permission is required to import the device dataset, `null` if
+     * syncing completed or there is nothing to sync
+     */
+    suspend fun syncPreferredDataset(
+        context: Context,
+        serverId: Int,
+        scope: CoroutineScope
+    ): IntentSender?
+
+    /**
      * Get the preferred Thread dataset from the server.
      */
     suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse?
 
     /**
-     * Import the preferred Thread dataset from the server to this device.
+     * Import a Thread dataset from the server to this device.
+     * @param datasetId The dataset ID as provided by the server
      * @throws Exception if a preferred dataset exists on the server, but it wasn't possible to
      * import it
      */
-    suspend fun importPreferredDatasetFromServer(context: Context, serverId: Int)
+    suspend fun importDatasetFromServer(context: Context, datasetId: String, serverId: Int)
 
     /**
      * Start a flow to get the preferred Thread dataset from this device to export to the server.
@@ -35,11 +50,11 @@ interface ThreadManager {
      * `null` if there are no datasets to import
      * @throws Exception if it is not possible to get the preferred dataset
      */
-    suspend fun getThreadPreferredDatasetExport(context: Context): IntentSender?
+    suspend fun getPreferredDatasetFromDevice(context: Context): IntentSender?
 
     /**
-     * Process the result from [getThreadPreferredDatasetExport]'s intent and add it to the server
-     * as a new Thread dataset.
+     * Process the result from [syncPreferredDataset] or [getPreferredDatasetFromDevice]'s intent
+     * and add the Thread dataset, if any, to the server.
      */
     suspend fun sendThreadDatasetExportResult(result: ActivityResult, serverId: Int)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -1,0 +1,45 @@
+package io.homeassistant.companion.android.thread
+
+import android.content.Context
+import android.content.IntentSender
+import androidx.activity.result.ActivityResult
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+
+interface ThreadManager {
+
+    /**
+     * Indicates if the app on this device supports Thread credential management.
+     */
+    fun appSupportsThread(): Boolean
+
+    /**
+     * Indicates if the server supports Thread credential management.
+     */
+    suspend fun coreSupportsThread(serverId: Int): Boolean
+
+    /**
+     * Get the preferred Thread dataset from the server.
+     */
+    suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse?
+
+    /**
+     * Import the preferred Thread dataset from the server to this device.
+     * @throws Exception if a preferred dataset exists on the server, but it wasn't possible to
+     * import it
+     */
+    suspend fun importPreferredDatasetFromServer(context: Context, serverId: Int)
+
+    /**
+     * Start a flow to get the preferred Thread dataset from this device to export to the server.
+     * @return [IntentSender] to ask the user for permission to share the preferred dataset, or
+     * `null` if there are no datasets to import
+     * @throws Exception if it is not possible to get the preferred dataset
+     */
+    suspend fun getThreadPreferredDatasetExport(context: Context): IntentSender?
+
+    /**
+     * Process the result from [getThreadPreferredDatasetExport]'s intent and add it to the server
+     * as a new Thread dataset.
+     */
+    suspend fun sendThreadDatasetExportResult(result: ActivityResult, serverId: Int)
+}

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadModule.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadModule.kt
@@ -1,0 +1,15 @@
+package io.homeassistant.companion.android.thread
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ThreadModule {
+    @Binds
+    @Singleton
+    abstract fun bindThreadManager(threadManager: ThreadManagerImpl): ThreadManager
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.webview
 
 import android.annotation.SuppressLint
-import android.app.Activity
 import android.app.DownloadManager
 import android.app.PictureInPictureParams
 import android.content.ActivityNotFoundException
@@ -164,9 +163,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         mFilePathCallback = null
     }
     private val commissionMatterDevice = registerForActivityResult(ActivityResultContracts.StartIntentSenderForResult()) { result ->
-        // Any errors will have been shown in the UI provided by Play Services
-        if (result.resultCode == Activity.RESULT_OK) Log.d(TAG, "Matter commissioning returned success")
-        else Log.d(TAG, "Matter commissioning returned with non-OK code ${result.resultCode}")
+        presenter.onMatterCommissioningIntentResult(this, result)
     }
 
     @Inject
@@ -683,6 +680,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 presenter.getMatterCommissioningStatusFlow().collect {
                     Log.d(TAG, "Matter commissioning status changed to $it")
                     when (it) {
+                        MatterFrontendCommissioningStatus.THREAD_EXPORT_TO_SERVER,
                         MatterFrontendCommissioningStatus.IN_PROGRESS -> {
                             presenter.getMatterCommissioningIntent()?.let { intentSender ->
                                 commissionMatterDevice.launch(IntentSenderRequest.Builder(intentSender).build())

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.webview
 
 import android.content.Context
 import android.content.IntentSender
+import androidx.activity.result.ActivityResult
 import io.homeassistant.companion.android.matter.MatterFrontendCommissioningStatus
 import kotlinx.coroutines.flow.Flow
 
@@ -47,5 +48,6 @@ interface WebViewPresenter {
     fun startCommissioningMatterDevice(context: Context)
     fun getMatterCommissioningStatusFlow(): Flow<MatterFrontendCommissioningStatus>
     fun getMatterCommissioningIntent(): IntentSender?
+    fun onMatterCommissioningIntentResult(context: Context, result: ActivityResult)
     fun confirmMatterCommissioningError()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -1,10 +1,12 @@
 package io.homeassistant.companion.android.webview
 
+import android.app.Activity
 import android.content.Context
 import android.content.IntentSender
 import android.graphics.Color
 import android.net.Uri
 import android.util.Log
+import androidx.activity.result.ActivityResult
 import dagger.hilt.android.qualifiers.ActivityContext
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
@@ -12,10 +14,12 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.matter.MatterFrontendCommissioningStatus
 import io.homeassistant.companion.android.matter.MatterManager
+import io.homeassistant.companion.android.thread.ThreadManager
 import io.homeassistant.companion.android.util.UrlHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +40,8 @@ class WebViewPresenterImpl @Inject constructor(
     @ActivityContext context: Context,
     private val serverManager: ServerManager,
     private val prefsRepository: PrefsRepository,
-    private val matterUseCase: MatterManager
+    private val matterUseCase: MatterManager,
+    private val threadUseCase: ThreadManager
 ) : WebViewPresenter {
 
     companion object {
@@ -289,19 +294,52 @@ class WebViewPresenterImpl @Inject constructor(
         if (_matterCommissioningStatus.value != MatterFrontendCommissioningStatus.REQUESTED) {
             _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.REQUESTED)
 
-            matterUseCase.startNewCommissioningFlow(
-                context,
-                { intentSender ->
-                    Log.d(TAG, "Matter commissioning is ready")
-                    matterCommissioningIntentSender = intentSender
-                    _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.IN_PROGRESS)
-                },
-                { e ->
-                    Log.e(TAG, "Matter commissioning couldn't be prepared", e)
-                    _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.ERROR)
+            mainScope.launch {
+                if (!threadUseCase.appSupportsThread() || !threadUseCase.coreSupportsThread(serverId)) {
+                    startMatterCommissioningFlow(context)
+                    return@launch
                 }
-            )
+
+                val getDeviceThreadIntent = async { threadUseCase.getThreadPreferredDatasetExport(context) }
+                val getCoreThreadDataset = async { threadUseCase.getPreferredDatasetFromServer(serverId) }
+                val deviceThreadIntent = getDeviceThreadIntent.await()
+                val coreThreadDataset = getCoreThreadDataset.await()
+                if (deviceThreadIntent == null && coreThreadDataset != null) {
+                    startThreadPreferredCredentialsImport(context)
+                } else if (deviceThreadIntent != null && coreThreadDataset == null) {
+                    Log.d(TAG, "Thread export is ready")
+                    matterCommissioningIntentSender = deviceThreadIntent
+                    _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.THREAD_EXPORT_TO_SERVER)
+                } else { // If device and core both have or don't have datasets, skip import/export
+                    startMatterCommissioningFlow(context)
+                }
+            }
         } // else already waiting for a result, don't send another request
+    }
+
+    private suspend fun startThreadPreferredCredentialsImport(context: Context) {
+        try {
+            threadUseCase.importPreferredDatasetFromServer(context, serverId)
+            Log.d(TAG, "Thread import to device completed")
+        } catch (e: Exception) {
+            Log.e(TAG, "Thread import to device failed, continuing with commissioning")
+        }
+        startMatterCommissioningFlow(context)
+    }
+
+    private fun startMatterCommissioningFlow(context: Context) {
+        matterUseCase.startNewCommissioningFlow(
+            context,
+            { intentSender ->
+                Log.d(TAG, "Matter commissioning is ready")
+                matterCommissioningIntentSender = intentSender
+                _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.IN_PROGRESS)
+            },
+            { e ->
+                Log.e(TAG, "Matter commissioning couldn't be prepared", e)
+                _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.ERROR)
+            }
+        )
     }
 
     override fun getMatterCommissioningStatusFlow(): Flow<MatterFrontendCommissioningStatus> =
@@ -311,6 +349,22 @@ class WebViewPresenterImpl @Inject constructor(
         val intent = matterCommissioningIntentSender
         matterCommissioningIntentSender = null
         return intent
+    }
+
+    override fun onMatterCommissioningIntentResult(context: Context, result: ActivityResult) {
+        when (_matterCommissioningStatus.value) {
+            MatterFrontendCommissioningStatus.THREAD_EXPORT_TO_SERVER -> {
+                mainScope.launch {
+                    threadUseCase.sendThreadDatasetExportResult(result, serverId)
+                    startMatterCommissioningFlow(context)
+                }
+            }
+            else -> {
+                // Any errors will have been shown in the UI provided by Play Services
+                if (result.resultCode == Activity.RESULT_OK) Log.d(TAG, "Matter commissioning returned success")
+                else Log.d(TAG, "Matter commissioning returned with non-OK code ${result.resultCode}")
+            }
+        }
     }
 
     override fun confirmMatterCommissioningError() {

--- a/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.thread
+
+import android.content.Context
+import android.content.IntentSender
+import androidx.activity.result.ActivityResult
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+import javax.inject.Inject
+
+class ThreadManagerImpl @Inject constructor() : ThreadManager {
+
+    // Thread support currently depends on Google Play Services,
+    // and as a result Thread is not supported with the minimal flavor
+
+    override fun appSupportsThread(): Boolean = false
+
+    override suspend fun coreSupportsThread(serverId: Int): Boolean = false
+
+    override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? = null
+
+    override suspend fun importPreferredDatasetFromServer(context: Context, serverId: Int) { }
+
+    override suspend fun getThreadPreferredDatasetExport(context: Context): IntentSender? {
+        throw IllegalStateException("Thread is not supported with the minimal flavor")
+    }
+
+    override suspend fun sendThreadDatasetExportResult(result: ActivityResult, serverId: Int) { }
+}

--- a/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 
 class ThreadManagerImpl @Inject constructor() : ThreadManager {
@@ -15,11 +16,17 @@ class ThreadManagerImpl @Inject constructor() : ThreadManager {
 
     override suspend fun coreSupportsThread(serverId: Int): Boolean = false
 
+    override suspend fun syncPreferredDataset(
+        context: Context,
+        serverId: Int,
+        scope: CoroutineScope
+    ): IntentSender? = null
+
     override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? = null
 
-    override suspend fun importPreferredDatasetFromServer(context: Context, serverId: Int) { }
+    override suspend fun importDatasetFromServer(context: Context, datasetId: String, serverId: Int) { }
 
-    override suspend fun getThreadPreferredDatasetExport(context: Context): IntentSender? {
+    override suspend fun getPreferredDatasetFromDevice(context: Context): IntentSender? {
         throw IllegalStateException("Thread is not supported with the minimal flavor")
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -16,6 +16,8 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ge
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.MatterCommissionResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.TemplateUpdatedEvent
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetTlvResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.TriggerEvent
 import kotlinx.coroutines.flow.Flow
 
@@ -41,6 +43,9 @@ interface WebSocketRepository {
     suspend fun ackNotification(confirmId: String): Boolean
     suspend fun commissionMatterDevice(code: String): MatterCommissionResponse?
     suspend fun commissionMatterDeviceOnNetwork(pin: Long): MatterCommissionResponse?
+    suspend fun getThreadDatasets(): List<ThreadDatasetResponse>?
+    suspend fun getThreadDatasetTlv(datasetId: String): ThreadDatasetTlvResponse?
+    suspend fun addThreadDataset(tlv: ByteArray): Boolean
     suspend fun getConversation(speech: String): ConversationResponse?
 }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
@@ -1,0 +1,13 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class ThreadDatasetResponse(
+    val datasetId: String,
+    val extendedPanId: String,
+    val networkName: String,
+    val panId: String,
+    val preferred: Boolean,
+    val source: String
+)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetTlvResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetTlvResponse.kt
@@ -1,0 +1,8 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+data class ThreadDatasetTlvResponse(
+    val tlv: String
+) {
+    val tlvAsByteArray: ByteArray
+        get() = tlv.chunked(2).map { it.toInt(16).toByte() }.toByteArray()
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/TextUtil.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/TextUtil.kt
@@ -1,0 +1,15 @@
+package io.homeassistant.companion.android.common.util
+
+import okhttp3.internal.and
+
+private val HEX_ARRAY = "0123456789ABCDEF".toCharArray()
+
+fun ByteArray.toHexString(): String { // From https://stackoverflow.com/a/9855338/4214819
+    val hexChars = CharArray(this.size * 2)
+    for (j in 0 until this.size) {
+        val v = get(j) and 0xFF
+        hexChars[j * 2] = HEX_ARRAY[v ushr 4]
+        hexChars[j * 2 + 1] = HEX_ARRAY[v and 0x0F]
+    }
+    return String(hexChars)
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When starting Matter commissioning, automatically check if there are Thread datasets on the device or in core but not the other, and if so sync them. This new dataset should be marked as 'preferred' by Play Services/core as it is the only dataset available.

The app currently doesn't try to update or delete datasets automatically, for now this should be handled from the Thread config panel (not yet implemented).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
There are no visible changes for importing a dataset to the device / exporting from Home Assistant, this happens in the background.

When exporting a dataset from the device / importing into Home Assistant, a permission dialog will be shown.

Frontend flow: see [the blog post about Thread earlier this month](https://www.home-assistant.io/blog/2023/02/08/state-of-matter-and-thread/#thread), including the [demo video](https://www.youtube.com/watch?v=Fk0n0r0eKcE) for the full flow.
![A dialog on top of the frontend titled 'Allow Home Assistant to access your home network?', with the message 'Devices managed by this app can connect to your home network'](https://www.home-assistant.io/images/blog/2023-02-08-state-of-matter-and-thread/android-thread.png)

Shared device flow: the permission dialog will be shown after confirming to import the device.
|Light|Dark|
|-----|-----|
|![A dialog on top of the shared device flow titled 'Allow Home Assistant to access your home network?', with the message 'Devices managed by this app can connect to your home network', light mode](https://user-images.githubusercontent.com/8148535/219876150-65a71b7c-de71-4c93-8e30-73d30100be58.png)|![A dialog on top of the shared device flow titled 'Allow Home Assistant to access your home network?', with the message 'Devices managed by this app can connect to your home network', dark mode](https://user-images.githubusercontent.com/8148535/219876153-70d3cd63-8c0b-4280-b9ee-b7ff399eb1bd.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
For testing:

 - Requires core >= 2023.3.
 - Thread datasets are stored in Play Services. Removing all stored data for Play Services will clear stored credentials, but probably also Matter and Thread support modules so you may need to reinstall Google Home while connected to a charger to get those back quickly.