### PR TITLE
Fix dialog options for high accuracy zone constraint entity id

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -394,7 +394,7 @@ class SensorDetailViewModel @Inject constructor(
                     .filter { entries == null || entries.contains(it) }
                     .map {
                         val server = servers.first { s -> s.id == it.split("_")[0].toInt() }
-                        val zone = it.split("_")[1]
+                        val zone = it.split("_", limit = 2)[1]
                         if (servers.size > 1) "${server.friendlyName}: $zone" else zone
                     }
                 val entriesNotInZones = entries


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3486: zone entity ids can contain underscores, only split on underscores once to keep those that belong to the entity id (string is `serverid_entityid`).

(The data was stored correctly, the bug is only for how settings are displayed.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->