### PR TITLE
Hide some sensors from unsupported devices

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import com.google.android.gms.location.ActivityRecognition
@@ -205,6 +206,14 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             )
         } else {
             arrayOf()
+        }
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            !context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+        } else {
+            true
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -35,7 +35,11 @@ class LastAppSensorManager : SensorManager {
     }
 
     override fun hasSensor(context: Context): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        return if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            false
+        } else {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        }
     }
 
     @RequiresApi(Build.VERSION_CODES.M)

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.UiModeManager
 import android.content.ComponentName
 import android.content.Context
+import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.MediaMetadata
 import android.media.session.MediaSessionManager
@@ -70,7 +71,11 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
     }
     override fun hasSensor(context: Context): Boolean {
         val uiManager = context.getSystemService<UiModeManager>()
-        return uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
+        return if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
+        } else {
+            false
+        }
     }
     override val name: Int
         get() = commonR.string.sensor_name_last_notification

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -70,8 +70,8 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors#notification-sensors"
     }
     override fun hasSensor(context: Context): Boolean {
-        val uiManager = context.getSystemService<UiModeManager>()
         return if (!context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            val uiManager = context.getSystemService<UiModeManager>()
             uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
         } else {
             false

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -115,6 +115,11 @@ class BatterySensorManager : SensorManager {
         )
     }
 
+    override fun hasSensor(context: Context): Boolean {
+        val intent = context.registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        return intent?.getBooleanExtra(BatteryManager.EXTRA_PRESENT, false) == true
+    }
+
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
@@ -298,6 +303,7 @@ class BatterySensorManager : SensorManager {
             BatteryManager.BATTERY_PLUGGED_AC -> "ac"
             BatteryManager.BATTERY_PLUGGED_USB -> "usb"
             BatteryManager.BATTERY_PLUGGED_WIRELESS -> "wireless"
+            BatteryManager.BATTERY_PLUGGED_DOCK -> "dock"
             else -> "none"
         }
     }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.sensors
 
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.RequiresApi
@@ -46,7 +47,11 @@ class DNDSensorManager : SensorManager {
 
     @ChecksSdkIntAtLeast(api = Build.VERSION_CODES.M)
     override fun hasSensor(context: Context): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        return if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            false
+        } else {
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+        }
     }
 
     private fun updateDNDState(context: Context) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
@@ -2,6 +2,8 @@ package io.homeassistant.companion.android.common.sensors
 
 import android.app.AlarmManager
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.database.AppDatabase
@@ -11,6 +13,7 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Date
 import java.util.GregorianCalendar
+import java.util.Locale
 import java.util.TimeZone
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -38,6 +41,14 @@ class NextAlarmManager : SensorManager {
 
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
         return listOf(nextAlarm)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            !context.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+        } else {
+            true
+        }
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -89,7 +100,7 @@ class NextAlarmManager : SensorManager {
                 local = cal.time.toString()
 
                 val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
-                val sdf = SimpleDateFormat(dateFormat)
+                val sdf = SimpleDateFormat(dateFormat, Locale.getDefault())
                 sdf.timeZone = TimeZone.getTimeZone("UTC")
                 utc = sdf.format(Date(triggerTime))
             } else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Hide some sensors that simply won't work in Automotive. Also hide battery manager if the device has no battery.

As these devices do not support the sensor they also wouldn't support for any registered intent so should be safe to continue hiding.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->