### PR TITLE
feature/minimumFontSize Proportional font styles are very blurry on l…

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -295,6 +295,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 }
             })
 
+            settings.minimumFontSize = 5
             settings.javaScriptEnabled = true
             settings.domStorageEnabled = true
             settings.displayZoomControls = false


### PR DESCRIPTION
Proportional font styles are very blurry on low resolution devices. 

Problem:
**minimumFontSize** default is 8
https://developer.android.com/reference/android/webkit/WebSettings#setMinimumFontSize(int)
Example when style **font-size: 1vw** is automatically cast to **8px** (device: honor 20 pro)
![4](https://user-images.githubusercontent.com/24318525/220207838-dc0f0f42-d6f3-4c99-aa06-b969f4d2c098.png)
