### PR TITLE
Add 'Manage assistants' button to native Assist

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -23,6 +23,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.assist.ui.AssistSheetView
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.webview.WebViewActivity
 
 @AndroidEntryPoint
 class AssistActivity : BaseActivity() {
@@ -90,6 +91,8 @@ class AssistActivity : BaseActivity() {
             )
         }
 
+        val fromFrontend = intent.getBooleanExtra(EXTRA_FROM_FRONTEND, false)
+
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             MdcTheme {
@@ -103,9 +106,25 @@ class AssistActivity : BaseActivity() {
                     conversation = viewModel.conversation,
                     pipelines = viewModel.pipelines,
                     inputMode = viewModel.inputMode,
-                    fromFrontend = intent.getBooleanExtra(EXTRA_FROM_FRONTEND, false),
+                    fromFrontend = fromFrontend,
                     currentPipeline = viewModel.currentPipeline,
                     onSelectPipeline = viewModel::changePipeline,
+                    onManagePipelines =
+                    if (fromFrontend && viewModel.userCanManagePipelines()) {
+                        {
+                            startActivity(
+                                WebViewActivity.newInstance(
+                                    this,
+                                    "config/voice-assistants/assistants"
+                                ).apply {
+                                    flags += Intent.FLAG_ACTIVITY_NEW_TASK // Delivers data in onNewIntent
+                                }
+                            )
+                            finish()
+                        }
+                    } else {
+                        null
+                    },
                     onChangeInput = viewModel::onChangeInput,
                     onTextInput = viewModel::onTextInput,
                     onMicrophoneInput = viewModel::onMicrophoneInput,

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -152,6 +152,8 @@ class AssistViewModel @Inject constructor(
         }
     }
 
+    fun userCanManagePipelines(): Boolean = serverManager.getServer()?.user?.isAdmin == true
+
     fun changePipeline(serverId: Int, id: String) = viewModelScope.launch {
         if (serverId == selectedServerId && id == selectedPipeline?.id) return@launch
 

--- a/app/src/main/java/io/homeassistant/companion/android/assist/ui/AssistSheetView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/ui/AssistSheetView.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
@@ -91,6 +92,7 @@ fun AssistSheetView(
     currentPipeline: AssistUiPipeline?,
     fromFrontend: Boolean,
     onSelectPipeline: (Int, String) -> Unit,
+    onManagePipelines: (() -> Unit)?,
     onChangeInput: () -> Unit,
     onTextInput: (String) -> Unit,
     onMicrophoneInput: () -> Unit,
@@ -133,7 +135,8 @@ fun AssistSheetView(
                         pipelines = pipelines,
                         currentPipeline = currentPipeline,
                         fromFrontend = fromFrontend,
-                        onSelectPipeline = onSelectPipeline
+                        onSelectPipeline = onSelectPipeline,
+                        onManagePipelines = onManagePipelines
                     )
                     LazyColumn(
                         state = lazyListState,
@@ -169,7 +172,8 @@ fun AssistSheetHeader(
     pipelines: List<AssistUiPipeline>,
     currentPipeline: AssistUiPipeline?,
     fromFrontend: Boolean,
-    onSelectPipeline: (Int, String) -> Unit
+    onSelectPipeline: (Int, String) -> Unit,
+    onManagePipelines: (() -> Unit)?
 ) = Column(verticalArrangement = Arrangement.Center) {
     Text(
         text = stringResource(if (fromFrontend) commonR.string.assist else commonR.string.app_name),
@@ -217,6 +221,12 @@ fun AssistSheetHeader(
                                 text = if (pipelineShowServer) "${it.serverName}: ${it.name}" else it.name,
                                 fontWeight = if (isSelected) FontWeight.SemiBold else null
                             )
+                        }
+                    }
+                    if (onManagePipelines != null) {
+                        Divider()
+                        DropdownMenuItem(onClick = { onManagePipelines() }) {
+                            Text(stringResource(commonR.string.assist_manage_pipelines))
                         }
                     }
                 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1065,6 +1065,7 @@
     <string name="assist_error">Oops, an error has occurred</string>
     <string name="assist_how_can_i_assist">How can I assist?</string>
     <string name="assist_log_in">Log in to Home Assistant to start using Assist</string>
+    <string name="assist_manage_pipelines">Manage assistants</string>
     <string name="assist_permission">To use Assist with your voice, allow Home Assistant to access the microphone</string>
     <string name="assist_send_text">Send text</string>
     <string name="assist_start_listening">Start listening</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
By request from @balloob, add a 'Manage assistants' link to the assistant dropdown in native Assist when launched from the frontend.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![Option 'Manage assistants' as the last Assist dropdown item, light mode](https://github.com/home-assistant/android/assets/8148535/929173d8-6184-4e71-be2b-63f34b74cffa)|![Option 'Manage assistants' as the last Assist dropdown item, dark mode](https://github.com/home-assistant/android/assets/8148535/abc7a563-be59-4594-ab6a-0a10f8c24f91)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->