### PR TITLE
Don't reset QS tile entity when changing servers if existing on new server

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -244,10 +244,10 @@ class ManageTilesViewModel @Inject constructor(
     }
 
     fun selectServerId(serverId: Int) {
-        val resetEntity = serverId != selectedServerId
+        val resetEntity = serverId != selectedServerId && entities[serverId]?.none { it.entityId == selectedEntityId } == true
         selectedServerId = serverId
         loadEntities(serverId)
-        if (resetEntity) selectEntityId("")
+        selectEntityId(if (resetEntity) "" else selectedEntityId)
     }
 
     private fun loadEntities(serverId: Int) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Prevent unnecessary changes to the selected entity when changing servers, if an entity exists on both servers. It already didn't clear everything like title/icon override, just the selected entity! The app is still calling `selectEntityId` in case the icon is different.

Resolves #3529

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
There is a video showing the selected entity not changing when selecting a server in the linked issue.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->