### PR TITLE
Bugfix/crash web view

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -401,6 +401,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     view: WebView?,
                     handler: RenderProcessGoneDetail?
                 ): Boolean {
+                    Log.e(TAG, "onRenderProcessGone: webView crashed")
                     webView.reload()
 
                     return true

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -34,6 +34,7 @@ import android.webkit.HttpAuthHandler
 import android.webkit.JavascriptInterface
 import android.webkit.JsResult
 import android.webkit.PermissionRequest
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.SslErrorHandler
 import android.webkit.URLUtil
 import android.webkit.ValueCallback
@@ -394,6 +395,17 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                         error,
                         null
                     )
+                }
+
+                override fun onRenderProcessGone(
+                    view: WebView?,
+                    handler: RenderProcessGoneDetail?
+                ): Boolean {
+                    webView.removeAllViews();
+                    webView.clearCache(true);
+                    webView.reload();
+
+                    return true;
                 }
 
                 override fun onLoadResource(

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -402,7 +402,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     handler: RenderProcessGoneDetail?
                 ): Boolean {
                     Log.e(TAG, "onRenderProcessGone: webView crashed")
-                    webView.reload()
+                    view!!.reload()
 
                     return true
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -402,7 +402,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     handler: RenderProcessGoneDetail?
                 ): Boolean {
                     Log.e(TAG, "onRenderProcessGone: webView crashed")
-                    view!!.reload()
+                    view?.let { reload() }
 
                     return true
                 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -724,9 +724,9 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                     // Set event lister for HA theme change
                                     webView.evaluateJavascript(
                                         "document.addEventListener('settheme', function ()" +
-                                                "{" +
-                                                "window.externalApp.onHomeAssistantSetTheme();" +
-                                                "});",
+                                            "{" +
+                                            "window.externalApp.onHomeAssistantSetTheme();" +
+                                            "});",
                                         null
                                     )
                                 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -401,8 +401,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     view: WebView?,
                     handler: RenderProcessGoneDetail?
                 ): Boolean {
-                    webView.removeAllViews()
-                    webView.clearCache(true)
                     webView.reload()
 
                     return true

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -225,7 +225,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private var downloadFileUrl = ""
     private var downloadFileContentDisposition = ""
     private var downloadFileMimetype = ""
-    private var javascriptInterface = "externalApp"
+    private val javascriptInterface = "externalApp"
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -401,11 +401,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                     view: WebView?,
                     handler: RenderProcessGoneDetail?
                 ): Boolean {
-                    webView.removeAllViews();
-                    webView.clearCache(true);
-                    webView.reload();
+                    webView.removeAllViews()
+                    webView.clearCache(true)
+                    webView.reload()
 
-                    return true;
+                    return true
                 }
 
                 override fun onLoadResource(


### PR DESCRIPTION
This PR fixes issue https://github.com/home-assistant/android/issues/3500. What was the issue:
I have a tablet hanging as a home control. The tablet is running home assistant. And about once a day the application crashes. And when I pass by it, I see the desktop. The reason is that the WebView is leaking memory. And in the event of the death of the WebView process (com.google.android.webview:sandboxed_process0:org.chromium.content.app.SandboxedProcessService), our application also died. It is unacceptable.
I immediately provide a reproduction of the problem:

1) use adb: `adb shell`
2) without permissions, we won't be able to kill the process: `su`
3) find and kill the process: `ps -A | grep sandboxed | awk '{print $2}' | xargs kill`

For clarity, I will add two videos (before / after)

[![before]](https://github.com/home-assistant/android/assets/24318525/e043fc7f-27cd-40c6-b626-b886e2328cbb)

[![after]](https://github.com/home-assistant/android/assets/24318525/16f01bac-0661-4606-b4d6-d5c115f925a2)