### PR TITLE
Assistant app intent fallback to 'safe' intent if not found

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.settings
 
 import android.annotation.SuppressLint
 import android.app.UiModeManager
+import android.content.ActivityNotFoundException
 import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -344,12 +345,23 @@ class SettingsFragment(
         }
     }
 
+    @SuppressLint("InlinedApi")
     private fun updateAssistantApp() {
         // On Android Q+, this is a workaround as Android doesn't allow requesting the assistant role
-        val openIntent = Intent(Intent.ACTION_MAIN)
-        openIntent.component = ComponentName("com.android.settings", "com.android.settings.Settings\$ManageAssistActivity")
-        openIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        startActivity(openIntent)
+        try {
+            val openIntent = Intent(Intent.ACTION_MAIN)
+            openIntent.component = ComponentName("com.android.settings", "com.android.settings.Settings\$ManageAssistActivity")
+            openIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(openIntent)
+        } catch (e: ActivityNotFoundException) {
+            // The exact activity/package doesn't exist on this device, use the official intent
+            // which sends the user to the 'Default apps' screen (one more tap required to change)
+            startActivity(
+                Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS).apply {
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            )
+        }
     }
 
     private fun updateBackgroundAccessPref() {


### PR DESCRIPTION
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
It looks like not all devices keep the original settings names, fallback to the 'manage default apps' intent if we cannot directly open the screen for the assistant app setting.

Play Console, Android 13, various devices (mostly Samsung):
```
Exception android.content.ActivityNotFoundException:
  at android.app.Instrumentation.checkStartActivityResult (Instrumentation.java:2203)
  at android.app.Instrumentation.execStartActivity (Instrumentation.java:1841)
  at android.app.Activity.startActivityForResult (Activity.java:5616)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:754)
  at android.app.Activity.startActivityForResult (Activity.java:5569)
  at androidx.activity.ComponentActivity.startActivityForResult (ComponentActivity.java:735)
  at android.app.Activity.startActivity (Activity.java:6087)
  at androidx.core.content.ContextCompat$Api16Impl.startActivity (ContextCompat.java:978)
  at androidx.core.content.ContextCompat.startActivity (ContextCompat.java:318)
  at androidx.fragment.app.FragmentHostCallback.onStartActivityFromFragment (FragmentHostCallback.java:166)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1448)
  at androidx.fragment.app.Fragment.startActivity (Fragment.java:1436)
  at io.homeassistant.companion.android.settings.SettingsFragment.updateAssistantApp (SettingsFragment.kt:352)
  at io.homeassistant.companion.android.settings.SettingsFragment.access$updateAssistantApp (SettingsFragment.kt:59)
  at io.homeassistant.companion.android.settings.SettingsFragment$onCreatePreferences$3$1$1.emit$lambda$2$lambda$0 (SettingsFragment.kt:121)
  at io.homeassistant.companion.android.settings.SettingsFragment$onCreatePreferences$3$1$1.$r8$lambda$JRDpt3soVxn8zS-IOA7ilxU7cb8
  at io.homeassistant.companion.android.settings.SettingsFragment$onCreatePreferences$3$1$1$$ExternalSyntheticLambda0.onPreferenceClick
  at androidx.preference.Preference.performClick (Preference.java:1200)
  at androidx.preference.Preference.performClick (Preference.java:1182)
  at androidx.preference.Preference$1.onClick (Preference.java:182)
  at android.view.View.performClick (View.java:7544)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->