### PR TITLE
Add Android 14 device controls panel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -243,7 +243,7 @@
             android:exported="true"
             android:resizeableActivity="true"
             android:taskAffinity="io.homeassistant.companion.android.controls"
-            android:enabled="true" />
+            android:enabled="false" />
 
         <receiver
             android:name=".sensors.LocationSensorManager"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -230,10 +230,20 @@
         <service android:name=".controls.HaControlsProviderService"
             android:permission="android.permission.BIND_CONTROLS"
             android:exported="true">
+            <meta-data
+                android:name="android.service.controls.META_DATA_PANEL_ACTIVITY"
+                android:value="${applicationId}/io.homeassistant.companion.android.controls.HaControlsPanelActivity" />
             <intent-filter>
                 <action android:name="android.service.controls.ControlsProviderService"/>
             </intent-filter>
         </service>
+
+        <activity android:name=".controls.HaControlsPanelActivity"
+            android:permission="android.permission.BIND_CONTROLS"
+            android:exported="true"
+            android:resizeableActivity="true"
+            android:taskAffinity="io.homeassistant.companion.android.controls"
+            android:enabled="true" />
 
         <receiver
             android:name=".sensors.LocationSensorManager"

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -15,9 +15,15 @@ class HaControlsPanelActivity : AppCompatActivity() {
                 context = this,
                 path = null,
                 serverId = null
-            )
+            ).apply {
+                putExtra(WebViewActivity.EXTRA_SHOW_WHEN_LOCKED, true)
+            }
         )
+        // finish() is in onPause to prevent lockscreen flickering
+    }
+
+    override fun onPause() {
+        super.onPause()
         finish()
-        overridePendingTransition(0, 0) // Disable activity start/stop animation
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -1,0 +1,23 @@
+package io.homeassistant.companion.android.controls
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.webview.WebViewActivity
+
+@AndroidEntryPoint
+class HaControlsPanelActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        startActivity(
+            WebViewActivity.newInstance(
+                context = this,
+                path = null,
+                serverId = null
+            )
+        )
+        finish()
+        overridePendingTransition(0, 0) // Disable activity start/stop animation
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -2,28 +2,40 @@ package io.homeassistant.companion.android.controls
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.webview.WebViewActivity
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class HaControlsPanelActivity : AppCompatActivity() {
 
+    @Inject
+    lateinit var serverManager: ServerManager
+
+    @Inject
+    lateinit var prefsRepository: PrefsRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        startActivity(
-            WebViewActivity.newInstance(
-                context = this,
-                path = null,
-                serverId = null
-            ).apply {
-                putExtra(WebViewActivity.EXTRA_SHOW_WHEN_LOCKED, true)
-            }
-        )
-        // finish() is in onPause to prevent lockscreen flickering
-    }
+        if (!serverManager.isRegistered()) return
 
-    override fun onPause() {
-        super.onPause()
-        finish()
+        lifecycleScope.launch {
+            val serverId = prefsRepository.getControlsPanelServer() ?: serverManager.getServer()?.id
+            val path = prefsRepository.getControlsPanelPath()
+            startActivity(
+                WebViewActivity.newInstance(
+                    context = this@HaControlsPanelActivity,
+                    path = path,
+                    serverId = serverId
+                ).apply {
+                    putExtra(WebViewActivity.EXTRA_SHOW_WHEN_LOCKED, true)
+                }
+            )
+            finish()
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -171,6 +171,10 @@ class SettingsFragment(
             return@setOnPreferenceClickListener true
         }
 
+        val isAutomotive =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+
         if (Build.MODEL != "Quest") {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
                 findPreference<PreferenceCategory>("shortcuts")?.let {
@@ -198,7 +202,7 @@ class SettingsFragment(
                 }
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (!isAutomotive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 findPreference<PreferenceCategory>("device_controls")?.let {
                     it.isVisible = true
                 }
@@ -325,7 +329,6 @@ class SettingsFragment(
             return@setOnPreferenceClickListener true
         }
 
-        val isAutomotive = requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
         findPreference<PreferenceCategory>("android_auto")?.let {
             it.isVisible =
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && (BuildConfig.FLAVOR == "full" || isAutomotive)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -172,8 +172,7 @@ class SettingsFragment(
         }
 
         val isAutomotive =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
         if (Build.MODEL != "Quest") {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
@@ -41,12 +41,14 @@ class ManageControlsSettingsFragment : Fragment() {
                         authRequiredList = viewModel.authRequiredList,
                         entitiesLoaded = viewModel.entitiesLoaded,
                         entitiesList = viewModel.entitiesList,
+                        panelSetting = viewModel.panelSetting,
                         serversList = serverManager.defaultServers,
                         defaultServer = serverManager.getServer()?.id ?: 0,
                         onSetPanelEnabled = viewModel::enablePanelForControls,
                         onSelectAll = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.NONE) },
                         onSelectNone = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.ALL) },
-                        onSelectEntity = { entityId, serverId -> viewModel.toggleAuthForEntity(entityId, serverId) }
+                        onSelectEntity = { entityId, serverId -> viewModel.toggleAuthForEntity(entityId, serverId) },
+                        onSetPanelSetting = { path, serverId -> viewModel.setPanelConfig(path, serverId) }
                     )
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
@@ -36,12 +36,14 @@ class ManageControlsSettingsFragment : Fragment() {
             setContent {
                 MdcTheme {
                     ManageControlsView(
+                        panelEnabled = viewModel.panelEnabled,
                         authSetting = viewModel.authRequired,
                         authRequiredList = viewModel.authRequiredList,
                         entitiesLoaded = viewModel.entitiesLoaded,
                         entitiesList = viewModel.entitiesList,
                         serversList = serverManager.defaultServers,
                         defaultServer = serverManager.getServer()?.id ?: 0,
+                        onSetPanelEnabled = viewModel::enablePanelForControls,
                         onSelectAll = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.NONE) },
                         onSelectNone = { viewModel.setAuthSetting(ControlsAuthRequiredSetting.ALL) },
                         onSelectEntity = { entityId, serverId -> viewModel.toggleAuthForEntity(entityId, serverId) }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
@@ -1,21 +1,30 @@
 package io.homeassistant.companion.android.settings.controls.views
 
+import android.os.Build
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
+import androidx.compose.material.Divider
 import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
+import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -25,12 +34,19 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.util.compose.ServerExposedDropdownMenu
 import io.homeassistant.companion.android.util.compose.getEntityDomainString
@@ -38,89 +54,127 @@ import io.homeassistant.companion.android.common.R as commonR
 
 @Composable
 fun ManageControlsView(
+    panelEnabled: Boolean,
     authSetting: ControlsAuthRequiredSetting,
     authRequiredList: List<String>,
     entitiesLoaded: Boolean,
     entitiesList: Map<Int, List<Entity<*>>>,
     serversList: List<Server>,
     defaultServer: Int,
+    onSetPanelEnabled: (Boolean) -> Unit,
     onSelectAll: () -> Unit,
     onSelectNone: () -> Unit,
     onSelectEntity: (String, Int) -> Unit
 ) {
     var selectedServer by remember { mutableStateOf(defaultServer) }
     LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
-        item {
-            Text(
-                text = stringResource(commonR.string.controls_setting_choose_setting),
-                modifier = Modifier.padding(horizontal = 16.dp)
-            )
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            item {
+                Text(
+                    text = stringResource(commonR.string.controls_setting_panel),
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+            item {
+                Row(
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp)
+                        .padding(top = 16.dp, bottom = 48.dp)
+                        .height(IntrinsicSize.Min)
+                ) {
+                    ManageControlsModeButton(
+                        isPanel = false,
+                        selected = !panelEnabled,
+                        onClick = { onSetPanelEnabled(false) },
+                        modifier = Modifier.weight(0.5f)
+                    )
+                    Divider(
+                        modifier = Modifier.fillMaxHeight().width(1.dp)
+                    )
+                    ManageControlsModeButton(
+                        isPanel = true,
+                        selected = panelEnabled,
+                        onClick = { onSetPanelEnabled(true) },
+                        modifier = Modifier.weight(0.5f)
+                    )
+                }
+            }
         }
-        if (entitiesLoaded) {
-            if (entitiesList.isNotEmpty()) {
-                item {
-                    Row(modifier = Modifier.padding(all = 16.dp)) {
-                        OutlinedButton(
-                            onClick = onSelectAll,
-                            enabled = authSetting !== ControlsAuthRequiredSetting.NONE,
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(stringResource(commonR.string.controls_setting_choose_all))
-                        }
-                        Spacer(modifier = Modifier.width(16.dp))
-                        OutlinedButton(
-                            onClick = onSelectNone,
-                            enabled = authSetting !== ControlsAuthRequiredSetting.ALL,
-                            modifier = Modifier.weight(1f)
-                        ) {
-                            Text(stringResource(commonR.string.controls_setting_choose_none))
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE || !panelEnabled) {
+            item {
+                Text(
+                    text = stringResource(commonR.string.controls_setting_choose_setting),
+                    modifier = Modifier.padding(horizontal = 16.dp)
+                )
+            }
+            if (entitiesLoaded) {
+                if (entitiesList.isNotEmpty()) {
+                    item {
+                        Row(modifier = Modifier.padding(all = 16.dp)) {
+                            OutlinedButton(
+                                onClick = onSelectAll,
+                                enabled = authSetting !== ControlsAuthRequiredSetting.NONE,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(stringResource(commonR.string.controls_setting_choose_all))
+                            }
+                            Spacer(modifier = Modifier.width(16.dp))
+                            OutlinedButton(
+                                onClick = onSelectNone,
+                                enabled = authSetting !== ControlsAuthRequiredSetting.ALL,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Text(stringResource(commonR.string.controls_setting_choose_none))
+                            }
                         }
                     }
-                }
-                if (serversList.size > 1) {
+                    if (serversList.size > 1) {
+                        item {
+                            ServerExposedDropdownMenu(
+                                servers = serversList,
+                                current = selectedServer,
+                                onSelected = { selectedServer = it },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                            )
+                        }
+                    }
+                    items(entitiesList[selectedServer]?.size ?: 0, key = { "$selectedServer.${entitiesList[selectedServer]?.get(it)?.entityId}" }) { index ->
+                        val entity = entitiesList[selectedServer]?.get(index) ?: return@items
+                        ManageControlsEntity(
+                            entityName = entity.friendlyName,
+                            entityDomain = entity.domain,
+                            selected = (
+                                authSetting == ControlsAuthRequiredSetting.NONE ||
+                                    (
+                                        authSetting == ControlsAuthRequiredSetting.SELECTION &&
+                                            !authRequiredList.contains("$selectedServer.${entity.entityId}")
+                                        )
+                                ),
+                            onClick = { onSelectEntity(entity.entityId, selectedServer) }
+                        )
+                    }
+                } else {
                     item {
-                        ServerExposedDropdownMenu(
-                            servers = serversList,
-                            current = selectedServer,
-                            onSelected = { selectedServer = it },
-                            modifier = Modifier.fillMaxWidth().padding(start = 16.dp, end = 16.dp, bottom = 16.dp)
+                        Text(
+                            text = stringResource(commonR.string.controls_setting_choose_empty),
+                            modifier = Modifier.padding(all = 16.dp),
+                            fontStyle = FontStyle.Italic
                         )
                     }
                 }
-                items(entitiesList[selectedServer]?.size ?: 0, key = { "$selectedServer.${entitiesList[selectedServer]?.get(it)?.entityId}" }) { index ->
-                    val entity = entitiesList[selectedServer]?.get(index) as Entity<Map<String, Any>>
-                    ManageControlsEntity(
-                        entityName = (
-                            entity.attributes["friendly_name"]
-                                ?: entity.entityId
-                            ) as String,
-                        entityDomain = entity.domain,
-                        selected = (
-                            authSetting == ControlsAuthRequiredSetting.NONE ||
-                                (
-                                    authSetting == ControlsAuthRequiredSetting.SELECTION &&
-                                        !authRequiredList.contains("$selectedServer.${entity.entityId}")
-                                    )
-                            ),
-                        onClick = { onSelectEntity(entity.entityId, selectedServer) }
-                    )
-                }
             } else {
                 item {
-                    Text(
-                        text = stringResource(commonR.string.controls_setting_choose_empty),
-                        modifier = Modifier.padding(all = 16.dp),
-                        fontStyle = FontStyle.Italic
-                    )
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Spacer(modifier = Modifier.height(24.dp))
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                    }
                 }
             }
         } else {
-            item {
-                Column(modifier = Modifier.fillMaxWidth()) {
-                    Spacer(modifier = Modifier.height(24.dp))
-                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
-                }
-            }
+            // TODO path entry
         }
     }
 }
@@ -154,6 +208,52 @@ fun ManageControlsEntity(
                     style = MaterialTheme.typography.body2
                 )
             }
+        }
+    }
+}
+
+@Composable
+fun ManageControlsModeButton(
+    isPanel: Boolean,
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(IntrinsicSize.Max)
+            .selectable(selected = selected, onClick = onClick)
+    ) {
+        Column(
+            modifier = Modifier.padding(all = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Image(
+                asset = if (isPanel) {
+                    CommunityMaterial.Icon3.cmd_view_dashboard
+                } else {
+                    CommunityMaterial.Icon.cmd_dip_switch
+                },
+                contentDescription = null,
+                modifier = Modifier.size(36.dp),
+                colorFilter = ColorFilter.tint(LocalContentColor.current)
+            )
+            Text(
+                text = stringResource(if (isPanel) commonR.string.lovelace else commonR.string.controls_setting_mode_builtin_title),
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = "${stringResource(if (isPanel) commonR.string.controls_setting_mode_panel_info else commonR.string.controls_setting_mode_builtin_info)}\n", // Newline for spacing
+                fontSize = 14.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            RadioButton(
+                selected = selected,
+                onClick = null // Handled by parent
+            )
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -227,8 +227,6 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
         if (
             intent.extras?.containsKey(EXTRA_SHOW_WHEN_LOCKED) == true &&
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
@@ -236,6 +234,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             // Allow showing this on the lock screen when using device controls panel
             setShowWhenLocked(intent.extras?.getBoolean(EXTRA_SHOW_WHEN_LOCKED) ?: false)
         }
+
+        super.onCreate(savedInstanceState)
 
         binding = ActivityWebviewBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -124,6 +124,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     companion object {
         const val EXTRA_PATH = "path"
         const val EXTRA_SERVER = "server"
+        const val EXTRA_SHOW_WHEN_LOCKED = "show_when_locked"
 
         private const val TAG = "WebviewActivity"
         private const val APP_PREFIX = "app://"
@@ -227,6 +228,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (
+            intent.extras?.containsKey(EXTRA_SHOW_WHEN_LOCKED) == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1
+        ) {
+            // Allow showing this on the lock screen when using device controls panel
+            setShowWhenLocked(intent.extras?.getBoolean(EXTRA_SHOW_WHEN_LOCKED) ?: false)
+        }
 
         binding = ActivityWebviewBinding.inflate(layoutInflater)
         setContentView(binding.root)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -27,6 +27,14 @@ interface PrefsRepository {
 
     suspend fun setControlsAuthEntities(entities: List<String>)
 
+    suspend fun getControlsPanelServer(): Int?
+
+    suspend fun setControlsPanelServer(serverId: Int)
+
+    suspend fun getControlsPanelPath(): String?
+
+    suspend fun setControlsPanelPath(path: String?)
+
     suspend fun isFullScreenEnabled(): Boolean
 
     suspend fun setFullScreenEnabled(enabled: Boolean)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -22,6 +22,8 @@ class PrefsRepositoryImpl @Inject constructor(
         private const val PREF_SCREEN_ORIENTATION = "screen_orientation"
         private const val PREF_CONTROLS_AUTH_REQUIRED = "controls_auth_required"
         private const val PREF_CONTROLS_AUTH_ENTITIES = "controls_auth_entities"
+        private const val CONTROLS_PANEL_SERVER = "controls_panel_server"
+        private const val CONTROLS_PANEL_PATH = "controls_panel_path"
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
         private const val PREF_KEEP_SCREEN_ON_ENABLED = "keep_screen_on_enabled"
         private const val PREF_PINCH_TO_ZOOM_ENABLED = "pinch_to_zoom_enabled"
@@ -127,6 +129,24 @@ class PrefsRepositoryImpl @Inject constructor(
         localStorage.putStringSet(PREF_CONTROLS_AUTH_ENTITIES, entities.toSet())
     }
 
+    override suspend fun getControlsPanelServer(): Int? =
+        localStorage.getInt(CONTROLS_PANEL_SERVER)
+
+    override suspend fun setControlsPanelServer(serverId: Int) {
+        localStorage.putInt(CONTROLS_PANEL_SERVER, serverId)
+    }
+
+    override suspend fun getControlsPanelPath(): String? =
+        localStorage.getString(CONTROLS_PANEL_PATH)
+
+    override suspend fun setControlsPanelPath(path: String?) {
+        if (path.isNullOrBlank()) {
+            localStorage.remove(CONTROLS_PANEL_PATH)
+        } else {
+            localStorage.putString(CONTROLS_PANEL_PATH, path)
+        }
+    }
+
     override suspend fun isFullScreenEnabled(): Boolean {
         return localStorage.getBoolean(PREF_FULLSCREEN_ENABLED)
     }
@@ -213,5 +233,10 @@ class PrefsRepositoryImpl @Inject constructor(
 
         val autoFavorites = getAutoFavorites().filter { it.split("-")[0].toIntOrNull() != serverId }
         setAutoFavorites(autoFavorites)
+
+        if (getControlsPanelServer() == serverId) {
+            localStorage.remove(CONTROLS_PANEL_SERVER)
+            setControlsPanelPath(null)
+        }
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="controls_setting_choose_all">Select all</string>
     <string name="controls_setting_choose_none">Select none</string>
     <string name="controls_setting_choose_empty">No entities available</string>
+    <string name="controls_setting_alert">If you previously used built-in device controls, you may need to remove all controls before the dashboard will be shown</string>
+    <string name="controls_setting_dashboard_setting">Enter the dashboard path you want to use. When left empty, the default dashboard will be used.</string>
     <string name="covers">Covers</string>
     <string name="crash_reporting_summary">Help the developers fix bugs and crashes by leaving this enabled. If the application crashes this will automatically generate and send a report. If you notice a crash also create an issue on GitHub!</string>
     <string name="crash_reporting">Crash reporting</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -153,7 +153,7 @@
     <string name="continue_connect">Continue</string>
     <string name="controls_setting_category">Device controls</string>
     <string name="controls_setting_title">Manage device controls</string>
-    <string name="controls_setting_panel">Choose which device controls experience you would like to use:</string>
+    <string name="controls_setting_panel">Choose which device controls mode you would like to use:</string>
     <string name="controls_setting_mode_builtin_title">Built-in</string>
     <string name="controls_setting_mode_builtin_info">Easy to use, with advanced features like locked device settings and multiple servers support</string>
     <string name="controls_setting_mode_panel_info">Use one of your Home Assistant dashboards to fully customize your controls</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -153,6 +153,10 @@
     <string name="continue_connect">Continue</string>
     <string name="controls_setting_category">Device controls</string>
     <string name="controls_setting_title">Manage device controls</string>
+    <string name="controls_setting_panel">Choose which device controls experience you would like to use:</string>
+    <string name="controls_setting_mode_builtin_title">Built-in</string>
+    <string name="controls_setting_mode_builtin_info">Easy to use, with advanced features like locked device settings and multiple servers support</string>
+    <string name="controls_setting_mode_panel_info">Use one of your Home Assistant dashboards to fully customize your controls</string>
     <string name="controls_setting_summary">Choose if quick access device controls can be used when this device is locked</string>
     <string name="controls_setting_choose_setting">Choose which entities you want to be able to control using the built-in device controls option when this device is locked:</string>
     <string name="controls_setting_choose_all">Select all</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implements #3566

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Device controls panel|Settings*, light mode|Settings*, dark mode|
|-----|-----|-----|
|![Device controls panel showing the Home Assistant app with a dashboard, instead of the previous built-in style](https://github.com/home-assistant/android/assets/8148535/e84010d4-528f-46fd-9af9-1ec6aaca0d87)|![Home Assistant app 'Manage device controls' screen, with two radio buttons: Built-in and Dashboard, allowing the user to choose between them, light mode](https://github.com/home-assistant/android/assets/8148535/aec2a562-04c2-49db-a5de-9565f21f595e)|![Home Assistant app 'Manage device controls' screen, with two radio buttons: Built-in and Dashboard, allowing the user to choose between them, dark mode](https://github.com/home-assistant/android/assets/8148535/c52a0c0c-8cd1-4477-bdc7-437616b001a9)|

\* The warning about removing previous controls only shows up when changing the setting from built-in to dashboard

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#978

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing note: transitioning activities like done here works but clearly it wasn't the intended use case and there may be some flickering when the device is locked. Finishing in `onPause()` instead of immediately after launching seems to reduce it but on quick, repeated launches I could still get some odd behavior (tested on Android 14 beta 5.3).