### PR TITLE
Hide android auto sensor section from devices that do not support it

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -38,6 +38,10 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
         }
     }
 
+    override fun hasSensor(context: Context): Boolean {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
+    }
+
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Hide the android auto sensor section on devices that don't support it. The list was already empty so users could not enable it but good to clean up the UI as the section is not needed to be displayed on those devices anyways.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->