### PR TITLE
Only add up to the allowed limit of list items to android auto

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
+import androidx.car.app.constraints.ConstraintManager
 import androidx.car.app.model.Action
 import androidx.car.app.model.CarColor
 import androidx.car.app.model.CarIcon
@@ -58,8 +59,15 @@ class EntityGridVehicleScreen(
     }
 
     override fun onGetTemplate(): Template {
+        val manager = carContext.getCarService(ConstraintManager::class.java)
+        val gridLimit = manager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_GRID)
+
         val listBuilder = ItemList.Builder()
-        entities.forEach { entity ->
+        entities.forEachIndexed { index, entity ->
+            if (index >= gridLimit) {
+                Log.i(TAG, "Grid limit ($gridLimit) reached, not adding more entities (${entities.size}) for $title ")
+                return@forEachIndexed
+            }
             val icon = entity.getIcon(carContext) ?: CommunityMaterial.Icon.cmd_cloud_question
             val gridItem =
                 GridItem.Builder()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3479 by only adding up to the allowed limit of entities.  It does not seem like we will always hit this issue as my own production instance goes over the limit however there are cases obviously where we add too many.

```
Grid limit (100) reached, not adding more entities (106) for Switches
```

Docs: https://developer.android.com/training/cars/apps#constraint-manager

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#962

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->