### PR TITLE
Fix Thread sync throwing exception sometimes crashing app

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -10,6 +10,7 @@ import io.homeassistant.companion.android.thread.ThreadManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -62,7 +63,7 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
     override fun runThreadDebug(context: Context, serverId: Int) {
         mainScope.launch {
             try {
-                when (val syncResult = threadManager.syncPreferredDataset(context, serverId, this)) {
+                when (val syncResult = threadManager.syncPreferredDataset(context, serverId, CoroutineScope(coroutineContext + SupervisorJob()))) {
                     is ThreadManager.SyncResult.ServerUnsupported ->
                         view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_unsupported_server), false)
                     is ThreadManager.SyncResult.OnlyOnServer -> {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -19,6 +19,7 @@ import io.homeassistant.companion.android.util.UrlUtil
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -333,7 +334,7 @@ class WebViewPresenterImpl @Inject constructor(
 
             mainScope.launch {
                 val deviceThreadIntent = try {
-                    when (val result = threadUseCase.syncPreferredDataset(context, serverId, this)) {
+                    when (val result = threadUseCase.syncPreferredDataset(context, serverId, CoroutineScope(coroutineContext + SupervisorJob()))) {
                         is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
                         is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
                         else -> null


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Thread credential syncing uses the provided `CoroutineScope` to run other functions that throw exceptions. [An user found an issue](https://discord.com/channels/330944238910963714/1049765219565576234/1125839085995573369) when not connected to their home network, this will throw an exception when getting the device credentials. Depending on where the function is called, this can crash the app.

When using a normal `Job`, like in the `mainScope` that we create in a few places, a thrown exception will mean that everything in that scope is cancelled and [the exception propagates up, even if 'caught'](https://medium.com/androiddevelopers/exceptions-in-coroutines-ce8da1ec060c#:~:text=Also%2C%20notice%20that%20we%E2%80%99re%20using%20a%20supervisorScope%20to%20call%20async%20and%20await.%20As%20we%20said%20before%2C%20a%20SupervisorJob%20lets%20the%20coroutine%20handle%20the%20exception%3B%20as%20opposed%20to%20Job%20that%20will%20automatically%20propagate%20it%20up%20in%20the%20hierarchy%20so%20the%20catch%20block%20won%E2%80%99t%20be%20called%3A). That isn't wanted so use a `SupervisorJob` instead, like the default `viewModelScope`, when running this function to make sure that when caught nothing else stops.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Easiest way to test is to access Home Assistant while only connected to mobile data and initiating a Thread credentials sync from the app settings.