### PR TITLE
Don't show assistant app suggestion on L, show on M

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -241,9 +241,11 @@ class SettingsPresenterImpl @Inject constructor(
         if (assistantSuggestion && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val roleManager = context.getSystemService<RoleManager>()
             assistantSuggestion = roleManager?.isRoleAvailable(RoleManager.ROLE_ASSISTANT) == true && !roleManager.isRoleHeld(RoleManager.ROLE_ASSISTANT)
-        } else if (assistantSuggestion && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        } else if (assistantSuggestion && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             val defaultApp: String? = Settings.Secure.getString(context.contentResolver, "assistant")
             assistantSuggestion = defaultApp?.contains(BuildConfig.APPLICATION_ID) == false
+        } else {
+            assistantSuggestion = false
         }
         if (assistantSuggestion) {
             suggestions += SettingsHomeSuggestion(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Minor fix for the settings suggestion:
 - Don't suggest setting HA as the assistant app on Android L as this setting doesn't exist yet
 - Allow suggesting setting HA as the assistant app on Android M as this setting was added in M

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->