### PR TITLE
Add logged out state to Wear tiles

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -707,6 +707,7 @@
     <string name="shortcuts_tile_description">Select up to 7 entities</string>
     <string name="shortcuts_tile_empty">Choose entities in settings</string>
     <string name="shortcuts_tile_text_setting">Show names on shortcuts tile</string>
+    <string name="shortcuts_tile_log_in">Log in to Home Assistant to add your first shortcut</string>
     <string name="shortcuts">Shortcuts</string>
     <string name="show">Show</string>
     <string name="show_share_logs_summary">Sharing logs with the Home Assistant team will help to solve issues. Please share the logs only if you have been asked to do so by a Home Assistant developer</string>
@@ -763,6 +764,7 @@
     <string name="template_tile_content">Template tile content</string>
     <string name="template_tile_desc">Renders and displays a template</string>
     <string name="template_tile_empty">Set template in the phone settings</string>
+    <string name="template_tile_log_in">Log in to Home Assistant to set up a template</string>
     <string name="template_error">Error in template</string>
     <string name="template_render_error">Error rendering template</string>
     <string name="template_tile_help">Provide a template below that will be displayed on the Wear OS template tile. See help for markup options.</string>
@@ -1044,7 +1046,8 @@
     <string name="no_conversation_support">You must be at least on Home Assistant 2023.1 and have the conversation integration enabled</string>
     <string name="conversation">Conversation</string>
     <string name="assist">Assist</string>
-    <string name="not_registered">Please launch the Home Assistant app and login before you can use the assist feature.</string>
+    <string name="assist_log_in">Log in to Home Assistant to start using Assist</string>
+    <string name="not_registered">Please launch the Home Assistant app and log in to start using Assist.</string>
     <string name="ha_assist">HA: Assist</string>
     <string name="only_favorites">Only Show Favorites</string>
     <string name="beacon_scanning">Beacon Monitor Scanning</string>

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
 
     implementation("com.google.guava:guava:31.1-android")
     implementation("androidx.wear.tiles:tiles:1.1.0")
+    implementation("androidx.wear.tiles:tiles-material:1.1.0")
 
     implementation("androidx.wear.watchface:watchface-complications-data-source-ktx:1.1.1")
 

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterImpl.kt
@@ -2,11 +2,15 @@ package io.homeassistant.companion.android.onboarding.integration
 
 import android.content.Context
 import android.util.Log
+import androidx.wear.tiles.TileService
 import dagger.hilt.android.qualifiers.ActivityContext
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.onboarding.getMessagingToken
+import io.homeassistant.companion.android.tiles.ConversationTile
+import io.homeassistant.companion.android.tiles.ShortcutsTile
+import io.homeassistant.companion.android.tiles.TemplateTile
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -47,7 +51,19 @@ class MobileAppIntegrationPresenterImpl @Inject constructor(
                 view.showError()
                 return@launch
             }
+            updateTiles()
             view.deviceRegistered()
+        }
+    }
+
+    private fun updateTiles() = mainScope.launch {
+        try {
+            val updater = TileService.getUpdater(view as Context)
+            updater.requestUpdate(ConversationTile::class.java)
+            updater.requestUpdate(ShortcutsTile::class.java)
+            updater.requestUpdate(TemplateTile::class.java)
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to request tiles update")
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/LoggedOutTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/LoggedOutTile.kt
@@ -1,0 +1,76 @@
+package io.homeassistant.companion.android.tiles
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.core.content.ContextCompat
+import androidx.wear.tiles.ActionBuilders
+import androidx.wear.tiles.ColorBuilders.argb
+import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.tiles.RequestBuilders
+import androidx.wear.tiles.TimelineBuilders.Timeline
+import androidx.wear.tiles.material.ChipColors
+import androidx.wear.tiles.material.Colors
+import androidx.wear.tiles.material.CompactChip
+import androidx.wear.tiles.material.Text
+import androidx.wear.tiles.material.Typography
+import androidx.wear.tiles.material.layouts.PrimaryLayout
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.splash.SplashActivity
+import io.homeassistant.companion.android.common.R as commonR
+
+/**
+ * A [Timeline] with a single entry, asking the user to log in to the app to start using the tile
+ * with a button to open the app. The tile is using the 'Dialog' style.
+ */
+fun loggedOutTimeline(
+    context: Context,
+    requestParams: RequestBuilders.TileRequest,
+    @StringRes title: Int,
+    @StringRes text: Int
+): Timeline {
+    val theme = Colors(
+        ContextCompat.getColor(context, R.color.colorPrimary), // Primary
+        ContextCompat.getColor(context, R.color.colorOnPrimary), // On primary
+        ContextCompat.getColor(context, R.color.colorOverlay), // Surface
+        ContextCompat.getColor(context, android.R.color.white) // On surface
+    )
+    val chipColors = ChipColors.primaryChipColors(theme)
+    val chipAction = ModifiersBuilders.Clickable.Builder()
+        .setId("login")
+        .setOnClick(
+            ActionBuilders.LaunchAction.Builder()
+                .setAndroidActivity(
+                    ActionBuilders.AndroidActivity.Builder()
+                        .setClassName(SplashActivity::class.java.name)
+                        .setPackageName(context.packageName)
+                        .build()
+                ).build()
+        ).build()
+    return Timeline.fromLayoutElement(
+        PrimaryLayout.Builder(requestParams.deviceParameters!!)
+            .setPrimaryLabelTextContent(
+                Text.Builder(context, context.getString(title))
+                    .setTypography(Typography.TYPOGRAPHY_CAPTION1)
+                    .setColor(argb(theme.primary))
+                    .build()
+            )
+            .setContent(
+                Text.Builder(context, context.getString(text))
+                    .setTypography(Typography.TYPOGRAPHY_BODY1)
+                    .setMaxLines(10)
+                    .setColor(argb(theme.onSurface))
+                    .build()
+            )
+            .setPrimaryChipContent(
+                CompactChip.Builder(
+                    context,
+                    context.getString(commonR.string.login),
+                    chipAction,
+                    requestParams.deviceParameters!!
+                )
+                    .setChipColors(chipColors)
+                    .build()
+            )
+            .build()
+    )
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -22,7 +22,6 @@ import androidx.wear.tiles.DimensionBuilders.dp
 import androidx.wear.tiles.LayoutElementBuilders
 import androidx.wear.tiles.LayoutElementBuilders.Box
 import androidx.wear.tiles.LayoutElementBuilders.FONT_WEIGHT_BOLD
-import androidx.wear.tiles.LayoutElementBuilders.Layout
 import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
 import androidx.wear.tiles.ModifiersBuilders
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
@@ -32,7 +31,6 @@ import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
 import androidx.wear.tiles.TimelineBuilders.Timeline
-import androidx.wear.tiles.TimelineBuilders.TimelineEntry
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
@@ -73,36 +71,22 @@ class TemplateTile : TileService() {
                 }
             }
 
-            val template = wearPrefsRepository.getTemplateTileContent()
-            val renderedText = try {
-                if (serverManager.isRegistered()) {
-                    serverManager.integrationRepository().renderTemplate(template, mapOf()).toString()
-                } else {
-                    ""
-                }
-            } catch (e: Exception) {
-                Log.e("TemplateTile", "Exception while rendering template", e)
-                // JsonMappingException suggests that template is not a String (= error)
-                if (e.cause is JsonMappingException) {
-                    getString(commonR.string.template_error)
-                } else {
-                    getString(commonR.string.template_render_error)
-                }
-            }
-
             Tile.Builder()
                 .setResourcesVersion("1")
                 .setFreshnessIntervalMillis(
                     wearPrefsRepository.getTemplateTileRefreshInterval().toLong() * 1000
                 )
                 .setTimeline(
-                    Timeline.Builder().addTimelineEntry(
-                        TimelineEntry.Builder().setLayout(
-                            Layout.Builder().setRoot(
-                                layout(renderedText)
-                            ).build()
-                        ).build()
-                    ).build()
+                    if (serverManager.isRegistered()) {
+                        timeline()
+                    } else {
+                        loggedOutTimeline(
+                            this@TemplateTile,
+                            requestParams,
+                            commonR.string.template,
+                            commonR.string.template_tile_log_in
+                        )
+                    }
                 ).build()
         }
 
@@ -126,6 +110,27 @@ class TemplateTile : TileService() {
         super.onDestroy()
         // Cleans up the coroutine
         serviceJob.cancel()
+    }
+
+    private suspend fun timeline(): Timeline {
+        val template = wearPrefsRepository.getTemplateTileContent()
+        val renderedText = try {
+            if (serverManager.isRegistered()) {
+                serverManager.integrationRepository().renderTemplate(template, mapOf()).toString()
+            } else {
+                ""
+            }
+        } catch (e: Exception) {
+            Log.e("TemplateTile", "Exception while rendering template", e)
+            // JsonMappingException suggests that template is not a String (= error)
+            if (e.cause is JsonMappingException) {
+                getString(commonR.string.template_error)
+            } else {
+                getString(commonR.string.template_render_error)
+            }
+        }
+
+        return Timeline.fromLayoutElement(layout(renderedText))
     }
 
     fun layout(renderedText: String): LayoutElement = Box.Builder().apply {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds a generic tile design to be used when the Wear app isn't logged in based on the [Dialog design as recommended](https://developer.android.com/training/wearables/design/tiles#dialogs): "In some cases, the user needs to (...) sign in (...) to see content on a Tile. Use dialogs to prompt users to take an action.".

Implements #3383

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Assist|Shortcuts|Template|
|-----|-----|-----|
|![A tile titled 'Assist', 'Log in to Home Assistant to start using Assist', with a button 'Login'](https://user-images.githubusercontent.com/8148535/228345235-9112e7bc-e5b7-4ea5-ba94-772b4dc3ec49.png)|![A tile titled 'Shortcuts', 'Log in to Home Assistant to add your first shortcut', with a button 'Login'](https://user-images.githubusercontent.com/8148535/228345341-74f4ad01-3cd4-4ccf-975b-3a2c7a9c4092.png)|![A tile titled 'Template', 'Log in to Home Assistant to set up a template', with a button 'Login'](https://user-images.githubusercontent.com/8148535/228345435-822a75ff-e814-4daa-adc9-42315e9ecdc9.png)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I'm using the Material Tiles layouts which fit in with Google's tile designs. It might be nice to update the empty states with the same text/button styles for consistency but that's out of scope for this PR.