### PR TITLE
Hide native mode UI from automotive play store builds

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -93,7 +93,7 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
             val carIntent = Intent(
                 this,
                 Class.forName("androidx.car.app.activity.CarAppActivity")
-            ).putExtra("TRANSITION_LAUNCH", true).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(carIntent)
         } else {
             startActivity(WebViewActivity.newInstance(this, intent.data?.path))

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.launch
 
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.setContent
@@ -84,12 +83,7 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
     override fun displayWebview() {
         presenter.setSessionExpireMillis(0)
 
-        val isAutomotive = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            this.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
-        } else {
-            false
-        }
-        if (isAutomotive && BuildConfig.FLAVOR == "full") {
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE) && BuildConfig.FLAVOR == "full") {
             val carIntent = Intent(
                 this,
                 Class.forName("androidx.car.app.activity.CarAppActivity")

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -1,5 +1,8 @@
 package io.homeassistant.companion.android.launch
 
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.setContent
@@ -81,7 +84,20 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
     override fun displayWebview() {
         presenter.setSessionExpireMillis(0)
 
-        startActivity(WebViewActivity.newInstance(this, intent.data?.path))
+        val isAutomotive = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            this.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+        } else {
+            false
+        }
+        if (isAutomotive && BuildConfig.FLAVOR == "full") {
+            val carIntent = Intent(
+                this,
+                Class.forName("androidx.car.app.activity.CarAppActivity")
+            ).putExtra("TRANSITION_LAUNCH", true).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(carIntent)
+        } else {
+            startActivity(WebViewActivity.newInstance(this, intent.data?.path))
+        }
         finish()
         overridePendingTransition(0, 0) // Disable activity start/stop animation
     }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -26,6 +26,7 @@ import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import com.mikepenz.iconics.utils.sizeDp
 import com.mikepenz.iconics.utils.toAndroidIconCompat
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
@@ -242,7 +243,7 @@ class MainVehicleScreen(
         return ListTemplate.Builder().apply {
             setTitle(carContext.getString(commonR.string.app_name))
             setHeaderAction(Action.APP_ICON)
-            if (isAutomotive && !iDrivingOptimized) {
+            if (isAutomotive && !iDrivingOptimized && BuildConfig.FLAVOR != "full") {
                 setActionStrip(
                     ActionStrip.Builder().addAction(
                         Action.Builder()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Based on feedback received we need to hide native mode for now in the automotive play store builds. The automotive minimal version is not impacted by these changes.

- Upon app launch and completing onboarding the template grid screen will load
- Native Mode button is hidden

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I have done testing in an emulator using the full version