### PR TITLE
Use Kelvin for light color temperature if available

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
     <string name="choose_server">Choose server</string>
     <string name="clear_favorites">Clear Favorites</string>
     <string name="close">Close</string>
-    <string name="color_temp">Color temperature: %1$d</string>
+    <string name="color_temp">Color temperature: %1$s</string>
     <string name="collapse">Collapse</string>
     <string name="complication_entity_invalid">Invalid entity</string>
     <string name="complication_entity_state_content_description">Entity state</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -19,7 +19,7 @@ interface HomePresenter {
     suspend fun onEntityClicked(entityId: String, state: String)
     suspend fun onFanSpeedChanged(entityId: String, speed: Float)
     suspend fun onBrightnessChanged(entityId: String, brightness: Float)
-    suspend fun onColorTempChanged(entityId: String, colorTemp: Float)
+    suspend fun onColorTempChanged(entityId: String, colorTemp: Float, isKelvin: Boolean)
     fun onLogoutClicked()
     fun onInvalidAuthorization()
     fun onFinish()

--- a/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -141,14 +141,15 @@ class HomePresenterImpl @Inject constructor(
         }
     }
 
-    override suspend fun onColorTempChanged(entityId: String, colorTemp: Float) {
+    override suspend fun onColorTempChanged(entityId: String, colorTemp: Float, isKelvin: Boolean) {
         try {
+            val colorTempKey = if (isKelvin) "color_temp_kelvin" else "color_temp"
             serverManager.integrationRepository().callService(
                 entityId.split(".")[0],
                 "turn_on",
                 hashMapOf(
                     "entity_id" to entityId,
-                    "color_temp" to colorTemp.toInt()
+                    colorTempKey to colorTemp.toInt()
                 )
             )
         } catch (e: Exception) {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -314,9 +314,9 @@ class MainViewModel @Inject constructor(
             homePresenter.onBrightnessChanged(entityId, brightness)
         }
     }
-    fun setColorTemp(entityId: String, colorTemp: Float) {
+    fun setColorTemp(entityId: String, colorTemp: Float, isKelvin: Boolean) {
         viewModelScope.launch {
-            homePresenter.onColorTempChanged(entityId, colorTemp)
+            homePresenter.onColorTempChanged(entityId, colorTemp, isKelvin)
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -91,10 +91,11 @@ fun LoadHomePage(
                                 brightness
                             )
                         },
-                        onColorTempChanged = { colorTemp ->
+                        onColorTempChanged = { colorTemp, isKelvin ->
                             mainViewModel.setColorTemp(
                                 entity.entityId,
-                                colorTemp
+                                colorTemp,
+                                isKelvin
                             )
                         },
                         isToastEnabled = mainViewModel.isToastEnabled.value,

--- a/wear/src/main/java/io/homeassistant/companion/android/util/ColorTemperature.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/ColorTemperature.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.graphics.Color
 import java.util.TreeMap
 import kotlin.math.abs
 
-fun getColorTemperature(ratio: Double): Color {
-    val colorMap = sortedMapOf<Double, Long>(
+fun getColorTemperature(ratio: Double, isKelvin: Boolean): Color {
+    val colorMap = sortedMapOf(
         0.00 to 0xffa6d1ff,
         0.05 to 0xffafd6ff,
         0.10 to 0xffb8dbff,
@@ -29,8 +29,9 @@ fun getColorTemperature(ratio: Double): Color {
         1.00 to 0xffffa000
     ) as TreeMap<Double, Long>
 
-    val previous = colorMap.floorEntry(ratio)
-    val next = colorMap.ceilingEntry(ratio)
+    val useRatio = if (isKelvin) (1 - ratio) else ratio
+    val previous = colorMap.floorEntry(useRatio)
+    val next = colorMap.ceilingEntry(useRatio)
     if (previous == null) return Color(next?.value ?: 0xffa6d1ff) // next and previous should never both be null
     if (next == null) return Color(previous.value)
     return if (abs(ratio - previous.key) < abs(ratio - next.key)) Color(previous.value) else Color(next.value)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When using at least HA 2022.11, use Kelvins for the color temperature instead of mireds to match the frontend.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![A screenshot of the Wear OS app with a slider for 'color temperature: 3086 K'](https://user-images.githubusercontent.com/8148535/232295460-1d7a92e6-d6c7-473b-af49-ccb9ef54e490.png)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->