### PR TITLE
Enable location tracking toggle in additional server onboarding

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -108,10 +108,7 @@ class SettingsFragment(
         findPreference<Preference>("server_add")?.let {
             it.setOnPreferenceClickListener {
                 requestOnboardingResult.launch(
-                    OnboardApp.Input(
-                        url = "", // Skip the 'Welcome' screen
-                        locationTrackingPossible = false // Skip because sensors are shared
-                    )
+                    OnboardApp.Input(url = "") // Empty url skips the 'Welcome' screen
                 )
                 return@setOnPreferenceClickListener true
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Enable the toggle for location tracking in onboarding when adding additional servers (when using the full flavor). This was previously disabled as sensors were shared between all servers but the app supports server-level sensor enabling now.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
It's the same toggle as in initial onboarding

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a, covered by note about multi-server sensors

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->