### PR TITLE
Thread updates: add border agent ID, multiserver improvements

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -48,10 +48,16 @@ interface ThreadManager {
     /**
      * Import a Thread dataset from the server to this device.
      * @param datasetId The dataset ID as provided by the server
+     * @param preferredBorderAgentId The ID for the border agent that provides the dataset
      * @throws Exception if a preferred dataset exists on the server, but it wasn't possible to
      * import it
      */
-    suspend fun importDatasetFromServer(context: Context, datasetId: String, serverId: Int)
+    suspend fun importDatasetFromServer(
+        context: Context,
+        datasetId: String,
+        preferredBorderAgentId: String?,
+        serverId: Int
+    )
 
     /**
      * Start a flow to get the preferred Thread dataset from this device to export to the server.

--- a/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -24,7 +24,12 @@ class ThreadManagerImpl @Inject constructor() : ThreadManager {
 
     override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? = null
 
-    override suspend fun importDatasetFromServer(context: Context, datasetId: String, serverId: Int) { }
+    override suspend fun importDatasetFromServer(
+        context: Context,
+        datasetId: String,
+        preferredBorderAgentId: String?,
+        serverId: Int
+    ) { }
 
     override suspend fun getPreferredDatasetFromDevice(context: Context): IntentSender? {
         throw IllegalStateException("Thread is not supported with the minimal flavor")

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -68,6 +68,12 @@ interface IntegrationRepository {
     suspend fun getLastUsedPipelineSttSupport(): Boolean
 
     suspend fun setLastUsedPipeline(pipelineId: String, supportsStt: Boolean)
+
+    /** @return List of border agent IDs added from the server to this device */
+    suspend fun getThreadBorderAgentIds(): List<String>
+
+    /** Set the list of border agent IDs added from the server to this device */
+    suspend fun setThreadBorderAgentIds(ids: List<String>)
 }
 
 @AssistedFactory

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -69,11 +69,17 @@ interface IntegrationRepository {
 
     suspend fun setLastUsedPipeline(pipelineId: String, supportsStt: Boolean)
 
-    /** @return List of border agent IDs added from the server to this device */
+    /** @return List of border agent IDs added to this device from the server */
     suspend fun getThreadBorderAgentIds(): List<String>
 
-    /** Set the list of border agent IDs added from the server to this device */
+    /** Set the list of border agent IDs added to this device from the server */
     suspend fun setThreadBorderAgentIds(ids: List<String>)
+
+    /** @return List of border agent IDs added to this device from a server that no longer exists */
+    suspend fun getOrphanedThreadBorderAgentIds(): List<String>
+
+    /** Clear the list of orphaned border agent IDs, to use after removing them from storage */
+    suspend fun clearOrphanedThreadBorderAgentIds()
 }
 
 @AssistedFactory

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -64,6 +64,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         private const val PREF_SEC_WARNING_NEXT = "sec_warning_last"
         private const val PREF_LAST_USED_PIPELINE_ID = "last_used_pipeline"
         private const val PREF_LAST_USED_PIPELINE_STT = "last_used_pipeline_stt"
+        private const val PREF_THREAD_BORDER_AGENT_IDS = "thread_border_agent_ids"
         private const val TAG = "IntegrationRepository"
         private const val RATE_LIMIT_URL = BuildConfig.RATE_LIMIT_URL
 
@@ -169,6 +170,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         localStorage.remove("${serverId}_$PREF_SEC_WARNING_NEXT")
         localStorage.remove("${serverId}_$PREF_LAST_USED_PIPELINE_ID")
         localStorage.remove("${serverId}_$PREF_LAST_USED_PIPELINE_STT")
+        // TODO Thread
         // app version and push token is device-specific
     }
 
@@ -563,6 +565,13 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
     override suspend fun setLastUsedPipeline(pipelineId: String, supportsStt: Boolean) {
         localStorage.putString("${serverId}_$PREF_LAST_USED_PIPELINE_ID", pipelineId)
         localStorage.putBoolean("${serverId}_$PREF_LAST_USED_PIPELINE_STT", supportsStt)
+    }
+
+    override suspend fun getThreadBorderAgentIds(): List<String> =
+        localStorage.getStringSet("${serverId}_$PREF_THREAD_BORDER_AGENT_IDS").orEmpty().toList()
+
+    override suspend fun setThreadBorderAgentIds(ids: List<String>) {
+        localStorage.putStringSet("${serverId}_$PREF_THREAD_BORDER_AGENT_IDS", ids.toSet())
     }
 
     override suspend fun getEntities(): List<Entity<Any>>? {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -56,6 +56,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
 
         private const val PREF_APP_VERSION = "app_version" // Note: _not_ server-specific
         private const val PREF_PUSH_TOKEN = "push_token" // Note: _not_ server-specific
+        private const val PREF_ORPHANED_THREAD_BORDER_AGENT_IDS = "orphaned_thread_border_agent_ids" // Note: _not_ server-specific
 
         private const val PREF_CHECK_SENSOR_REGISTRATION_NEXT = "sensor_reg_last"
         private const val PREF_SESSION_TIMEOUT = "session_timeout"
@@ -170,7 +171,15 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         localStorage.remove("${serverId}_$PREF_SEC_WARNING_NEXT")
         localStorage.remove("${serverId}_$PREF_LAST_USED_PIPELINE_ID")
         localStorage.remove("${serverId}_$PREF_LAST_USED_PIPELINE_STT")
-        // TODO Thread
+
+        // Thread credentials are managed in the app module and can't be deleted now, so store them
+        val threadBorderAgentIds = getThreadBorderAgentIds()
+        if (threadBorderAgentIds.any()) {
+            val orphanedBorderAgentIds = localStorage.getStringSet(PREF_ORPHANED_THREAD_BORDER_AGENT_IDS).orEmpty()
+            localStorage.putStringSet(PREF_ORPHANED_THREAD_BORDER_AGENT_IDS, orphanedBorderAgentIds + threadBorderAgentIds.toSet())
+        }
+        localStorage.remove("${serverId}_$PREF_THREAD_BORDER_AGENT_IDS")
+
         // app version and push token is device-specific
     }
 
@@ -572,6 +581,13 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
 
     override suspend fun setThreadBorderAgentIds(ids: List<String>) {
         localStorage.putStringSet("${serverId}_$PREF_THREAD_BORDER_AGENT_IDS", ids.toSet())
+    }
+
+    override suspend fun getOrphanedThreadBorderAgentIds(): List<String> =
+        localStorage.getStringSet(PREF_ORPHANED_THREAD_BORDER_AGENT_IDS).orEmpty().toList()
+
+    override suspend fun clearOrphanedThreadBorderAgentIds() {
+        localStorage.remove(PREF_ORPHANED_THREAD_BORDER_AGENT_IDS)
     }
 
     override suspend fun getEntities(): List<Entity<Any>>? {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
@@ -9,5 +9,6 @@ data class ThreadDatasetResponse(
     val networkName: String,
     val panId: String,
     val preferred: Boolean,
+    val preferredBorderAgentId: String?, // only on core >= 2023.9, may still be null
     val source: String
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Updates to the Thread credentials sync:
- Home Assistant core 2023.9 will expose the border agent ID for networks meaning we can finally move away from the placeholder ID if provided, otherwise continue using the placeholder ID.
- Improve multiserver handling. Because there is no UI provided by Play Services to select a Thread network to use, to prevent confusion the app needs to make sure only one HA credential is added. This means deleting orphaned/old credentials and credentials from other servers on sync, before adding the server preferred credential.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->