### PR TITLE
Don't send group summary notifications to Android Auto

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -963,31 +963,23 @@ class MessagingManager @Inject constructor(
         if (useCarNotification) {
             CarNotificationManager.from(context).apply {
                 notify(tag, messageId, notificationBuilder)
-                if (!group.isNullOrBlank()) {
-                    Log.d(TAG, "Show group notification with tag \"$group\" and id \"$groupId\"")
-                    notify(group, groupId, getGroupNotificationBuilder(context, channelId, group, data))
-                } else if (previousGroup.isNotBlank()) {
-                    val systemManager = context.getSystemService<NotificationManager>() ?: return@apply
-                    Log.d(
-                        TAG,
-                        "Remove group notification with tag \"$previousGroup\" and id \"$previousGroupId\""
-                    )
-                    cancelGroupIfNeeded(systemManager, previousGroup, previousGroupId)
-                }
             }
         } else {
             notificationManagerCompat.apply {
                 notify(tag, messageId, notificationBuilder.build())
-                if (!group.isNullOrBlank()) {
-                    Log.d(TAG, "Show group notification with tag \"$group\" and id \"$groupId\"")
-                    notify(group, groupId, getGroupNotificationBuilder(context, channelId, group, data).build())
-                } else if (previousGroup.isNotBlank()) {
-                    Log.d(
-                        TAG,
-                        "Remove group notification with tag \"$previousGroup\" and id \"$previousGroupId\""
-                    )
-                    cancelGroupIfNeeded(previousGroup, previousGroupId)
-                }
+            }
+        }
+
+        notificationManagerCompat.apply {
+            if (!group.isNullOrBlank()) {
+                Log.d(TAG, "Show group notification with tag \"$group\" and id \"$groupId\"")
+                notify(group, groupId, getGroupNotificationBuilder(context, channelId, group, data).build())
+            } else if (previousGroup.isNotBlank()) {
+                Log.d(
+                    TAG,
+                    "Remove group notification with tag \"$previousGroup\" and id \"$previousGroupId\""
+                )
+                cancelGroupIfNeeded(previousGroup, previousGroupId)
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3667 as mentioned in [my last comment](https://github.com/home-assistant/android/issues/3667#issuecomment-1642751512) - Android Auto shows group summary notifications and the individual notifications, which is not expected, so don't mark the summary notification as available on cars to prevent this.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Group summary notifications still appears on phone:
![Summary notification for the 'Security alarm' group](https://github.com/home-assistant/android/assets/8148535/2683a5bc-4726-4f44-87a3-e3e5dcbe02d8)

But not in the Android Auto interface, only the two individual notifications:
![Two individual notifications for the 'Security alarm' group](https://github.com/home-assistant/android/assets/8148535/60d9f4fc-284c-42b2-8a3a-1cbce4c5705b)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I don't think this is needed, the docs already mention not all features are supported and this change will make it better match expectations.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->