### PR TITLE
Auto: reload entity registry, show loading when changing servers

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -51,6 +51,7 @@ class MainVehicleScreen(
     private var isLoggedIn: Boolean? = null
     private val domains = mutableSetOf<String>()
     private var domainsAdded = false
+    private var domainsAddedFor: Int? = null
 
     private val isAutomotive get() = carContext.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
@@ -69,23 +70,31 @@ class MainVehicleScreen(
                         .getSessionState() == SessionState.CONNECTED
                     invalidate()
                 }
-                entityRegistry = serverManager.webSocketRepository(serverId.value).getEntityRegistry()
-                allEntities.collect { entities ->
-                    val newDomains = entities.values
-                        .map { it.domain }
-                        .distinct()
-                        .filter { it in SUPPORTED_DOMAINS }
-                        .toSet()
-                    var invalidate = newDomains.size != domains.size || newDomains != domains || !domainsAdded
-                    domains.clear()
-                    domains.addAll(newDomains)
-                    domainsAdded = true
+                serverId.collect { server ->
+                    if (domainsAddedFor != server) {
+                        domainsAdded = false
+                        domainsAddedFor = server
+                        invalidate() // Show loading state
+                        entityRegistry = serverManager.webSocketRepository(server).getEntityRegistry()
+                    }
 
-                    val newFavorites = getFavoritesList(entities)
-                    invalidate = invalidate || (newFavorites.size != favoritesEntities.size || newFavorites.toSet() != favoritesEntities.toSet())
-                    favoritesEntities = newFavorites
+                    allEntities.collect { entities ->
+                        val newDomains = entities.values
+                            .map { it.domain }
+                            .distinct()
+                            .filter { it in SUPPORTED_DOMAINS }
+                            .toSet()
+                        var invalidate = newDomains.size != domains.size || newDomains != domains || !domainsAdded
+                        domains.clear()
+                        domains.addAll(newDomains)
+                        domainsAdded = true
 
-                    if (invalidate) invalidate()
+                        val newFavorites = getFavoritesList(entities)
+                        invalidate = invalidate || newFavorites.size != favoritesEntities.size || newFavorites.toSet() != favoritesEntities.toSet()
+                        favoritesEntities = newFavorites
+
+                        if (invalidate) invalidate()
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When changing servers the Auto interface (should) reload some server related stuff: the device registry and entities. In this PR:
- actually reload the entity registry instead of keeping the registry for the first server
- show a loading indicator while changing servers and loading registry/entities, instead of the screen for no entities while loading

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, it is like the first load

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->