### PR TITLE
Thread sync BA ID troubleshooting updates

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -114,6 +114,7 @@ class ThreadManagerImpl @Inject constructor(
                                         }
                                     )
                                 }
+                                Log.d(TAG, "Thread update device completed: deleted ${localIds.size} datasets, updated 1")
                                 true
                             } else { // Core prefers imported from other app, this shouldn't be managed by HA
                                 localIds.forEach { baId ->
@@ -126,9 +127,9 @@ class ThreadManagerImpl @Inject constructor(
                                 serverManager.defaultServers.forEach {
                                     serverManager.integrationRepository(it.id).setThreadBorderAgentIds(emptyList())
                                 }
+                                Log.d(TAG, "Thread update device completed: deleted ${localIds.size} datasets")
                                 false
                             }
-                            Log.d(TAG, "Thread update device completed")
                         } catch (e: Exception) {
                             Log.e(TAG, "Thread update device failed", e)
                         }

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -211,7 +211,13 @@ class ThreadManagerImpl @Inject constructor(
                 .addOnFailureListener { cont.resume(null) }
         }
         return try {
-            appCredentials?.any { isPreferredCredentials(context, it) } ?: false
+            appCredentials?.any {
+                val isPreferred = isPreferredCredentials(context, it)
+                if (isPreferred) {
+                    Log.d(TAG, "Thread device prefers app added dataset: ${it.networkName} (PAN ${it.panId}, EXTPAN ${it.extendedPanId})")
+                }
+                isPreferred
+            } ?: false
         } catch (e: Exception) {
             Log.e(TAG, "Thread app added credentials preferred check failed", e)
             false

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -239,7 +239,7 @@ class ThreadManagerImpl @Inject constructor(
     }
 
     private suspend fun deleteOrphanedThreadCredentials(context: Context, serverId: Int) {
-        val orphanedCredentials = serverManager.integrationRepository(serverId).getThreadBorderAgentIds()
+        val orphanedCredentials = serverManager.integrationRepository(serverId).getOrphanedThreadBorderAgentIds()
         if (orphanedCredentials.isEmpty()) return
 
         orphanedCredentials.forEach {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A few changes to improve troubleshooting sync with border agent IDs.

- Always try to delete border agent with ID `0000000000000001` before syncing if all servers are updated to 2023.9 or later
- Adding a log statement for app preferred dataset with name, PAN ID and extended PAN ID to help with troubleshooting
- More detailed log statement for app dataset update with details to match UI
- Fixing a bug that might be deleting more datasets on sync than intended

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->