### PR TITLE
Set car sensors state appropriately if sensor registers with unit of measurement

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -25,7 +25,6 @@ class CarSensorManager :
 
     companion object {
         internal const val TAG = "CarSM"
-        private const val OPEN_APP = "Open Home Assistant app to activate the sensor"
 
         private val fuelLevel = SensorManager.BasicSensor(
             "car_fuel",
@@ -174,11 +173,9 @@ class CarSensorManager :
                         onSensorUpdated(
                             context,
                             it,
-                            if (it.unitOfMeasurement.isNullOrEmpty()) OPEN_APP else "unknown",
+                            "unavailable",
                             it.statelessIcon,
-                            mapOf(
-                                "status" to OPEN_APP
-                            )
+                            mapOf()
                         )
                     }
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -25,6 +25,7 @@ class CarSensorManager :
 
     companion object {
         internal const val TAG = "CarSM"
+        private const val OPEN_APP = "Open Home Assistant app to activate the sensor"
 
         private val fuelLevel = SensorManager.BasicSensor(
             "car_fuel",
@@ -173,9 +174,11 @@ class CarSensorManager :
                         onSensorUpdated(
                             context,
                             it,
-                            context.getString(R.string.car_data_unavailable),
+                            if (it.unitOfMeasurement.isNullOrEmpty()) OPEN_APP else "unknown",
                             it.statelessIcon,
-                            mapOf()
+                            mapOf(
+                                "status" to OPEN_APP
+                            )
                         )
                     }
                 }
@@ -257,9 +260,12 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 fuelLevel,
-                fuelStatus ?: data.fuelPercent.value!!,
+                if (fuelStatus == "success") data.fuelPercent.value!! else "unknown",
                 fuelLevel.statelessIcon,
-                mapOf()
+                mapOf(
+                    "status" to fuelStatus
+                ),
+                forceUpdate = true
             )
         }
         val batteryStatus = carValueStatus(data.batteryPercent.status)
@@ -267,9 +273,12 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 batteryLevel,
-                batteryStatus ?: data.batteryPercent.value!!,
+                if (batteryStatus == "success") data.batteryPercent.value!! else "unknown",
                 batteryLevel.statelessIcon,
-                mapOf()
+                mapOf(
+                    "status" to batteryStatus
+                ),
+                forceUpdate = true
             )
         }
         setListener(Listener.ENERGY, false)
@@ -282,12 +291,14 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 carName,
-                status ?: data.name.value!!,
+                if (status == "success") data.name.value!! else "unknown",
                 carName.statelessIcon,
                 mapOf(
                     "car_manufacturer" to data.manufacturer.value,
-                    "car_manufactured_year" to data.year.value
-                )
+                    "car_manufactured_year" to data.year.value,
+                    "status" to status
+                ),
+                forceUpdate = true
             )
         }
         setListener(Listener.MODEL, false)
@@ -301,11 +312,13 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 carStatus,
-                status ?: (data.evChargePortConnected.value == true),
+                if (status == "success") (data.evChargePortConnected.value == true) else "unknown",
                 carStatus.statelessIcon,
                 mapOf(
-                    "car_charge_port_open" to (data.evChargePortOpen.value == true)
-                )
+                    "car_charge_port_open" to (data.evChargePortOpen.value == true),
+                    "status" to status
+                ),
+                forceUpdate = true
             )
         }
         setListener(Listener.STATUS, false)
@@ -319,9 +332,12 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 odometerValue,
-                status ?: data.odometerMeters.value!!,
+                if (status == "success") data.odometerMeters.value!! else "unknown",
                 odometerValue.statelessIcon,
-                mapOf()
+                mapOf(
+                    "status" to status
+                ),
+                forceUpdate = true
             )
         }
         setListener(Listener.MILEAGE, false)
@@ -335,29 +351,35 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 fuelType,
-                fuelTypeStatus ?: getFuelType(data.fuelTypes.value!!),
+                if (fuelTypeStatus == "success") getFuelType(data.fuelTypes.value!!) else "unknown",
                 fuelType.statelessIcon,
-                mapOf()
+                mapOf(
+                    "status" to fuelTypeStatus
+                ),
+                forceUpdate = true
             )
         }
         if (isEnabled(context, evConnector)) {
             onSensorUpdated(
                 context,
                 evConnector,
-                evConnectorTypeStatus ?: getEvConnectorType(data.evConnectorTypes.value!!),
+                if (evConnectorTypeStatus == "success") getEvConnectorType(data.evConnectorTypes.value!!) else "unknown",
                 evConnector.statelessIcon,
-                mapOf()
+                mapOf(
+                    "status" to evConnectorTypeStatus
+                ),
+                forceUpdate = true
             )
         }
     }
 
     private fun carValueStatus(value: Int): String? {
         return when (value) {
-            CarValue.STATUS_SUCCESS -> null
+            CarValue.STATUS_SUCCESS -> "success"
             CarValue.STATUS_UNAVAILABLE -> "unavailable"
             CarValue.STATUS_UNKNOWN -> "unknown"
             CarValue.STATUS_UNIMPLEMENTED -> "unimplemented"
-            else -> "unavailable"
+            else -> null
         }
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1125,7 +1125,6 @@
     <string name="ha_assist">HA: Assist</string>
     <string name="only_favorites">Only Show Favorites</string>
     <string name="beacon_scanning">Beacon Monitor Scanning</string>
-    <string name="car_data_unavailable">Open Home Assistant app to activate the sensor</string>
     <string name="basic_sensor_name_car_fuel_type">Car Fuel Type</string>
     <string name="sensor_description_car_fuel_type">List of available fuel types for the connected car</string>
     <string name="basic_sensor_name_car_ev_connector_type">Car EV Connector Type</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes #3762 

When a sensor has a unit of measurement HA will expect certain states if non-numerical otherwise the sensor will not be added.

By default when we do not have `carInfo` the state will be `unavailable`. After the app is open user will either see the real state or `unknown` if the status is not `success`.  All sensors will show the `status` attribute which will show  the status of the sensor.

As the sensors get triggered by a listener we can safely call `forceUpdate = true` we either get a real state or we are getting a real status of the value to send to the user.

Removed the old string because we actually should not translate the states that we send, missed this in the original review 😬

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#969

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->