### PR TITLE
Reset carInfo when our session is destroyed since data will be stale

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
@@ -120,6 +120,11 @@ class HaCarAppService : CarAppService() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        carInfo = null
+    }
+
     private fun loadEntities(scope: CoroutineScope, id: Int) {
         allEntitiesJob?.cancel()
         allEntitiesJob = scope.launch {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

I noticed that my car info based sensors seemed a bit stuck. In fact I think the expectation is that the state should reset once you are no longer in the car. So now we will actively set the variable to `null` so we can set the state appropriately.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->