### PR TITLE
Send device-preferred Thread dataset if different from core

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.matter
 
 import android.app.Application
 import android.content.IntentSender
+import android.util.Log
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +22,10 @@ class MatterCommissioningViewModel @Inject constructor(
     private val serverManager: ServerManager,
     application: Application
 ) : AndroidViewModel(application) {
+
+    companion object {
+        private const val TAG = "MatterCommissioningView"
+    }
 
     sealed class CommissioningFlowStep {
         object NotStarted : CommissioningFlowStep()
@@ -84,11 +89,16 @@ class MatterCommissioningViewModel @Inject constructor(
 
     suspend fun syncThreadIfNecessary(): IntentSender? {
         step = CommissioningFlowStep.Working
-        return threadManager.syncPreferredDataset(
-            getApplication<Application>().applicationContext,
-            serverId,
-            viewModelScope
-        )
+        return try {
+            threadManager.syncPreferredDataset(
+                getApplication<Application>().applicationContext,
+                serverId,
+                viewModelScope
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to sync preferred Thread dataset, continuing", e)
+            null
+        }
     }
 
     fun onThreadPermissionResult(result: ActivityResult, code: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -20,8 +20,8 @@ interface ThreadManager {
 
     /**
      * Try to sync the preferred Thread dataset with the device and server. If one has a preferred
-     * dataset while the other one doesn't, it will sync. If both have or don't have preferred
-     * datasets, skip syncing.
+     * dataset while the other one doesn't, it will sync. If both have preferred datasets, it will
+     * send updated data to the server if needed. If neither has a preferred dataset, skip syncing.
      * @return [IntentSender] if permission is required to import the device dataset, `null` if
      * syncing completed or there is nothing to sync
      */

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -332,7 +332,12 @@ class WebViewPresenterImpl @Inject constructor(
             _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.REQUESTED)
 
             mainScope.launch {
-                val deviceThreadIntent = threadUseCase.syncPreferredDataset(context, serverId, this)
+                val deviceThreadIntent = try {
+                    threadUseCase.syncPreferredDataset(context, serverId, this)
+                } catch (e: Exception) {
+                    Log.w(TAG, "Unable to sync preferred Thread dataset, continuing", e)
+                    null
+                }
                 if (deviceThreadIntent != null) {
                     matterCommissioningIntentSender = deviceThreadIntent
                     _matterCommissioningStatus.tryEmit(MatterFrontendCommissioningStatus.THREAD_EXPORT_TO_SERVER)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Expand the automatic Thread dataset sync on Matter commissioning to also send the device-preferred Thread dataset if it's different from core (it will either receive something new or update).

Thread datasets are now synced:
- If the device has a preferred dataset that doesn't match the server (because it has nothing or a different one), send the device dataset to the server
- If the device doesn't have a preferred dataset and the server does, add the server dataset to the device

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->