### PR TITLE
Fix old server references in app-level preferences

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -70,4 +70,7 @@ interface PrefsRepository {
     suspend fun getAutoFavorites(): List<String>
 
     suspend fun setAutoFavorites(favorites: List<String>)
+
+    /** Clean up any app-level preferences that might reference servers */
+    suspend fun removeServer(serverId: Int)
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -206,4 +206,12 @@ class PrefsRepositoryImpl @Inject constructor(
     override suspend fun setAutoFavorites(favorites: List<String>) {
         localStorage.putString(PREF_AUTO_FAVORITES, favorites.toString())
     }
+
+    override suspend fun removeServer(serverId: Int) {
+        val controlsAuthEntities = getControlsAuthEntities().filter { it.split(".")[0].toIntOrNull() != serverId }
+        setControlsAuthEntities(controlsAuthEntities)
+
+        val autoFavorites = getAutoFavorites().filter { it.split("-")[0].toIntOrNull() != serverId }
+        setAutoFavorites(autoFavorites)
+    }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
@@ -5,6 +5,7 @@ import io.homeassistant.companion.android.common.data.authentication.Authenticat
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepositoryFactory
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepositoryFactory
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager.Companion.SERVER_ID_ACTIVE
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepositoryFactory
@@ -30,6 +31,7 @@ class ServerManagerImpl @Inject constructor(
     private val authenticationRepositoryFactory: AuthenticationRepositoryFactory,
     private val integrationRepositoryFactory: IntegrationRepositoryFactory,
     private val webSocketRepositoryFactory: WebSocketRepositoryFactory,
+    private val prefsRepository: PrefsRepository,
     private val serverDao: ServerDao,
     private val sensorDao: SensorDao,
     private val settingsDao: SettingsDao,
@@ -144,6 +146,7 @@ class ServerManagerImpl @Inject constructor(
     override suspend fun removeServer(id: Int) {
         authenticationRepository(id).deletePreferences()
         integrationRepository(id).deletePreferences()
+        prefsRepository.removeServer(id)
         removeServerFromManager(id)
         if (localStorage.getInt(PREF_ACTIVE_SERVER) == id) localStorage.remove(PREF_ACTIVE_SERVER)
         settingsDao.delete(id)
@@ -155,6 +158,7 @@ class ServerManagerImpl @Inject constructor(
         if (_servers[id]?.type == ServerType.TEMPORARY) {
             authenticationRepository(id).deletePreferences()
             integrationRepository(id).deletePreferences()
+            prefsRepository.removeServer(id)
         } // else handled in removeServer
         authenticationRepos.remove(id)
         integrationRepos.remove(id)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While testing the navigation entities in Android Auto PR I noticed the 'All entities' button showing up while also showing the domains list. It turns out this was because my preference still held some favorites, but they were for servers that had been deleted.

![image](https://github.com/home-assistant/android/assets/8148535/eefbd038-d084-49e0-bb93-7346951c17a6)

_(icon cut off at the bottom is 'All entities')_

When deleting a server most of the server-specific stuff is already deleted, but app-level preferences that reference a server aren't updated. This PR fixes that and adds a function to clean up any server references there might be in the app-level preferences.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a / above screenshot will change but that is because it fixes the described bug

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->