### PR TITLE
Handle no `WifiManager` and prevent crash

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
@@ -122,7 +122,7 @@ class ServerSettingsFragment : ServerSettingsView, PreferenceFragmentCompat() {
         }
 
         findPreference<SwitchPreference>("app_lock_home_bypass")?.let {
-            it.isVisible = findPreference<SwitchPreference>("app_lock")?.isChecked == true
+            it.isVisible = findPreference<SwitchPreference>("app_lock")?.isChecked == true && presenter.hasWifi()
         }
 
         findPreference<EditTextPreference>("session_timeout")?.let { pref ->
@@ -138,6 +138,7 @@ class ServerSettingsFragment : ServerSettingsView, PreferenceFragmentCompat() {
             }
             it.onPreferenceChangeListener =
                 onChangeUrlValidator
+            it.isVisible = presenter.hasWifi()
         }
 
         findPreference<Preference>("connection_external")?.setOnPreferenceClickListener {
@@ -157,6 +158,7 @@ class ServerSettingsFragment : ServerSettingsView, PreferenceFragmentCompat() {
                 onDisplaySsidScreen()
                 return@setOnPreferenceClickListener true
             }
+            it.isVisible = presenter.hasWifi()
         }
 
         findPreference<PreferenceCategory>("security_category")?.isVisible = Build.MODEL != "Quest"
@@ -317,7 +319,7 @@ class ServerSettingsFragment : ServerSettingsView, PreferenceFragmentCompat() {
         // Prevent requesting authentication after just enabling the app lock
         presenter.setAppActive(true)
 
-        findPreference<SwitchPreference>("app_lock_home_bypass")?.isVisible = success
+        findPreference<SwitchPreference>("app_lock_home_bypass")?.isVisible = success && presenter.hasWifi()
         findPreference<EditTextPreference>("session_timeout")?.isVisible = success
         return (result == Authenticator.SUCCESS || result == Authenticator.CANCELED)
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenter.kt
@@ -11,6 +11,7 @@ interface ServerSettingsPresenter {
     fun hasMultipleServers(): Boolean
     fun updateServerName()
     fun updateUrlStatus()
+    fun hasWifi(): Boolean
     fun isSsidUsed(): Boolean
     fun clearSsids()
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.settings.server
 import android.util.Log
 import androidx.preference.PreferenceDataStore
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.wifi.WifiHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -12,7 +13,8 @@ import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class ServerSettingsPresenterImpl @Inject constructor(
-    private val serverManager: ServerManager
+    private val serverManager: ServerManager,
+    private val wifiHelper: WifiHelper
 ) : ServerSettingsPresenter, PreferenceDataStore() {
 
     companion object {
@@ -162,6 +164,8 @@ class ServerSettingsPresenterImpl @Inject constructor(
             view.updateSsids(ssids)
         }
     }
+
+    override fun hasWifi(): Boolean = wifiHelper.hasWifi()
 
     override fun isSsidUsed(): Boolean = runBlocking {
         serverManager.getServer(serverId)?.connection?.internalSsids?.isNotEmpty() == true

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/WebsocketSettingFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/WebsocketSettingFragment.kt
@@ -22,8 +22,10 @@ import androidx.fragment.app.viewModels
 import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.data.wifi.WifiHelper
 import io.homeassistant.companion.android.settings.SettingViewModel
 import io.homeassistant.companion.android.settings.websocket.views.WebsocketSettingView
+import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -32,6 +34,9 @@ class WebsocketSettingFragment : Fragment() {
     companion object {
         const val EXTRA_SERVER = "server"
     }
+
+    @Inject
+    lateinit var wifiHelper: WifiHelper
 
     val viewModel: SettingViewModel by viewModels()
 
@@ -73,6 +78,7 @@ class WebsocketSettingFragment : Fragment() {
                     WebsocketSettingView(
                         websocketSetting = settings.value.websocketSetting,
                         unrestrictedBackgroundAccess = isIgnoringBatteryOptimizations,
+                        hasWifi = wifiHelper.hasWifi(),
                         onSettingChanged = { viewModel.updateWebsocketSetting(serverId, it) },
                         onBackgroundAccessTapped = {
                             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/views/WebsocketSettingView.kt
@@ -30,6 +30,7 @@ import io.homeassistant.companion.android.util.compose.RadioButtonRow
 fun WebsocketSettingView(
     websocketSetting: WebsocketSetting,
     unrestrictedBackgroundAccess: Boolean,
+    hasWifi: Boolean,
     onSettingChanged: (WebsocketSetting) -> Unit,
     onBackgroundAccessTapped: () -> Unit
 ) {
@@ -55,11 +56,13 @@ fun WebsocketSettingView(
                 selected = websocketSetting == WebsocketSetting.NEVER,
                 onClick = { onSettingChanged(WebsocketSetting.NEVER) }
             )
-            RadioButtonRow(
-                text = stringResource(if (BuildConfig.FLAVOR == "full") R.string.websocket_setting_home_wifi else R.string.websocket_setting_home_wifi_minimal),
-                selected = websocketSetting == WebsocketSetting.HOME_WIFI,
-                onClick = { onSettingChanged(WebsocketSetting.HOME_WIFI) }
-            )
+            if (hasWifi) {
+                RadioButtonRow(
+                    text = stringResource(if (BuildConfig.FLAVOR == "full") R.string.websocket_setting_home_wifi else R.string.websocket_setting_home_wifi_minimal),
+                    selected = websocketSetting == WebsocketSetting.HOME_WIFI,
+                    onClick = { onSettingChanged(WebsocketSetting.HOME_WIFI) }
+                )
+            }
             RadioButtonRow(
                 text = stringResource(if (BuildConfig.FLAVOR == "full") R.string.websocket_setting_while_screen_on else R.string.websocket_setting_while_screen_on_minimal),
                 selected = websocketSetting == WebsocketSetting.SCREEN_ON,

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
@@ -138,7 +138,7 @@ abstract class DataModule {
 
         @Provides
         @Singleton
-        fun wifiManager(@ApplicationContext appContext: Context) = appContext.getSystemService<WifiManager>()!!
+        fun wifiManager(@ApplicationContext appContext: Context) = appContext.getSystemService<WifiManager>()
     }
 
     @Binds

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
@@ -7,6 +7,9 @@ interface WifiHelper {
         const val INVALID_BSSID = "02:00:00:00:00:00"
     }
 
+    /** Returns if the device exposes Wi-Fi adapter(s) to apps. To check if Wi-Fi is used, see [isUsingWifi]. */
+    fun hasWifi(): Boolean
+
     /** Returns if the active data connection is using Wi-Fi */
     fun isUsingWifi(): Boolean
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -9,8 +9,11 @@ import javax.inject.Inject
 @Suppress("DEPRECATION")
 class WifiHelperImpl @Inject constructor(
     private val connectivityManager: ConnectivityManager,
-    private val wifiManager: WifiManager
+    private val wifiManager: WifiManager?
 ) : WifiHelper {
+    override fun hasWifi(): Boolean =
+        wifiManager != null
+
     override fun isUsingWifi(): Boolean =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             connectivityManager.activeNetwork?.let {
@@ -42,8 +45,8 @@ class WifiHelperImpl @Inject constructor(
     }
 
     override fun getWifiSsid(): String? =
-        wifiManager.connectionInfo.ssid
+        wifiManager?.connectionInfo?.ssid
 
     override fun getWifiBssid(): String? =
-        wifiManager.connectionInfo.bssid
+        wifiManager?.connectionInfo?.bssid
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -125,16 +125,20 @@ class NetworkSensorManager : SensorManager {
     override val name: Int
         get() = commonR.string.sensor_name_network
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        val list = listOf(
+        val wifiSensors = listOf(
             wifiConnection,
             bssidState,
             wifiIp,
             wifiLinkSpeed,
             wifiState,
             wifiFrequency,
-            wifiSignalStrength,
-            publicIp
+            wifiSignalStrength
         )
+        val list = if (hasWifi(context)) {
+            wifiSensors.plus(publicIp)
+        } else {
+            listOf(publicIp)
+        }
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             list.plus(networkType)
         } else {
@@ -175,8 +179,11 @@ class NetworkSensorManager : SensorManager {
         }
     }
 
+    private fun hasWifi(context: Context): Boolean =
+        context.applicationContext.getSystemService<WifiManager>() != null
+
     private fun updateWifiConnectionSensor(context: Context) {
-        if (!isEnabled(context, wifiConnection)) {
+        if (!isEnabled(context, wifiConnection) || !hasWifi(context)) {
             return
         }
 
@@ -218,7 +225,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateBSSIDSensor(context: Context) {
-        if (!isEnabled(context, bssidState)) {
+        if (!isEnabled(context, bssidState) || !hasWifi(context)) {
             return
         }
 
@@ -263,7 +270,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiIPSensor(context: Context) {
-        if (!isEnabled(context, wifiIp)) {
+        if (!isEnabled(context, wifiIp) || !hasWifi(context)) {
             return
         }
 
@@ -291,7 +298,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiLinkSpeedSensor(context: Context) {
-        if (!isEnabled(context, wifiLinkSpeed)) {
+        if (!isEnabled(context, wifiLinkSpeed) || !hasWifi(context)) {
             return
         }
 
@@ -335,7 +342,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiSensor(context: Context) {
-        if (!isEnabled(context, wifiState)) {
+        if (!isEnabled(context, wifiState) || !hasWifi(context)) {
             return
         }
 
@@ -359,7 +366,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiFrequencySensor(context: Context) {
-        if (!isEnabled(context, wifiFrequency)) {
+        if (!isEnabled(context, wifiFrequency) || !hasWifi(context)) {
             return
         }
 
@@ -387,7 +394,7 @@ class NetworkSensorManager : SensorManager {
     }
 
     private fun updateWifiSignalStrengthSensor(context: Context) {
-        if (!isEnabled(context, wifiSignalStrength)) {
+        if (!isEnabled(context, wifiSignalStrength) || !hasWifi(context)) {
             return
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3536 by gracefully handling no `WifiManager` and hiding related options and features.

Unable to test this as all my devices and emulators have Wi-Fi, but manually changing things to false seems to work as expected.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|Settings for internal connection + networks, app lock bypass on internal network are removed|![Settings screen without the mentioned settings, light mode](https://github.com/home-assistant/android/assets/8148535/58324181-6ba4-4b69-b1e9-9ed6c510513f)|![Settings screen without the mentioned settings, dark mode](https://github.com/home-assistant/android/assets/8148535/f0d9d671-6ece-4595-853c-48c48b96d7d0)|
|Setting for persistent connection on home Wi-Fi is removed|![Persistent connection settings with only Never, While screen is on, Always as options, light mode](https://github.com/home-assistant/android/assets/8148535/3227b790-14c0-431c-a91b-51917a412108)|![Persistent connection settings with only Never, While screen is on, Always as options, dark mode](https://github.com/home-assistant/android/assets/8148535/141c5381-4667-4c99-a879-7615cb3048bb)|
|Sensors for Wi-Fi are removed|![Sensors list only showing two sensors in the Network sensors category, light mode](https://github.com/home-assistant/android/assets/8148535/2826bd98-e06d-4c46-8a3c-043de1d2d8c7)|![Sensors list only showing two sensors in the Network sensors category, dark mode](https://github.com/home-assistant/android/assets/8148535/53a004d0-5bbf-4dc8-b593-3f4550a83118)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
<!-- Documentation: home-assistant/companion.home-assistant# -->
No Wi-Fi is clearly an exception, I don't think this is worth mentioning in the docs

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->