### PR TITLE
Add throttling/debouncing on Wear OS for registry updates

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/util/FlowUtil.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/FlowUtil.kt
@@ -1,0 +1,20 @@
+package io.homeassistant.companion.android.util
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.transform
+
+/**
+ * Emit the first value from a Flow, and then after the period has passed the last item emitted
+ * by the Flow during that period (if different). This ensures throttling/debouncing but also
+ * always receiving the first and last item of the Flow.
+ *
+ * From https://github.com/Kotlin/kotlinx.coroutines/issues/1446#issuecomment-1198103541
+ */
+fun <T> Flow<T>.throttleLatest(delayMillis: Long): Flow<T> = this
+    .conflate()
+    .transform {
+        emit(it)
+        delay(delayMillis)
+    }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -29,6 +29,7 @@ import io.homeassistant.companion.android.database.wear.getAll
 import io.homeassistant.companion.android.database.wear.getAllFlow
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.util.RegistriesDataHandler
+import io.homeassistant.companion.android.util.throttleLatest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
@@ -217,7 +218,7 @@ class MainViewModel @Inject constructor(
         if (!homePresenter.isConnected() || isFavoritesOnly) {
             return
         }
-        homePresenter.getAreaRegistryUpdates()?.collect {
+        homePresenter.getAreaRegistryUpdates()?.throttleLatest(1000)?.collect {
             areaRegistry = homePresenter.getAreaRegistry()
             areas.clear()
             areaRegistry?.let {
@@ -231,7 +232,7 @@ class MainViewModel @Inject constructor(
         if (!homePresenter.isConnected() || isFavoritesOnly) {
             return
         }
-        homePresenter.getDeviceRegistryUpdates()?.collect {
+        homePresenter.getDeviceRegistryUpdates()?.throttleLatest(1000)?.collect {
             deviceRegistry = homePresenter.getDeviceRegistry()
             updateEntityDomains()
         }
@@ -241,7 +242,7 @@ class MainViewModel @Inject constructor(
         if (!homePresenter.isConnected()) {
             return
         }
-        homePresenter.getEntityRegistryUpdates()?.collect {
+        homePresenter.getEntityRegistryUpdates()?.throttleLatest(1000)?.collect {
             entityRegistry = homePresenter.getEntityRegistry()
             _supportedEntities.value = getSupportedEntities()
             updateEntityDomains()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In order to improve performance on Wear OS, throttle/debounce getting registry data when the websocket subscription tells the app there is an update to it. This significantly reduces network traffic and background work for displaying the UI when there are a lot of changes in a short amount of time, and also lightens load on the server. [The frontend also does this](https://github.com/home-assistant/frontend/blob/4e390b4c5707bcd1d769217d87fd250d1b1af68f/src/data/entity_registry.ts#L199).

Example: with a period of 1000ms and 110 events 10ms apart, only event 1, 100 and 110 are emitted.

Scenarios where this can happen: logging in to the app for the first time (device registration + sensor registrations), or adding new integrations on the server, or lots of changes like updates.

I've placed the throttling function in `common` as this might also be useful to apply to other parts of the app in the future.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->