### PR TITLE
Allow clickAction to be set to noAction to do nothing

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -112,6 +112,7 @@ class MessagingManager @Inject constructor(
         const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
         const val SETTINGS_PREFIX = "settings://"
         const val NOTIFICATION_HISTORY = "notification_history"
+        const val NO_ACTION = "noAction"
 
         const val SUBJECT = "subject"
         const val TIMEOUT = "timeout"
@@ -979,7 +980,9 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         val actionUri = data["clickAction"] ?: "/"
-        builder.setContentIntent(createOpenUriPendingIntent(actionUri, data))
+        if (actionUri != NO_ACTION) {
+            builder.setContentIntent(createOpenUriPendingIntent(actionUri, data))
+        }
     }
 
     private fun handleDeleteIntent(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3400 by adding a new constant of `noAction` so the notification does nothing as it has no content intent.

```yaml
service: notify.mobile_app_pixel_7_pro
data:
  message: test
  data:
    clickAction: noAction
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#922

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->