### PR TITLE
Automatically fix broken registrations/webhooks

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/notifications/FirebaseCloudMessagingService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/notifications/FirebaseCloudMessagingService.kt
@@ -49,9 +49,8 @@ class FirebaseCloudMessagingService : FirebaseMessagingService() {
                 launch {
                     try {
                         serverManager.integrationRepository(it.id).updateRegistration(
-                            DeviceRegistration(
-                                pushToken = token
-                            )
+                            deviceRegistration = DeviceRegistration(pushToken = token),
+                            allowReregistration = false
                         )
                     } catch (e: Exception) {
                         Log.e(TAG, "Issue updating token", e)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface IntegrationRepository {
 
     suspend fun registerDevice(deviceRegistration: DeviceRegistration)
-    suspend fun updateRegistration(deviceRegistration: DeviceRegistration)
+    suspend fun updateRegistration(deviceRegistration: DeviceRegistration, allowReregistration: Boolean = true)
     suspend fun getRegistration(): DeviceRegistration
     suspend fun deletePreferences()
 

--- a/wear/src/main/java/io/homeassistant/companion/android/notifications/FirebaseCloudMessagingService.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/notifications/FirebaseCloudMessagingService.kt
@@ -49,10 +49,11 @@ class FirebaseCloudMessagingService : FirebaseMessagingService() {
                 launch {
                     try {
                         serverManager.integrationRepository(it.id).updateRegistration(
-                            DeviceRegistration(
+                            deviceRegistration = DeviceRegistration(
                                 pushToken = token,
                                 pushWebsocket = false
-                            )
+                            ),
+                            allowReregistration = false
                         )
                     } catch (e: Exception) {
                         Log.e(TAG, "Issue updating token", e)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After helping a few users recently with broken webhooks causing issues, as the app appears to be working but anything depending on the webhook doesn't, I decided to implement an automatic fix for this. It's easy to recognise in the log files so it also should be easy to handle with code:
- HTTP 200 with empty body: direct connection broken webhook
- HTTP 404: broken cloudhook
- HTTP 410: no config entry (and as a result, also a broken webhook)

By doing a new registration we get a new webhook. Removes the need for the user to log out and back in again.

[The iOS app does something very similar](https://github.com/home-assistant/iOS/blob/e065d9bfe05bf1a179a729c3f63ec7745f5b3446/Sources/Shared/API/HAAPI.swift#L184-L197).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->