### PR TITLE
Add toggle for Assist as assistant app on Wear

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="automation">Automation</string>
     <string name="autoplay_video_summary">Autoplay Videos when dashboard is active. Enabling this setting may increase data usage unexpectedly, proceed with caution.</string>
     <string name="autoplay_video">Autoplay Videos</string>
+    <string name="available_as_assistant_app">Available as assistant app</string>
     <string name="background_access_disabled">Home Assistant does not have access to run in the background. Without this permission the app will not be able to reliably send data back to your server. Click here to request permissions.</string>
     <string name="background_access_enabled">Home Assistant has access to run in the background.</string>
     <string name="background_access_title">Background Access</string>

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -64,7 +64,6 @@
         <activity android:name=".home.HomeActivity" />
         <activity android:name=".splash.SplashActivity"
             android:theme="@style/SplashTheme"
-            android:label="@string/app_name"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -96,12 +95,18 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+        <activity-alias
+            android:name=".conversation.AssistantActivity"
+            android:targetActivity=".conversation.ConversationActivity"
+            android:label="@string/ha_assist"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.ASSIST" />
                 <action android:name="android.intent.action.VOICE_ASSIST"/>
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <!-- Tiles -->
         <service

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -142,10 +142,13 @@ fun LoadHomePage(
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
                     isToastEnabled = mainViewModel.isToastEnabled.value,
                     isFavoritesOnly = mainViewModel.isFavoritesOnly,
+                    isAssistantAppAllowed = mainViewModel.isAssistantAppAllowed,
                     onHapticEnabled = { mainViewModel.setHapticEnabled(it) },
                     onToastEnabled = { mainViewModel.setToastEnabled(it) },
-                    setFavoritesOnly = { mainViewModel.setWearFavoritesOnly(it) }
-                ) { swipeDismissableNavController.navigate(SCREEN_SET_TILE_TEMPLATE) }
+                    setFavoritesOnly = { mainViewModel.setWearFavoritesOnly(it) },
+                    onClickTemplateTile = { swipeDismissableNavController.navigate(SCREEN_SET_TILE_TEMPLATE) },
+                    onAssistantAppAllowed = mainViewModel::setAssistantApp
+                )
             }
             composable(SCREEN_SET_FAVORITES) {
                 SetFavoritesView(

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
@@ -70,10 +70,12 @@ fun SettingsView(
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
     isFavoritesOnly: Boolean,
+    isAssistantAppAllowed: Boolean,
     onHapticEnabled: (Boolean) -> Unit,
     onToastEnabled: (Boolean) -> Unit,
     setFavoritesOnly: (Boolean) -> Unit,
-    onClickTemplateTile: () -> Unit
+    onClickTemplateTile: () -> Unit,
+    onAssistantAppAllowed: (Boolean) -> Unit
 ) {
     val scalingLazyListState: ScalingLazyListState = rememberScalingLazyListState()
 
@@ -239,6 +241,37 @@ fun SettingsView(
                 }
                 item {
                     ListHeader(
+                        id = commonR.string.assist
+                    )
+                }
+                item {
+                    ToggleChip(
+                        modifier = Modifier.fillMaxWidth(),
+                        checked = isAssistantAppAllowed,
+                        onCheckedChange = onAssistantAppAllowed,
+                        label = {
+                            Text(stringResource(commonR.string.available_as_assistant_app))
+                        },
+                        appIcon = {
+                            Image(
+                                asset = CommunityMaterial.Icon.cmd_comment_processing_outline,
+                                colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+                            )
+                        },
+                        toggleControl = {
+                            Icon(
+                                imageVector = ToggleChipDefaults.switchIcon(isAssistantAppAllowed),
+                                contentDescription = if (isFavoritesOnly) {
+                                    stringResource(commonR.string.enabled)
+                                } else {
+                                    stringResource(commonR.string.disabled)
+                                }
+                            )
+                        }
+                    )
+                }
+                item {
+                    ListHeader(
                         id = commonR.string.account
                     )
                 }
@@ -287,8 +320,11 @@ private fun PreviewSettingsView() {
         isHapticEnabled = true,
         isToastEnabled = false,
         isFavoritesOnly = false,
+        isAssistantAppAllowed = true,
         onHapticEnabled = {},
         onToastEnabled = {},
-        setFavoritesOnly = {}
-    ) {}
+        setFavoritesOnly = {},
+        onClickTemplateTile = {},
+        onAssistantAppAllowed = {}
+    )
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 Adds a toggle for enabling/disabling the option to use Assist as an assistant app (= intent filter on Assist activity), as users may not be able to change the app used after choosing 'Always' and Wear OS 2 doesn't ask the user which app to use, and users can't change the default assistant app, which can result in Assist instead of the Google Assistant being forced.

Also reported in [this forum post](https://community.home-assistant.io/t/wearos-companion-issues/592070) and [these Discord messages](https://discord.com/channels/330944238910963714/562408603345092636/1129914534732243085).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Ironically, this is best visible when you can choose the assistant app, as you will see Home Assistant show or hide depending on the setting:
|Setting in app|On: HA available|Off: HA removed|
|-----|-----|-----|
|!['Available as assistant app' setting in the Home Assistant app, on with an Assist icon](https://github.com/home-assistant/android/assets/8148535/e1ae4bc2-a5ea-48f2-9931-361d3538a19a)|!['Default digital assistant app' system setting showing 'None', 'Google Assistant', and 'Home Assistant' as options](https://github.com/home-assistant/android/assets/8148535/29513ac5-b6c4-4c7a-9654-4e12b57ead32)|!['Default digital assistant app' system setting showing only 'None' and 'Google Assistant' as options](https://github.com/home-assistant/android/assets/8148535/298737de-4c7d-4920-a73f-9c16d0a30703)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Tested on Wear OS 2 emulator with `adb shell am start -a android.intent.action.VOICE_ASSIST` and a Galaxy Watch 4.