### PR TITLE
Add support for alarm control panels in android auto

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
@@ -3,7 +3,7 @@ package io.homeassistant.companion.android.util.vehicle
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
-import io.homeassistant.companion.android.common.data.integration.supportsArmedAway
+import io.homeassistant.companion.android.common.data.integration.supportsAlarmControlPanelArmAway
 
 val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
     "alarm_control_panel" to R.string.alarm_control_panels,
@@ -49,5 +49,5 @@ fun canNavigate(entity: Entity<*>): Boolean {
 fun alarmHasNoCode(entity: Entity<*>): Boolean {
     return entity.domain == "alarm_control_panel" &&
         (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null &&
-        entity.supportsArmedAway()
+        entity.supportsAlarmControlPanelArmAway()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.util.vehicle
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.integration.supportsArmedAway
 
 val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
     "alarm_control_panel" to R.string.alarm_control_panels,
@@ -47,5 +48,6 @@ fun canNavigate(entity: Entity<*>): Boolean {
 
 fun alarmHasNoCode(entity: Entity<*>): Boolean {
     return entity.domain == "alarm_control_panel" &&
-        (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null
+        (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null &&
+        entity.supportsArmedAway()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
@@ -5,6 +5,7 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
 
 val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
+    "alarm_control_panel" to R.string.alarm_control_panels,
     "button" to R.string.buttons,
     "cover" to R.string.covers,
     "input_boolean" to R.string.input_booleans,
@@ -25,6 +26,7 @@ val MAP_DOMAINS = listOf(
 )
 
 val NOT_ACTIONABLE_DOMAINS = listOf(
+    "alarm_control_panel",
     "binary_sensor",
     "sensor"
 )
@@ -41,4 +43,8 @@ fun canNavigate(entity: Entity<*>): Boolean {
             ((entity.attributes as? Map<*, *>)?.get("latitude") as? Double != null) &&
             ((entity.attributes as? Map<*, *>)?.get("longitude") as? Double != null)
         )
+}
+
+fun alarmHasNoCode(entity: Entity<*>): Boolean {
+    return (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null
 }

--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
@@ -46,5 +46,6 @@ fun canNavigate(entity: Entity<*>): Boolean {
 }
 
 fun alarmHasNoCode(entity: Entity<*>): Boolean {
-    return (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null
+    return entity.domain == "alarm_control_panel" &&
+        (entity.attributes as? Map<*, *>)?.get("code_format") as? String == null
 }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -37,6 +37,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.En
 import io.homeassistant.companion.android.util.vehicle.MAP_DOMAINS
 import io.homeassistant.companion.android.util.vehicle.NOT_ACTIONABLE_DOMAINS
 import io.homeassistant.companion.android.util.vehicle.SUPPORTED_DOMAINS
+import io.homeassistant.companion.android.util.vehicle.alarmHasNoCode
 import io.homeassistant.companion.android.util.vehicle.canNavigate
 import io.homeassistant.companion.android.util.vehicle.getChangeServerGridItem
 import io.homeassistant.companion.android.util.vehicle.getDomainList
@@ -169,7 +170,7 @@ class EntityGridVehicleScreen(
             if (entity.isExecuting()) {
                 gridItem.setLoading(entity.isExecuting())
             } else {
-                if (entity.domain !in NOT_ACTIONABLE_DOMAINS || canNavigate(entity)) {
+                if (entity.domain !in NOT_ACTIONABLE_DOMAINS || canNavigate(entity) || alarmHasNoCode(entity)) {
                     gridItem
                         .setOnClickListener {
                             Log.i(TAG, "${entity.entityId} clicked")

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -636,9 +636,11 @@ fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions
         "armed_home" -> context.getString(commonR.string.state_armed_home)
         "armed_night" -> context.getString(commonR.string.state_armed_night)
         "armed_vacation" -> context.getString(commonR.string.state_armed_vacation)
+        "arming" -> context.getString(commonR.string.state_arming)
         "closed" -> context.getString(commonR.string.state_closed)
         "closing" -> context.getString(commonR.string.state_closing)
         "disarmed" -> context.getString(commonR.string.state_disarmed)
+        "disarming" -> context.getString(commonR.string.state_disarming)
         "jammed" -> context.getString(commonR.string.state_jammed)
         "locked" -> context.getString(commonR.string.state_locked)
         "locking" -> context.getString(commonR.string.state_locking)
@@ -646,6 +648,7 @@ fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions
         "on" -> context.getString(commonR.string.state_on)
         "open" -> context.getString(commonR.string.state_open)
         "opening" -> context.getString(commonR.string.state_opening)
+        "pending" -> context.getString(commonR.string.state_pending)
         "triggered" -> context.getString(commonR.string.state_triggered)
         "unavailable" -> context.getString(commonR.string.state_unavailable)
         "unlocked" -> context.getString(commonR.string.state_unlocked)
@@ -696,12 +699,13 @@ fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions
 fun <T> Entity<T>.canSupportPrecision() = domain == "sensor" && state.toDoubleOrNull() != null
 
 fun <T> Entity<T>.isExecuting() = when (state) {
+    "arming" -> true
+    "buffering" -> true
     "closing" -> true
+    "disarming" -> true
     "locking" -> true
     "opening" -> true
+    "pending" -> true
     "unlocking" -> true
-    "buffering" -> true
-    "disarming" -> true
-    "arming" -> true
     else -> false
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -41,7 +41,7 @@ object EntityExt {
     val LIGHT_MODE_NO_BRIGHTNESS_SUPPORT = listOf("unknown", "onoff")
     const val LIGHT_SUPPORT_BRIGHTNESS_DEPR = 1
     const val LIGHT_SUPPORT_COLOR_TEMP_DEPR = 2
-    const val ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY = 2
+    const val ALARM_CONTROL_PANEL_SUPPORT_ARM_AWAY = 2
 }
 
 val <T> Entity<T>.domain: String
@@ -115,10 +115,10 @@ fun <T> Entity<T>.getCoverPosition(): EntityPosition? {
     }
 }
 
-fun <T> Entity<T>.supportsArmedAway(): Boolean {
+fun <T> Entity<T>.supportsAlarmControlPanelArmAway(): Boolean {
     return try {
         if (domain != "alarm_control_panel") return false
-        ((attributes as Map<*, *>)["supported_features"] as Int) and EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY == EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY
+        ((attributes as Map<*, *>)["supported_features"] as Int) and EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARM_AWAY == EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARM_AWAY
     } catch (e: Exception) {
         Log.e(EntityExt.TAG, "Unable to get supportsArmedAway", e)
         false
@@ -631,8 +631,14 @@ val <T> Entity<T>.friendlyName: String
 
 fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions? = null, appendUnitOfMeasurement: Boolean = false): String {
     var friendlyState = when (state) {
+        "armed_away" -> context.getString(commonR.string.state_armed_away)
+        "armed_custom_bypass" -> context.getString(commonR.string.state_armed_custom_bypass)
+        "armed_home" -> context.getString(commonR.string.state_armed_home)
+        "armed_night" -> context.getString(commonR.string.state_armed_night)
+        "armed_vacation" -> context.getString(commonR.string.state_armed_vacation)
         "closed" -> context.getString(commonR.string.state_closed)
         "closing" -> context.getString(commonR.string.state_closing)
+        "disarmed" -> context.getString(commonR.string.state_disarmed)
         "jammed" -> context.getString(commonR.string.state_jammed)
         "locked" -> context.getString(commonR.string.state_locked)
         "locking" -> context.getString(commonR.string.state_locking)
@@ -640,6 +646,7 @@ fun <T> Entity<T>.friendlyState(context: Context, options: EntityRegistryOptions
         "on" -> context.getString(commonR.string.state_on)
         "open" -> context.getString(commonR.string.state_open)
         "opening" -> context.getString(commonR.string.state_opening)
+        "triggered" -> context.getString(commonR.string.state_triggered)
         "unavailable" -> context.getString(commonR.string.state_unavailable)
         "unlocked" -> context.getString(commonR.string.state_unlocked)
         "unlocking" -> context.getString(commonR.string.state_unlocking)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -259,8 +259,19 @@ fun <T> Entity<T>.getIcon(context: Context): IIcon? {
         val compareState =
             state.ifBlank { attributes["state"] as String? }
         when (domain) {
-            "alert" -> CommunityMaterial.Icon.cmd_alert
             "air_quality" -> CommunityMaterial.Icon.cmd_air_filter
+            "alarm_control_panel" -> when (compareState) {
+                "armed_away" -> CommunityMaterial.Icon3.cmd_shield_lock
+                "armed_custom_bypass" -> CommunityMaterial.Icon3.cmd_security
+                "armed_home" -> CommunityMaterial.Icon3.cmd_shield_home
+                "armed_night" -> CommunityMaterial.Icon3.cmd_shield_moon
+                "armed_vacation" -> CommunityMaterial.Icon3.cmd_shield_airplane
+                "disarmed" -> CommunityMaterial.Icon3.cmd_shield_off
+                "pending" -> CommunityMaterial.Icon3.cmd_shield_outline
+                "triggered" -> CommunityMaterial.Icon.cmd_bell_ring
+                else -> CommunityMaterial.Icon3.cmd_shield
+            }
+            "alert" -> CommunityMaterial.Icon.cmd_alert
             "automation" -> if (compareState == "off") {
                 CommunityMaterial.Icon3.cmd_robot_off
             } else {
@@ -581,6 +592,9 @@ suspend fun <T> Entity<T>.onPressed(
         }
         "cover" -> {
             if (state == "open") "close_cover" else "open_cover"
+        }
+        "alarm_control_panel" -> {
+            if (state != "disarmed") "alarm_disarm" else "alarm_arm_away"
         }
         "button",
         "input_button" -> "press"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -41,6 +41,7 @@ object EntityExt {
     val LIGHT_MODE_NO_BRIGHTNESS_SUPPORT = listOf("unknown", "onoff")
     const val LIGHT_SUPPORT_BRIGHTNESS_DEPR = 1
     const val LIGHT_SUPPORT_COLOR_TEMP_DEPR = 2
+    const val ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY = 2
 }
 
 val <T> Entity<T>.domain: String
@@ -111,6 +112,16 @@ fun <T> Entity<T>.getCoverPosition(): EntityPosition? {
     } catch (e: Exception) {
         Log.e(EntityExt.TAG, "Unable to get getCoverPosition", e)
         null
+    }
+}
+
+fun <T> Entity<T>.supportsArmedAway(): Boolean {
+    return try {
+        if (domain != "alarm_control_panel") return false
+        ((attributes as Map<*, *>)["supported_features"] as Int) and EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY == EntityExt.ALARM_CONTROL_PANEL_SUPPORT_ARMED_AWAY
+    } catch (e: Exception) {
+        Log.e(EntityExt.TAG, "Unable to get supportsArmedAway", e)
+        false
     }
 }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1136,4 +1136,11 @@
     <string name="android_automotive">Android Automotive</string>
     <string name="android_automotive_favorites">Driving Favorites</string>
     <string name="alarm_control_panels">Alarm Control Panels</string>
+    <string name="state_triggered">Triggered</string>
+    <string name="state_disarmed">Disarmed</string>
+    <string name="state_armed_vacation">Armed Vacation</string>
+    <string name="state_armed_night">Armed Night</string>
+    <string name="state_armed_home">Armed Home</string>
+    <string name="state_armed_custom_bypass">Armed Custom Bypass</string>
+    <string name="state_armed_away">Armed Away</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1135,4 +1135,5 @@
     <string name="aa_favorites_summary">Select your favorite entities to be shown in the app while viewing the Home Assistant driving interface</string>
     <string name="android_automotive">Android Automotive</string>
     <string name="android_automotive_favorites">Driving Favorites</string>
+    <string name="alarm_control_panels">Alarm Control Panels</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1138,9 +1138,12 @@
     <string name="alarm_control_panels">Alarm Control Panels</string>
     <string name="state_triggered">Triggered</string>
     <string name="state_disarmed">Disarmed</string>
-    <string name="state_armed_vacation">Armed Vacation</string>
-    <string name="state_armed_night">Armed Night</string>
-    <string name="state_armed_home">Armed Home</string>
-    <string name="state_armed_custom_bypass">Armed Custom Bypass</string>
-    <string name="state_armed_away">Armed Away</string>
+    <string name="state_armed_vacation">Armed vacation</string>
+    <string name="state_armed_night">Armed night</string>
+    <string name="state_armed_home">Armed home</string>
+    <string name="state_armed_custom_bypass">Armed custom bypass</string>
+    <string name="state_armed_away">Armed away</string>
+    <string name="state_arming">Arming</string>
+    <string name="state_disarming">Disarming</string>
+    <string name="state_pending">Pending</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3710 

We will show Alarm Control Panels as a supported domain because they are important enough IMO.

Only if we detect a code is not required will a user be able to click on it, otherwise it will be non-actionable.

Given the use case we will either `disarm` or `arm_away` the alarm, the other arming options don't feel as if they would be used as much as `armed_away`

Used the same icons from the frontend: https://github.com/home-assistant/frontend/blob/858dd738684b604b7861ccb9e2c449f9280f8723/src/common/entity/alarm_panel_icon.ts#L15-L36

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#968

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
After going on the first road trip this weekend the question of "did we turn on the alarm" came while in the car and it would've been easy to answer that 😂 