### PR TITLE
Properly handle multiple permissions requests

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -504,7 +504,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                         val alreadyGranted = ArrayList<String>()
                         val toBeGranted = ArrayList<String>()
                         request?.resources?.forEach {
-
                             if (it == PermissionRequest.RESOURCE_VIDEO_CAPTURE) {
                                 if (ActivityCompat.checkSelfPermission(
                                         context,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR starts while investigating the app crashing while trying to make a SIP call with the sip-hass-card (https://github.com/TECH7Fox/sip-hass-card/issues/96). After giving permissions to both microphone and camera, the app just crashes with the following log:
```
03-08 16:50:12.261  9201  9201 W System.err: java.lang.IllegalStateException: Either grant() or deny() has been already called.
03-08 16:50:12.262  9201  9201 W System.err:    at org.chromium.android_webview.permission.AwPermissionRequest.a(chromium-TrichromeWebViewGoogle.aab-stable-548115333:34)
03-08 16:50:12.262  9201  9201 W System.err:    at Wz0.grant(chromium-TrichromeWebViewGoogle.aab-stable-548115333:109)
03-08 16:50:12.262  9201  9201 W System.err:    at io.homeassistant.companion.android.webview.WebViewActivity$onCreate$2$4.onPermissionRequest(WebViewActivity.kt:491)
03-08 16:50:12.262  9201  9201 W System.err:    at org.chromium.android_webview.AwContents.onPermissionRequest(chromium-TrichromeWebViewGoogle.aab-stable-548115333:46)
03-08 16:50:12.262  9201  9201 W System.err:    at android.os.MessageQueue.nativePollOnce(Native Method)
03-08 16:50:12.262  9201  9201 W System.err:    at android.os.MessageQueue.next(MessageQueue.java:363)
03-08 16:50:12.262  9201  9201 W System.err:    at android.os.Looper.loop(Looper.java:176)
03-08 16:50:12.262  9201  9201 W System.err:    at android.app.ActivityThread.main(ActivityThread.java:8668)
03-08 16:50:12.262  9201  9201 W System.err:    at java.lang.reflect.Method.invoke(Native Method)
03-08 16:50:12.262  9201  9201 W System.err:    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
03-08 16:50:12.262  9201  9201 W System.err:    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)
```
I soon discovered that there was a bug in the code: when multiple permissions are requested within the same request (as in my case camera and microphone) and at least two of them have been already granted by the user, the code calls `request.grant` twice (because it is inside the foreach loop). This is not allowed by the webview, thus the crash.

In order to fix it, I created two lists, the first one for the permissions already granted, the second one for the yet-ungranted ones. After the foreach loop populates the two lists, the `request.grant` is called once with all the granted permissions and then the `requestPermissions.launch` is called with all the yet-ungranted ones. For this last part, I have changed the `requestPermissions` member to use `RequestMultiplePermissions` instead of `RequestPermission`.

I thoroughly test the fix and all issues seems to be gone, without any regression on the existing code.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
<img src="https://user-images.githubusercontent.com/830773/224028091-025d4385-6712-43be-b590-53afc9259378.jpg"  width="200px">

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#
_No functionality has been impacted_

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
While fixing the issue I also noticed that there were two _else if_ branches with the _same_ condition (`it == PermissionRequest.RESOURCE_AUDIO_CAPTURE`), so the second one was never executed; i deleted it