### PR TITLE
Hide all entities when we dont have domains to show, show empty message just in case

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/GridItems.kt
@@ -189,6 +189,8 @@ fun getDomainList(
             )
         }
     }
+    listBuilder.setNoItemsMessage(carContext.getString(R.string.no_supported_entities))
+
     return listBuilder
 }
 

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -39,6 +39,7 @@ class DomainListScreen(
     }
 
     private val domains = mutableSetOf<String>()
+    private var domainsAdded = false
 
     override fun onDrivingOptimizedChanged(newState: Boolean) {
         invalidate()
@@ -52,11 +53,11 @@ class DomainListScreen(
                     .distinct()
                     .filter { it in SUPPORTED_DOMAINS }
                     .toSet()
-                if (newDomains.size != domains.size || newDomains != domains) {
-                    domains.clear()
-                    domains.addAll(newDomains)
-                    invalidate()
-                }
+                val invalidate = newDomains.size != domains.size || newDomains != domains || !domainsAdded
+                domains.clear()
+                domains.addAll(newDomains)
+                domainsAdded = true
+                if (invalidate) invalidate()
             }
         }
     }
@@ -82,7 +83,7 @@ class DomainListScreen(
                 setActionStrip(nativeModeActionStrip(carContext))
             }
             val domainBuild = domainList.build()
-            if (domainBuild.items.isEmpty()) {
+            if (!domainsAdded) {
                 setLoading(true)
             } else {
                 setLoading(false)

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -108,18 +108,20 @@ class EntityGridVehicleScreen(
                     allEntities
                 ).build()
             )
-            listBuilder.addItem(
-                getDomainsGridItem(
-                    carContext,
-                    screenManager,
-                    serverManager,
-                    integrationRepository,
-                    serverId,
-                    allEntities,
-                    prefsRepository,
-                    entityRegistry
-                ).build()
-            )
+            if (domains.isNotEmpty()) {
+                listBuilder.addItem(
+                    getDomainsGridItem(
+                        carContext,
+                        screenManager,
+                        serverManager,
+                        integrationRepository,
+                        serverId,
+                        allEntities,
+                        prefsRepository,
+                        entityRegistry
+                    ).build()
+                )
+            }
             if (shouldSwitchServers) {
                 listBuilder.addItem(
                     getChangeServerGridItem(

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -124,7 +124,7 @@ class MainVehicleScreen(
             ) { onChangeServer(it) }.getEntityGridItems(favoritesEntities)
         } else {
             var builder = ItemList.Builder()
-            if (domains.isNotEmpty()) {
+            if (domains.isNotEmpty() && domainsAdded) {
                 builder = getDomainList(
                     domains,
                     carContext,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

While testing another PR came across an issue where if user had multi server and a server was down we would show all entities and the domain list would never load as a result. So handle loading domains like the other screen, add some checks to only show all entities if we can and add an empty message just in case.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->