### PR TITLE
Keep track of adding domains to remove loader when user has no actionable entities

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -76,7 +76,7 @@ class MainVehicleScreen(
                         .distinct()
                         .filter { it in SUPPORTED_DOMAINS }
                         .toSet()
-                    var invalidate = newDomains.size != domains.size || newDomains != domains
+                    var invalidate = newDomains.size != domains.size || newDomains != domains || !domainsAdded
                     domains.clear()
                     domains.addAll(newDomains)
                     domainsAdded = true

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -50,6 +50,7 @@ class MainVehicleScreen(
     private var favoritesList = emptyList<String>()
     private var isLoggedIn: Boolean? = null
     private val domains = mutableSetOf<String>()
+    private var domainsAdded = false
 
     private val isAutomotive get() = carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
@@ -78,6 +79,7 @@ class MainVehicleScreen(
                     var invalidate = newDomains.size != domains.size || newDomains != domains
                     domains.clear()
                     domains.addAll(newDomains)
+                    domainsAdded = true
 
                     val newFavorites = getFavoritesList(entities)
                     invalidate = invalidate || (newFavorites.size != favoritesEntities.size || newFavorites.toSet() != favoritesEntities.toSet())
@@ -164,7 +166,7 @@ class MainVehicleScreen(
             if (isAutomotive && !isDrivingOptimized && BuildConfig.FLAVOR != "full") {
                 setActionStrip(nativeModeActionStrip(carContext))
             }
-            if (domains.isEmpty()) {
+            if (!domainsAdded) {
                 setLoading(true)
             } else {
                 setLoading(false)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes #3756 by keeping track of when we first load domains so we only show the loader for a brief period of time instead of endlessly when a user has no entities that are considered actionable by the app.

at a minimum users will have 1 person entity so we should expect once domains are loaded that we have all entities
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->