### PR TITLE
Thread debug log: make extended PAN ID more readable

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -213,7 +213,7 @@ class ThreadManagerImpl @Inject constructor(
             appCredentials?.any {
                 val isPreferred = isPreferredCredentials(context, it)
                 if (isPreferred) {
-                    Log.d(TAG, "Thread device prefers app added dataset: ${it.networkName} (PAN ${it.panId}, EXTPAN ${it.extendedPanId})")
+                    Log.d(TAG, "Thread device prefers app added dataset: ${it.networkName} (PAN ${it.panId}, EXTPAN ${String(it.extendedPanId)})")
                 }
                 isPreferred
             } ?: false


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Missed this one before: the extended PAN ID logged during Thread sync is a `byte[]`, which needs converting to a string to be readable in a log statement as you'll get object hashes otherwise:
```
09-15 13:17:13.623  4934  4934 D ThreadManagerImpl: Thread device prefers app added dataset: home-assistant (PAN 16530, EXTPAN [B@d4f921c)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->