### PR TITLE
Share Wear session with main app to fix mismatch

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/AuthenticationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/AuthenticationRepository.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.common.data.authentication.impl.Authen
 interface AuthenticationRepository {
 
     suspend fun registerAuthorizationCode(authorizationCode: String)
+    suspend fun registerRefreshToken(refreshToken: String)
 
     suspend fun retrieveExternalAuthentication(forceRefresh: Boolean): String
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -55,6 +55,15 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
         }
     }
 
+    override suspend fun registerRefreshToken(refreshToken: String) {
+        val url = server.connection.getUrl()?.toHttpUrlOrNull()
+        if (url == null) {
+            Log.e(TAG, "Unable to register session with refresh token.")
+            return
+        }
+        refreshSessionWithToken(refreshToken)
+    }
+
     override suspend fun retrieveExternalAuthentication(forceRefresh: Boolean): String {
         ensureValidSession(forceRefresh)
         return jacksonObjectMapper().writeValueAsString(
@@ -133,33 +142,37 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
         }
 
         if (server.session.isExpired() || forceRefresh) {
-            return authenticationService.refreshToken(
-                url.newBuilder().addPathSegments("auth/token").build(),
-                AuthenticationService.GRANT_TYPE_REFRESH,
-                server.session.refreshToken!!,
-                AuthenticationService.CLIENT_ID
-            ).let {
-                if (it.isSuccessful) {
-                    val refreshedToken = it.body() ?: throw AuthorizationException()
-                    serverManager.updateServer(
-                        server.copy(
-                            session = ServerSessionInfo(
-                                refreshedToken.accessToken,
-                                server.session.refreshToken,
-                                System.currentTimeMillis() / 1000 + refreshedToken.expiresIn,
-                                refreshedToken.tokenType,
-                                installId
-                            )
+            refreshSessionWithToken(server.session.refreshToken!!)
+        }
+    }
+
+    private suspend fun refreshSessionWithToken(refreshToken: String) {
+        return authenticationService.refreshToken(
+            server.connection.getUrl()?.toHttpUrlOrNull()!!.newBuilder().addPathSegments("auth/token").build(),
+            AuthenticationService.GRANT_TYPE_REFRESH,
+            refreshToken,
+            AuthenticationService.CLIENT_ID
+        ).let {
+            if (it.isSuccessful) {
+                val refreshedToken = it.body() ?: throw AuthorizationException()
+                serverManager.updateServer(
+                    server.copy(
+                        session = ServerSessionInfo(
+                            refreshedToken.accessToken,
+                            refreshToken,
+                            System.currentTimeMillis() / 1000 + refreshedToken.expiresIn,
+                            refreshedToken.tokenType,
+                            installId
                         )
                     )
-                    return@let
-                } else if (it.code() == 400 &&
-                    it.errorBody()?.string()?.contains("invalid_grant") == true
-                ) {
-                    revokeSession()
-                }
-                throw AuthorizationException()
+                )
+                return@let
+            } else if (it.code() == 400 &&
+                it.errorBody()?.string()?.contains("invalid_grant") == true
+            ) {
+                revokeSession()
             }
+            throw AuthorizationException()
         }
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/WearDataMessages.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/WearDataMessages.kt
@@ -1,0 +1,18 @@
+package io.homeassistant.companion.android.common.util
+
+object WearDataMessages {
+    const val KEY_UPDATE_TIME = "UpdateTime"
+
+    const val CONFIG_IS_AUTHENTICATED = "isAuthenticated"
+    const val CONFIG_SERVER_ID = "serverId"
+    const val CONFIG_SERVER_EXTERNAL_URL = "serverExternalUrl"
+    const val CONFIG_SERVER_WEBHOOK_ID = "serverWebhookId"
+    const val CONFIG_SERVER_CLOUD_URL = "serverCloudUrl"
+    const val CONFIG_SERVER_CLOUDHOOK_URL = "serverCloudhookUrl"
+    const val CONFIG_SERVER_USE_CLOUD = "serverUseCloud"
+    const val CONFIG_SERVER_REFRESH_TOKEN = "serverRefreshToken"
+    const val CONFIG_SUPPORTED_DOMAINS = "supportedDomains"
+    const val CONFIG_FAVORITES = "favorites"
+    const val CONFIG_TEMPLATE_TILE = "templateTile"
+    const val CONFIG_TEMPLATE_TILE_REFRESH_INTERVAL = "templateTileRefreshInterval"
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR fixes a mismatch between the Wear and main app server settings / fixes #3086 by sharing the Wear server's session with the main app, and adding it as a temporary server to the main app to be used in the Wear device settings screen. This ensures both devices use the same information and authorizations.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->