### PR TITLE
Fix Thread border agent IDs encoded as hex

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -252,8 +252,10 @@ class ThreadManagerImpl @Inject constructor(
         serverManager.integrationRepository(serverId).clearOrphanedThreadBorderAgentIds()
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     private suspend fun deleteThreadCredential(context: Context, borderAgentId: String) = suspendCoroutine { cont ->
-        val threadBorderAgent = ThreadBorderAgent.newBuilder(borderAgentId.toByteArray()).build()
+        val idAsBytes = borderAgentId.let { if (it.length == 16) it.toByteArray() else it.hexToByteArray() }
+        val threadBorderAgent = ThreadBorderAgent.newBuilder(idAsBytes).build()
         ThreadNetwork.getClient(context)
             .removeCredentials(threadBorderAgent)
             .addOnSuccessListener { cont.resume(true) }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Core border agent IDs use a hex-encoded string (length 32), whereas the app assumed 'normal' strings (length 16). Check to make sure we use the correct conversion.

Fixes:

```
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: Thread update device failed
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: java.lang.IllegalArgumentException: Invalid length of the ID (length = 32, expectedLength = 16)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at com.google.android.gms.common.internal.Preconditions.checkArgument(com.google.android.gms:play-services-basement@@18.1.0:3)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at com.google.android.gms.threadnetwork.ThreadBorderAgent$Builder.<init>(com.google.android.gms:play-services-threadnetwork@@16.0.0:1)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at com.google.android.gms.threadnetwork.ThreadBorderAgent.newBuilder(com.google.android.gms:play-services-threadnetwork@@16.0.0:1)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at io.homeassistant.companion.android.thread.ThreadManagerImpl.importDatasetFromServer(ThreadManagerImpl.kt:175)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at io.homeassistant.companion.android.thread.ThreadManagerImpl$importDatasetFromServer$1.invokeSuspend(Unknown Source:18)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:32)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at android.os.Handler.handleCallback(Handler.java:942)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at android.os.Handler.dispatchMessage(Handler.java:99)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at android.os.Looper.loopOnce(Looper.java:201)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at android.os.Looper.loop(Looper.java:288)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at android.app.ActivityThread.main(ActivityThread.java:7918)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at java.lang.reflect.Method.invoke(Native Method)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
08-28 22:33:07.782 19429 19429 E ThreadManagerImpl: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->