### PR TITLE
Resume Assist voice input on new intent (as assistant app/brought to front)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -146,4 +146,10 @@ class AssistActivity : BaseActivity() {
         super.onPause()
         viewModel.onPause()
     }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        this.intent = intent
+        viewModel.onNewIntent(intent)
+    }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -106,7 +106,7 @@ class AssistViewModel @Inject constructor(
         if (
             (
                 (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
-                    intent?.action in listOf("android.intent.action.ASSIST", "android.intent.action.VOICE_ASSIST")
+                    intent?.action in listOf(Intent.ACTION_ASSIST, "android.intent.action.VOICE_ASSIST")
                 ) &&
             (inputMode == AssistInputMode.VOICE_ACTIVE || inputMode == AssistInputMode.VOICE_INACTIVE)
         ) {

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.assist
 
 import android.app.Application
+import android.content.Intent
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -98,6 +99,18 @@ class AssistViewModel @Inject constructor(
                     loadPipelines()
                 }
             }
+        }
+    }
+
+    fun onNewIntent(intent: Intent?) {
+        if (
+            (
+                (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
+                    intent?.action in listOf("android.intent.action.ASSIST", "android.intent.action.VOICE_ASSIST")
+                ) &&
+            (inputMode == AssistInputMode.VOICE_ACTIVE || inputMode == AssistInputMode.VOICE_INACTIVE)
+        ) {
+            onMicrophoneInput()
         }
     }
 

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -90,6 +90,7 @@
             android:name=".conversation.ConversationActivity"
             android:icon="@mipmap/ic_assist_launcher"
             android:label="@string/ha_assist"
+            android:launchMode="singleTask"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
@@ -78,6 +78,16 @@ class ConversationActivity : ComponentActivity() {
         }
     }
 
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        this.intent = intent
+
+        val launchIntent = conversationViewModel.onNewIntent(intent)
+        if (launchIntent) {
+            launchVoiceInputIntent()
+        }
+    }
+
     private fun launchVoiceInputIntent() {
         val searchIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
             putExtra(

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.conversation
 
 import android.app.Application
+import android.content.Intent
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -96,6 +97,24 @@ class ConversationViewModel @Inject constructor(
             )
         }
 
+        return false
+    }
+
+    /** @return `true` if the voice input intent should be fired */
+    fun onNewIntent(intent: Intent?): Boolean {
+        if (
+            (
+                (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
+                    intent?.action in listOf("android.intent.action.ASSIST", "android.intent.action.VOICE_ASSIST")
+                ) &&
+            inputMode != AssistInputMode.BLOCKED
+        ) {
+            if (inputMode == AssistInputMode.TEXT) {
+                return true
+            } else {
+                onMicrophoneInput()
+            }
+        }
         return false
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -105,7 +105,7 @@ class ConversationViewModel @Inject constructor(
         if (
             (
                 (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
-                    intent?.action in listOf("android.intent.action.ASSIST", "android.intent.action.VOICE_ASSIST")
+                    intent?.action in listOf(Intent.ACTION_ASSIST, "android.intent.action.VOICE_ASSIST")
                 ) &&
             inputMode != AssistInputMode.BLOCKED
         ) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3690 - if the Assist activity receives a new intent voice input should resume. This can happen when:
- the Assistant gesture/button is invoked while the activity is already open
- the Assist activity was paused, and is now resumed using the Assistant gesture/button, a shortcut, tile or complication (user pressed home after using Assist)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->