### PR TITLE
Speed up cold start by skipping Jackson ObjectMapper if possible

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
@@ -106,19 +106,27 @@ data class ServerConnectionInfo(
 class InternalSsidTypeConverter {
     @TypeConverter
     fun fromStringToList(value: String): List<String> {
-        return try {
-            jacksonObjectMapper().readValue(value)
-        } catch (e: JsonProcessingException) {
+        return if (value == "[]" || value.isBlank()) {
             emptyList()
+        } else {
+            try {
+                jacksonObjectMapper().readValue(value)
+            } catch (e: JsonProcessingException) {
+                emptyList()
+            }
         }
     }
 
     @TypeConverter
     fun fromListToString(value: List<String>): String {
-        return try {
-            jacksonObjectMapper().writeValueAsString(value)
-        } catch (e: JsonProcessingException) {
-            ""
+        return if (value.isEmpty()) {
+            "[]"
+        } else {
+            try {
+                jacksonObjectMapper().writeValueAsString(value)
+            } catch (e: JsonProcessingException) {
+                ""
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While doing performance tracing on a Pixel 4a, I noticed that when launching the app it takes on average 75-100ms to read server data. Almost all of that time is spent getting a Jackson `ObjectMapper` to convert the database value for internal SSIDs to a list...
![Performance trace showing 133 ms spent on fromStringToList function](https://github.com/home-assistant/android/assets/8148535/de1bcd7a-d126-4963-85fe-817b70c52f70)

... which if empty `"[]"` is a huge waste of time. So this PR adds a simple string comparison before getting Jackson to speed up startup. This performance improvement is even nicer on watches which are usually slower and will **never** have SSIDs.

It might be easier to compare the `setContent` function in the trace, reading from the database is now negligible:
![Performance trace showing 4 ms spent on reading from the database. The setContent function is about 1/3rd of all time spent on launching the activity, whereas before it was closer to 1/10th of all time spent launching.](https://github.com/home-assistant/android/assets/8148535/31021487-d40d-493f-8418-c762bfd23254)

Jackson will be used later for network but at that point the app isn't waiting on it to continue launching.

Modern phones don't take quite as long to get Jackson but it still shaves ~20ms off launch (Pixel 7a).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Using Android Studio's "low overhead" profiling, averages of 5-6 launches.