### PR TITLE
Use WifiManager deprecations again for instant 'location' info

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.common.data.wifi
 
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
-import android.net.wifi.WifiInfo
 import android.net.wifi.WifiManager
 import android.os.Build
 import javax.inject.Inject
@@ -46,22 +45,8 @@ class WifiHelperImpl @Inject constructor(
     }
 
     override fun getWifiSsid(): String? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            connectivityManager.activeNetwork?.let {
-                val info = connectivityManager.getNetworkCapabilities(it)?.transportInfo ?: return null
-                (info as? WifiInfo)?.ssid
-            }
-        } else {
-            wifiManager?.connectionInfo?.ssid
-        }
+        wifiManager?.connectionInfo?.ssid // Deprecated but callback doesn't provide SSID info instantly
 
     override fun getWifiBssid(): String? =
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            connectivityManager.activeNetwork?.let {
-                val info = connectivityManager.getNetworkCapabilities(it)?.transportInfo ?: return null
-                (info as? WifiInfo)?.bssid
-            }
-        } else {
-            wifiManager?.connectionInfo?.bssid
-        }
+        wifiManager?.connectionInfo?.bssid // Deprecated but callback doesn't provide BSSID info instantly
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -192,7 +192,8 @@ class NetworkSensorManager : SensorManager {
         var connected = false
 
         if (checkPermission(context, wifiConnection.id)) {
-            conInfo = getWifiConnectionInfo(context)
+            @Suppress("DEPRECATION") // Unable to get SSID info (instantly) using callback
+            conInfo = context.getSystemService<WifiManager>()?.connectionInfo
 
             if (conInfo == null || conInfo.networkId == -1) {
                 if (conInfo == null || conInfo.linkSpeed == -1) {
@@ -230,7 +231,8 @@ class NetworkSensorManager : SensorManager {
         var conInfo: WifiInfo? = null
 
         if (checkPermission(context, bssidState.id)) {
-            conInfo = getWifiConnectionInfo(context)
+            @Suppress("DEPRECATION") // Unable to get BSSID info (instantly) using callback
+            conInfo = context.getSystemService<WifiManager>()?.connectionInfo
         }
 
         var bssid = if (conInfo?.bssid == null) "<not connected>" else conInfo.bssid
@@ -522,6 +524,7 @@ class NetworkSensorManager : SensorManager {
         )
     }
 
+    /** Get WiFi connection info (without location data such as (B)SSID on Android >=S) */
     private fun getWifiConnectionInfo(context: Context): WifiInfo? =
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             val connectivityManager = context.applicationContext.getSystemService<ConnectivityManager>()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3704 / SSID and BSSID functionality on Android 12+ by using deprecated APIs when we need this information instantly and/or without network changes, as explained in my comment on the issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->