### PR TITLE
Disable auto suggest on input fields for URLs

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupView.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -59,7 +60,7 @@ fun ManualSetupView(
             modifier = Modifier.align(Alignment.CenterHorizontally),
             label = { Text(stringResource(id = commonR.string.input_url)) },
             singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, autoCorrect = false, keyboardType = KeyboardType.Uri),
             keyboardActions = KeyboardActions(
                 onDone = {
                     keyboardController?.hide()

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
@@ -133,6 +133,9 @@ class ServerSettingsFragment : ServerSettingsView, PreferenceFragmentCompat() {
         }
 
         findPreference<EditTextPreference>("connection_internal")?.let {
+            it.setOnBindEditTextListener { edit ->
+                edit.inputType = InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
+            }
             it.onPreferenceChangeListener =
                 onChangeUrlValidator
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlInputView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/views/ExternalUrlInputView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import io.homeassistant.companion.android.common.R as commonR
@@ -53,7 +54,7 @@ fun ExternalUrlInputView(
                 urlInput = it
                 urlError = false
             },
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done, autoCorrect = false, keyboardType = KeyboardType.Uri),
             keyboardActions = KeyboardActions(
                 onDone = {
                     urlError = !performUrlUpdate(urlInput?.trim(), url, onSaveUrl)

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -20,7 +20,7 @@
             android:layout_marginTop="8dp"
             android:ems="10"
             android:hint="@string/input_url_hint"
-            android:inputType="textPersonName"
+            android:inputType="textNoSuggestions"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textView"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that our input text fields for URLs (onboarding and server info) do not stop auto suggest from doing its thing. This has an undesirable effect of changing `homeassistant` to `home assistant` so if a user tries to type in `http://homeassistant.local` they may end up with `http://home assistant. local` or something similar. So disabling auto suggest on these fields to prevent that issue from occurring.
 
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->