### PR TITLE
Use a black background for Wear OS onboarding screens

### DIFF
--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@android:color/black"
     android:padding="@dimen/box_inset_layout_padding"
     tools:context=".onboarding.integration.MobileAppIntegrationActivity"
     tools:deviceIds="wear">

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@android:color/black"
     android:padding="@dimen/box_inset_layout_padding"
     tools:deviceIds="wear">
 

--- a/wear/src/main/res/layout/activity_onboarding.xml
+++ b/wear/src/main/res/layout/activity_onboarding.xml
@@ -5,6 +5,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
+    android:background="@android:color/black"
     android:layout_height="match_parent">
 
     <androidx.wear.widget.WearableRecyclerView

--- a/wear/src/main/res/layout/view_loading.xml
+++ b/wear/src/main/res/layout/view_loading.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
-    android:background="@color/colorActivityBackground">
+    android:background="@android:color/black">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/loading_text"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This update is to meet upcoming play policy requirements where all backgrounds should be black on a wearable. I noticed the background was not exactly black so now forcing it for all the onboarding screens.

`Use a black background for all apps and tiles.`

https://developer.android.com/docs/quality-guidelines/wear-app-quality#upcoming

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

Before
![image](https://user-images.githubusercontent.com/1634145/222508134-ea46decf-818c-49ea-852e-3dc2d52a722c.png)

After
![image](https://user-images.githubusercontent.com/1634145/222508363-f0f0f2b6-bceb-4d9c-bf72-b407a2877467.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->