### PR TITLE
Force update on media session sensor when a session is in progress

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -283,7 +283,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             primaryPlaybackState,
             mediaSession.statelessIcon,
             attr,
-            forceUpdate = primaryPlaybackState != "Unavailable"
+            forceUpdate = primaryPlaybackState == "Playing"
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -282,7 +282,8 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             mediaSession,
             primaryPlaybackState,
             mediaSession.statelessIcon,
-            attr
+            attr,
+            forceUpdate = primaryPlaybackState != "Unavailable"
         )
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3648  by forcing updates of the sensor when a media session is in progress. I chose to go by `Unavailable` state as that particular state should only get 1 update.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->