### PR TITLE
Fix notification for missing notification command permissions

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -559,13 +559,14 @@ class MessagingManager @Inject constructor(
     private fun handleDeviceCommands(data: Map<String, String>) {
         val message = data[NotificationData.MESSAGE]
         val command = data[NotificationData.COMMAND]
+        val serverId = data[THIS_SERVER_ID]!!
         when (message) {
             COMMAND_DND -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     val notificationManager =
                         context.getSystemService<NotificationManager>()
                     if (notificationManager?.isNotificationPolicyAccessGranted == false) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         when (command) {
                             DND_ALARMS_ONLY -> notificationManager?.setInterruptionFilter(
@@ -589,7 +590,7 @@ class MessagingManager @Inject constructor(
                     val notificationManager =
                         context.getSystemService<NotificationManager>()
                     if (notificationManager?.isNotificationPolicyAccessGranted == false) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         processRingerMode(audioManager!!, command)
                     }
@@ -629,7 +630,7 @@ class MessagingManager @Inject constructor(
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     val notificationManager = context.getSystemService<NotificationManager>()
                     if (notificationManager?.isNotificationPolicyAccessGranted == false) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         processStreamVolume(
                             audioManager!!,
@@ -654,7 +655,7 @@ class MessagingManager @Inject constructor(
                         }
                         else -> {
                             Log.e(TAG, "Missing Bluetooth permissions, notifying user to grant permissions")
-                            notifyMissingPermission(message.toString())
+                            notifyMissingPermission(message.toString(), serverId)
                         }
                     }
                 }
@@ -680,7 +681,7 @@ class MessagingManager @Inject constructor(
             COMMAND_ACTIVITY -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.canDrawOverlays(context)) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else if (ContextCompat.checkSelfPermission(context, Manifest.permission.CALL_PHONE) != PackageManager.PERMISSION_GRANTED && data["tag"] == Intent.ACTION_CALL) {
                         Handler(Looper.getMainLooper()).post {
                             Toast.makeText(
@@ -705,7 +706,7 @@ class MessagingManager @Inject constructor(
             COMMAND_WEBVIEW -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.canDrawOverlays(context)) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         openWebview(command, data)
                     }
@@ -737,7 +738,7 @@ class MessagingManager @Inject constructor(
                     if (!NotificationManagerCompat.getEnabledListenerPackages(context)
                         .contains(context.packageName)
                     ) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         processMediaCommand(data)
                     }
@@ -746,7 +747,7 @@ class MessagingManager @Inject constructor(
             COMMAND_LAUNCH_APP -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     if (!Settings.canDrawOverlays(context)) {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     } else {
                         launchApp(data)
                     }
@@ -764,7 +765,7 @@ class MessagingManager @Inject constructor(
                             mainScope.launch { sendNotification(data) }
                         }
                     } else {
-                        notifyMissingPermission(message.toString())
+                        notifyMissingPermission(message.toString(), serverId)
                     }
                 } else if (!processScreenCommands(data)) {
                     mainScope.launch { sendNotification(data) }
@@ -1775,7 +1776,7 @@ class MessagingManager @Inject constructor(
         return success
     }
 
-    private fun notifyMissingPermission(type: String) {
+    private fun notifyMissingPermission(type: String, serverId: String) {
         val appManager =
             context.getSystemService<ActivityManager>()
         val currentProcess = appManager?.runningAppProcesses
@@ -1783,8 +1784,10 @@ class MessagingManager @Inject constructor(
             for (item in currentProcess) {
                 if (context.applicationInfo.processName == item.processName) {
                     if (item.importance != ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
-                        val data =
-                            mutableMapOf(NotificationData.MESSAGE to context.getString(commonR.string.missing_command_permission))
+                        val data = mutableMapOf(
+                            NotificationData.MESSAGE to context.getString(commonR.string.missing_command_permission),
+                            THIS_SERVER_ID to serverId
+                        )
                         runBlocking {
                             sendNotification(data)
                         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes notifications for missing notification command permissions crashing the app because there was no server ID included for the notification

```
FATAL EXCEPTION: main
Process: io.homeassistant.companion.android.debug, PID: 29759
java.lang.NullPointerException
	at io.homeassistant.companion.android.notifications.MessagingManager.createOpenUriPendingIntent(MessagingManager.kt:1388)
	at io.homeassistant.companion.android.notifications.MessagingManager.handleContentIntent(MessagingManager.kt:950)
	at io.homeassistant.companion.android.notifications.MessagingManager.sendNotification(MessagingManager.kt:893)
	at io.homeassistant.companion.android.notifications.MessagingManager.sendNotification$default(MessagingManager.kt:832)
	at io.homeassistant.companion.android.notifications.MessagingManager$notifyMissingPermission$1.invokeSuspend(MessagingManager.kt:1789)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:284)
	at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:85)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:59)
	at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source:1)
	at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:38)
	at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source:1)
	at io.homeassistant.companion.android.notifications.MessagingManager.notifyMissingPermission(MessagingManager.kt:1788)
	at io.homeassistant.companion.android.notifications.MessagingManager.handleDeviceCommands(MessagingManager.kt:749)
	at io.homeassistant.companion.android.notifications.MessagingManager.access$handleDeviceCommands(MessagingManager.kt:97)
	at io.homeassistant.companion.android.notifications.MessagingManager$handleMessage$4.invokeSuspend(MessagingManager.kt:478)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
	at android.os.Handler.handleCallback(Handler.java:942)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7884)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
	Suppressed: kotlinx.coroutines.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@9dc74d1, Dispatchers.Main]
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->