### PR TITLE
Update deeplink support with multiserver: ask which to use

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -29,6 +29,7 @@ import io.homeassistant.companion.android.onboarding.OnboardApp
 import io.homeassistant.companion.android.onboarding.getMessagingToken
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.settings.SettingViewModel
+import io.homeassistant.companion.android.settings.server.ServerChooserFragment
 import io.homeassistant.companion.android.util.UrlUtil
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.CoroutineScope
@@ -89,6 +90,20 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
                 Class.forName("androidx.car.app.activity.CarAppActivity")
             ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(carIntent)
+        } else if (presenter.hasMultipleServers() && intent.data?.path?.isNotBlank() == true) {
+            supportFragmentManager.setFragmentResultListener(ServerChooserFragment.RESULT_KEY, this) { _, bundle ->
+                val serverId = if (bundle.containsKey(ServerChooserFragment.RESULT_SERVER)) {
+                    bundle.getInt(ServerChooserFragment.RESULT_SERVER)
+                } else {
+                    null
+                }
+                supportFragmentManager.clearFragmentResultListener(ServerChooserFragment.RESULT_KEY)
+                startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverId))
+                finish()
+                overridePendingTransition(0, 0) // Disable activity start/stop animation
+            }
+            ServerChooserFragment().show(supportFragmentManager, ServerChooserFragment.TAG)
+            return
         } else {
             startActivity(WebViewActivity.newInstance(this, intent.data?.path))
         }

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenter.kt
@@ -6,5 +6,7 @@ interface LaunchPresenter {
 
     fun setSessionExpireMillis(value: Long)
 
+    fun hasMultipleServers(): Boolean
+
     fun onFinish()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
@@ -49,6 +49,8 @@ abstract class LaunchPresenterBase(
         }
     }
 
+    override fun hasMultipleServers(): Boolean = serverManager.defaultServers.size > 1
+
     override fun onFinish() {
         mainScope.cancel()
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Ask the user which server to use, instead of assuming the most recently used, when using deeplinks with an app that has multiple servers configured. This matches iOS behavior.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The existing server chooser that is, for example, also visible when swiping up with 3 fingers.

Video showing the usage with my and homeassistant://navigate links:

https://github.com/home-assistant/android/assets/8148535/d01feb52-a5e7-440f-89e3-0563feea23ad

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Coming soon
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->