### PR TITLE
More dependency bumps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ converterJackson = "2.9.0"
 coreKtx = "1.10.1"
 cronet-embedded = "113.5672.61"
 emojiJava = "5.1.1"
-firebase-bom = "32.2.0"
+firebase-bom = "32.2.2"
 firebaseAppdistributionGradle = "4.0.0"
 fragment-ktx = "1.6.1"
 googleServices = "4.3.15"
@@ -40,7 +40,7 @@ ktlint = "11.5.1"
 lifecycle = "2.6.1"
 loggingInterceptor = "4.11.0"
 material = "1.9.0"
-media3 = "1.1.0"
+media3 = "1.1.1"
 navigation-compose = "2.7.1"
 okhttp = "4.11.0"
 picasso = "2.8"
@@ -48,16 +48,17 @@ play-services-threadnetwork = "16.0.0"
 play-services-home = "16.0.0"
 play-services-location = "21.0.1"
 play-services-wearable = "18.0.0"
-preference-ktx = "1.2.0"
+preference-ktx = "1.2.1"
 recyclerview = "1.3.1"
 reorderable = "0.9.6"
 retrofit = "2.9.0"
 room = "2.5.2"
 sentry-android = "6.28.0"
 watchfaceComplicationsDataSourceKtx = "1.1.1"
-wear = "1.2.0"
+wear = "1.3.0"
 wear-compose-foundation = "1.2.0"
-wear-tiles = "1.2.0-alpha07"
+wear-protolayout = "1.0.0"
+wear-tiles = "1.2.0"
 wearPhoneInteractions = "1.0.1"
 wearInput = "1.2.0-alpha02"
 webkit = "1.7.0"
@@ -152,10 +153,13 @@ wear-compose-material = { module = "androidx.wear.compose:compose-material", ver
 wear-compose-navigation = { module = "androidx.wear.compose:compose-navigation", version.ref = "wear-compose-foundation" }
 wear-phone-interactions = { module = "androidx.wear:wear-phone-interactions", version.ref = "wearPhoneInteractions" }
 wear-input = { module = "androidx.wear:wear-input", version.ref = "wearInput" }
+wear-protolayout-expression = { module = "androidx.wear.protolayout:protolayout-expression", version.ref = "wear-protolayout" }
+wear-protolayout-main = { module = "androidx.wear.protolayout:protolayout", version.ref = "wear-protolayout" }
+wear-protolayout-material = { module = "androidx.wear.protolayout:protolayout-material", version.ref = "wear-protolayout" }
 wear-remote-interactions = { module = "androidx.wear:wear-remote-interactions", version.ref = "wear-remote-interactions" }
-wear-tiles-material = { module = "androidx.wear.tiles:tiles-material", version.ref = "wear-tiles" }
 wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "wear-tiles" }
 webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 
 [bundles]
 media3 = ["media3-exoplayer", "media3-exoplayer-hls", "media3-ui"]
+wear-tiles = ["wear-tiles", "wear-protolayout-main", "wear-protolayout-expression", "wear-protolayout-material"]

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -109,8 +109,7 @@ dependencies {
     implementation(libs.wear.compose.navigation)
 
     implementation(libs.guava)
-    implementation(libs.wear.tiles)
-    implementation(libs.wear.tiles.material)
+    implementation(libs.bundles.wear.tiles)
 
     implementation(libs.androidx.watchface.complications.data.source.ktx)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ConversationTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ConversationTile.kt
@@ -1,21 +1,21 @@
 package io.homeassistant.companion.android.tiles
 
 import androidx.core.content.ContextCompat
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.ColorBuilders.argb
-import androidx.wear.tiles.DimensionBuilders.dp
-import androidx.wear.tiles.DimensionBuilders.sp
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
-import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DimensionBuilders.dp
+import androidx.wear.protolayout.DimensionBuilders.sp
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.VERTICAL_ALIGN_CENTER
+import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.ResourceBuilders.ImageResource
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.TimelineBuilders.Timeline
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.ResourceBuilders.ImageResource
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
-import androidx.wear.tiles.TimelineBuilders.Timeline
 import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R
@@ -40,7 +40,7 @@ class ConversationTile : TileService() {
         serviceScope.future {
             Tile.Builder()
                 .setResourcesVersion("1")
-                .setTimeline(
+                .setTileTimeline(
                     if (serverManager.isRegistered()) {
                         Timeline.fromLayoutElement(boxLayout())
                     } else {
@@ -54,7 +54,7 @@ class ConversationTile : TileService() {
                 ).build()
         }
 
-    override fun onResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
+    override fun onTileResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
         serviceScope.future {
             Resources.Builder()
                 .setVersion("1")

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/LoggedOutTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/LoggedOutTile.kt
@@ -3,17 +3,17 @@ package io.homeassistant.companion.android.tiles
 import android.content.Context
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.ColorBuilders.argb
-import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.TimelineBuilders.Timeline
+import androidx.wear.protolayout.material.ChipColors
+import androidx.wear.protolayout.material.Colors
+import androidx.wear.protolayout.material.CompactChip
+import androidx.wear.protolayout.material.Text
+import androidx.wear.protolayout.material.Typography
+import androidx.wear.protolayout.material.layouts.PrimaryLayout
 import androidx.wear.tiles.RequestBuilders
-import androidx.wear.tiles.TimelineBuilders.Timeline
-import androidx.wear.tiles.material.ChipColors
-import androidx.wear.tiles.material.Colors
-import androidx.wear.tiles.material.CompactChip
-import androidx.wear.tiles.material.Text
-import androidx.wear.tiles.material.Typography
-import androidx.wear.tiles.material.layouts.PrimaryLayout
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.splash.SplashActivity
 import io.homeassistant.companion.android.common.R as commonR
@@ -47,7 +47,7 @@ fun loggedOutTimeline(
                 ).build()
         ).build()
     return Timeline.fromLayoutElement(
-        PrimaryLayout.Builder(requestParams.deviceParameters!!)
+        PrimaryLayout.Builder(requestParams.deviceConfiguration)
             .setPrimaryLabelTextContent(
                 Text.Builder(context, context.getString(title))
                     .setTypography(Typography.TYPOGRAPHY_CAPTION1)
@@ -66,7 +66,7 @@ fun loggedOutTimeline(
                     context,
                     context.getString(commonR.string.login),
                     chipAction,
-                    requestParams.deviceParameters!!
+                    requestParams.deviceConfiguration
                 )
                     .setChipColors(chipColors)
                     .build()

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -6,26 +6,26 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.toBitmap
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.ColorBuilders.argb
-import androidx.wear.tiles.DimensionBuilders.dp
-import androidx.wear.tiles.DimensionBuilders.sp
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders.argb
+import androidx.wear.protolayout.DimensionBuilders.dp
+import androidx.wear.protolayout.DimensionBuilders.sp
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.Box
+import androidx.wear.protolayout.LayoutElementBuilders.Column
+import androidx.wear.protolayout.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.LayoutElementBuilders.Row
+import androidx.wear.protolayout.LayoutElementBuilders.Spacer
+import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.TimelineBuilders.Timeline
 import androidx.wear.tiles.EventBuilders
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.LayoutElementBuilders.Box
-import androidx.wear.tiles.LayoutElementBuilders.Column
-import androidx.wear.tiles.LayoutElementBuilders.HORIZONTAL_ALIGN_CENTER
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.LayoutElementBuilders.Row
-import androidx.wear.tiles.LayoutElementBuilders.Spacer
-import androidx.wear.tiles.ModifiersBuilders
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
-import androidx.wear.tiles.TimelineBuilders.Timeline
 import com.google.common.util.concurrent.ListenableFuture
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
@@ -71,8 +71,8 @@ class ShortcutsTile : TileService() {
 
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> =
         serviceScope.future {
-            val state = requestParams.state
-            if (state != null && state.lastClickableId.isNotEmpty()) {
+            val state = requestParams.currentState
+            if (state.lastClickableId.isNotEmpty()) {
                 Intent().also { intent ->
                     intent.action = "io.homeassistant.companion.android.TILE_ACTION"
                     intent.putExtra("entity_id", state.lastClickableId)
@@ -86,7 +86,7 @@ class ShortcutsTile : TileService() {
 
             Tile.Builder()
                 .setResourcesVersion(entities.toString())
-                .setTimeline(
+                .setTileTimeline(
                     if (serverManager.isRegistered()) {
                         timeline(tileId)
                     } else {
@@ -100,11 +100,11 @@ class ShortcutsTile : TileService() {
                 ).build()
         }
 
-    override fun onResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
+    override fun onTileResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
         serviceScope.future {
             val showLabels = wearPrefsRepository.getShowShortcutText()
             val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
-            val density = requestParams.deviceParameters!!.screenDensity
+            val density = requestParams.deviceConfiguration.screenDensity
             val iconSizePx = (iconSize * density).roundToInt()
             val entities = getEntities(requestParams.tileId)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TemplateTile.kt
@@ -15,22 +15,22 @@ import android.util.Log
 import androidx.core.content.getSystemService
 import androidx.core.text.HtmlCompat.FROM_HTML_MODE_LEGACY
 import androidx.core.text.HtmlCompat.fromHtml
-import androidx.wear.tiles.ActionBuilders
-import androidx.wear.tiles.ColorBuilders
-import androidx.wear.tiles.DimensionBuilders
-import androidx.wear.tiles.DimensionBuilders.dp
-import androidx.wear.tiles.LayoutElementBuilders
-import androidx.wear.tiles.LayoutElementBuilders.Box
-import androidx.wear.tiles.LayoutElementBuilders.FONT_WEIGHT_BOLD
-import androidx.wear.tiles.LayoutElementBuilders.LayoutElement
-import androidx.wear.tiles.ModifiersBuilders
+import androidx.wear.protolayout.ActionBuilders
+import androidx.wear.protolayout.ColorBuilders
+import androidx.wear.protolayout.DimensionBuilders
+import androidx.wear.protolayout.DimensionBuilders.dp
+import androidx.wear.protolayout.LayoutElementBuilders
+import androidx.wear.protolayout.LayoutElementBuilders.Box
+import androidx.wear.protolayout.LayoutElementBuilders.FONT_WEIGHT_BOLD
+import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
+import androidx.wear.protolayout.ModifiersBuilders
+import androidx.wear.protolayout.ResourceBuilders
+import androidx.wear.protolayout.ResourceBuilders.Resources
+import androidx.wear.protolayout.TimelineBuilders.Timeline
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
 import androidx.wear.tiles.RequestBuilders.TileRequest
-import androidx.wear.tiles.ResourceBuilders
-import androidx.wear.tiles.ResourceBuilders.Resources
 import androidx.wear.tiles.TileBuilders.Tile
 import androidx.wear.tiles.TileService
-import androidx.wear.tiles.TimelineBuilders.Timeline
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
@@ -57,8 +57,8 @@ class TemplateTile : TileService() {
 
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> =
         serviceScope.future {
-            val state = requestParams.state
-            if (state != null && state.lastClickableId == "refresh") {
+            val state = requestParams.currentState
+            if (state.lastClickableId == "refresh") {
                 if (wearPrefsRepository.getWearHapticFeedback()) {
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
                         val vibratorManager = applicationContext.getSystemService<VibratorManager>()
@@ -77,7 +77,7 @@ class TemplateTile : TileService() {
                 .setFreshnessIntervalMillis(
                     wearPrefsRepository.getTemplateTileRefreshInterval().toLong() * 1000
                 )
-                .setTimeline(
+                .setTileTimeline(
                     if (serverManager.isRegistered()) {
                         timeline()
                     } else {
@@ -91,7 +91,7 @@ class TemplateTile : TileService() {
                 ).build()
         }
 
-    override fun onResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
+    override fun onTileResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
         serviceScope.future {
             Resources.Builder()
                 .setVersion("1")
@@ -150,9 +150,7 @@ class TemplateTile : TileService() {
         addContent(
             LayoutElementBuilders.Arc.Builder()
                 .setAnchorAngle(
-                    DimensionBuilders.DegreesProp.Builder()
-                        .setValue(180f)
-                        .build()
+                    DimensionBuilders.DegreesProp.Builder(180f).build()
                 )
                 .addContent(
                     LayoutElementBuilders.ArcAdapter.Builder()
@@ -204,9 +202,7 @@ class TemplateTile : TileService() {
                                     .build()
                             )
                             is ForegroundColorSpan -> setColor(
-                                ColorBuilders.ColorProp.Builder()
-                                    .setArgb(span.foregroundColor)
-                                    .build()
+                                ColorBuilders.ColorProp.Builder(span.foregroundColor).build()
                             )
                             is RelativeSizeSpan -> {
                                 val defaultSize = 16 // https://developer.android.com/training/wearables/design/typography

--- a/wear/src/main/res/layout/view_loading.xml
+++ b/wear/src/main/res/layout/view_loading.xml
@@ -4,6 +4,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@android:color/black"
     android:gravity="center">
 
     <androidx.appcompat.widget.AppCompatTextView


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After bumping Kotlin/Compose dependencies in another big PR, this one bumps the remaining dependencies. More renaming for changed packages and a bug fix for loading during Wear onboarding included.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
androidx.wear:wear 1.3 updates the appearance of confirmation overlays for Wear to something more modern:

![image](https://github.com/home-assistant/android/assets/8148535/68ae8179-ca6c-4f07-a2cf-cdbb0345d636)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->