### PR TITLE
Align dependency versions and bump Google dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,7 +46,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.4.7"
     }
 
     kotlinOptions {
@@ -147,10 +147,10 @@ dependencies {
     implementation("com.maltaisn:iconpack-community-material:5.3.45")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.10")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.21")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1")
-    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
 
     implementation("com.google.dagger:hilt-android:2.46.1")
     kapt("com.google.dagger:hilt-android-compiler:2.46.1")
@@ -160,8 +160,8 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.recyclerview:recyclerview:1.3.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
-    implementation("com.google.android.material:material:1.8.0")
-    implementation("androidx.fragment:fragment-ktx:1.5.6")
+    implementation("com.google.android.material:material:1.9.0")
+    implementation("androidx.fragment:fragment-ktx:1.5.7")
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.5")
     implementation("com.squareup.okhttp3:okhttp:4.11.0")
@@ -170,28 +170,28 @@ dependencies {
     "fullImplementation"("com.google.android.gms:play-services-location:21.0.1")
     "fullImplementation"("com.google.android.gms:play-services-home:16.0.0")
     "fullImplementation"("com.google.android.gms:play-services-threadnetwork:16.0.0")
-    "fullImplementation"(platform("com.google.firebase:firebase-bom:31.4.0"))
+    "fullImplementation"(platform("com.google.firebase:firebase-bom:32.1.0"))
     "fullImplementation"("com.google.firebase:firebase-messaging")
     "fullImplementation"("io.sentry:sentry-android:6.19.1")
-    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
     "fullImplementation"("com.google.android.gms:play-services-wearable:18.0.0")
     "fullImplementation"("androidx.wear:wear-remote-interactions:1.0.0")
 
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("androidx.webkit:webkit:1.6.1")
+    implementation("androidx.webkit:webkit:1.7.0")
 
-    implementation("com.google.android.exoplayer:exoplayer-core:2.18.5")
-    implementation("com.google.android.exoplayer:exoplayer-hls:2.18.5")
-    implementation("com.google.android.exoplayer:exoplayer-ui:2.18.5")
-    "fullImplementation"("com.google.android.exoplayer:extension-cronet:2.18.5")
-    "minimalImplementation"("com.google.android.exoplayer:extension-cronet:2.18.3") {
+    implementation("com.google.android.exoplayer:exoplayer-core:2.18.7")
+    implementation("com.google.android.exoplayer:exoplayer-hls:2.18.7")
+    implementation("com.google.android.exoplayer:exoplayer-ui:2.18.7")
+    "fullImplementation"("com.google.android.exoplayer:extension-cronet:2.18.7")
+    "minimalImplementation"("com.google.android.exoplayer:extension-cronet:2.18.7") {
         exclude(group = "com.google.android.gms", module = "play-services-cronet")
     }
-    "minimalImplementation"("org.chromium.net:cronet-embedded:108.5359.79")
+    "minimalImplementation"("org.chromium.net:cronet-embedded:113.5672.61")
 
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.05.01"))
     implementation("androidx.compose.animation:animation")
-    implementation("androidx.compose.compiler:compiler:1.4.4")
+    implementation("androidx.compose.compiler:compiler:1.4.7")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material:material")
     implementation("androidx.compose.material:material-icons-core")
@@ -199,7 +199,7 @@ dependencies {
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.activity:activity-compose:1.7.0")
+    implementation("androidx.activity:activity-compose:1.7.1")
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("com.google.accompanist:accompanist-themeadapter-material:0.30.1")
 

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1191,7 +1191,7 @@ class MessagingManager @Inject constructor(
                     .setStyle(
                         NotificationCompat.BigPictureStyle()
                             .bigPicture(bitmap)
-                            .bigLargeIcon(null)
+                            .bigLargeIcon(null as Bitmap?)
                     )
             }
         }

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -58,7 +58,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.2"
+        kotlinCompilerExtensionVersion = "1.4.7"
     }
 
     kotlinOptions {
@@ -153,21 +153,21 @@ dependencies {
     implementation("com.maltaisn:iconpack-community-material:5.3.45")
 
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.10")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.21")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1")
-    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    "fullImplementation"("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
 
     implementation("com.google.dagger:hilt-android:2.46.1")
     kapt("com.google.dagger:hilt-android-compiler:2.46.1")
 
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.5.1")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
-    implementation("androidx.recyclerview:recyclerview:1.2.1")
+    implementation("androidx.recyclerview:recyclerview:1.3.0")
     implementation("androidx.preference:preference-ktx:1.2.0")
-    implementation("com.google.android.material:material:1.8.0")
-    implementation("androidx.fragment:fragment-ktx:1.5.5")
+    implementation("com.google.android.material:material:1.9.0")
+    implementation("androidx.fragment:fragment-ktx:1.5.7")
 
     implementation("com.squareup.retrofit2:retrofit:2.9.0")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.13.5")
@@ -176,29 +176,29 @@ dependencies {
 
     implementation("com.google.android.gms:play-services-location:21.0.1")
     implementation("com.google.android.gms:play-services-home:16.0.0")
-    implementation("com.google.android.gms:play-services-threadnetwork:16.0.0-beta02")
-    implementation(platform("com.google.firebase:firebase-bom:31.2.2"))
+    implementation("com.google.android.gms:play-services-threadnetwork:16.0.0")
+    implementation(platform("com.google.firebase:firebase-bom:32.1.0"))
     implementation("com.google.firebase:firebase-messaging")
     implementation("io.sentry:sentry-android:6.19.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
     implementation("com.google.android.gms:play-services-wearable:18.0.0")
     implementation("androidx.wear:wear-remote-interactions:1.0.0")
 
     implementation("androidx.biometric:biometric:1.1.0")
-    implementation("androidx.webkit:webkit:1.6.0")
+    implementation("androidx.webkit:webkit:1.7.0")
 
-    implementation("com.google.android.exoplayer:exoplayer-core:2.18.2")
-    implementation("com.google.android.exoplayer:exoplayer-hls:2.18.2")
-    implementation("com.google.android.exoplayer:exoplayer-ui:2.18.2")
-    implementation("com.google.android.exoplayer:extension-cronet:2.18.2")
-    "minimalImplementation"("com.google.android.exoplayer:extension-cronet:2.18.2") {
+    implementation("com.google.android.exoplayer:exoplayer-core:2.18.7")
+    implementation("com.google.android.exoplayer:exoplayer-hls:2.18.7")
+    implementation("com.google.android.exoplayer:exoplayer-ui:2.18.7")
+    implementation("com.google.android.exoplayer:extension-cronet:2.18.7")
+    "minimalImplementation"("com.google.android.exoplayer:extension-cronet:2.18.7") {
         exclude(group = "com.google.android.gms", module = "play-services-cronet")
     }
-    "minimalImplementation"("org.chromium.net:cronet-embedded:108.5359.79")
+    "minimalImplementation"("org.chromium.net:cronet-embedded:113.5672.61")
 
-    implementation(platform("androidx.compose:compose-bom:2023.01.00"))
+    implementation(platform("androidx.compose:compose-bom:2023.05.01"))
     implementation("androidx.compose.animation:animation")
-    implementation("androidx.compose.compiler:compiler:1.4.2")
+    implementation("androidx.compose.compiler:compiler:1.4.7")
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.material:material")
     implementation("androidx.compose.material:material-icons-core")
@@ -206,7 +206,7 @@ dependencies {
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling")
-    implementation("androidx.activity:activity-compose:1.6.1")
+    implementation("androidx.activity:activity-compose:1.7.1")
     implementation("androidx.navigation:navigation-compose:2.5.3")
     implementation("com.google.accompanist:accompanist-themeadapter-material:0.30.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ buildscript {
     }
     dependencies {
         classpath("com.android.tools.build:gradle:8.0.2")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.10")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.8.21")
         classpath("com.google.gms:google-services:4.3.15")
         classpath("com.google.firebase:firebase-appdistribution-gradle:4.0.0")
         classpath("de.mannodermaus.gradle.plugins:android-junit5:1.9.3.0")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -56,7 +56,7 @@ android {
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.10")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.21")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
 
     implementation("com.google.dagger:hilt-android:2.46.1")

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -35,7 +35,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.4.7"
     }
 
     signingConfigs {
@@ -91,12 +91,12 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-guava:1.7.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.7.1")
 
-    implementation("com.google.android.material:material:1.8.0")
+    implementation("com.google.android.material:material:1.9.0")
 
     implementation("androidx.wear:wear:1.2.0")
-    implementation("androidx.core:core-ktx:1.10.0")
+    implementation("androidx.core:core-ktx:1.10.1")
     implementation("com.google.android.gms:play-services-wearable:18.0.0")
     implementation("androidx.wear:wear-input:1.2.0-alpha02")
     implementation("androidx.wear:wear-remote-interactions:1.0.0")
@@ -113,10 +113,10 @@ dependencies {
     implementation("com.mikepenz:community-material-typeface:7.0.96.0-kotlin@aar")
     implementation("com.mikepenz:iconics-compose:5.4.0")
 
-    implementation("androidx.activity:activity-ktx:1.7.0")
-    implementation("androidx.activity:activity-compose:1.7.0")
-    implementation("androidx.compose.compiler:compiler:1.4.4")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation("androidx.activity:activity-ktx:1.7.1")
+    implementation("androidx.activity:activity-compose:1.7.1")
+    implementation("androidx.compose.compiler:compiler:1.4.7")
+    implementation(platform("androidx.compose:compose-bom:2023.05.01"))
     implementation("androidx.compose.foundation:foundation")
     implementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.wear.compose:compose-foundation:1.1.2")
@@ -131,6 +131,6 @@ dependencies {
 
     implementation("androidx.health:health-services-client:1.0.0-beta03")
 
-    implementation(platform("com.google.firebase:firebase-bom:31.4.0"))
+    implementation(platform("com.google.firebase:firebase-bom:32.1.0"))
     implementation("com.google.firebase:firebase-messaging")
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR:
- aligns dependency versions between projects (for example, the app was using two different Kotlin patch releases) / modules (`automotive` was behind on dependencies already increased in `app`), and
- updates Google dependencies that are not picked up by dependabot.

Noteworthy changes:
https://developer.android.com/jetpack/androidx/releases/compose-compiler support for Kotlin 1.8.21
https://developer.android.com/jetpack/androidx/releases/compose-runtime#1.4.3 fixes a "potential deadlock in snapshot list and map" which may be what I was encountering with the ANR (see below)
https://firebase.google.com/support/release-notes/android no cloud messaging changes

These changes also seem to resolve a frequent ANR after load I'm facing with the latest beta for the Wear app and wasn't able to figure out. Not server related probably as it also happens with <10 supported entities and no state changes.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->