### PR TITLE
Fix zone event zone ID including server ID

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -744,7 +744,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                     "provider" to geofencingEvent.triggeringLocation!!.provider,
                     "time" to geofencingEvent.triggeringLocation!!.time,
                     "vertical_accuracy" to if (Build.VERSION.SDK_INT >= 26) geofencingEvent.triggeringLocation!!.verticalAccuracyMeters.toInt() else 0,
-                    "zone" to zone
+                    "zone" to zone.substring(zone.indexOf("_") + 1)
                 )
                 ioScope.launch {
                     try {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Noticed the following JSON while trying to reproduce another issue:

```json
{"type":"fire_event","data":{"event_type":"android.zone_entered","event_data":{"accuracy":21.372,"altitude":47.274253209390835,"bearing":0.0,"latitude":0,"longitude":0,"provider":"fused","time":1680622928882,"vertical_accuracy":1,"zone":"27_zone.home","device_id":"bd78a79654bb7d61"}}}
```

The zone ID sent to the server includes the server ID, which could break automations listening for the zone ID (server ID isn't intended to be exposed). Update to remove it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->