### PR TITLE
Fix listed beacons that are out of range after enable

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/IBeaconMonitor.kt
@@ -38,6 +38,10 @@ class IBeaconMonitor {
         }
     }
 
+    fun clearBeacons() {
+        beacons = listOf()
+    }
+
     fun setBeacons(context: Context, newBeacons: Collection<Beacon>) {
         lastSeenBeacons = newBeacons // unfiltered list, for the settings UI
         var requireUpdate = false

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
@@ -66,10 +66,12 @@ class MonitoringManager {
             region = buildRegion()
             scope.launch(Dispatchers.Main) {
                 beaconManager.getRegionViewModel(region).rangedBeacons.observeForever { beacons ->
-                    haMonitor.setBeacons(
-                        context,
-                        beacons
-                    )
+                    if(beaconManager.isAnyConsumerBound) {
+                        haMonitor.setBeacons(
+                            context,
+                            beacons
+                        )
+                    }
                 }
             }
         }
@@ -95,6 +97,7 @@ class MonitoringManager {
     fun stopMonitoring(context: Context, haMonitor: IBeaconMonitor) {
         if (isMonitoring()) {
             beaconManager.stopRangingBeacons(region)
+            haMonitor.clearBeacons()
             beaconManager.disableForegroundServiceScanning()
             haMonitor.sensorManager.updateBeaconMonitoringSensor(context)
         }

--- a/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/bluetooth/ble/MonitoringManager.kt
@@ -66,7 +66,7 @@ class MonitoringManager {
             region = buildRegion()
             scope.launch(Dispatchers.Main) {
                 beaconManager.getRegionViewModel(region).rangedBeacons.observeForever { beacons ->
-                    if(beaconManager.isAnyConsumerBound) {
+                    if (beaconManager.isAnyConsumerBound) {
                         haMonitor.setBeacons(
                             context,
                             beacons


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This MR fixes a bug, where the beacon monitor lists iBeacons that are out of range after enabling.
https://github.com/home-assistant/android/issues/3010 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->