### PR TITLE
Add smooth scrolling for rotary input

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ wearInput = "1.2.0-alpha02"
 webkit = "1.8.0"
 wear-remote-interactions = "1.0.0"
 workRuntimeKtx = "2.8.1"
+horologist = "0.5.5"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidPlugin" }
@@ -120,6 +121,7 @@ constraintlayout = { module = "androidx.constraintlayout:constraintlayout", vers
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+horologist-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
 iconics-compose = { module = "com.mikepenz:iconics-compose", version.ref = "iconics" }
 iconics-core = { module = "com.mikepenz:iconics-core", version.ref = "iconics" }
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson-module-kotlin" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -108,6 +108,8 @@ dependencies {
     implementation(libs.wear.compose.material)
     implementation(libs.wear.compose.navigation)
 
+    implementation(libs.horologist.layout)
+
     implementation(libs.guava)
     implementation(libs.bundles.wear.tiles)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/views/ThemeLazyColumn.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ThemeLazyColumn.kt
@@ -1,7 +1,5 @@
 package io.homeassistant.companion.android.views
 
-import androidx.compose.foundation.focusable
-import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,15 +10,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
 import androidx.wear.compose.foundation.lazy.ScalingLazyListState
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
-import kotlinx.coroutines.launch
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.compose.rotaryinput.rotaryWithScroll
 
+@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun ThemeLazyColumn(
     state: ScalingLazyListState = rememberScalingLazyListState(),
@@ -31,14 +29,7 @@ fun ThemeLazyColumn(
     ScalingLazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .onRotaryScrollEvent {
-                coroutineScope.launch {
-                    state.scrollBy(it.verticalScrollPixels)
-                }
-                true
-            }
-            .focusRequester(focusRequester)
-            .focusable(),
+            .rotaryWithScroll(state, focusRequester),
         contentPadding = PaddingValues(
             start = 8.dp,
             end = 8.dp


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
This pull request adds smooth scrolling for rotary input. That's especially important on Galaxy Watch Classic models, since it has "low-res" input.
Unfortunately, unlike views, Compose for Wear OS still doesn't have smooth scrolling for lists by default, but there's a [horologist](https://github.com/google/horologist) library by Google, which has an implementation of it. That's what I used.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

https://github.com/home-assistant/android/assets/18244287/97b950a1-d886-4e2d-9b32-49e86e1dee3f