### PR TITLE
Fix (potential) crashes when deleting a server

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
@@ -27,13 +27,17 @@ abstract class LaunchPresenterBase(
                 .filter { serverManager.authenticationRepository(it.id).getSessionState() == SessionState.ANONYMOUS }
                 .forEach { serverManager.removeServer(it.id) }
 
-            if (
-                serverManager.isRegistered() &&
-                serverManager.authenticationRepository().getSessionState() == SessionState.CONNECTED
-            ) {
-                resyncRegistration()
-                view.displayWebview()
-            } else {
+            try {
+                if (
+                    serverManager.isRegistered() &&
+                    serverManager.authenticationRepository().getSessionState() == SessionState.CONNECTED
+                ) {
+                    resyncRegistration()
+                    view.displayWebview()
+                } else {
+                    view.displayOnBoarding(false)
+                }
+            } catch (e: IllegalArgumentException) { // Server was just removed, nothing is added
                 view.displayOnBoarding(false)
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsActivity.kt
@@ -207,7 +207,11 @@ class SettingsActivity : BaseActivity() {
 
     fun setAppActive(serverId: Int?, active: Boolean) = runBlocking {
         serverManager.getServer(serverId ?: ServerManager.SERVER_ID_ACTIVE)?.let {
-            serverManager.integrationRepository(it.id).setAppActive(active)
+            try {
+                serverManager.integrationRepository(it.id).setAppActive(active)
+            } catch (e: IllegalArgumentException) {
+                Log.w(TAG, "Cannot set app active $active for server $serverId")
+            }
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -112,7 +112,10 @@ class ServerSettingsPresenterImpl @Inject constructor(
                 // Remove server anyway, the user wants to delete and we don't need the server for that
             }
             serverManager.removeServer(serverId)
-            view.onRemovedServer(success = true, hasAnyRemaining = serverManager.defaultServers.any())
+            view.onRemovedServer(
+                success = true,
+                hasAnyRemaining = serverManager.defaultServers.any { it.id != serverId }
+            )
         } ?: run {
             view.onRemovedServer(success = false, hasAnyRemaining = true)
         }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -178,6 +178,11 @@ class ServerSettingsPresenterImpl @Inject constructor(
     }
 
     override fun setAppActive(active: Boolean) = runBlocking {
-        serverManager.integrationRepository(serverId).setAppActive(active)
+        try {
+            serverManager.integrationRepository(serverId).setAppActive(active)
+        } catch (e: IllegalArgumentException) {
+            Log.w(TAG, "Cannot set app active $active for server $serverId")
+            Unit
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -247,7 +247,12 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun setAppActive(active: Boolean) = runBlocking {
         serverManager.getServer(serverId)?.let {
-            serverManager.integrationRepository(serverId).setAppActive(active)
+            try {
+                serverManager.integrationRepository(serverId).setAppActive(active)
+            } catch (e: IllegalStateException) {
+                Log.w(TAG, "Cannot set app active $active for server $serverId")
+                Unit
+            }
         } ?: Unit
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Noticed a crash when removing a server that wasn't there before, turns out there are possible race conditions as we usually remove a server and at the same time or immediately after that finish an activity or do something else that tries to update the active server, which now no longer exists. Catch exceptions in these cases as they are expected to prevent a crash.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->