### PR TITLE
Expose docs for websocket Matter/Thread functions

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -44,10 +44,38 @@ interface WebSocketRepository {
     suspend fun getTemplateUpdates(template: String): Flow<TemplateUpdatedEvent>?
     suspend fun getNotifications(): Flow<Map<String, Any>>?
     suspend fun ackNotification(confirmId: String): Boolean
+
+    /**
+     * Request the server to add a Matter device to the network and commission it.
+     * @return [MatterCommissionResponse] detailing the server's response, or `null` if the server
+     * did not return a response.
+     */
     suspend fun commissionMatterDevice(code: String): MatterCommissionResponse?
+
+    /**
+     * Request the server to commission a Matter device that is already on the network.
+     * @return [MatterCommissionResponse] detailing the server's response, or `null` if the server
+     * did not return a response.
+     */
     suspend fun commissionMatterDeviceOnNetwork(pin: Long): MatterCommissionResponse?
+
+    /**
+     * Return a list of all Thread datasets known to the server.
+     * @return List with [ThreadDatasetResponse]s, or `null` if not an admin or no response.
+     */
     suspend fun getThreadDatasets(): List<ThreadDatasetResponse>?
+
+    /**
+     * Return the TLV value for a dataset.
+     * @return [ThreadDatasetTlvResponse] for the Thread dataset, or `null` if not found, not an
+     * admin or no response.
+     */
     suspend fun getThreadDatasetTlv(datasetId: String): ThreadDatasetTlvResponse?
+
+    /**
+     * Add a new set of Thread network credentials to the server.
+     * @return `true` if the server indicated success
+     */
     suspend fun addThreadDataset(tlv: ByteArray): Boolean
 
     /**

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -370,11 +370,6 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         return response?.success == true
     }
 
-    /**
-     * Request the server to add a Matter device to the network and commission it
-     * @return [MatterCommissionResponse] detailing the server's response, or `null` if the server
-     * did not return a response
-     */
     override suspend fun commissionMatterDevice(code: String): MatterCommissionResponse? {
         val response = sendMessage(
             WebSocketRequest(
@@ -400,11 +395,6 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         }
     }
 
-    /**
-     * Request the server to commission a Matter device that is already on the network
-     * @return [MatterCommissionResponse] detailing the server's response, or `null` if the server
-     * did not return a response
-     */
     override suspend fun commissionMatterDeviceOnNetwork(pin: Long): MatterCommissionResponse? {
         val response = sendMessage(
             WebSocketRequest(
@@ -430,10 +420,6 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         }
     }
 
-    /**
-     * Return a list of all Thread datasets known to the server.
-     * @return List with [ThreadDatasetResponse]s, or `null` if not an admin or no response.
-     */
     override suspend fun getThreadDatasets(): List<ThreadDatasetResponse>? {
         val response = sendMessage(
             mapOf(
@@ -447,11 +433,6 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         }
     }
 
-    /**
-     * Return the TLV value for a dataset.
-     * @return [ThreadDatasetTlvResponse] for the Thread dataset, or `null` if not found, not an
-     * admin or no response.
-     */
     override suspend fun getThreadDatasetTlv(datasetId: String): ThreadDatasetTlvResponse? {
         val response = sendMessage(
             mapOf(
@@ -463,10 +444,6 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         return mapResponse(response)
     }
 
-    /**
-     * Add a new set of Thread network credentials to the server.
-     * @return `true` if the server indicated success
-     */
     override suspend fun addThreadDataset(tlv: ByteArray): Boolean {
         val response = sendMessage(
             mapOf(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While working on other code I noticed that the documentation for websocket Matter/Thread functions was misplaced in the `WebSocketRepositoryImpl` class, hiding it from outside. Moving it to the interface to expose it 'publicly' and allow it to e.g. show up in IDE tooltips.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->