### PR TITLE
Fix device controls lock toggle action (invert)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -48,7 +48,7 @@ object LockControl : HaControl {
     ): Boolean {
         integrationRepository.callService(
             action.templateId.split(".")[0],
-            if ((action as? BooleanAction)?.newState == true) "lock" else "unlock",
+            if ((action as? BooleanAction)?.newState == true) "unlock" else "lock",
             hashMapOf("entity_id" to action.templateId)
         )
         return true


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The active state for locks was changed to match the frontend, meaning that locked is now inactive. Update the device controls toggle action accordingly. Other toggles (qs, Wear) aren't affected as they use the entity state object to determine the call to use. Fixes #3867.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->