### PR TITLE
Android auto: Switch to GridTemplate for home screen and default to favorites if defined

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
@@ -1,0 +1,211 @@
+package io.homeassistant.companion.android.util.vehicle
+
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.car.app.CarContext
+import androidx.car.app.ScreenManager
+import androidx.car.app.model.CarColor
+import androidx.car.app.model.CarIcon
+import androidx.car.app.model.GridItem
+import androidx.car.app.model.ItemList
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.sizeDp
+import com.mikepenz.iconics.utils.toAndroidIconCompat
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.capitalize
+import io.homeassistant.companion.android.vehicle.ChangeServerScreen
+import io.homeassistant.companion.android.vehicle.DomainListScreen
+import io.homeassistant.companion.android.vehicle.EntityGridVehicleScreen
+import io.homeassistant.companion.android.vehicle.MainVehicleScreen
+import io.homeassistant.companion.android.vehicle.MapVehicleScreen
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import java.util.Calendar
+import java.util.Locale
+
+private const val TAG = "GridItems"
+
+fun getChangeServerGridItem(
+    carContext: CarContext,
+    screenManager: ScreenManager,
+    serverManager: ServerManager,
+    serverId: StateFlow<Int>,
+    onChangeServer: (Int) -> Unit
+): GridItem.Builder {
+    return GridItem.Builder().apply {
+        setTitle(carContext.getString(R.string.aa_change_server))
+        setImage(
+            CarIcon.Builder(
+                IconicsDrawable(
+                    carContext,
+                    CommunityMaterial.Icon2.cmd_home_switch
+                ).apply {
+                    sizeDp = 48
+                }.toAndroidIconCompat()
+            )
+                .setTint(CarColor.DEFAULT)
+                .build()
+        )
+        setOnClickListener {
+            Log.i(TAG, "Change server clicked")
+            screenManager.pushForResult(
+                ChangeServerScreen(
+                    carContext,
+                    serverManager,
+                    serverId
+                )
+            ) {
+                it?.toString()?.toIntOrNull()?.let { serverId ->
+                    onChangeServer(serverId)
+                }
+            }
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun getNavigationGridItem(
+    carContext: CarContext,
+    screenManager: ScreenManager,
+    integrationRepository: IntegrationRepository,
+    allEntities: Flow<Map<String, Entity<*>>>
+): GridItem.Builder {
+    return GridItem.Builder().apply {
+        setTitle(carContext.getString(R.string.aa_navigation))
+        setImage(
+            CarIcon.Builder(
+                IconicsDrawable(
+                    carContext,
+                    CommunityMaterial.Icon3.cmd_map_outline
+                ).apply {
+                    sizeDp = 48
+                }.toAndroidIconCompat()
+            )
+                .setTint(CarColor.DEFAULT)
+                .build()
+        )
+        setOnClickListener {
+            Log.i(TAG, "Navigation clicked")
+            screenManager.push(
+                MapVehicleScreen(
+                    carContext,
+                    integrationRepository,
+                    allEntities.map { it.values.filter { entity -> entity.domain in MainVehicleScreen.MAP_DOMAINS } }
+                )
+            )
+        }
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun getDomainList(
+    domains: MutableSet<String>,
+    carContext: CarContext,
+    screenManager: ScreenManager,
+    serverManager: ServerManager,
+    serverId: StateFlow<Int>,
+    prefsRepository: PrefsRepository,
+    allEntities: Flow<Map<String, Entity<*>>>
+): ItemList.Builder {
+    val listBuilder = ItemList.Builder()
+    domains.forEach { domain ->
+        val friendlyDomain =
+            MainVehicleScreen.SUPPORTED_DOMAINS_WITH_STRING[domain]?.let { carContext.getString(it) }
+                ?: domain.split("_").joinToString(" ") { word ->
+                    word.capitalize(Locale.getDefault())
+                }
+        val icon = Entity(
+            "$domain.ha_android_placeholder",
+            "",
+            mapOf<Any, Any>(),
+            Calendar.getInstance(),
+            Calendar.getInstance(),
+            null
+        ).getIcon(carContext)
+
+        listBuilder.addItem(
+            GridItem.Builder().apply {
+                if (icon != null) {
+                    setImage(
+                        CarIcon.Builder(
+                            IconicsDrawable(carContext, icon)
+                                .apply {
+                                    sizeDp = 48
+                                }.toAndroidIconCompat()
+                        )
+                            .setTint(CarColor.DEFAULT)
+                            .build()
+                    )
+                }
+            }
+                .setTitle(friendlyDomain)
+                .setOnClickListener {
+                    Log.i(TAG, "Domain:$domain clicked")
+                    screenManager.push(
+                        EntityGridVehicleScreen(
+                            carContext,
+                            serverManager,
+                            serverId,
+                            prefsRepository,
+                            serverManager.integrationRepository(serverId.value),
+                            friendlyDomain,
+                            domains,
+                            allEntities.map { it.values.filter { entity -> entity.domain == domain } },
+                            allEntities
+                        ) { }
+                    )
+                }
+                .build()
+        )
+    }
+    return listBuilder
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun getDomainsGridItem(
+    carContext: CarContext,
+    screenManager: ScreenManager,
+    serverManager: ServerManager,
+    integrationRepository: IntegrationRepository,
+    serverId: StateFlow<Int>,
+    allEntities: Flow<Map<String, Entity<*>>>,
+    prefsRepository: PrefsRepository
+): GridItem.Builder {
+    return GridItem.Builder().apply {
+        setTitle(carContext.getString(R.string.all_entities))
+        setImage(
+            CarIcon.Builder(
+                IconicsDrawable(
+                    carContext,
+                    CommunityMaterial.Icon3.cmd_view_list
+                ).apply {
+                    sizeDp = 48
+                }.toAndroidIconCompat()
+            )
+                .setTint(CarColor.DEFAULT)
+                .build()
+        )
+        setOnClickListener {
+            Log.i(TAG, "Categories clicked")
+            screenManager.push(
+                DomainListScreen(
+                    carContext,
+                    serverManager,
+                    integrationRepository,
+                    serverId,
+                    allEntities,
+                    prefsRepository
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
@@ -49,7 +49,7 @@ fun getChangeServerGridItem(
                     carContext,
                     CommunityMaterial.Icon2.cmd_home_switch
                 ).apply {
-                    sizeDp = 48
+                    sizeDp = 64
                 }.toAndroidIconCompat()
             )
                 .setTint(CarColor.DEFAULT)
@@ -87,7 +87,7 @@ fun getNavigationGridItem(
                     carContext,
                     CommunityMaterial.Icon3.cmd_map_outline
                 ).apply {
-                    sizeDp = 48
+                    sizeDp = 64
                 }.toAndroidIconCompat()
             )
                 .setTint(CarColor.DEFAULT)
@@ -139,7 +139,7 @@ fun getDomainList(
                         CarIcon.Builder(
                             IconicsDrawable(carContext, icon)
                                 .apply {
-                                    sizeDp = 48
+                                    sizeDp = 64
                                 }.toAndroidIconCompat()
                         )
                             .setTint(CarColor.DEFAULT)
@@ -188,7 +188,7 @@ fun getDomainsGridItem(
                     carContext,
                     CommunityMaterial.Icon3.cmd_view_list
                 ).apply {
-                    sizeDp = 48
+                    sizeDp = 64
                 }.toAndroidIconCompat()
             )
                 .setTint(CarColor.DEFAULT)

--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/NativeModeActionStrip.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/NativeModeActionStrip.kt
@@ -1,0 +1,39 @@
+package io.homeassistant.companion.android.util.vehicle
+
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.car.app.CarContext
+import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.launch.LaunchActivity
+
+private const val TAG = "NativeActionStrip"
+
+fun nativeModeActionStrip(carContext: CarContext): ActionStrip {
+    return ActionStrip.Builder().addAction(
+        Action.Builder()
+            .setTitle(carContext.getString(R.string.aa_launch_native))
+            .setOnClickListener {
+                startNativeActivity(carContext)
+            }.build()
+    ).build()
+}
+
+fun startNativeActivity(carContext: CarContext) {
+    Log.i(TAG, "Starting login activity")
+    with(carContext) {
+        startActivity(
+            Intent(
+                carContext,
+                LaunchActivity::class.java
+            ).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            }
+        )
+        if (carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            finishCarApp()
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
@@ -1,0 +1,58 @@
+package io.homeassistant.companion.android.vehicle
+
+import android.car.Car
+import android.car.drivingstate.CarUxRestrictionsManager
+import android.content.pm.PackageManager
+import android.util.Log
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+
+abstract class BaseVehicleScreen(
+    carContext: CarContext
+) : Screen(carContext) {
+
+    companion object {
+        private const val TAG = "BaseVehicle"
+    }
+    var car: Car? = null
+    var carRestrictionManager: CarUxRestrictionsManager? = null
+    protected val isDrivingOptimized
+        get() = car?.let {
+            (
+                it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+                ).getCurrentCarUxRestrictions().isRequiresDistractionOptimization()
+        } ?: false
+
+    init {
+        lifecycle.addObserver(object : DefaultLifecycleObserver {
+
+            override fun onResume(owner: LifecycleOwner) {
+                registerAutomotiveRestrictionListener()
+            }
+
+            override fun onPause(owner: LifecycleOwner) {
+                carRestrictionManager?.unregisterListener()
+                car?.disconnect()
+                car = null
+            }
+        })
+    }
+
+    abstract fun onDrivingOptimizedChanged(newState: Boolean)
+
+    private fun registerAutomotiveRestrictionListener() {
+        if (carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            Log.i(TAG, "Register for Automotive Restrictions")
+            car = Car.createCar(carContext)
+            carRestrictionManager =
+                car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+            val listener =
+                CarUxRestrictionsManager.OnUxRestrictionsChangedListener { restrictions ->
+                    onDrivingOptimizedChanged(restrictions.isRequiresDistractionOptimization())
+                }
+            carRestrictionManager?.registerListener(listener)
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
@@ -16,8 +16,8 @@ abstract class BaseVehicleScreen(
     companion object {
         private const val TAG = "BaseVehicle"
     }
-    var car: Car? = null
-    var carRestrictionManager: CarUxRestrictionsManager? = null
+    private var car: Car? = null
+    private var carRestrictionManager: CarUxRestrictionsManager? = null
     protected val isDrivingOptimized
         get() = car?.let {
             (

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -15,6 +15,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.util.vehicle.getDomainList
 import io.homeassistant.companion.android.util.vehicle.nativeModeActionStrip
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -56,7 +57,15 @@ class DomainListScreen(
             allEntities,
             prefsRepository
         ) { }
-        val domainList = screen.addDomainList(domains)
+        val domainList = getDomainList(
+            domains,
+            carContext,
+            screenManager,
+            serverManager,
+            serverId,
+            prefsRepository,
+            allEntities
+        )
 
         return GridTemplate.Builder().apply {
             setTitle(carContext.getString(R.string.all_entities))

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -1,12 +1,9 @@
 package io.homeassistant.companion.android.vehicle
 
-import android.car.Car
-import android.car.drivingstate.CarUxRestrictionsManager
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
-import androidx.car.app.Screen
 import androidx.car.app.model.Action
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.Template
@@ -32,9 +29,17 @@ class DomainListScreen(
     private val serverId: StateFlow<Int>,
     private val allEntities: Flow<Map<String, Entity<*>>>,
     private val prefsRepository: PrefsRepository
-) : Screen(carContext) {
+) : BaseVehicleScreen(carContext) {
+
+    companion object {
+        private const val TAG = "DomainList"
+    }
 
     private val domains = mutableSetOf<String>()
+
+    override fun onDrivingOptimizedChanged(newState: Boolean) {
+        invalidate()
+    }
 
     init {
         lifecycleScope.launch {
@@ -52,20 +57,9 @@ class DomainListScreen(
             }
         }
     }
+
     override fun onGetTemplate(): Template {
         val isAutomotive = carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
-        val screen = MainVehicleScreen(
-            carContext,
-            serverManager,
-            serverId,
-            allEntities,
-            prefsRepository
-        ) { }
-        val isDrivingOptimized = screen.car?.let {
-            (
-                it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
-                ).getCurrentCarUxRestrictions().isRequiresDistractionOptimization()
-        } ?: false
         val domainList = getDomainList(
             domains,
             carContext,

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -52,6 +52,13 @@ class DomainListScreen(
     }
     override fun onGetTemplate(): Template {
         val isAutomotive = carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+        val screen = MainVehicleScreen(
+            carContext,
+            serverManager,
+            serverId,
+            allEntities,
+            prefsRepository
+        ) { }
         val domainList = getDomainList(
             domains,
             carContext,
@@ -65,7 +72,7 @@ class DomainListScreen(
         return GridTemplate.Builder().apply {
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
-            if (isAutomotive && !HaCarAppService().isDrivingOptimized && BuildConfig.FLAVOR != "full") {
+            if (isAutomotive && !screen.isDrivingOptimized && BuildConfig.FLAVOR != "full") {
                 setActionStrip(nativeModeActionStrip(carContext))
             }
             val domainBuild = domainList.build()

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -1,0 +1,74 @@
+package io.homeassistant.companion.android.vehicle
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.car.app.model.Action
+import androidx.car.app.model.ListTemplate
+import androidx.car.app.model.Template
+import androidx.lifecycle.lifecycleScope
+import io.homeassistant.companion.android.BuildConfig
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+@RequiresApi(Build.VERSION_CODES.O)
+class DomainListScreen(
+    carContext: CarContext,
+    val serverManager: ServerManager,
+    val integrationRepository: IntegrationRepository,
+    private val serverId: StateFlow<Int>,
+    private val allEntities: Flow<Map<String, Entity<*>>>,
+    private val prefsRepository: PrefsRepository
+) : Screen(carContext) {
+
+    private val domains = mutableSetOf<String>()
+
+    init {
+        lifecycleScope.launch {
+            allEntities.collect { entities ->
+                val newDomains = entities.values
+                    .map { it.domain }
+                    .distinct()
+                    .filter { it in MainVehicleScreen.SUPPORTED_DOMAINS }
+                    .toSet()
+                if (newDomains.size != domains.size || newDomains != domains) {
+                    domains.clear()
+                    domains.addAll(newDomains)
+                    invalidate()
+                }
+            }
+        }
+    }
+    override fun onGetTemplate(): Template {
+        val screen = MainVehicleScreen(
+            carContext,
+            serverManager,
+            serverId,
+            allEntities,
+            prefsRepository
+        ) { }
+        val domainList = screen.addDomainList(domains)
+
+        return ListTemplate.Builder().apply {
+            setTitle(carContext.getString(R.string.all_entities))
+            setHeaderAction(Action.BACK)
+            if (screen.isAutomotive && !screen.iDrivingOptimized && BuildConfig.FLAVOR != "full") {
+                setActionStrip(screen.nativeModeActionStrip())
+            }
+            if (domainList.build().items.isEmpty()) {
+                setLoading(true)
+            } else {
+                setLoading(false)
+                setSingleList(domainList.build())
+            }
+        }.build()
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -5,7 +5,7 @@ import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.model.Action
-import androidx.car.app.model.ListTemplate
+import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.Template
 import androidx.lifecycle.lifecycleScope
 import io.homeassistant.companion.android.BuildConfig
@@ -57,7 +57,7 @@ class DomainListScreen(
         ) { }
         val domainList = screen.addDomainList(domains)
 
-        return ListTemplate.Builder().apply {
+        return GridTemplate.Builder().apply {
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
             if (screen.isAutomotive && !screen.iDrivingOptimized && BuildConfig.FLAVOR != "full") {

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.vehicle
 
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
@@ -50,13 +51,7 @@ class DomainListScreen(
         }
     }
     override fun onGetTemplate(): Template {
-        val screen = MainVehicleScreen(
-            carContext,
-            serverManager,
-            serverId,
-            allEntities,
-            prefsRepository
-        ) { }
+        val isAutomotive = carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
         val domainList = getDomainList(
             domains,
             carContext,
@@ -70,14 +65,15 @@ class DomainListScreen(
         return GridTemplate.Builder().apply {
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
-            if (screen.isAutomotive && !screen.iDrivingOptimized && BuildConfig.FLAVOR != "full") {
+            if (isAutomotive && !HaCarAppService().isDrivingOptimized && BuildConfig.FLAVOR != "full") {
                 setActionStrip(nativeModeActionStrip(carContext))
             }
-            if (domainList.build().items.isEmpty()) {
+            val domainBuild = domainList.build()
+            if (domainBuild.items.isEmpty()) {
                 setLoading(true)
             } else {
                 setLoading(false)
-                setSingleList(domainList.build())
+                setSingleList(domainBuild)
             }
         }.build()
     }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -15,6 +15,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.util.vehicle.nativeModeActionStrip
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -61,7 +62,7 @@ class DomainListScreen(
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
             if (screen.isAutomotive && !screen.iDrivingOptimized && BuildConfig.FLAVOR != "full") {
-                setActionStrip(screen.nativeModeActionStrip())
+                setActionStrip(nativeModeActionStrip(carContext))
             }
             if (domainList.build().items.isEmpty()) {
                 setLoading(true)

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.vehicle
 
+import android.car.Car
+import android.car.drivingstate.CarUxRestrictionsManager
 import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.RequiresApi
@@ -59,6 +61,11 @@ class DomainListScreen(
             allEntities,
             prefsRepository
         ) { }
+        val isDrivingOptimized = screen.car?.let {
+            (
+                it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+                ).getCurrentCarUxRestrictions().isRequiresDistractionOptimization()
+        } ?: false
         val domainList = getDomainList(
             domains,
             carContext,
@@ -72,7 +79,7 @@ class DomainListScreen(
         return GridTemplate.Builder().apply {
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
-            if (isAutomotive && !screen.isDrivingOptimized && BuildConfig.FLAVOR != "full") {
+            if (isAutomotive && !isDrivingOptimized && BuildConfig.FLAVOR != "full") {
                 setActionStrip(nativeModeActionStrip(carContext))
             }
             val domainBuild = domainList.build()

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -73,10 +73,11 @@ class EntityGridVehicleScreen(
     fun getEntityGridItems(entities: List<Entity<*>>): ItemList.Builder {
         val manager = carContext.getCarService(ConstraintManager::class.java)
         val gridLimit = manager.getContentLimit(ConstraintManager.CONTENT_LIMIT_TYPE_GRID)
-
+        val shouldSwitchServers = serverManager.defaultServers.size > 1
+        val extraGrid = if (shouldSwitchServers) 3 else 2
         val listBuilder = ItemList.Builder()
         entities.forEachIndexed { index, entity ->
-            if (index >= gridLimit) {
+            if (index >= (gridLimit - if (isFavorites) extraGrid else 0)) {
                 Log.i(TAG, "Grid limit ($gridLimit) reached, not adding more entities (${entities.size}) for $title ")
                 return@forEachIndexed
             }
@@ -166,7 +167,7 @@ class EntityGridVehicleScreen(
                 }
             }
             listBuilder.addItem(categoryItem.build())
-            if (serverManager.defaultServers.size > 1) {
+            if (shouldSwitchServers) {
                 val changeServerItem = GridItem.Builder().apply {
                     setTitle(carContext.getString(R.string.aa_change_server))
                     setImage(

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.vehicle
 
+import android.car.Car
+import android.car.drivingstate.CarUxRestrictionsManager
 import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.os.Build
@@ -13,6 +15,8 @@ import androidx.car.app.SessionInfo
 import androidx.car.app.hardware.CarHardwareManager
 import androidx.car.app.hardware.info.CarInfo
 import androidx.car.app.validation.HostValidator
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
@@ -48,6 +52,14 @@ class HaCarAppService : CarAppService() {
     private val serverId = MutableStateFlow(0)
     private val allEntities = MutableStateFlow<Map<String, Entity<*>>>(emptyMap())
     private var allEntitiesJob: Job? = null
+    var car: Car? = null
+    var carRestrictionManager: CarUxRestrictionsManager? = null
+    val isDrivingOptimized
+        get() = car?.let {
+            (
+                it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+                ).getCurrentCarUxRestrictions().isRequiresDistractionOptimization()
+        } ?: false
 
     override fun createHostValidator(): HostValidator {
         return if (applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0) {
@@ -65,6 +77,24 @@ class HaCarAppService : CarAppService() {
                 serverManager.getServer()?.let {
                     loadEntities(lifecycleScope, it.id)
                 }
+                lifecycle.addObserver(object : DefaultLifecycleObserver {
+
+                    override fun onResume(owner: LifecycleOwner) {
+                        MainVehicleScreen(
+                            carContext,
+                            serverManager,
+                            serverIdFlow,
+                            entityFlow,
+                            prefsRepository
+                        ) { loadEntities(lifecycleScope, it) }.registerAutomotiveRestrictionListener()
+                    }
+
+                    override fun onPause(owner: LifecycleOwner) {
+                        HaCarAppService().carRestrictionManager?.unregisterListener()
+                        HaCarAppService().car?.disconnect()
+                        HaCarAppService().car = null
+                    }
+                })
             }
 
             val serverIdFlow = serverId.asStateFlow()

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -76,7 +76,7 @@ class MainVehicleScreen(
     private val domains = mutableSetOf<String>()
     var car: Car? = null
     var carRestrictionManager: CarUxRestrictionsManager? = null
-    val isDrivingOptimized
+    private val isDrivingOptimized
         get() = car?.let {
             (
                 it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -109,6 +109,13 @@ class MainVehicleScreen(
     }
 
     override fun onGetTemplate(): Template {
+        if (isLoggedIn != true) {
+            return GridTemplate.Builder().apply {
+                setTitle(carContext.getString(commonR.string.app_name))
+                setHeaderAction(Action.APP_ICON)
+                setLoading(true)
+            }.build()
+        }
         val listBuilder = if (favoritesList.isNotEmpty()) {
             EntityGridVehicleScreen(
                 carContext,

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -170,7 +170,11 @@ class MainVehicleScreen(
                 carContext.getString(commonR.string.favorites),
                 favoriteEntities,
                 allEntities
-            ) { }.getEntityGridItems(entities)
+            ) {
+                it.toString().toIntOrNull()?.let { serverId ->
+                    onChangeServer(serverId)
+                }
+            }.getEntityGridItems(entities)
         }
         if (domains.isNotEmpty()) {
             listBuilder = addDomainList(domains)

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -13,10 +13,9 @@ import androidx.car.app.model.Action
 import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.CarColor
 import androidx.car.app.model.CarIcon
+import androidx.car.app.model.GridItem
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.ItemList
-import androidx.car.app.model.ListTemplate
-import androidx.car.app.model.Row
 import androidx.car.app.model.Template
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
@@ -162,6 +161,7 @@ class MainVehicleScreen(
                 prefsRepository,
                 serverManager.integrationRepository(serverId.value),
                 carContext.getString(commonR.string.favorites),
+                domains,
                 favoriteEntities,
                 allEntities
             ) { onChangeServer(it) }.getEntityGridItems(entities)
@@ -171,7 +171,7 @@ class MainVehicleScreen(
         }
 
         listBuilder.addItem(
-            Row.Builder()
+            GridItem.Builder()
                 .setImage(
                     CarIcon.Builder(
                         IconicsDrawable(
@@ -200,7 +200,7 @@ class MainVehicleScreen(
 
         if (serverManager.defaultServers.size > 1) {
             listBuilder.addItem(
-                Row.Builder()
+                GridItem.Builder()
                     .setImage(
                         CarIcon.Builder(
                             IconicsDrawable(
@@ -232,35 +232,19 @@ class MainVehicleScreen(
             )
         }
 
-        return if (favoritesList.isEmpty()) {
-            ListTemplate.Builder().apply {
-                setTitle(carContext.getString(commonR.string.app_name))
-                setHeaderAction(Action.APP_ICON)
-                if (isAutomotive && !iDrivingOptimized && BuildConfig.FLAVOR != "full") {
-                    setActionStrip(nativeModeActionStrip())
-                }
-                if (domains.isEmpty()) {
-                    setLoading(true)
-                } else {
-                    setLoading(false)
-                    setSingleList(listBuilder.build())
-                }
-            }.build()
-        } else {
-            GridTemplate.Builder().apply {
-                setTitle(carContext.getString(commonR.string.app_name))
-                setHeaderAction(Action.APP_ICON)
-                if (isAutomotive && !iDrivingOptimized && BuildConfig.FLAVOR != "full") {
-                    setActionStrip(nativeModeActionStrip())
-                }
-                if (domains.isEmpty()) {
-                    setLoading(true)
-                } else {
-                    setLoading(false)
-                    setSingleList(favoritesGrid!!.build())
-                }
-            }.build()
-        }
+        return GridTemplate.Builder().apply {
+            setTitle(carContext.getString(commonR.string.app_name))
+            setHeaderAction(Action.APP_ICON)
+            if (isAutomotive && !iDrivingOptimized && BuildConfig.FLAVOR != "full") {
+                setActionStrip(nativeModeActionStrip())
+            }
+            if (domains.isEmpty()) {
+                setLoading(true)
+            } else {
+                setLoading(false)
+                setSingleList(if (favoritesList.isNotEmpty()) favoritesGrid!!.build() else listBuilder.build())
+            }
+        }.build()
     }
 
     private fun registerAutomotiveRestrictionListener() {
@@ -312,7 +296,7 @@ class MainVehicleScreen(
             ).getIcon(carContext)
 
             listBuilder.addItem(
-                Row.Builder().apply {
+                GridItem.Builder().apply {
                     if (icon != null) {
                         setImage(
                             CarIcon.Builder(
@@ -337,6 +321,7 @@ class MainVehicleScreen(
                                 prefsRepository,
                                 serverManager.integrationRepository(serverId.value),
                                 friendlyDomain,
+                                domains,
                                 allEntities.map { it.values.filter { entity -> entity.domain == domain } },
                                 allEntities
                             ) { }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -111,18 +111,9 @@ class MainVehicleScreen(
                         domains.addAll(newDomains)
                         invalidate()
                     }
+                    entityList = getFavoritesList(entities)
                 }
-            }
-        }
-        lifecycleScope.launch {
-            favoriteEntities = allEntities.map {
-                it.values.filter { entity -> favoritesList.contains("${serverId.value}-${entity.entityId}") }
-                    .sortedBy { entity -> favoritesList.indexOf("${serverId.value}-${entity.entityId}") }
-            }
-            favoriteEntities.collect {
-                val hasChanged = entityList.size != it.size || entityList.toSet() != it.toSet()
-                entityList = it
-                if (hasChanged) invalidate()
+                favoriteEntities = allEntities.map { getFavoritesList(it) }
             }
         }
 
@@ -216,5 +207,10 @@ class MainVehicleScreen(
                 }
             carRestrictionManager?.registerListener(listener)
         }
+    }
+
+    private fun getFavoritesList(entities: Map<String, Entity<*>>): List<Entity<*>> {
+        return entities.values.filter { entity -> favoritesList.contains("${serverId.value}-${entity.entityId}") }
+            .sortedBy { entity -> favoritesList.indexOf("${serverId.value}-${entity.entityId}") }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -9,9 +9,6 @@ import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
 import androidx.car.app.model.Action
-import androidx.car.app.model.CarColor
-import androidx.car.app.model.CarIcon
-import androidx.car.app.model.GridItem
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.ItemList
 import androidx.car.app.model.Template
@@ -20,18 +17,15 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
-import com.mikepenz.iconics.utils.sizeDp
-import com.mikepenz.iconics.utils.toAndroidIconCompat
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
-import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.util.capitalize
+import io.homeassistant.companion.android.util.vehicle.getChangeServerGridItem
+import io.homeassistant.companion.android.util.vehicle.getDomainList
+import io.homeassistant.companion.android.util.vehicle.getNavigationGridItem
 import io.homeassistant.companion.android.util.vehicle.nativeModeActionStrip
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -39,8 +33,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
-import java.util.Calendar
-import java.util.Locale
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -56,7 +48,7 @@ class MainVehicleScreen(
     companion object {
         private const val TAG = "MainVehicleScreen"
 
-        private val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
+        val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
             "button" to commonR.string.buttons,
             "cover" to commonR.string.covers,
             "input_boolean" to commonR.string.input_booleans,
@@ -164,68 +156,34 @@ class MainVehicleScreen(
         } else {
             var builder = ItemList.Builder()
             if (domains.isNotEmpty()) {
-                builder = addDomainList(domains)
+                builder = getDomainList(
+                    domains,
+                    carContext,
+                    screenManager,
+                    serverManager,
+                    serverId,
+                    prefsRepository,
+                    allEntities
+                )
             }
 
             builder.addItem(
-                GridItem.Builder()
-                    .setImage(
-                        CarIcon.Builder(
-                            IconicsDrawable(
-                                carContext,
-                                CommunityMaterial.Icon3.cmd_map_outline
-                            ).apply {
-                                sizeDp = 48
-                            }.toAndroidIconCompat()
-                        )
-                            .setTint(CarColor.DEFAULT)
-                            .build()
-                    )
-                    .setTitle(carContext.getString(commonR.string.aa_navigation))
-                    .setOnClickListener {
-                        Log.i(TAG, "Navigation clicked")
-                        screenManager.push(
-                            MapVehicleScreen(
-                                carContext,
-                                serverManager.integrationRepository(serverId.value),
-                                allEntities.map { it.values.filter { entity -> entity.domain in MAP_DOMAINS } }
-                            )
-                        )
-                    }
-                    .build()
+                getNavigationGridItem(
+                    carContext,
+                    screenManager,
+                    serverManager.integrationRepository(serverId.value),
+                    allEntities
+                ).build()
             )
 
             if (serverManager.defaultServers.size > 1) {
                 builder.addItem(
-                    GridItem.Builder()
-                        .setImage(
-                            CarIcon.Builder(
-                                IconicsDrawable(
-                                    carContext,
-                                    CommunityMaterial.Icon2.cmd_home_switch
-                                ).apply {
-                                    sizeDp = 48
-                                }.toAndroidIconCompat()
-                            )
-                                .setTint(CarColor.DEFAULT)
-                                .build()
-                        )
-                        .setTitle(carContext.getString(commonR.string.aa_change_server))
-                        .setOnClickListener {
-                            Log.i(TAG, "Change server clicked")
-                            screenManager.pushForResult(
-                                ChangeServerScreen(
-                                    carContext,
-                                    serverManager,
-                                    serverId
-                                )
-                            ) {
-                                it?.toString()?.toIntOrNull()?.let { serverId ->
-                                    onChangeServer(serverId)
-                                }
-                            }
-                        }
-                        .build()
+                    getChangeServerGridItem(
+                        carContext,
+                        screenManager,
+                        serverManager,
+                        serverId
+                    ) { onChangeServer(it) }.build()
                 )
             }
             builder
@@ -258,60 +216,5 @@ class MainVehicleScreen(
                 }
             carRestrictionManager?.registerListener(listener)
         }
-    }
-
-    fun addDomainList(domains: MutableSet<String>): ItemList.Builder {
-        val listBuilder = ItemList.Builder()
-        domains.forEach { domain ->
-            val friendlyDomain =
-                SUPPORTED_DOMAINS_WITH_STRING[domain]?.let { carContext.getString(it) }
-                    ?: domain.split("_").joinToString(" ") { word ->
-                        word.capitalize(Locale.getDefault())
-                    }
-            val icon = Entity(
-                "$domain.ha_android_placeholder",
-                "",
-                mapOf<Any, Any>(),
-                Calendar.getInstance(),
-                Calendar.getInstance(),
-                null
-            ).getIcon(carContext)
-
-            listBuilder.addItem(
-                GridItem.Builder().apply {
-                    if (icon != null) {
-                        setImage(
-                            CarIcon.Builder(
-                                IconicsDrawable(carContext, icon)
-                                    .apply {
-                                        sizeDp = 48
-                                    }.toAndroidIconCompat()
-                            )
-                                .setTint(CarColor.DEFAULT)
-                                .build()
-                        )
-                    }
-                }
-                    .setTitle(friendlyDomain)
-                    .setOnClickListener {
-                        Log.i(TAG, "Domain:$domain clicked")
-                        screenManager.push(
-                            EntityGridVehicleScreen(
-                                carContext,
-                                serverManager,
-                                serverId,
-                                prefsRepository,
-                                serverManager.integrationRepository(serverId.value),
-                                friendlyDomain,
-                                domains,
-                                allEntities.map { it.values.filter { entity -> entity.domain == domain } },
-                                allEntities
-                            ) { }
-                        )
-                    }
-                    .build()
-            )
-        }
-        return listBuilder
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -200,7 +200,7 @@ class PrefsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAutoFavorites(): List<String> {
-        return localStorage.getString(PREF_AUTO_FAVORITES)?.removeSurrounding("[", "]")?.split(", ") ?: emptyList()
+        return localStorage.getString(PREF_AUTO_FAVORITES)?.removeSurrounding("[", "]")?.split(", ")?.filter { it.isNotBlank() } ?: emptyList()
     }
 
     override suspend fun setAutoFavorites(favorites: List<String>) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

The default home screen now uses `GridTemplate` instead of `ListTemplate` to allow for more domains and buttons to be shown. My Subaru has a giant 11" screen, `ListTemplate` shows a total of 10 items but `GridTemplate` shows 15 before needing to scroll.

When favorites are defined we will now show the entity grid screen with the user defined favorites. We will also add Navigation, All entities and Change servers (if applicable) to the grid view.

If favorites are defined but user has multiple servers they will continue to see all domains listed
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/home-assistant/android/assets/1634145/6ae6c339-2516-466c-bd9f-9d864db73ee6)

![image](https://github.com/home-assistant/android/assets/1634145/b12c8a55-1f4d-40f6-b72d-e1bf217a5433)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#964

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->