### PR TITLE
Discard notifications when not registered to prevent crash

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -296,6 +296,10 @@ class MessagingManager @Inject constructor(
         val serverId = jsonData[NotificationData.WEBHOOK_ID]?.let { webhookId ->
             serverManager.getServer(webhookId = webhookId)?.id
         } ?: ServerManager.SERVER_ID_ACTIVE
+        if (serverManager.getServer(serverId) == null) {
+            Log.w(TAG, "Received notification but no server for it, discarding")
+            return
+        }
         jsonData = jsonData + mutableMapOf<String, String>().apply { put(THIS_SERVER_ID, serverId.toString()) }
 
         mainScope.launch {

--- a/wear/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -55,6 +55,10 @@ class MessagingManager @Inject constructor(
         val notificationRow =
             NotificationItem(0, now, notificationData[NotificationData.MESSAGE].toString(), jsonObject.toString(), source, serverId)
         notificationDao.add(notificationRow)
+        if (serverManager.getServer(serverId) == null) {
+            Log.w(TAG, "Received notification but no server for it, discarding")
+            return
+        }
 
         mainScope.launch {
             val allowCommands = serverManager.integrationRepository(serverId).isTrusted()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix crash 1 from #3708 ([link to line for version in issue](https://github.com/home-assistant/android/blob/f4eb29cee32b971d4e1005cb59b02a49976e090c/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt#L304)). `IllegalArgumentException` suggests the server for the ID doesn't exist, which can only happen if a notification is received while not registered (as it already falls back to the default server if there is no server found for the webhook ID). As a lot of features depend on having a server for notifications discard them.

I guess people are sending notifications after logging out? (Note that the notification data is still saved to the database so not completely lost and available for troubleshooting if required.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->