### PR TITLE
Fix rotary input after first screen & for picker

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,7 +64,7 @@ wearInput = "1.2.0-alpha02"
 webkit = "1.8.0"
 wear-remote-interactions = "1.0.0"
 workRuntimeKtx = "2.8.1"
-horologist = "0.5.5"
+horologist = "0.5.7"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidPlugin" }
@@ -121,6 +121,7 @@ constraintlayout = { module = "androidx.constraintlayout:constraintlayout", vers
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+horologist-composables = { module = "com.google.android.horologist:horologist-composables", version.ref = "horologist" }
 horologist-layout = { module = "com.google.android.horologist:horologist-compose-layout", version.ref = "horologist" }
 iconics-compose = { module = "com.mikepenz:iconics-compose", version.ref = "iconics" }
 iconics-core = { module = "com.mikepenz:iconics-core", version.ref = "iconics" }
@@ -163,5 +164,6 @@ wear-tiles = { module = "androidx.wear.tiles:tiles", version.ref = "wear-tiles" 
 webkit = { module = "androidx.webkit:webkit", version.ref = "webkit" }
 
 [bundles]
+horologist = ["horologist-layout", "horologist-composables"]
 media3 = ["media3-exoplayer", "media3-exoplayer-hls", "media3-ui"]
 wear-tiles = ["wear-tiles", "wear-protolayout-main", "wear-protolayout-expression", "wear-protolayout-material"]

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
     implementation(libs.wear.compose.material)
     implementation(libs.wear.compose.navigation)
 
-    implementation(libs.horologist.layout)
+    implementation(libs.bundles.horologist)
 
     implementation(libs.guava)
     implementation(libs.bundles.wear.tiles)

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
@@ -1,19 +1,12 @@
 package io.homeassistant.companion.android.home.views
 
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.input.rotary.onRotaryScrollEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Devices
@@ -25,15 +18,17 @@ import androidx.wear.compose.material.ButtonDefaults
 import androidx.wear.compose.material.Picker
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.rememberPickerState
+import com.google.android.horologist.annotations.ExperimentalHorologistApi
+import com.google.android.horologist.composables.picker.toRotaryScrollAdapter
+import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.intervalToString
 import io.homeassistant.companion.android.views.ListHeader
-import kotlinx.coroutines.launch
-import kotlin.math.sign
 import io.homeassistant.companion.android.common.R as R
 
+@OptIn(ExperimentalHorologistApi::class)
 @Composable
 fun RefreshIntervalPickerView(
     currentInterval: Int,
@@ -46,8 +41,6 @@ fun RefreshIntervalPickerView(
         initiallySelectedOption = if (initialIndex != -1) initialIndex else 0,
         repeatItems = true
     )
-    val coroutineScope = rememberCoroutineScope()
-    val focusRequester = remember { FocusRequester() }
 
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -60,16 +53,7 @@ fun RefreshIntervalPickerView(
             modifier = Modifier
                 .weight(1f)
                 .padding(all = 8.dp)
-                .onRotaryScrollEvent {
-                    coroutineScope.launch {
-                        state.scrollToOption(
-                            state.selectedOption + it.verticalScrollPixels.sign.toInt()
-                        )
-                    }
-                    true
-                }
-                .focusRequester(focusRequester)
-                .focusable()
+                .rotaryWithSnap(state.toRotaryScrollAdapter())
         ) {
             Text(
                 intervalToString(LocalContext.current, options[it]),
@@ -86,10 +70,6 @@ fun RefreshIntervalPickerView(
                 CommunityMaterial.Icon.cmd_check
             )
         }
-    }
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
     }
 }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/views/ThemeLazyColumn.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ThemeLazyColumn.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.foundation.lazy.ScalingLazyColumn
 import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
@@ -24,12 +20,10 @@ fun ThemeLazyColumn(
     state: ScalingLazyListState = rememberScalingLazyListState(),
     content: ScalingLazyListScope.() -> Unit
 ) {
-    val coroutineScope = rememberCoroutineScope()
-    val focusRequester = remember { FocusRequester() }
     ScalingLazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .rotaryWithScroll(state, focusRequester),
+            .rotaryWithScroll(state),
         contentPadding = PaddingValues(
             start = 8.dp,
             end = 8.dp
@@ -39,8 +33,4 @@ fun ThemeLazyColumn(
         state = state,
         content = content
     )
-
-    LaunchedEffect(Unit) {
-        focusRequester.requestFocus()
-    }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The recent switch to Horologist modifiers for rotary input in #3876 broke rotary input after the first screen, presumably because of manual focus requesting, and the refresh interval picker in general. This PR fixes it by removing manual focus requesting (like in the Horologist sample) and also switches the refresh picker to a Horologist modifier.

Tested it on a Galaxy Watch 4 where now screens after the first one seem to work again.

Closes #3879, the dependency bump was required to get the rotary scroll adapter function for pickers.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->