### PR TITLE
Fix Android Auto connected sensor intent crash

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -46,13 +46,13 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
     private var carConnection: CarConnection? = null
 
     override fun requestSensorUpdate(context: Context) {
-        this.context = context
+        this.context = context.applicationContext
         if (!isEnabled(context, androidAutoConnected)) {
             return
         }
         CoroutineScope(Dispatchers.Main + Job()).launch {
             if (carConnection == null) {
-                carConnection = CarConnection(context)
+                carConnection = CarConnection(context.applicationContext)
             }
             carConnection?.type?.observeForever(this@AndroidAutoSensorManager)
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The `CarConnection` class registers for intents using the provided context which is not always accepted, so switch to application context instead. [Object created here](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/car/app/app/src/main/java/androidx/car/app/connection/CarConnection.java#94) -> [registers intent here](https://android.googlesource.com/platform/frameworks/support/+/androidx-main/car/app/app/src/main/java/androidx/car/app/connection/CarConnectionTypeLiveData.java#72). The docs mention this [limitation](https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter)); by using the application context, it will be tied to the application object lifecycle instead.

Fixes #3408

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->