### PR TITLE
Implement a frontend-like single entity picker

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/views/ManageTilesView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/views/ManageTilesView.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.settings.qs.ManageTilesViewModel
 import io.homeassistant.companion.android.util.compose.ServerDropdownButton
+import io.homeassistant.companion.android.util.compose.SingleEntityPicker
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -128,25 +129,16 @@ fun ManageTilesView(
                     )
                 }
 
-                Text(
-                    text = stringResource(id = R.string.tile_entity),
-                    fontSize = 15.sp
+                SingleEntityPicker(
+                    entities = viewModel.sortedEntities,
+                    currentEntity = viewModel.selectedEntityId,
+                    onEntityCleared = { viewModel.selectEntityId("") },
+                    onEntitySelected = viewModel::selectEntityId,
+                    modifier = Modifier
+                        .padding(10.dp)
+                        .fillMaxWidth(),
+                    label = { Text(stringResource(R.string.tile_entity)) }
                 )
-                Box {
-                    OutlinedButton(onClick = { expandedEntity = true }) {
-                        Text(text = viewModel.selectedEntityId)
-                    }
-                    DropdownMenu(expanded = expandedEntity, onDismissRequest = { expandedEntity = false }) {
-                        for (item in viewModel.sortedEntities) {
-                            DropdownMenuItem(onClick = {
-                                viewModel.selectEntityId(item.entityId)
-                                expandedEntity = false
-                            }) {
-                                Text(text = item.entityId, fontSize = 15.sp)
-                            }
-                        }
-                    }
-                }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/SingleEntityPicker.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/SingleEntityPicker.kt
@@ -64,16 +64,21 @@ fun SingleEntityPicker(
     var listTooLarge by remember { mutableStateOf(false) }
     LaunchedEffect(entities.size, inputValue) {
         list = withContext(Dispatchers.IO) {
+            val query = inputValue.trim()
             val items = if (inputValue.isBlank() || inputValue == (entities.firstOrNull { it.entityId == currentEntity }?.friendlyName ?: currentEntity)) {
                 entities
             } else {
-                entities.filter { it.friendlyName.contains(inputValue, ignoreCase = true) }
+                entities.filter {
+                    it.friendlyName.contains(query, ignoreCase = true) ||
+                        it.entityId.contains(query.replace(" ", "_"), ignoreCase = true)
+                }
             }
             // The amount of items is limited because Compose ExposedDropdownMenu isn't lazy
             listTooLarge = items.size > 150
             items.sortedWith(
                 compareBy(
-                    { !it.friendlyName.lowercase().startsWith(inputValue) },
+                    { !it.friendlyName.startsWith(query, ignoreCase = true) },
+                    { !it.entityId.split(".")[1].startsWith(query.replace(" ", "_"), ignoreCase = true) },
                     { it.friendlyName.lowercase() }
                 )
             ).take(150)

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/SingleEntityPicker.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/SingleEntityPicker.kt
@@ -1,0 +1,155 @@
+package io.homeassistant.companion.android.util.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.ContentAlpha
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBox
+import androidx.compose.material.ExposedDropdownMenuDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.friendlyName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import io.homeassistant.companion.android.common.R as commonR
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun SingleEntityPicker(
+    entities: List<Entity<*>>,
+    currentEntity: String?,
+    onEntityCleared: () -> Unit,
+    onEntitySelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    label: @Composable (() -> Unit) = { Text(stringResource(commonR.string.select_entity_to_display)) }
+) {
+    val focusManager = LocalFocusManager.current
+
+    var expanded by remember { mutableStateOf(false) }
+    var inputValue by remember(currentEntity, entities.size) {
+        mutableStateOf(
+            if (currentEntity == null) {
+                ""
+            } else {
+                entities.firstOrNull { it.entityId == currentEntity }?.friendlyName ?: currentEntity
+            }
+        )
+    }
+
+    var list by remember { mutableStateOf(entities) }
+    var listTooLarge by remember { mutableStateOf(false) }
+    LaunchedEffect(entities.size, inputValue) {
+        list = withContext(Dispatchers.IO) {
+            val items = if (inputValue.isBlank() || inputValue == (entities.firstOrNull { it.entityId == currentEntity }?.friendlyName ?: currentEntity)) {
+                entities
+            } else {
+                entities.filter { it.friendlyName.contains(inputValue, ignoreCase = true) }
+            }
+            // The amount of items is limited because Compose ExposedDropdownMenu isn't lazy
+            listTooLarge = items.size > 150
+            items.sortedWith(
+                compareBy(
+                    { !it.friendlyName.lowercase().startsWith(inputValue) },
+                    { it.friendlyName.lowercase() }
+                )
+            ).take(150)
+        }
+    }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = !expanded },
+        modifier = modifier
+    ) {
+        TextField(
+            value = inputValue,
+            onValueChange = {
+                expanded = true
+                inputValue = it
+            },
+            label = label,
+            trailingIcon =
+            {
+                Row {
+                    if (currentEntity?.isNotBlank() == true) {
+                        IconButton(onClick = onEntityCleared, modifier = Modifier.clearAndSetSemantics { }) {
+                            Icon(
+                                Icons.Filled.Clear,
+                                stringResource(commonR.string.search_clear_selection)
+                            )
+                        }
+                    }
+                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                }
+            },
+            colors = ExposedDropdownMenuDefaults.textFieldColors(),
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        if (list.isNotEmpty()) {
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                list.forEach {
+                    DropdownMenuItem(
+                        onClick = {
+                            onEntitySelected(it.entityId)
+                            inputValue = it.friendlyName
+                            focusManager.clearFocus()
+                            expanded = false
+                        },
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        Column {
+                            Text(
+                                text = it.friendlyName,
+                                style = MaterialTheme.typography.body1,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                                Text(
+                                    text = it.entityId,
+                                    style = MaterialTheme.typography.body2,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                    }
+                }
+                if (listTooLarge) {
+                    DropdownMenuItem(onClick = { /* No-op */ }, enabled = false) {
+                        Text(
+                            text = stringResource(commonR.string.search_refine_for_more),
+                            style = MaterialTheme.typography.body2,
+                            fontStyle = FontStyle.Italic
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -487,9 +487,11 @@
     <string name="scene">Scene</string>
     <string name="scenes">Scenes</string>
     <string name="scripts">Scripts</string>
+    <string name="search_clear_selection">Clear selection</string>
     <string name="search_icons">Search icons</string>
     <string name="search_icons_in_english">Search icons (in English)</string>
     <string name="search_notifications">Search notifications</string>
+    <string name="search_refine_for_more">Refine your search to view more…</string>
     <string name="search_results">Search Results</string>
     <string name="search_sensors">Search sensors</string>
     <string name="security_vulnerably_message">Your version of Home Assistant does not protect for recently discovered security vulnerabilities in custom components. Please view the details via the bulletin and update as soon as possible.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a new Composable `SingleEntityPicker` which aims to provide a text input with autocomplete search for entities like the frontend, where you can pick one and easily see which one was picked. This will be useful to have in various places.

Replaced the picker in tiles for now as an example of how it would be used to [resolve this unsubmitted feature request](https://discord.com/channels/330944238910963714/562408603345092636/1127934779426353322). I'll follow up with another PR implementing it in more places if this is accepted.

The frontend includes full fuzzy searching which I'm not going to attempt in the first PR, starting with a search based on friendly name and entity ID, sorting results based on friendly name starts with > entity ID starts with > friendly name to hopefully show the most relevant results first while not requiring an exact match.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|Closed/selected state shows friendly name and clear button|![Text input with title 'Select a entity to toggle or call (required)', clear icon and dropdown indicator at the end, light mode](https://github.com/home-assistant/android/assets/8148535/3b341d99-c53b-4d86-95e2-321e87c4b277)|![Text input with title 'Select a entity to toggle or call (required)', clear icon and dropdown indicator at the end, dark mode](https://github.com/home-assistant/android/assets/8148535/865b7350-8fd0-4bd0-a10c-6cd518046305)|
|Opened with selection: current entity at top, other entities sorted by friendly name follow|![Text input with dropdown menu as described, light mode](https://github.com/home-assistant/android/assets/8148535/97feebe5-c61b-4279-beef-b4138c1ffb95)|![Text input with dropdown menu as described, dark mode](https://github.com/home-assistant/android/assets/8148535/fcda5fbd-e040-41bf-a5e4-694506eceb46)|
|If there are a lot of entities, use a more specific query to view more|![List of entities from the picker with the last item 'Refine your search to view more...', light mode](https://github.com/home-assistant/android/assets/8148535/ec0dc6a6-d008-433f-976f-2ac261809e98)|![List of entities from the picker with the last item 'Refine your search to view more...', dark mode](https://github.com/home-assistant/android/assets/8148535/8c7de211-a013-4be5-8fb7-d5c328c6dd9d)|
|Searching not only considers the friendly name, but also the entity ID|![Text input with 'roboro' and one result with a friendly name 'Do not disturb' but entity ID 'switch.roborock_s6_do_not_disturb', light mode](https://github.com/home-assistant/android/assets/8148535/48721659-3b3d-4333-9af5-2e3e4d03e86b)|![Text input with 'roboro' and one result with a friendly name 'Do not disturb' but entity ID 'switch.roborock_s6_do_not_disturb', dark mode](https://github.com/home-assistant/android/assets/8148535/c89e58ad-214d-488c-8a48-5f66b52aef88)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->