### PR TITLE
Update Thread network sync to update/delete HA networks

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -83,6 +83,10 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
                             view.onThreadPermissionRequest(syncResult.exportIntent, serverId, false)
                         } else if (syncResult.matches == true) {
                             view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_match), true)
+                        } else if (syncResult.fromApp == true && syncResult.updated == true) {
+                            view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_updated), true)
+                        } else if (syncResult.fromApp == true && syncResult.updated == false) {
+                            view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_removed), true)
                         } else {
                             view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_error), false)
                         }

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -13,7 +13,7 @@ interface ThreadManager {
         object ServerUnsupported : SyncResult()
         class OnlyOnServer(val imported: Boolean) : SyncResult()
         class OnlyOnDevice(val exportIntent: IntentSender?) : SyncResult()
-        class AllHaveCredentials(val matches: Boolean?, val exportIntent: IntentSender?) : SyncResult()
+        class AllHaveCredentials(val matches: Boolean?, val fromApp: Boolean?, val updated: Boolean?, val exportIntent: IntentSender?) : SyncResult()
         object NoneHaveCredentials : SyncResult()
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1084,7 +1084,9 @@
     <string name="thread_debug_result_mismatch">Home Assistant and this device prefer different networks</string>
     <string name="thread_debug_result_mismatch_detail">(device prefers: %1$s)</string>
     <string name="thread_debug_result_none">No credentials to sync</string>
+    <string name="thread_debug_result_removed">Removed old network from Home Assistant on this device</string>
     <string name="thread_debug_result_unsupported_server">The Home Assistant server does not support Thread</string>
+    <string name="thread_debug_result_updated">Updated network from Home Assistant on this device</string>
     <string name="thread_debug_summary">Manually update device and server Thread credentials and verify results</string>
     <string name="tile_vibrate">Vibrate when clicked</string>
     <string name="tile_auth_required">Requires unlocked device</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The Thread credential sync currently only adds the HA credentials once; once added it is not updated or removed.

This PR updates the sync to update or remove the HA credential if detected that the device prefers a credential added by the app, but it isn't the same one preferred by the server.

This might also resolve the error from https://github.com/home-assistant/android/issues/3582#issuecomment-1633618476, but not 100% sure.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->