### PR TITLE
Hide a few GMS features unavailable on Automotive

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.matter
 import android.content.ComponentName
 import android.content.Context
 import android.content.IntentSender
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import com.google.android.gms.home.matter.Matter
@@ -12,7 +13,8 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ma
 import javax.inject.Inject
 
 class MatterManagerImpl @Inject constructor(
-    private val serverManager: ServerManager
+    private val serverManager: ServerManager,
+    private val packageManager: PackageManager
 ) : MatterManager {
 
     companion object {
@@ -20,7 +22,7 @@ class MatterManagerImpl @Inject constructor(
     }
 
     override fun appSupportsCommissioning(): Boolean =
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && !packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
     override suspend fun coreSupportsCommissioning(serverId: Int): Boolean {
         if (!serverManager.isRegistered() || serverManager.getServer(serverId)?.user?.isAdmin != true) return false

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/SettingsWearDetection.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.settings.wear
 
 import android.content.Context
+import android.content.pm.PackageManager
 import android.util.Log
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.common.api.CommonStatusCodes
@@ -16,6 +17,7 @@ object SettingsWearDetection {
      * if they have the Home Assistant app installed.
      */
     suspend fun hasAnyNodes(context: Context): Boolean {
+        if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) return false
         return try {
             val nodeClient = Wearable.getNodeClient(context)
             nodeClient.connectedNodes.await().any()

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.thread
 import android.app.Activity
 import android.content.Context
 import android.content.IntentSender
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.activity.result.ActivityResult
@@ -21,7 +22,8 @@ import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
 class ThreadManagerImpl @Inject constructor(
-    private val serverManager: ServerManager
+    private val serverManager: ServerManager,
+    private val packageManager: PackageManager
 ) : ThreadManager {
     companion object {
         private const val TAG = "ThreadManagerImpl"
@@ -31,7 +33,7 @@ class ThreadManagerImpl @Inject constructor(
     }
 
     override fun appSupportsThread(): Boolean =
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && !packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
     override suspend fun coreSupportsThread(serverId: Int): Boolean {
         if (!serverManager.isRegistered() || serverManager.getServer(serverId)?.user?.isAdmin != true) return false

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
@@ -139,6 +139,10 @@ abstract class DataModule {
         @Provides
         @Singleton
         fun wifiManager(@ApplicationContext appContext: Context) = appContext.getSystemService<WifiManager>()
+
+        @Provides
+        @Singleton
+        fun packageManager(@ApplicationContext appContext: Context) = appContext.packageManager
     }
 
     @Binds


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Hides a few features that depend on GMS APIs currently unavailable on Automotive according to this list: https://developer.android.com/training/cars/google-services. Including the dependencies in the app doesn't cause the crash considering the current release so a simple check will be enough and keeps manifest/dependencies the same for `app` and `automotive`.

(activity sensors are in `com.google.android.gms.location` weirdly enough, so not hiding those for now)

With the native interface now hidden it doesn't really matter that much but still nice to be prepared.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->