### PR TITLE
Allow selecting unavailable entities for complications/tiles

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
@@ -137,7 +137,6 @@ private fun ChooseEntityChip(
                 overflow = TextOverflow.Ellipsis
             )
         },
-        enabled = entity.state != "unavailable",
         onClick = {
             onEntitySelected(
                 SimplifiedEntity(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
It should be possible to choose an unavailable entity for display on a complication or tile, as you can with favorites, and even entities that are available now can become unavailable later.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After|
|---|---|
|![List of entities, entity named 'Do not disturbed' is greyed out and disabled](https://github.com/home-assistant/android/assets/8148535/153c46e8-9d95-4899-993d-6da87910c6a9)|![List of entities, entity named 'Do not disturbed' is enabled like others around it](https://github.com/home-assistant/android/assets/8148535/82cf5f2f-12c0-42c6-9ff0-72b2b2b1f272)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->