### PR TITLE
Minor update to Auto(motive) login screen

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/LoginScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/LoginScreen.kt
@@ -5,6 +5,7 @@ import android.content.pm.PackageManager
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.model.Action
+import androidx.car.app.model.CarIcon
 import androidx.car.app.model.MessageTemplate
 import androidx.car.app.model.ParkedOnlyOnClickListener
 import androidx.car.app.model.Template
@@ -42,17 +43,17 @@ class LoginScreen(context: CarContext, val serverManager: ServerManager) : Scree
     }
 
     override fun onGetTemplate(): Template {
-        return MessageTemplate.Builder(carContext.getString(R.string.aa_app_not_logged_in))
-            .setTitle(carContext.getString(R.string.app_name))
-            .setHeaderAction(Action.APP_ICON)
+        return MessageTemplate.Builder(carContext.getString(R.string.welcome_hass))
+            .setIcon(CarIcon.APP_ICON)
             .addAction(
                 Action.Builder()
-                    .setTitle(carContext.getString(R.string.login))
+                    .setTitle(carContext.getString(if (isAutomotive) R.string.login else R.string.login_on_phone))
                     .setOnClickListener(
                         ParkedOnlyOnClickListener.create {
                             startNativeActivity()
                         }
                     )
+                    .setFlags(Action.FLAG_PRIMARY)
                     .build()
             )
             .build()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -342,6 +342,7 @@
     <string name="logbook">Logbook</string>
     <string name="logged_in">Logged in</string>
     <string name="login">Login</string>
+    <string name="login_on_phone">Login on your phone</string>
     <string name="login_wear_os_device">Login Wear OS Device</string>
     <string name="logout">Logout</string>
     <string name="lovelace_view_dashboard">Dashboard View or Dashboard</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The car interface login screen is quite basic and doesn't give any feedback after pressing login for Auto users, trying to improve it a bit and make it more consistent with the normal onboarding because it is the first screen Automotive users see.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After|
|-----|-----|
|![Home Assistant title in the top bar with a text 'Not logged in', button 'Login'](https://github.com/home-assistant/android/assets/8148535/f365cb48-b622-4f57-a556-a7f77e79d4c5)|![Centered Home Assistant logo with the text 'Welcome to Home Assistant Companion!' and a button 'Login on your phone'](https://github.com/home-assistant/android/assets/8148535/b74a06e0-846f-41ab-b366-ad8a4e2b5af6)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->