### PR TITLE
Resize camera widget images to screen width

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -155,7 +155,7 @@ class CameraWidget : AppWidgetProvider() {
                         }
                         try {
                             picasso.invalidate(url)
-                            picasso.load(url).resize(getScreenWidth(), 0).into(
+                            picasso.load(url).resize(getScreenWidth(), 0).onlyScaleDown().into(
                                 this,
                                 R.id.widgetCameraImage,
                                 intArrayOf(appWidgetId)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -6,6 +6,7 @@ import android.appwidget.AppWidgetProvider
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.content.res.Resources
 import android.net.ConnectivityManager
 import android.os.Bundle
 import android.os.Handler
@@ -154,7 +155,7 @@ class CameraWidget : AppWidgetProvider() {
                         }
                         try {
                             picasso.invalidate(url)
-                            picasso.load(url).into(
+                            picasso.load(url).resize(getScreenWidth(), 0).into(
                                 this,
                                 R.id.widgetCameraImage,
                                 intArrayOf(appWidgetId)
@@ -260,5 +261,9 @@ class CameraWidget : AppWidgetProvider() {
         val connectivityManager = context.getSystemService<ConnectivityManager>()
         val activeNetworkInfo = connectivityManager?.activeNetworkInfo
         return activeNetworkInfo?.isConnected ?: false
+    }
+
+    private fun getScreenWidth(): Int {
+        return Resources.getSystem().displayMetrics.widthPixels
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3443 by resizing the camera images to the screen width to help preserve the image proportions and reduce the size of the image.

~~We should get some users in the issue to confirm the fix as my cameras and phone do not hit any limit set by the system.~~

Confirmation its working: https://github.com/home-assistant/android/issues/3443#issuecomment-1496232675

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->