### PR TITLE
Don't force on/yes/y/off/no/n to booleans for service button

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -205,21 +205,9 @@ class WidgetDynamicFieldAdapter(
         }
     }
 
-    private fun String.toBooleanOrNull(): Boolean? {
-        // Parse all valid YAML boolean values
-        return when (this.trim().lowercase(Locale.getDefault())) {
-            "true" -> true
-            "on" -> true
-            "yes" -> true
-            "y" -> true
-
-            "false" -> false
-            "off" -> false
-            "no" -> false
-            "n" -> false
-
-            // If it's not a valid YAML boolean, return null
-            else -> null
-        }
+    private fun String.toBooleanOrNull(): Boolean? = when (lowercase()) {
+        "true" -> true
+        "false" -> false
+        else -> null
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3715 by relaxing string conversion to boolean as this breaks other use cases. The app isn't a full YAML parser, and doesn't need to be as the user can enter true/false in the same text field.

This will _not_ be a breaking change as existing widgets have already had their `on`/`yes`/`y`/`off`/`no`/`n` strings* converted to `true`/`false`, which will continue to work.

\*Depending on the YAML version these weren't a valid boolean anyway so confusion everywhere.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I couldn't find documentation about Home Assistant's YAML version or parsing anywhere so I think it's OK not to mention this anywhere.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->