### PR TITLE
Fix restoring custom fields in service button widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -148,6 +148,8 @@ class WidgetDynamicFieldAdapter(
                 // Set text to empty string to prevent a recycled, incorrect value
                 autoCompleteTextView.setText("")
             }
+        } else {
+            autoCompleteTextView.setText("")
         }
 
         // Have the text view store its text for later recall


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3812 and two other bugs found while working on it:
 - Fix RecyclerView not setting fields to empty when no value is present, potentially showing input from other recycled fields if the field doesn't have any value.
 - Fix adding a new custom field destroying any input currently held in the views by using a specific insertion method instead of all changed, which will reset the values.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->