### PR TITLE
Fix phone state sensor only considering 1 subscription's calls

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -84,13 +84,9 @@ class PhoneStateSensorManager : SensorManager {
                 val telephonyManager =
                     context.applicationContext.getSystemService<TelephonyManager>()!!
 
-                val callState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                    telephonyManager.callStateForSubscription
-                } else {
-                    @Suppress("DEPRECATION")
-                    telephonyManager.callState
-                }
-                currentPhoneState = when (callState) {
+                // Deprecated function provides state for any call, not for a specific subscription only
+                @Suppress("DEPRECATION")
+                currentPhoneState = when (telephonyManager.callState) {
                     TelephonyManager.CALL_STATE_IDLE -> "idle"
                     TelephonyManager.CALL_STATE_RINGING -> "ringing"
                     TelephonyManager.CALL_STATE_OFFHOOK -> "offhook"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3801. The change to a non-deprecated API means the sensor was limited to calls placed linked to a specific subscription, which causes inconsistency between Android versions and also might not be desired (for example, in case of multi SIM usage or non-telephony calls with VOIP apps).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->