### PR TITLE
Breaking change: support last_used/preferred pipeline IDs and use last_used by default

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -22,6 +22,7 @@ import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.assist.ui.AssistSheetView
+import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.webview.WebViewActivity
 
@@ -79,9 +80,9 @@ class AssistActivity : BaseActivity() {
                     null
                 },
                 pipelineId = if (intent.hasExtra(EXTRA_PIPELINE)) {
-                    intent.getStringExtra(EXTRA_PIPELINE)
+                    intent.getStringExtra(EXTRA_PIPELINE) ?: AssistViewModelBase.PIPELINE_LAST_USED
                 } else {
-                    null
+                    AssistViewModelBase.PIPELINE_LAST_USED
                 },
                 startListening = if (intent.hasExtra(EXTRA_START_LISTENING)) {
                     intent.getBooleanExtra(EXTRA_START_LISTENING, true)

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -83,7 +83,14 @@ class AssistViewModel @Inject constructor(
                     )
                 )
             } else {
-                setPipeline(pipelineId?.ifBlank { null })
+                setPipeline(
+                    when {
+                        pipelineId == PIPELINE_LAST_USED -> serverManager.integrationRepository(selectedServerId).getLastUsedPipeline()
+                        pipelineId == PIPELINE_PREFERRED -> null
+                        pipelineId?.isNotBlank() == true -> pipelineId
+                        else -> null
+                    }
+                )
             }
 
             if (serverManager.isRegistered()) {
@@ -149,6 +156,7 @@ class AssistViewModel @Inject constructor(
                 id = it.id,
                 name = it.name
             )
+            serverManager.integrationRepository(selectedServerId).setLastUsedPipeline(it.id)
 
             _conversation.clear()
             _conversation.add(startMessage)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/assist/AssistShortcutView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/assist/AssistShortcutView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineListResponse
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.util.compose.ExposedDropdownMenu
@@ -79,16 +80,25 @@ fun AssistShortcutView(
                         ExposedDropdownMenu(
                             label = stringResource(commonR.string.assist_pipeline),
                             keys = listOf(
+                                stringResource(commonR.string.assist_last_used_pipeline),
                                 stringResource(
                                     commonR.string.assist_preferred_pipeline,
                                     pipelines.pipelines.first { it.id == pipelines.preferredPipeline }.name
                                 )
                             ) +
                                 pipelines.pipelines.map { it.name },
-                            currentIndex = pipelineId?.let { pid -> 1 + pipelines.pipelines.indexOfFirst { it.id == pid } }
-                                ?: 0,
+                            currentIndex = when {
+                                pipelineId == AssistViewModelBase.PIPELINE_LAST_USED -> 0
+                                pipelineId == AssistViewModelBase.PIPELINE_PREFERRED -> 1
+                                pipelineId != null -> 2 + pipelines.pipelines.indexOfFirst { it.id == pipelineId }
+                                else -> 0
+                            },
                             onSelected = {
-                                pipelineId = if (it == 0) null else pipelines.pipelines[it - 1].id
+                                pipelineId = when (it) {
+                                    0 -> AssistViewModelBase.PIPELINE_LAST_USED
+                                    1 -> AssistViewModelBase.PIPELINE_PREFERRED
+                                    else -> pipelines.pipelines[it - 2].id
+                                }
                             }
                         )
                         Spacer(modifier = Modifier.height(16.dp))

--- a/common/src/main/java/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -26,6 +26,11 @@ abstract class AssistViewModelBase(
     application: Application
 ) : AndroidViewModel(application) {
 
+    companion object {
+        const val PIPELINE_PREFERRED = "preferred"
+        const val PIPELINE_LAST_USED = "last_used"
+    }
+
     enum class AssistInputMode {
         TEXT,
         TEXT_ONLY,

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -62,6 +62,10 @@ interface IntegrationRepository {
         pipelineId: String? = null,
         conversationId: String? = null
     ): Flow<AssistPipelineEvent>?
+
+    suspend fun getLastUsedPipeline(): String?
+
+    suspend fun setLastUsedPipeline(pipelineId: String)
 }
 
 @AssistedFactory

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -65,6 +65,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         private const val PREF_SESSION_EXPIRE = "session_expire"
         private const val PREF_TRUSTED = "trusted"
         private const val PREF_SEC_WARNING_NEXT = "sec_warning_last"
+        private const val PREF_LAST_USED_PIPELINE = "last_used_pipeline"
         private const val TAG = "IntegrationRepository"
         private const val RATE_LIMIT_URL = BuildConfig.RATE_LIMIT_URL
 
@@ -170,6 +171,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         localStorage.remove("${serverId}_$PREF_SESSION_EXPIRE")
         localStorage.remove("${serverId}_$PREF_TRUSTED")
         localStorage.remove("${serverId}_$PREF_SEC_WARNING_NEXT")
+        localStorage.remove("${serverId}_$PREF_LAST_USED_PIPELINE")
         // app version and push token is device-specific
     }
 
@@ -554,6 +556,12 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
             }
         }
     }
+
+    override suspend fun getLastUsedPipeline(): String? =
+        localStorage.getString("${serverId}_$PREF_LAST_USED_PIPELINE")
+
+    override suspend fun setLastUsedPipeline(pipelineId: String) =
+        localStorage.putString("${serverId}_$PREF_LAST_USED_PIPELINE", pipelineId)
 
     override suspend fun getEntities(): List<Entity<Any>>? {
         val response = webSocketRepository.getStates()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1100,6 +1100,7 @@
     <string name="assist_enter_a_request">Enter a request</string>
     <string name="assist_error">Oops, an error has occurred</string>
     <string name="assist_how_can_i_assist">How can I assist?</string>
+    <string name="assist_last_used_pipeline">Last used assistant</string>
     <string name="assist_log_in">Log in to Home Assistant to start using Assist</string>
     <string name="assist_manage_pipelines">Manage assistants</string>
     <string name="assist_permission">To use Assist with your voice, allow Home Assistant to access the microphone</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -87,7 +87,13 @@ class ConversationViewModel @Inject constructor(
                 }
             }
 
-            return setPipeline(null)
+            return setPipeline(
+                if (useAssistPipeline) {
+                    serverManager.integrationRepository().getLastUsedPipeline()
+                } else {
+                    null
+                }
+            )
         }
 
         return false
@@ -142,6 +148,9 @@ class ConversationViewModel @Inject constructor(
         useAssistPipelineStt = false
         if (pipeline != null || !useAssistPipeline) {
             currentPipeline = pipeline
+            currentPipeline?.let {
+                serverManager.integrationRepository().setLastUsedPipeline(it.id)
+            }
 
             _conversation.clear()
             _conversation.add(startMessage)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Update native Assist to better match frontend Assist behavior:
 - default to the last used pipeline if not specified instead of the preferred pipeline
 - allow the frontend to choose between `last_used`, `preferred`, or a specific pipeline -> requires home-assistant/frontend#17329 / 2023.8

Breaking change, matching frontend: Assist shortcuts will open last used pipeline by default instead of preferred. To use preferred, recreate the shortcut.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|Assist shortcut options updated with 'Last used assistant' (default)|![Assist shortcut options menu for 'Assistant', now includes an option 'Last used assistant', light mode](https://github.com/home-assistant/android/assets/8148535/4abf3b99-38f8-4c5a-a581-4935a2b8df75)|![Assist shortcut options menu for 'Assistant', now includes an option 'Last used assistant', dark mode](https://github.com/home-assistant/android/assets/8148535/51e1f9f0-83ba-422b-8347-5fd1c488b01b)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->