### PR TITLE
Disable favorites only view on Wear if all favorites are deleted

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -25,6 +25,7 @@ import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.wear.FavoriteCaches
 import io.homeassistant.companion.android.database.wear.FavoriteCachesDao
 import io.homeassistant.companion.android.database.wear.FavoritesDao
+import io.homeassistant.companion.android.database.wear.getAll
 import io.homeassistant.companion.android.database.wear.getAllFlow
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.util.RegistriesDataHandler
@@ -381,6 +382,7 @@ class MainViewModel @Inject constructor(
     fun clearFavorites() {
         viewModelScope.launch {
             favoritesDao.deleteAll()
+            setWearFavoritesOnly(false)
         }
     }
 
@@ -457,6 +459,10 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             favoritesDao.delete(entityId)
             favoriteCachesDao.delete(entityId)
+
+            if (favoritesDao.getAll().isEmpty() && isFavoritesOnly) {
+                setWearFavoritesOnly(false)
+            }
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -180,6 +180,10 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
 
         mainScope.launch {
             favoritesDao.replaceAll(favoritesIds)
+
+            if (favoritesIds.isEmpty() && wearPrefsRepository.getWearFavoritesOnly()) {
+                wearPrefsRepository.setWearFavoritesOnly(false)
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the 'favorites only' setting staying enabled on Wear watches after removing all favorites, which blocked the user from turning the setting off.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->