### PR TITLE
Use unavailable and unknown states consistently when dealing with sensors and entities

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -17,6 +17,7 @@ import com.google.android.gms.location.SleepSegmentRequest
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import java.util.concurrent.TimeUnit
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -168,8 +169,8 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             DetectedActivity.STILL -> "still"
             DetectedActivity.TILTING -> "tilting"
             DetectedActivity.WALKING -> "walking"
-            DetectedActivity.UNKNOWN -> "unknown"
-            else -> "unknown"
+            DetectedActivity.UNKNOWN -> STATE_UNKNOWN
+            else -> STATE_UNKNOWN
         }
     }
 
@@ -184,7 +185,7 @@ class ActivitySensorManager : BroadcastReceiver(), SensorManager {
             SleepSegmentEvent.STATUS_SUCCESSFUL -> "successful"
             SleepSegmentEvent.STATUS_MISSING_DATA -> "missing data"
             SleepSegmentEvent.STATUS_NOT_DETECTED -> "not detected"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
     }
 

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -9,6 +9,7 @@ import android.os.Build.VERSION.SDK_INT
 import android.util.Log
 import com.google.android.gms.location.LocationServices
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
@@ -132,7 +133,7 @@ class GeocodeSensorManager : SensorManager {
         onSensorUpdated(
             context,
             geocodedLocation,
-            if (!prettyAddress.isNullOrEmpty()) prettyAddress else "Unknown",
+            if (!prettyAddress.isNullOrEmpty()) prettyAddress else STATE_UNKNOWN,
             geocodedLocation.statelessIcon,
             attributes
         )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
@@ -15,6 +15,7 @@ import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -47,7 +48,7 @@ object CameraControl : HaControl {
         control.setControlTemplate(
             ThumbnailTemplate(
                 entity.entityId,
-                entity.state != "unavailable" && image != null,
+                entity.state != STATE_UNAVAILABLE && image != null,
                 icon,
                 context.getString(commonR.string.widget_camera_contentdescription)
             )

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -16,6 +16,8 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.vehicle.HaCarAppService
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -173,7 +175,7 @@ class CarSensorManager :
                         onSensorUpdated(
                             context,
                             it,
-                            "unavailable",
+                            STATE_UNAVAILABLE,
                             it.statelessIcon,
                             mapOf()
                         )
@@ -257,7 +259,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 fuelLevel,
-                if (fuelStatus == "success") data.fuelPercent.value!! else "unknown",
+                if (fuelStatus == "success") data.fuelPercent.value!! else STATE_UNKNOWN,
                 fuelLevel.statelessIcon,
                 mapOf(
                     "status" to fuelStatus
@@ -270,7 +272,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 batteryLevel,
-                if (batteryStatus == "success") data.batteryPercent.value!! else "unknown",
+                if (batteryStatus == "success") data.batteryPercent.value!! else STATE_UNKNOWN,
                 batteryLevel.statelessIcon,
                 mapOf(
                     "status" to batteryStatus
@@ -288,7 +290,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 carName,
-                if (status == "success") data.name.value!! else "unknown",
+                if (status == "success") data.name.value!! else STATE_UNKNOWN,
                 carName.statelessIcon,
                 mapOf(
                     "car_manufacturer" to data.manufacturer.value,
@@ -309,7 +311,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 carStatus,
-                if (status == "success") (data.evChargePortConnected.value == true) else "unknown",
+                if (status == "success") (data.evChargePortConnected.value == true) else STATE_UNKNOWN,
                 carStatus.statelessIcon,
                 mapOf(
                     "car_charge_port_open" to (data.evChargePortOpen.value == true),
@@ -329,7 +331,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 odometerValue,
-                if (status == "success") data.odometerMeters.value!! else "unknown",
+                if (status == "success") data.odometerMeters.value!! else STATE_UNKNOWN,
                 odometerValue.statelessIcon,
                 mapOf(
                     "status" to status
@@ -348,7 +350,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 fuelType,
-                if (fuelTypeStatus == "success") getFuelType(data.fuelTypes.value!!) else "unknown",
+                if (fuelTypeStatus == "success") getFuelType(data.fuelTypes.value!!) else STATE_UNKNOWN,
                 fuelType.statelessIcon,
                 mapOf(
                     "status" to fuelTypeStatus
@@ -360,7 +362,7 @@ class CarSensorManager :
             onSensorUpdated(
                 context,
                 evConnector,
-                if (evConnectorTypeStatus == "success") getEvConnectorType(data.evConnectorTypes.value!!) else "unknown",
+                if (evConnectorTypeStatus == "success") getEvConnectorType(data.evConnectorTypes.value!!) else STATE_UNKNOWN,
                 evConnector.statelessIcon,
                 mapOf(
                     "status" to evConnectorTypeStatus

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -375,8 +375,8 @@ class CarSensorManager :
     private fun carValueStatus(value: Int): String? {
         return when (value) {
             CarValue.STATUS_SUCCESS -> "success"
-            CarValue.STATUS_UNAVAILABLE -> "unavailable"
-            CarValue.STATUS_UNKNOWN -> "unknown"
+            CarValue.STATUS_UNAVAILABLE -> STATE_UNAVAILABLE
+            CarValue.STATUS_UNKNOWN -> STATE_UNKNOWN
             CarValue.STATUS_UNIMPLEMENTED -> "unimplemented"
             else -> null
         }
@@ -397,9 +397,9 @@ class CarSensorManager :
                 EnergyProfile.FUEL_TYPE_LNG -> "Liquified natural gas"
                 EnergyProfile.FUEL_TYPE_LPG -> "Liquified petroleum gas"
                 EnergyProfile.FUEL_TYPE_OTHER -> "Other"
-                EnergyProfile.FUEL_TYPE_UNKNOWN -> "unknown"
+                EnergyProfile.FUEL_TYPE_UNKNOWN -> STATE_UNKNOWN
                 EnergyProfile.FUEL_TYPE_UNLEADED -> "Unleaded gasoline"
-                else -> "unknown"
+                else -> STATE_UNKNOWN
             }
         }
         return fuelTypeList.toString()
@@ -421,8 +421,8 @@ class CarSensorManager :
                 EnergyProfile.EVCONNECTOR_TYPE_TESLA_HPWC -> "High Power Wall Charger of Tesla"
                 EnergyProfile.EVCONNECTOR_TYPE_TESLA_ROADSTER -> "Connector of Tesla Roadster"
                 EnergyProfile.EVCONNECTOR_TYPE_TESLA_SUPERCHARGER -> "Supercharger of Tesla"
-                EnergyProfile.EVCONNECTOR_TYPE_UNKNOWN -> "unknown"
-                else -> "unknown"
+                EnergyProfile.EVCONNECTOR_TYPE_UNKNOWN -> STATE_UNKNOWN
+                else -> STATE_UNKNOWN
             }
         }
         return evConnectorList.toString()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/LastAppSensorManager.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.R as commonR
 
 class LastAppSensorManager : SensorManager {
@@ -64,7 +65,7 @@ class LastAppSensorManager : SensorManager {
         val current = System.currentTimeMillis()
         val lastApp = usageStats.queryUsageStats(UsageStatsManager.INTERVAL_DAILY, current - 1000 * 1000, current).maxByOrNull { it.lastTimeUsed }?.packageName ?: "none"
 
-        var appLabel = "unknown"
+        var appLabel = STATE_UNKNOWN
 
         try {
             val pm = context.packageManager

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -17,6 +17,7 @@ import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -266,7 +267,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         val mediaSessionManager = context.getSystemService<MediaSessionManager>()!!
         val mediaList = mediaSessionManager.getActiveSessions(ComponentName(context, NotificationSensorManager::class.java))
         val sessionCount = mediaList.size
-        val primaryPlaybackState = if (sessionCount > 0) getPlaybackState(mediaList[0].playbackState?.state) else "Unavailable"
+        val primaryPlaybackState = if (sessionCount > 0) getPlaybackState(mediaList[0].playbackState?.state) else STATE_UNAVAILABLE
         val attr: MutableMap<String, Any?> = mutableMapOf()
         if (mediaList.size > 0) {
             for (item in mediaList) {

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -18,6 +18,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -307,7 +308,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             PlaybackState.STATE_SKIPPING_TO_NEXT -> "Skip to Next"
             PlaybackState.STATE_SKIPPING_TO_PREVIOUS -> "Skip to Previous"
             PlaybackState.STATE_SKIPPING_TO_QUEUE_ITEM -> "Skip to Queue Item"
-            else -> "Unknown"
+            else -> STATE_UNKNOWN
         }
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/AndroidOsSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/AndroidOsSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.sensors
 
 import android.content.Context
 import android.os.Build
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.R as commonR
 
 class AndroidOsSensorManager : SensorManager {
@@ -67,10 +68,10 @@ class AndroidOsSensorManager : SensorManager {
                 osSecurityPatch.id -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                     Build.VERSION.SECURITY_PATCH
                 } else {
-                    "unknown"
+                    STATE_UNKNOWN
                 }
                 else -> {
-                    "unknown"
+                    STATE_UNKNOWN
                 }
             },
             sensor.statelessIcon,

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/AudioSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/AudioSensorManager.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.R as commonR
 
 class AudioSensorManager : SensorManager {
@@ -187,7 +188,7 @@ class AudioSensorManager : SensorManager {
             AudioManager.RINGER_MODE_NORMAL -> "normal"
             AudioManager.RINGER_MODE_SILENT -> "silent"
             AudioManager.RINGER_MODE_VIBRATE -> "vibrate"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
 
         val icon = when (audioManager.ringerMode) {
@@ -216,7 +217,7 @@ class AudioSensorManager : SensorManager {
             AudioManager.MODE_IN_CALL -> "in_call"
             AudioManager.MODE_IN_COMMUNICATION -> "in_communication"
             AudioManager.MODE_CALL_SCREENING -> "call_screening"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
 
         val icon = when (audioManager.mode) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import java.math.RoundingMode
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -314,7 +315,7 @@ class BatterySensorManager : SensorManager {
             BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
             BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
             BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
     }
 
@@ -326,7 +327,7 @@ class BatterySensorManager : SensorManager {
             BatteryManager.BATTERY_HEALTH_OVERHEAT -> "overheated"
             BatteryManager.BATTERY_HEALTH_OVER_VOLTAGE -> "over_voltage"
             BatteryManager.BATTERY_HEALTH_UNSPECIFIED_FAILURE -> "failed"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.bluetooth.ble.KalmanFilter
 import io.homeassistant.companion.android.common.bluetooth.ble.MonitoringManager
 import io.homeassistant.companion.android.common.bluetooth.ble.TransmitterManager
 import io.homeassistant.companion.android.common.bluetooth.ble.name
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
@@ -353,7 +354,7 @@ class BluetoothSensorManager : SensorManager {
             TransmitterManager.stopTransmitting(bleTransmitterDevice)
         }
 
-        val lastState = AppDatabase.getInstance(context).sensorDao().get(bleTransmitter.id).firstOrNull()?.state ?: "unknown"
+        val lastState = AppDatabase.getInstance(context).sensorDao().get(bleTransmitter.id).firstOrNull()?.state ?: STATE_UNKNOWN
         val state = if (isBtOn(context)) bleTransmitterDevice.state else "Bluetooth is turned off"
         val icon = if (bleTransmitterDevice.transmitting) "mdi:bluetooth" else "mdi:bluetooth-off"
         onSensorUpdated(

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DNDSensorManager.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.R as commonR
 
 @RequiresApi(Build.VERSION_CODES.M)
@@ -67,8 +68,8 @@ class DNDSensorManager : SensorManager {
             NotificationManager.INTERRUPTION_FILTER_ALL -> "off"
             NotificationManager.INTERRUPTION_FILTER_NONE -> "total_silence"
             NotificationManager.INTERRUPTION_FILTER_PRIORITY -> "priority_only"
-            NotificationManager.INTERRUPTION_FILTER_UNKNOWN -> "unknown"
-            else -> "unknown"
+            NotificationManager.INTERRUPTION_FILTER_UNKNOWN -> STATE_UNKNOWN
+            else -> STATE_UNKNOWN
         }
 
         onSensorUpdated(

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastRebootSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/LastRebootSensorManager.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.SystemClock
 import android.util.Log
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
@@ -62,7 +63,7 @@ class LastRebootSensorManager : SensorManager {
 
         var timeInMillis = 0L
         var local = ""
-        var utc = "unavailable"
+        var utc = STATE_UNAVAILABLE
 
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
         val fullSensor = sensorDao.getFull(lastRebootSensor.id).toSensorWithAttributes()

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -11,6 +11,8 @@ import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
@@ -188,7 +190,7 @@ class NetworkSensorManager : SensorManager {
         }
 
         var conInfo: WifiInfo? = null
-        var ssid = "Unknown"
+        var ssid = STATE_UNKNOWN
         var connected = false
 
         if (checkPermission(context, wifiConnection.id)) {
@@ -272,7 +274,7 @@ class NetworkSensorManager : SensorManager {
             return
         }
 
-        var deviceIp = "Unknown"
+        var deviceIp = STATE_UNKNOWN
 
         if (checkPermission(context, wifiIp.id)) {
             val conInfo = getWifiConnectionInfo(context)
@@ -445,7 +447,7 @@ class NetworkSensorManager : SensorManager {
             return
         }
 
-        var ip = "unknown"
+        var ip = STATE_UNKNOWN
         val client = OkHttpClient()
         val request = Request.Builder().url("https://api.ipify.org?format=json").build()
 
@@ -485,7 +487,7 @@ class NetworkSensorManager : SensorManager {
         val activeNetwork = connectivityManager?.activeNetwork
         val capabilities = connectivityManager?.getNetworkCapabilities(activeNetwork)
 
-        var networkCapability = "unavailable"
+        var networkCapability = STATE_UNAVAILABLE
         var metered = false
         if (capabilities != null) {
             networkCapability =

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -500,7 +500,7 @@ class NetworkSensorManager : SensorManager {
                     (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) -> "vpn"
                     (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) -> "wifi"
                     (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) -> "wifi_aware"
-                    else -> "unknown"
+                    else -> STATE_UNKNOWN
                 }
 
             metered = !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED)

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NextAlarmManager.kt
@@ -6,6 +6,8 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
@@ -68,7 +70,7 @@ class NextAlarmManager : SensorManager {
 
         var triggerTime = 0L
         var local = ""
-        var utc = "unavailable"
+        var utc = STATE_UNAVAILABLE
         var pendingIntent = ""
 
         val sensorDao = AppDatabase.getInstance(context).sensorDao()
@@ -81,7 +83,7 @@ class NextAlarmManager : SensorManager {
             val alarmClockInfo = alarmManager.nextAlarmClock
 
             if (alarmClockInfo != null) {
-                pendingIntent = alarmClockInfo.showIntent?.creatorPackage ?: "Unknown"
+                pendingIntent = alarmClockInfo.showIntent?.creatorPackage ?: STATE_UNKNOWN
                 triggerTime = alarmClockInfo.triggerTime
 
                 Log.d(TAG, "Next alarm is scheduled by $pendingIntent with trigger time $triggerTime")

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -10,6 +10,8 @@ import android.telephony.SubscriptionManager
 import android.telephony.TelephonyManager
 import android.util.Log
 import androidx.core.content.getSystemService
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.R as commonR
 
 class PhoneStateSensorManager : SensorManager {
@@ -78,7 +80,7 @@ class PhoneStateSensorManager : SensorManager {
     @SuppressLint("MissingPermission")
     private fun checkPhoneState(context: Context) {
         if (isEnabled(context, phoneState)) {
-            var currentPhoneState = "unknown"
+            var currentPhoneState = STATE_UNKNOWN
 
             if (checkPermission(context, phoneState.id)) {
                 val telephonyManager =
@@ -90,7 +92,7 @@ class PhoneStateSensorManager : SensorManager {
                     TelephonyManager.CALL_STATE_IDLE -> "idle"
                     TelephonyManager.CALL_STATE_RINGING -> "ringing"
                     TelephonyManager.CALL_STATE_OFFHOOK -> "offhook"
-                    else -> "unknown"
+                    else -> STATE_UNKNOWN
                 }
             }
 
@@ -124,7 +126,7 @@ class PhoneStateSensorManager : SensorManager {
             return
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            var displayName = "Unavailable"
+            var displayName = STATE_UNAVAILABLE
             val attrs = mutableMapOf<String, Any>()
 
             if (checkPermission(context, basicSimSensor.id)) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/util/States.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/util/States.kt
@@ -1,0 +1,4 @@
+package io.homeassistant.companion.android.common.util
+
+const val STATE_UNAVAILABLE = "unavailable"
+const val STATE_UNKNOWN = "unknown"

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -27,6 +27,7 @@ import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.integration.isActive
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.WearToggleChip
 import io.homeassistant.companion.android.util.onEntityClickedFeedback
@@ -59,7 +60,7 @@ fun EntityUi(
                 .fillMaxWidth(),
             appIcon = {
                 Image(
-                    asset = iconBitmap ?: CommunityMaterial.Icon.cmd_bookmark,
+                    asset = iconBitmap,
                     colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
                 )
             },
@@ -87,7 +88,7 @@ fun EntityUi(
                     }
                 )
             },
-            enabled = entity.state != "unavailable",
+            enabled = entity.state != STATE_UNAVAILABLE,
             toggleControl = {
                 Icon(
                     imageVector = ToggleChipDefaults.switchIcon(isChecked),
@@ -106,7 +107,7 @@ fun EntityUi(
                 .fillMaxWidth(),
             icon = {
                 Image(
-                    asset = iconBitmap ?: CommunityMaterial.Icon.cmd_bookmark,
+                    asset = iconBitmap,
                     colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
                 )
             },
@@ -134,7 +135,7 @@ fun EntityUi(
                     }
                 )
             },
-            enabled = entity.state != "unavailable",
+            enabled = entity.state != STATE_UNAVAILABLE,
             onClick = {
                 onEntityClicked(entity.entityId, entity.state)
                 onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, friendlyName, haptic)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -20,7 +20,6 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleChip
 import androidx.wear.compose.material.ToggleChipDefaults
 import com.mikepenz.iconics.compose.Image
-import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -35,6 +35,7 @@ import androidx.wear.compose.material.Text
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.wearColorPalette
@@ -107,7 +108,7 @@ fun MainView(
                                         )
                                     },
                                     onClick = {
-                                        onEntityClicked(favoriteEntityID, "unknown")
+                                        onEntityClicked(favoriteEntityID, STATE_UNKNOWN)
                                         onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, favoriteEntityID, haptic)
                                     },
                                     colors = ChipDefaults.secondaryChipColors()

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -20,6 +20,7 @@ import androidx.health.services.client.data.PassiveMonitoringCapabilities
 import androidx.health.services.client.data.UserActivityInfo
 import androidx.health.services.client.data.UserActivityState
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.database.AppDatabase
 import kotlinx.coroutines.guava.await
 import kotlinx.coroutines.runBlocking
@@ -199,7 +200,7 @@ class HealthServicesSensorManager : SensorManager {
                         UserActivityState.USER_ACTIVITY_ASLEEP -> "asleep"
                         UserActivityState.USER_ACTIVITY_PASSIVE -> "passive"
                         UserActivityState.USER_ACTIVITY_EXERCISE -> "exercise"
-                        else -> "unknown"
+                        else -> STATE_UNKNOWN
                     },
                     getActivityIcon(info),
                     mapOf(

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -15,6 +15,7 @@ import android.hardware.SensorManager.SENSOR_STATUS_UNRELIABLE
 import android.util.Log
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import kotlin.math.roundToInt
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -135,7 +136,7 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
             SENSOR_STATUS_ACCURACY_LOW -> "low"
             SENSOR_STATUS_UNRELIABLE -> "unreliable"
             SENSOR_STATUS_NO_CONTACT -> "no_contact"
-            else -> "unknown"
+            else -> STATE_UNKNOWN
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Breaking change: `Unavailable` is now `unavailable` and `Unknown` is now `unknown` for all sensors that report those states. Phone SIM, Next Alarm, Media Session, Geocoded location

- Noticed in a few places our casing was off causing issues in the frontend not showing unavailable entities properly
- Use a consistent variable in all places where we send or evaluate the state to avoid mistakes. In some places this is kept for function consistency purposes like when comparing multiple states.


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/home-assistant/android/assets/1634145/286cd7ff-bb2b-468b-bf33-07679ec7b6cf)

![image](https://github.com/home-assistant/android/assets/1634145/02a0d92d-b360-4040-bccd-ac9aa5197f2b)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->