### PR TITLE
Android Auto: Set icon color when entity is considered in an active state

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -29,6 +29,7 @@ import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.data.integration.isExecuting
 import io.homeassistant.companion.android.common.data.integration.onPressed
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
@@ -212,7 +213,16 @@ class EntityGridVehicleScreen(
                                 sizeDp = 64
                             }.toAndroidIconCompat()
                         )
-                            .setTint(CarColor.DEFAULT)
+                            .setTint(
+                                if (entity.isActive()) {
+                                    CarColor.createCustom(
+                                        carContext.getColor(R.color.colorYellow),
+                                        carContext.getColor(R.color.colorYellow)
+                                    )
+                                } else {
+                                    CarColor.DEFAULT
+                                }
+                            )
                             .build()
                     )
             }

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
@@ -29,6 +29,7 @@ import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.isActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import io.homeassistant.companion.android.common.R as commonR
@@ -103,7 +104,16 @@ class MapVehicleScreen(
                                         sizeDp = 64
                                     }.toAndroidIconCompat()
                             )
-                                .setTint(CarColor.DEFAULT)
+                                .setTint(
+                                    if (pair.first.isActive()) {
+                                        CarColor.createCustom(
+                                            carContext.getColor(R.color.colorYellow),
+                                            carContext.getColor(R.color.colorYellow)
+                                        )
+                                    } else {
+                                        CarColor.DEFAULT
+                                    }
+                                )
                                 .build()
                         )
                         .setOnClickListener {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -746,3 +746,21 @@ fun <T> Entity<T>.isExecuting() = when (state) {
     "unlocking" -> true
     else -> false
 }
+
+fun <T> Entity<T>.isActive() = when {
+    (domain in listOf("button", "input_button", "event", "scene")) -> state != "unavailable"
+    (state == "unavailable" || state == "unknown") -> false
+    (state == "off" && domain != "alert") -> false
+    (domain == "alarm_control_panel") -> state != "disarmed"
+    (domain == "alert") -> state != "idle"
+    (domain == "cover") -> state != "closed"
+    (domain in listOf("device_tracker", "person")) -> state != "not_home"
+    (domain == "lock") -> state != "locked"
+    (domain == "media_player") -> state != "standby"
+    (domain == "vacuum") -> state !in listOf("idle", "docked", "paused")
+    (domain == "plant") -> state == "problem"
+    (domain == "group") -> state in listOf("on", "home", "open", "locked", "problem")
+    (domain == "timer") -> state == "active"
+    (domain == "camera") -> state == "streaming"
+    else -> true
+}

--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -29,6 +29,7 @@
     <color name="colorAlertWarning">#1fffa600</color>
     <color name="colorOnAlertWarning">#ffa600</color>
     <color name="colorDeviceControlsLightOn">#FDD663</color>
+    <color name="colorYellow">#F6C344</color>
     <color name="colorDeviceControlsOff">#9AA0A6</color>
     <color name="colorDeviceControlsDefaultOn">#8AB4F8</color>
     <color name="colorDeviceControlsThermostatHeat">#FF8B66</color>

--- a/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
@@ -5,7 +5,7 @@ import androidx.wear.compose.material.Colors
 
 val Blue = Color(0xFF03A9F4)
 val BlueDark = Color(0xFF0288D1)
-val Yellow = Color(0xFFFDD835)
+val Yellow = Color(0xFFF6C344)
 val Orange = Color(0xFFFF9800)
 val Red = Color(0xFFD32F2F)
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Implements: https://community.home-assistant.io/t/add-accent-color-to-the-android-auto-ui/604634

Sets the icon color tint to the frontend yellow color if the entity is considered to be active according to the [frontend](https://github.com/home-assistant/frontend/blob/dev/src/common/entity/state_active.ts)

Also updates the Wear OS yellow color to more closely match the color from the HA frontend.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/home-assistant/android/assets/1634145/914b58c4-4f47-44cd-a296-c68c7d4f8094)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I had thought about mimicking the frontend using blue for off and yellow for on but the screen looked a bit busy so decided to  only change teh default color if the entity is considered active.

![image](https://github.com/home-assistant/android/assets/1634145/8c2f6518-e565-43a9-8396-874cbc30718d)
