### PR TITLE
Handle updated intents for Matter commissioning

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -14,7 +14,8 @@
             android:name=".matter.MatterCommissioningActivity"
             android:configChanges="orientation|screenSize"
             android:exported="true"
-            android:theme="@style/Theme.HomeAssistant.Config">
+            android:theme="@style/Theme.HomeAssistant.Config"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="com.google.android.gms.home.matter.ACTION_COMMISSION_DEVICE"/>
                 <category android:name="android.intent.category.DEFAULT"/>

--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
@@ -45,9 +45,13 @@ class MatterCommissioningViewModel @Inject constructor(
     var serverId by mutableStateOf(0)
         private set
 
-    fun checkSetup() {
+    fun checkSetup(isNewDevice: Boolean) {
         viewModelScope.launch {
-            if (step != CommissioningFlowStep.NotStarted) return@launch
+            if (!isNewDevice && step != CommissioningFlowStep.NotStarted) {
+                return@launch
+            } else {
+                step = CommissioningFlowStep.NotStarted
+            }
 
             if (!serverManager.isRegistered()) {
                 step = CommissioningFlowStep.NotRegistered


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
It looks like fast pair/shared Matter devices now re-use the commissioning activity if it is still open in the background. Set the launch mode to single top to be able to use `onNewIntent` and get data for new devices.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a; the flow will restart if a new intent is delivered

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->