### PR TITLE
Hide devices that are home from the android auto navigation screen

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
@@ -24,6 +24,7 @@ import com.mikepenz.iconics.utils.toAndroidIconCompat
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.getIcon
 import kotlinx.coroutines.flow.Flow
@@ -61,6 +62,9 @@ class MapVehicleScreen(
         entities
             .mapNotNull {
                 val attrs = it.attributes as? Map<*, *>
+                if (it.domain == "device_tracker" && it.state == "home") {
+                    return@mapNotNull null
+                }
                 if (attrs != null) {
                     val lat = attrs["latitude"] as? Double
                     val lon = attrs["longitude"] as? Double


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Just a small clean up PR. I think if you have a lot of devices that are at home and have a device tracker it may seem a bit redundant to list them all. One example is if a user has wall mounted tablets with the app installed.

I decided not to touch `person` entity as you may not care if they are home or not, you just want to navigate to them.

sensors and zones are left untouched as sensors may not have an expected state and zones should always be shown like person.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#949

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->