### PR TITLE
Fix Duplicate Biometric prompts

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -207,6 +207,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     private var firstAuthTime: Long = 0
     private var resourceURL: String = ""
     private var appLocked = true
+    private var unlockingApp = false
     private var exoPlayer: ExoPlayer? = null
     private var isExoFullScreen = false
     private var exoTop = 0 // These margins are from the DOM and scaled to screen
@@ -1025,6 +1026,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
             else -> Log.d(TAG, "Authentication failed, retry attempts allowed")
         }
+        unlockingApp = false
     }
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
@@ -1053,7 +1055,10 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         appLocked = presenter.isAppLocked()
         if (appLocked) {
             binding.blurView.setBlurEnabled(true)
-            authenticator.authenticate(getString(commonR.string.biometric_title))
+            if (!unlockingApp) {
+                authenticator.authenticate(getString(commonR.string.biometric_title))
+            }
+            unlockingApp = true
         } else {
             binding.blurView.setBlurEnabled(false)
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Check if there's a pending unlock action before triggering a (new) biometric prompt to unlock the app. 

Fix for #2222.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This is definately a workaround, but as we have no influence on the `onWindowFocusChanged` calls being produced it seems to be a necessary one.