### PR TITLE
Support sensor display precision

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -168,12 +168,10 @@ class EntityWidget : BaseWidgetProvider() {
             return ResolvedText(staticWidgetDao.get(appWidgetId)?.lastUpdate, entityCaughtException)
         }
 
-        var fetchedAttributes: Map<*, *>
-        var attributeValues: List<String?>
         try {
-            fetchedAttributes = entity?.attributes as? Map<*, *> ?: mapOf<String, String>()
-            attributeValues =
-                attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
+            val fetchedAttributes = entity?.attributes as? Map<*, *> ?: mapOf<String, String>()
+            val attributeValues =
+                attributeIds.split(",").map { id -> fetchedAttributes[id]?.toString() }
             val lastUpdate =
                 entity?.friendlyState(context, entityOptions).plus(if (attributeValues.isNotEmpty()) stateSeparator else "")
                     .plus(attributeValues.joinToString(attributeSeparator))

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -17,6 +17,8 @@ import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.canSupportPrecision
+import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.database.widget.StaticWidgetDao
 import io.homeassistant.companion.android.database.widget.StaticWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
@@ -81,6 +83,7 @@ class EntityWidget : BaseWidgetProvider() {
 
                 // Content
                 val resolvedText = resolveTextToShow(
+                    context,
                     serverId,
                     entityId,
                     suggestedEntity,
@@ -128,6 +131,7 @@ class EntityWidget : BaseWidgetProvider() {
         staticWidgetDao.getAll().associate { it.id to (it.serverId to listOf(it.entityId)) }
 
     private suspend fun resolveTextToShow(
+        context: Context,
         serverId: Int,
         entityId: String?,
         suggestedEntity: Entity<Map<String, Any>>?,
@@ -148,10 +152,18 @@ class EntityWidget : BaseWidgetProvider() {
             Log.e(TAG, "Unable to fetch entity", e)
             entityCaughtException = true
         }
+        val entityOptions = if (
+            entity?.canSupportPrecision() == true &&
+            serverManager.getServer(serverId)?.version?.isAtLeast(2023, 3) == true
+        ) {
+            serverManager.webSocketRepository(serverId).getEntityRegistryFor(entity.entityId)?.options
+        } else {
+            null
+        }
         if (attributeIds == null) {
             staticWidgetDao.updateWidgetLastUpdate(
                 appWidgetId,
-                entity?.state ?: staticWidgetDao.get(appWidgetId)?.lastUpdate ?: ""
+                entity?.friendlyState(context, entityOptions) ?: staticWidgetDao.get(appWidgetId)?.lastUpdate ?: ""
             )
             return ResolvedText(staticWidgetDao.get(appWidgetId)?.lastUpdate, entityCaughtException)
         }
@@ -163,7 +175,7 @@ class EntityWidget : BaseWidgetProvider() {
             attributeValues =
                 attributeIds.split(",").map { id -> fetchedAttributes.get(id)?.toString() }
             val lastUpdate =
-                entity?.state.plus(if (attributeValues.isNotEmpty()) stateSeparator else "")
+                entity?.friendlyState(context, entityOptions).plus(if (attributeValues.isNotEmpty()) stateSeparator else "")
                     .plus(attributeValues.joinToString(attributeSeparator))
             staticWidgetDao.updateWidgetLastUpdate(appWidgetId, lastUpdate)
             return ResolvedText(lastUpdate)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -9,6 +9,7 @@ import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedStateDiff
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryOptions
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
@@ -603,7 +604,7 @@ suspend fun <T> Entity<T>.onPressed(
 val <T> Entity<T>.friendlyName: String
     get() = (attributes as? Map<*, *>)?.get("friendly_name")?.toString() ?: entityId
 
-fun <T> Entity<T>.friendlyState(context: Context): String {
+fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions? = null): String {
     var friendlyState = when (state) {
         "closed" -> context.getString(commonR.string.state_closed)
         "closing" -> context.getString(commonR.string.state_closing)
@@ -633,7 +634,15 @@ fun <T> Entity<T>.friendlyState(context: Context): String {
             ).toString()
         } catch (e: DateTimeParseException) { /* Not a timestamp */ }
     }
-    if (friendlyState == state) {
+    if (
+        friendlyState == state &&
+        canSupportPrecision() &&
+        (options?.sensor?.displayPrecision != null || options?.sensor?.suggestedDisplayPrecision != null)
+    ) {
+        val number = friendlyState.toDouble()
+        val precision = options.sensor.displayPrecision ?: options.sensor.suggestedDisplayPrecision!!
+        friendlyState = String.format(Locale.getDefault(), "%.${precision}f", number)
+    } else if (friendlyState == state) {
         friendlyState = state.split("_").joinToString(" ") { word ->
             word.replaceFirstChar {
                 if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
@@ -642,6 +651,8 @@ fun <T> Entity<T>.friendlyState(context: Context): String {
     }
     return friendlyState
 }
+
+fun <T> Entity<T>.canSupportPrecision() = domain == "sensor" && state.toDoubleOrNull() != null
 
 fun <T> Entity<T>.isExecuting() = when (state) {
     "closing" -> true

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -35,6 +35,7 @@ interface WebSocketRepository {
     suspend fun getAreaRegistry(): List<AreaRegistryResponse>?
     suspend fun getDeviceRegistry(): List<DeviceRegistryResponse>?
     suspend fun getEntityRegistry(): List<EntityRegistryResponse>?
+    suspend fun getEntityRegistryFor(entityId: String): EntityRegistryResponse?
     suspend fun getServices(): List<DomainResponse>?
     suspend fun getStateChanges(): Flow<StateChangedEvent>?
     suspend fun getStateChanges(entityIds: List<String>): Flow<TriggerEvent>?

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -196,6 +196,17 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         return mapResponse(socketResponse)
     }
 
+    override suspend fun getEntityRegistryFor(entityId: String): EntityRegistryResponse? {
+        val socketResponse = sendMessage(
+            mapOf(
+                "type" to "config/entity_registry/get",
+                "entity_id" to entityId
+            )
+        )
+
+        return mapResponse(socketResponse)
+    }
+
     override suspend fun getServices(): List<DomainResponse>? {
         val socketResponse = sendMessage(
             mapOf(

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/EntityRegistryResponse.kt
@@ -1,9 +1,24 @@
 package io.homeassistant.companion.android.common.data.websocket.impl.entities
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class EntityRegistryResponse(
     val areaId: String?,
     val deviceId: String?,
     val entityCategory: String?,
     val entityId: String,
-    val hiddenBy: String?
+    val hiddenBy: String?,
+    val options: EntityRegistryOptions?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EntityRegistryOptions(
+    val sensor: EntityRegistrySensorOptions?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class EntityRegistrySensorOptions(
+    val displayPrecision: Int?,
+    val suggestedDisplayPrecision: Int?
 )

--- a/wear/src/main/java/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
@@ -17,6 +17,7 @@ import com.mikepenz.iconics.typeface.library.community.material.CommunityMateria
 import com.mikepenz.iconics.utils.colorInt
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.integration.canSupportPrecision
 import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.common.data.integration.getIcon
@@ -59,6 +60,15 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
             }
         }
 
+        val entityOptions = if (
+            entity.canSupportPrecision() &&
+            serverManager.getServer()?.version?.isAtLeast(2023, 3) == true
+        ) {
+            serverManager.webSocketRepository().getEntityRegistryFor(entityId)?.options
+        } else {
+            null
+        }
+
         val icon = entity.getIcon(applicationContext) ?: CommunityMaterial.Icon.cmd_bookmark
         val iconBitmap = IconicsDrawable(this, icon).apply {
             colorInt = Color.WHITE
@@ -69,7 +79,7 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
         } else {
             null
         }
-        val text = PlainComplicationText.Builder(entity.friendlyState(this)).build()
+        val text = PlainComplicationText.Builder(entity.friendlyState(this, entityOptions)).build()
         val contentDescription = PlainComplicationText.Builder(getText(R.string.complication_entity_state_content_description)).build()
         val monochromaticImage = MonochromaticImage.Builder(Icon.createWithBitmap(iconBitmap)).build()
         val tapAction = ComplicationReceiver.getComplicationToggleIntent(this, request.complicationInstanceId)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3397 by switching the entity state widget to use the friendly state (= formatted and translated), which now uses the entity registry options for more formatting.

Because friendly state is used to fix this, it also means:
- the Wear entity state complication also receives this fix
- state should now be displayed the same for the main app widget and Wear entity state complication

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
This sensor has a state of `52.94685`, options `display_precision` `null` and `suggested_display_precision` `2`. The stable app ignores all this, the updated app formats the number as shown in the frontend.
![Two widgets, one for the stable app showing '52.94685kWh' as the state, and one for the dev app showing '52.95kWh' as the state](https://github.com/home-assistant/android/assets/8148535/cf7bc502-7e7f-4817-9b55-d775b60db2e7)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->