### PR TITLE
Fix Thread border agent IDs encoded as hex second instance

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -158,6 +158,7 @@ class ThreadManagerImpl @Inject constructor(
     override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? =
         getDatasetsFromServer(serverId)?.firstOrNull { it.preferred }
 
+    @OptIn(ExperimentalStdlibApi::class)
     override suspend fun importDatasetFromServer(
         context: Context,
         datasetId: String,
@@ -172,7 +173,8 @@ class ThreadManagerImpl @Inject constructor(
                     BORDER_AGENT_ID
                 }
                 ).toByteArray()
-            val threadBorderAgent = ThreadBorderAgent.newBuilder(borderAgentId).build()
+            val idAsBytes = borderAgentId.let { if (it.length == 16) it.toByteArray() else it.hexToByteArray() }
+            val threadBorderAgent = ThreadBorderAgent.newBuilder(idAsBytes).build()
             val threadNetworkCredentials = ThreadNetworkCredentials.fromActiveOperationalDataset(tlv)
             suspendCoroutine { cont ->
                 ThreadNetwork.getClient(context).addCredentials(threadBorderAgent, threadNetworkCredentials)

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -168,9 +168,9 @@ class ThreadManagerImpl @Inject constructor(
         val tlv = serverManager.webSocketRepository(serverId).getThreadDatasetTlv(datasetId)?.tlvAsByteArray
         if (tlv != null) {
             val borderAgentId = preferredBorderAgentId ?: run {
-                    Log.w(TAG, "Adding dataset with placeholder border agent ID")
-                    BORDER_AGENT_ID
-                }
+                Log.w(TAG, "Adding dataset with placeholder border agent ID")
+                BORDER_AGENT_ID
+            }
             val idAsBytes = borderAgentId.let { if (it.length == 16) it.toByteArray() else it.hexToByteArray() }
             val threadBorderAgent = ThreadBorderAgent.newBuilder(idAsBytes).build()
             val threadNetworkCredentials = ThreadNetworkCredentials.fromActiveOperationalDataset(tlv)

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -167,12 +167,10 @@ class ThreadManagerImpl @Inject constructor(
     ) {
         val tlv = serverManager.webSocketRepository(serverId).getThreadDatasetTlv(datasetId)?.tlvAsByteArray
         if (tlv != null) {
-            val borderAgentId = (
-                preferredBorderAgentId ?: run {
+            val borderAgentId = preferredBorderAgentId ?: run {
                     Log.w(TAG, "Adding dataset with placeholder border agent ID")
                     BORDER_AGENT_ID
                 }
-                ).toByteArray()
             val idAsBytes = borderAgentId.let { if (it.length == 16) it.toByteArray() else it.hexToByteArray() }
             val threadBorderAgent = ThreadBorderAgent.newBuilder(idAsBytes).build()
             val threadNetworkCredentials = ThreadNetworkCredentials.fromActiveOperationalDataset(tlv)


### PR DESCRIPTION
## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Core border agent IDs use a hex-encoded string (length 32), whereas the app assumed 'normal' strings (length 16). Check to make sure we use the correct conversion when adding new new dataset as well.

```
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: Thread update device failed
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: java.lang.IllegalArgumentException: Invalid length of the ID (length = 32, expectedLength = 16)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at com.google.android.gms.common.internal.Preconditions.checkArgument(com.google.android.gms:play-services-basement@@18.1.0:3)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at com.google.android.gms.threadnetwork.ThreadBorderAgent$Builder.<init>(com.google.android.gms:play-services-threadnetwork@@16.0.0:1)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at com.google.android.gms.threadnetwork.ThreadBorderAgent.newBuilder(com.google.android.gms:play-services-threadnetwork@@16.0.0:1)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at io.homeassistant.companion.android.thread.ThreadManagerImpl.importDatasetFromServer(ThreadManagerImpl.kt:175)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at io.homeassistant.companion.android.thread.ThreadManagerImpl$importDatasetFromServer$1.invokeSuspend(Unknown Source:18)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at kotlinx.coroutines.internal.ScopeCoroutine.afterResume(Scopes.kt:32)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at kotlinx.coroutines.AbstractCoroutine.resumeWith(AbstractCoroutine.kt:102)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:46)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:108)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at android.os.Handler.handleCallback(Handler.java:942)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at android.os.Handler.dispatchMessage(Handler.java:99)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at android.os.Looper.loopOnce(Looper.java:201)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at android.os.Looper.loop(Looper.java:288)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at android.app.ActivityThread.main(ActivityThread.java:7918)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at java.lang.reflect.Method.invoke(Native Method)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
09-01 08:33:24.959 26648 26648 E ThreadManagerImpl: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->