### PR TITLE
Fix expanded zone id for high accuracy zone constraint

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -947,7 +947,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
                 val configuredZones = getZones(serverId, forceRefresh = true)
                 configuredZones.forEach {
                     addGeofenceToBuilder(geofencingRequestBuilder, serverId, it)
-                    if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains(it.entityId)) {
+                    if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains("${serverId}_${it.entityId}")) {
                         addGeofenceToBuilder(geofencingRequestBuilder, serverId, it, highAccuracyTriggerRange)
                     }
                 }
@@ -963,7 +963,7 @@ class LocationSensorManager : LocationSensorManagerBase() {
         zone: Entity<ZoneAttributes>,
         triggerRange: Int = 0
     ) {
-        val postRequestId = if (triggerRange > 0)"_expanded" else ""
+        val postRequestId = if (triggerRange > 0) "_expanded" else ""
         geofencingRequestBuilder
             .addGeofence(
                 Geofence.Builder()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When checking if an expanded zone geofence should be created include the server ID in the comparison as that is what is used everywhere else. Otherwise expanded zones are never added, and as a result high accuracy mode won't work as expected.

The setting in the database looks like `1_zone.work, 1_zone.treehouse` which is converted to the list `highAccuracyZones`. So when comparing we should add `1_` before the zone ID we're looking for :)

~~Marked as draft because I want to get some feedback from users in #3445 first, I normally don't use this feature.~~ 3 users in the linked issue indicate this resolves the issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->