### PR TITLE
Only invalidate vehicle template UI when contents change

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -49,8 +49,9 @@ class EntityGridVehicleScreen(
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 entitiesFlow.collect {
                     loading = false
+                    val hasChanged = entities.size != it.size || entities.toSet() != it.toSet()
                     entities = it
-                    invalidate()
+                    if (hasChanged) invalidate()
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -103,13 +103,16 @@ class MainVehicleScreen(
                     invalidate()
                 }
                 allEntities.collect { entities ->
-                    domains.clear()
-                    entities.values.forEach {
-                        if (it.domain in SUPPORTED_DOMAINS) {
-                            domains.add(it.domain)
-                        }
+                    val newDomains = entities.values
+                        .map { it.domain }
+                        .distinct()
+                        .filter { it in SUPPORTED_DOMAINS }
+                        .toSet()
+                    if (newDomains.size != domains.size || newDomains != domains) {
+                        domains.clear()
+                        domains.addAll(newDomains)
+                        invalidate()
                     }
-                    invalidate()
                 }
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
@@ -43,15 +43,30 @@ class MapVehicleScreen(
     }
 
     var loading = true
-    var entities: List<Entity<*>> = listOf()
+    var entities: Set<Entity<*>> = setOf()
 
     init {
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 entitiesFlow.collect {
                     loading = false
-                    entities = it
-                    invalidate()
+                    val newSet = it
+                        .filter { entity ->
+                            if (entity.domain == "device_tracker" && entity.state == "home") {
+                                return@filter false
+                            }
+                            val attrs = entity.attributes as? Map<*, *>
+                            if (attrs != null) {
+                                val lat = attrs["latitude"] as? Double
+                                val lon = attrs["longitude"] as? Double
+                                return@filter lat != null && lon != null
+                            }
+                            return@filter false
+                        }
+                        .toSet()
+                    val hasChanged = entities.size != newSet.size || entities != newSet
+                    entities = newSet
+                    if (hasChanged) invalidate()
                 }
             }
         }
@@ -60,19 +75,11 @@ class MapVehicleScreen(
     override fun onGetTemplate(): Template {
         val listBuilder = ItemList.Builder()
         entities
-            .mapNotNull {
-                val attrs = it.attributes as? Map<*, *>
-                if (it.domain == "device_tracker" && it.state == "home") {
-                    return@mapNotNull null
-                }
-                if (attrs != null) {
-                    val lat = attrs["latitude"] as? Double
-                    val lon = attrs["longitude"] as? Double
-                    if (lat != null && lon != null) {
-                        return@mapNotNull Pair(it, listOf(lat, lon))
-                    }
-                }
-                return@mapNotNull null
+            .map { // Null checks handled during collection
+                val attrs = it.attributes as Map<*, *>
+                val lat = attrs["latitude"] as Double
+                val lon = attrs["longitude"] as Double
+                Pair(it, listOf(lat, lon))
             }
             .sortedBy { it.first.friendlyName }
             .forEach { (entity, location) ->


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR updates the vehicle service entity state changes collection to only cause an invalidation of the template UI if the contents change, instead of on every change (which is any state change, as a 'new' list is received).

Fixes #3328, which is easily reproduced when using the DHU + rotary input + a state change. Any invalidation would cause the position to be reset when scrolling, after this change it is far less likely to be invalidated while scrolling.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual changes if the code is correct :)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->