### PR TITLE
Fix isActive for locks

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -829,6 +829,7 @@ fun <T> Entity<T>.isActive() = when {
     (domain == "cover") -> state != "closed"
     (domain in listOf("device_tracker", "person")) -> state != "not_home"
     (domain == "lawn_mower") -> state in listOf("mowing", "error")
+    // on Android, contrary to HA Frontend, a lock is considered active when locked
     (domain == "lock") -> state == "locked"
     (domain == "media_player") -> state != "standby"
     (domain == "vacuum") -> state !in listOf("idle", "docked", "paused")

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -829,7 +829,7 @@ fun <T> Entity<T>.isActive() = when {
     (domain == "cover") -> state != "closed"
     (domain in listOf("device_tracker", "person")) -> state != "not_home"
     (domain == "lawn_mower") -> state in listOf("mowing", "error")
-    (domain == "lock") -> state != "locked"
+    (domain == "lock") -> state == "locked"
     (domain == "media_player") -> state != "standby"
     (domain == "vacuum") -> state !in listOf("idle", "docked", "paused")
     (domain == "plant") -> state == "problem"


### PR DESCRIPTION
## Summary
Lock entity should be active when locked, inactive otherwise

## Screenshots
*irrelevant*

## Link to pull request in Documentation repository
*irrelevant*

## Any other notes
A recent PR (#3816) made changes to how different entities and their states are represented. This change caused the locks to be represented by active (on) tiles when *unlocked*, and inactive (off) tiles when locked. This new representation is counter-intuitive, and contradicts the lock representation in tiles provided by other home automation software (e.g. Google Home).

This PR reverts this change at its core (the logic of `isActive` for lock entities), while keeping the rest of the changes in #3816 intact.