### PR TITLE
Only show unit of measurement if we have it and if the state is not a string while managing sensors

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -312,7 +312,7 @@ fun SensorDetailTopPanel(
                                     if (sensor.state.isBlank()) {
                                         stringResource(commonR.string.enabled)
                                     } else {
-                                        if (sensor.unitOfMeasurement.isNullOrBlank()) {
+                                        if (sensor.unitOfMeasurement.isNullOrBlank() || (sensor.state.toDoubleOrNull() == null)) {
                                             sensor.state
                                         } else {
                                             "${sensor.state} ${sensor.unitOfMeasurement}"

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -312,7 +312,7 @@ fun SensorDetailTopPanel(
                                     if (sensor.state.isBlank()) {
                                         stringResource(commonR.string.enabled)
                                     } else {
-                                        if (sensor.unitOfMeasurement.isNullOrBlank() || (sensor.state.toDoubleOrNull() == null)) {
+                                        if (sensor.unitOfMeasurement.isNullOrBlank() || sensor.state.toDoubleOrNull() == null) {
                                             sensor.state
                                         } else {
                                             "${sensor.state} ${sensor.unitOfMeasurement}"

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorListView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorListView.kt
@@ -100,7 +100,7 @@ fun SensorRow(
             if (dbSensor.state.isBlank()) {
                 stringResource(commonR.string.enabled)
             } else {
-                if (basicSensor.unitOfMeasurement.isNullOrBlank()) {
+                if (basicSensor.unitOfMeasurement.isNullOrBlank() || (dbSensor.state.toDoubleOrNull() == null)) {
                     dbSensor.state
                 } else {
                     "${dbSensor.state} ${basicSensor.unitOfMeasurement}"

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorListView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorListView.kt
@@ -100,7 +100,7 @@ fun SensorRow(
             if (dbSensor.state.isBlank()) {
                 stringResource(commonR.string.enabled)
             } else {
-                if (basicSensor.unitOfMeasurement.isNullOrBlank() || (dbSensor.state.toDoubleOrNull() == null)) {
+                if (basicSensor.unitOfMeasurement.isNullOrBlank() || dbSensor.state.toDoubleOrNull() == null) {
                     dbSensor.state
                 } else {
                     "${dbSensor.state} ${basicSensor.unitOfMeasurement}"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that sometimes we were showing unit of measurement when the state was not numeric, so now we will hide the units to show the string properly.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->