### PR TITLE
Update Wear Scaffold usage to be more consistent

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -44,7 +44,7 @@ fun ConversationResultView(
                     PositionIndicator(scalingLazyListState = scrollState)
                 }
             },
-            timeText = { TimeText(visible = !scrollState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scrollState) }
         ) {
             ScalingLazyColumn(
                 state = scrollState,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -72,7 +72,7 @@ fun MainView(
                     PositionIndicator(scalingLazyListState = scalingLazyListState)
                 }
             },
-            timeText = { TimeText(!scalingLazyListState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             ThemeLazyColumn(
                 state = scalingLazyListState

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorManagerUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorManagerUi.kt
@@ -40,7 +40,7 @@ fun SensorManagerUi(
                     PositionIndicator(scalingLazyListState = scalingLazyListState)
                 }
             },
-            timeText = { TimeText(!scalingLazyListState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             ThemeLazyColumn(
                 state = scalingLazyListState

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorsView.kt
@@ -36,7 +36,7 @@ fun SensorsView(
                     PositionIndicator(scalingLazyListState = scalingLazyListState)
                 }
             },
-            timeText = { TimeText(!scalingLazyListState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             val sensorManagers = getSensorManagers()
             ThemeLazyColumn(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -47,7 +47,7 @@ fun SetFavoritesView(
                     PositionIndicator(scalingLazyListState = scalingLazyListState)
                 }
             },
-            timeText = { TimeText(!scalingLazyListState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             ThemeLazyColumn(
                 state = scalingLazyListState

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetTileShortcutsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetTileShortcutsView.kt
@@ -17,9 +17,12 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
 import androidx.wear.compose.material.Icon
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
+import androidx.wear.compose.material.rememberScalingLazyListState
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.data.SimplifiedEntity
@@ -38,88 +41,98 @@ fun SetTileShortcutsView(
     isShowShortcutTextEnabled: Boolean,
     onShowShortcutTextEnabled: (Boolean) -> Unit
 ) {
+    val scalingLazyListState = rememberScalingLazyListState()
     WearAppTheme {
-        ThemeLazyColumn {
-            item {
-                ListHeader(id = commonR.string.shortcuts_tile)
-            }
-            item {
-                ToggleChip(
-                    modifier = Modifier.fillMaxWidth(),
-                    checked = isShowShortcutTextEnabled,
-                    onCheckedChange = { onShowShortcutTextEnabled(it) },
-                    label = {
-                        Text(stringResource(commonR.string.shortcuts_tile_text_setting))
-                    },
-                    appIcon = {
-                        Image(
-                            asset =
-                            if (isShowShortcutTextEnabled) {
-                                CommunityMaterial.Icon.cmd_alphabetical
-                            } else {
-                                CommunityMaterial.Icon.cmd_alphabetical_off
-                            },
-                            colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
-                        )
-                    },
-                    toggleControl = {
-                        Icon(
-                            imageVector = ToggleChipDefaults.checkboxIcon(isShowShortcutTextEnabled),
-                            contentDescription = if (isShowShortcutTextEnabled) {
-                                stringResource(commonR.string.show)
-                            } else {
-                                stringResource(commonR.string.hide)
-                            }
-                        )
-                    }
-                )
-            }
-            item {
-                ListHeader(id = commonR.string.shortcuts_choose)
-            }
-            items(shortcutEntities.size) { index ->
-
-                val iconBitmap = getIcon(
-                    shortcutEntities[index].icon,
-                    shortcutEntities[index].domain,
-                    LocalContext.current
-                )
-
-                Chip(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    icon = {
-                        Image(
-                            iconBitmap ?: CommunityMaterial.Icon.cmd_bookmark,
-                            colorFilter = ColorFilter.tint(Color.White)
-                        )
-                    },
-                    label = {
-                        Text(
-                            text = stringResource(commonR.string.shortcut_n, index + 1)
-                        )
-                    },
-                    secondaryLabel = {
-                        Text(
-                            text = shortcutEntities[index].friendlyName,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    },
-                    onClick = { onShortcutEntitySelectionChange(index) },
-                    colors = ChipDefaults.secondaryChipColors()
-                )
-            }
-            if (shortcutEntities.size < 7) {
+        Scaffold(
+            positionIndicator = {
+                if (scalingLazyListState.isScrollInProgress) {
+                    PositionIndicator(scalingLazyListState = scalingLazyListState)
+                }
+            },
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
+        ) {
+            ThemeLazyColumn(state = scalingLazyListState) {
                 item {
-                    Button(
-                        modifier = Modifier.padding(top = 16.dp),
-                        onClick = { onShortcutEntitySelectionChange(shortcutEntities.size) },
-                        colors = ButtonDefaults.primaryButtonColors()
-                    ) {
-                        Image(
-                            CommunityMaterial.Icon3.cmd_plus_thick
-                        )
+                    ListHeader(id = commonR.string.shortcuts_tile)
+                }
+                item {
+                    ToggleChip(
+                        modifier = Modifier.fillMaxWidth(),
+                        checked = isShowShortcutTextEnabled,
+                        onCheckedChange = { onShowShortcutTextEnabled(it) },
+                        label = {
+                            Text(stringResource(commonR.string.shortcuts_tile_text_setting))
+                        },
+                        appIcon = {
+                            Image(
+                                asset =
+                                if (isShowShortcutTextEnabled) {
+                                    CommunityMaterial.Icon.cmd_alphabetical
+                                } else {
+                                    CommunityMaterial.Icon.cmd_alphabetical_off
+                                },
+                                colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+                            )
+                        },
+                        toggleControl = {
+                            Icon(
+                                imageVector = ToggleChipDefaults.checkboxIcon(isShowShortcutTextEnabled),
+                                contentDescription = if (isShowShortcutTextEnabled) {
+                                    stringResource(commonR.string.show)
+                                } else {
+                                    stringResource(commonR.string.hide)
+                                }
+                            )
+                        }
+                    )
+                }
+                item {
+                    ListHeader(id = commonR.string.shortcuts_choose)
+                }
+                items(shortcutEntities.size) { index ->
+
+                    val iconBitmap = getIcon(
+                        shortcutEntities[index].icon,
+                        shortcutEntities[index].domain,
+                        LocalContext.current
+                    )
+
+                    Chip(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        icon = {
+                            Image(
+                                iconBitmap ?: CommunityMaterial.Icon.cmd_bookmark,
+                                colorFilter = ColorFilter.tint(Color.White)
+                            )
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(commonR.string.shortcut_n, index + 1)
+                            )
+                        },
+                        secondaryLabel = {
+                            Text(
+                                text = shortcutEntities[index].friendlyName,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        },
+                        onClick = { onShortcutEntitySelectionChange(index) },
+                        colors = ChipDefaults.secondaryChipColors()
+                    )
+                }
+                if (shortcutEntities.size < 7) {
+                    item {
+                        Button(
+                            modifier = Modifier.padding(top = 16.dp),
+                            onClick = { onShortcutEntitySelectionChange(shortcutEntities.size) },
+                            colors = ButtonDefaults.primaryButtonColors()
+                        ) {
+                            Image(
+                                CommunityMaterial.Icon3.cmd_plus_thick
+                            )
+                        }
                     }
                 }
             }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
@@ -84,7 +84,7 @@ fun SettingsView(
                     PositionIndicator(scalingLazyListState = scalingLazyListState)
                 }
             },
-            timeText = { TimeText(!scalingLazyListState.isScrollInProgress) }
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             ThemeLazyColumn(
                 state = scalingLazyListState

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/TemplateTileSettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/TemplateTileSettingsView.kt
@@ -12,10 +12,14 @@ import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.PositionIndicator
+import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
+import androidx.wear.compose.material.rememberScalingLazyListState
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.IntervalToString
 import io.homeassistant.companion.android.views.ListHeader
@@ -27,41 +31,53 @@ fun TemplateTileSettingsView(
     refreshInterval: Int,
     onClickRefreshInterval: () -> Unit
 ) {
-    ThemeLazyColumn {
-        item {
-            ListHeader(id = R.string.template_tile)
-        }
-        item {
-            Chip(
-                modifier = Modifier
-                    .fillMaxWidth(),
-                icon = {
-                    Image(
-                        asset = CommunityMaterial.Icon3.cmd_timer_cog,
-                        colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+    val scalingLazyListState = rememberScalingLazyListState()
+    WearAppTheme {
+        Scaffold(
+            positionIndicator = {
+                if (scalingLazyListState.isScrollInProgress) {
+                    PositionIndicator(scalingLazyListState = scalingLazyListState)
+                }
+            },
+            timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
+        ) {
+            ThemeLazyColumn(state = scalingLazyListState) {
+                item {
+                    ListHeader(id = R.string.template_tile)
+                }
+                item {
+                    Chip(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        icon = {
+                            Image(
+                                asset = CommunityMaterial.Icon3.cmd_timer_cog,
+                                colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+                            )
+                        },
+                        colors = ChipDefaults.secondaryChipColors(),
+                        label = {
+                            Text(
+                                text = stringResource(id = R.string.refresh_interval)
+                            )
+                        },
+                        secondaryLabel = { Text(IntervalToString(LocalContext.current, refreshInterval)) },
+                        onClick = onClickRefreshInterval
                     )
-                },
-                colors = ChipDefaults.secondaryChipColors(),
-                label = {
+                }
+                item {
+                    ListHeader(R.string.template_tile_content)
+                }
+                item {
+                    Text(stringResource(R.string.template_tile_change_message))
+                }
+                item {
                     Text(
-                        text = stringResource(id = R.string.refresh_interval)
+                        templateContent,
+                        color = Color.DarkGray
                     )
-                },
-                secondaryLabel = { Text(IntervalToString(LocalContext.current, refreshInterval)) },
-                onClick = onClickRefreshInterval
-            )
-        }
-        item {
-            ListHeader(R.string.template_tile_content)
-        }
-        item {
-            Text(stringResource(R.string.template_tile_change_message))
-        }
-        item {
-            Text(
-                templateContent,
-                color = Color.DarkGray
-            )
+                }
+            }
         }
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/TimeText.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/TimeText.kt
@@ -1,31 +1,28 @@
 package io.homeassistant.companion.android.home.views
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.wear.compose.material.ScalingLazyListState
 import androidx.wear.compose.material.TimeText
+import androidx.wear.compose.material.rememberScalingLazyListState
+import androidx.wear.compose.material.scrollAway
 
 @Composable
 fun TimeText(
-    visible: Boolean
+    scalingLazyListState: ScalingLazyListState
 ) {
-    AnimatedVisibility(
-        visible = visible,
-        enter = slideInVertically(),
-        exit = slideOutVertically()
-    ) {
-        TimeText()
-    }
+    TimeText(
+        modifier = Modifier.scrollAway(scrollState = scalingLazyListState)
+    )
 }
 
 @Preview(device = Devices.WEAR_OS_LARGE_ROUND)
 @Composable
 private fun PreviewTimeText() {
     CompositionLocalProvider {
-        TimeText(visible = true)
+        TimeText(scalingLazyListState = rememberScalingLazyListState())
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/phoneinstall/PhoneInstallView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/phoneinstall/PhoneInstallView.kt
@@ -39,7 +39,7 @@ fun PhoneInstallView(
                 PositionIndicator(scalingLazyListState = scrollState)
             }
         },
-        timeText = { TimeText(visible = !scrollState.isScrollInProgress) }
+        timeText = { TimeText(scalingLazyListState = scrollState) }
     ) {
         Box(modifier = Modifier.background(MaterialTheme.colors.background)) {
             ThemeLazyColumn(state = scrollState) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Add a `Scaffold` which provides a `PositionIndicator` while scrolling and `TimeText` to screens which didn't have them. This also contributes to the upcoming app quality requirement 'Visual quality: Show time (apps)':
   > We recommend that you display the time of day at the top of all activities except dialogs and confirmation screens.
 - Change `TimeText` to only show up at the top of the screen contents instead of at the top of the screen, in line with other Material 3 Google apps.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Time and scrollbar on a screen that previously didn't have it:
![Device details screen for an entity named 'Stekkerblok', now showing the time at the top and a scrollbar on the right](https://github.com/home-assistant/android/assets/8148535/c0c971ac-7b80-4341-921b-a479bc9b66c3)

A screen that is scrolled down now doesn't show the time at the top of the screen:
![Sensors screen, about halfway down, with nothing fixed to the top of the screen](https://github.com/home-assistant/android/assets/8148535/df56d91b-9365-44b3-a762-900fd3119283)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->