### PR TITLE
Set Wear theme background color to black

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/phoneinstall/PhoneInstallView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/phoneinstall/PhoneInstallView.kt
@@ -1,8 +1,6 @@
 package io.homeassistant.companion.android.onboarding.phoneinstall
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -41,50 +39,48 @@ fun PhoneInstallView(
         },
         timeText = { TimeText(scalingLazyListState = scrollState) }
     ) {
-        Box(modifier = Modifier.background(MaterialTheme.colors.background)) {
-            ThemeLazyColumn(state = scrollState) {
-                item {
-                    Image(
-                        painter = painterResource(R.drawable.app_icon),
-                        contentDescription = null,
-                        modifier = Modifier.size(48.dp)
-                    )
+        ThemeLazyColumn(state = scrollState) {
+            item {
+                Image(
+                    painter = painterResource(R.drawable.app_icon),
+                    contentDescription = null,
+                    modifier = Modifier.size(48.dp)
+                )
+            }
+            item {
+                Text(
+                    text = stringResource(commonR.string.install_phone_to_continue),
+                    style = MaterialTheme.typography.title3,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp)
+                )
+            }
+            item {
+                Button(
+                    onClick = onInstall,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(stringResource(commonR.string.install))
                 }
-                item {
-                    Text(
-                        text = stringResource(commonR.string.install_phone_to_continue),
-                        style = MaterialTheme.typography.title3,
-                        textAlign = TextAlign.Center,
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp)
-                    )
+            }
+            item {
+                Button(
+                    onClick = onRefresh,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.secondaryButtonColors()
+                ) {
+                    Text(stringResource(commonR.string.refresh))
                 }
-                item {
-                    Button(
-                        onClick = onInstall,
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(stringResource(commonR.string.install))
-                    }
-                }
-                item {
-                    Button(
-                        onClick = onRefresh,
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = ButtonDefaults.secondaryButtonColors()
-                    ) {
-                        Text(stringResource(commonR.string.refresh))
-                    }
-                }
-                item {
-                    Button(
-                        onClick = onAdvanced,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 16.dp),
-                        colors = ButtonDefaults.secondaryButtonColors()
-                    ) {
-                        Text(stringResource(commonR.string.advanced))
-                    }
+            }
+            item {
+                Button(
+                    onClick = onAdvanced,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 16.dp),
+                    colors = ButtonDefaults.secondaryButtonColors()
+                ) {
+                    Text(stringResource(commonR.string.advanced))
                 }
             }
         }

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
     android:padding="@dimen/box_inset_layout_padding"
     tools:context=".onboarding.integration.MobileAppIntegrationActivity"
     tools:deviceIds="wear">

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -4,7 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@android:color/black"
     android:padding="@dimen/box_inset_layout_padding"
     tools:deviceIds="wear">
 

--- a/wear/src/main/res/layout/activity_onboarding.xml
+++ b/wear/src/main/res/layout/activity_onboarding.xml
@@ -5,7 +5,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:background="@android:color/black"
     android:layout_height="match_parent">
 
     <androidx.wear.widget.WearableRecyclerView

--- a/wear/src/main/res/layout/view_loading.xml
+++ b/wear/src/main/res/layout/view_loading.xml
@@ -4,8 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:background="@android:color/black">
+    android:gravity="center">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/loading_text"

--- a/wear/src/main/res/values/colors.xml
+++ b/wear/src/main/res/values/colors.xml
@@ -3,7 +3,7 @@
     <color name="colorDialogBackground">#111111</color>
     <color name="colorDialogMessage">@android:color/white</color>
     <color name="colorDialogTitle">@android:color/white</color>
-    <color name="colorActivityBackground">#1c1c1c</color>
+    <color name="colorActivityBackground">@android:color/black</color>
     <color name="colorPrimary">#03A9F4</color>
     <color name="colorPrimaryDark">#111111</color>
     <color name="colorAccent">#03A9F4</color>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
I noticed that the background for Assist on watches was still dark grey instead of black. It's black in most other activities because of Compose's `SwipeToDismissBox` adding it for us, or because we manually added it.

This PR sets the theme default to black to match the [app quality guidelines](https://developer.android.com/docs/quality-guidelines/wear-app-quality#upcoming) + removes activity/view specific backgrounds that are black and no longer needed.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After|
|-----|-----|
|![Assist activity with a dark grey background](https://github.com/home-assistant/android/assets/8148535/40bea696-2c02-440d-8733-0cb519695a77)|![Assist activity with a black background](https://github.com/home-assistant/android/assets/8148535/af86e4ac-baf5-4b8a-8c10-0a5800817a73)|


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
> Visual quality | Black background | `WO-V13` | Use a black background for all apps and tiles.