### PR TITLE
Add helper class for ordered maps

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/complications/views/ComplicationConfigMainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/complications/views/ComplicationConfigMainView.kt
@@ -64,7 +64,6 @@ fun LoadConfigView(
             }
             composable(SCREEN_CHOOSE_ENTITY) {
                 ChooseEntityView(
-                    entitiesByDomainOrder = complicationConfigViewModel.entitiesByDomainOrder,
                     entitiesByDomain = complicationConfigViewModel.entitiesByDomain,
                     favoriteEntityIds = complicationConfigViewModel.favoriteEntityIds,
                     onNoneClicked = {},

--- a/wear/src/main/java/io/homeassistant/companion/android/data/OrderedMap.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/data/OrderedMap.kt
@@ -1,0 +1,50 @@
+package io.homeassistant.companion.android.data
+
+import androidx.compose.runtime.Composable
+import androidx.wear.compose.foundation.lazy.ScalingLazyListItemScope
+import androidx.wear.compose.foundation.lazy.ScalingLazyListScope
+
+/**
+ * A map that has an associated ordered list used to iterate over the map in a specific order.
+ */
+class OrderedMap<K : Any, V>(
+    items: Map<K, V>,
+    val orderedKeys: List<K>
+) : Map<K, V> by items
+
+private val emptyOrderedMap = OrderedMap<Any, Nothing>(emptyMap(), emptyList())
+
+/**
+ * Returns an empty read-only ordered map of specified type.
+ * @see [emptyMap]
+ */
+fun <K : Any, V> emptyOrderedMap(): OrderedMap<K, V> = @Suppress("UNCHECKED_CAST") (emptyOrderedMap as OrderedMap<K, V>)
+
+/**
+ * Returns a new read-only ordered map, mapping only the specified key to the specified value.
+ */
+fun <K : Any, V> orderedMapOf(pair: Pair<K, V>): OrderedMap<K, V> = OrderedMap(mapOf(pair), listOf(pair.first))
+
+/**
+ * Adds an [OrderedMap] of items to the view.
+ * @param itemsMap - the map of items to add.
+ * @param key - a factory of stable keys for the items.
+ * Type of the key should be saveable via Bundle on Android.
+ * If null is passed the position in the ordered keys list will represent the key.
+ * By default, the map key is used.
+ * @param itemContent - the content displayed by a single item.
+ */
+inline fun <K : Any, V> ScalingLazyListScope.items(
+    itemsMap: OrderedMap<K, V>,
+    noinline key: ((mapKey: K) -> Any)? = { it },
+    crossinline itemContent: @Composable ScalingLazyListItemScope.(Pair<K, V>) -> Unit
+) = items(
+    count = itemsMap.orderedKeys.size,
+    key = if (key != null) { index: Int -> key(itemsMap.orderedKeys[index]) } else null
+) { index ->
+    val mapKey = itemsMap.orderedKeys[index]
+    val mapValue = itemsMap[mapKey]
+    mapValue?.let {
+        itemContent(mapKey to mapValue)
+    }
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/data/OrderedMap.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/data/OrderedMap.kt
@@ -18,12 +18,17 @@ private val emptyOrderedMap = OrderedMap<Any, Nothing>(emptyMap(), emptyList())
  * Returns an empty read-only ordered map of specified type.
  * @see [emptyMap]
  */
-fun <K : Any, V> emptyOrderedMap(): OrderedMap<K, V> = @Suppress("UNCHECKED_CAST") (emptyOrderedMap as OrderedMap<K, V>)
+fun <K : Any, V> emptyOrderedMap(): OrderedMap<K, V> =
+    @Suppress("UNCHECKED_CAST")
+    (emptyOrderedMap as OrderedMap<K, V>)
 
 /**
  * Returns a new read-only ordered map, mapping only the specified key to the specified value.
  */
-fun <K : Any, V> orderedMapOf(pair: Pair<K, V>): OrderedMap<K, V> = OrderedMap(mapOf(pair), listOf(pair.first))
+fun <K : Any, V> orderedMapOf(pair: Pair<K, V>): OrderedMap<K, V> = OrderedMap(
+    mapOf(pair),
+    orderedKeys = listOf(pair.first)
+)
 
 /**
  * Adds an [OrderedMap] of items to the view.

--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -110,9 +110,7 @@ class MainViewModel @Inject constructor(
 
     // Content of EntityListView
     var entityLists by mutableStateOf(emptyOrderedMap<String, List<Entity<*>>>())
-        private set
     var entityListFilter: (Entity<*>) -> Boolean = { true }
-        private set
 
     // settings
     var loadingState = mutableStateOf(LoadingState.LOADING)
@@ -516,15 +514,6 @@ class MainViewModel @Inject constructor(
 
         // also clear cache when logging out
         clearCache()
-    }
-
-    fun prepareToNavigateToEntityListScreen(
-        entityLists: Map<String, List<Entity<*>>>,
-        listOrder: List<String>,
-        filter: (Entity<*>) -> Boolean
-    ) {
-        this.entityLists = OrderedMap(entityLists, orderedKeys = listOrder)
-        entityListFilter = filter
     }
 
     private fun clearCache() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -14,6 +14,8 @@ import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.data.OrderedMap
+import io.homeassistant.companion.android.data.orderedMapOf
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.util.playPreviewEntityScene1
 import io.homeassistant.companion.android.util.playPreviewEntityScene2
@@ -28,8 +30,7 @@ import io.homeassistant.companion.android.common.R as commonR
 
 @Composable
 fun EntityViewList(
-    entityLists: Map<String, List<Entity<*>>>,
-    entityListsOrder: List<String>,
+    entityLists: OrderedMap<String, List<Entity<*>>>,
     entityListFilter: (Entity<*>) -> Boolean,
     onEntityClicked: (String, String) -> Unit,
     onEntityLongClicked: (String) -> Unit,
@@ -50,10 +51,10 @@ fun EntityViewList(
             timeText = { TimeText(scalingLazyListState = scalingLazyListState) }
         ) {
             ThemeLazyColumn(state = scalingLazyListState) {
-                for (header in entityListsOrder) {
+                for (header in entityLists.orderedKeys) {
                     val entities = entityLists[header].orEmpty()
                     if (entities.isNotEmpty()) {
-                        item {
+                        item(header) {
                             if (entityLists.size > 1) {
                                 ExpandableListHeader(
                                     string = header,
@@ -103,8 +104,7 @@ fun EntityViewList(
 @Composable
 private fun PreviewEntityListView() {
     EntityViewList(
-        entityLists = mapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
-        entityListsOrder = listOf(stringResource(commonR.string.lights)),
+        entityLists = orderedMapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
         entityListFilter = { true },
         onEntityClicked = { _, _ -> },
         onEntityLongClicked = { },
@@ -117,8 +117,7 @@ private fun PreviewEntityListView() {
 @Composable
 private fun PreviewEntityListScenes() {
     EntityViewList(
-        entityLists = mapOf(stringResource(commonR.string.scenes) to listOf(playPreviewEntityScene1, playPreviewEntityScene2, playPreviewEntityScene3)),
-        entityListsOrder = listOf(stringResource(commonR.string.scenes)),
+        entityLists = orderedMapOf(stringResource(commonR.string.scenes) to listOf(playPreviewEntityScene1, playPreviewEntityScene2, playPreviewEntityScene3)),
         entityListFilter = { true },
         onEntityClicked = { _, _ -> },
         onEntityLongClicked = { },

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.home.views
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
@@ -71,11 +70,7 @@ fun LoadHomePage(
                     onRetryLoadEntitiesClicked = mainViewModel::loadEntities,
                     onSettingsClicked = { swipeDismissableNavController.navigate(SCREEN_SETTINGS) },
                     onNavigationClicked = { lists, order, filter ->
-                        mainViewModel.entityLists.clear()
-                        mainViewModel.entityLists.putAll(lists)
-                        mainViewModel.entityListsOrder.clear()
-                        mainViewModel.entityListsOrder.addAll(order)
-                        mainViewModel.entityListFilter = filter
+                        mainViewModel.prepareToNavigateToEntityListScreen(lists, order, filter)
                         swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                     },
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
@@ -117,7 +112,6 @@ fun LoadHomePage(
             composable(SCREEN_ENTITY_LIST) {
                 EntityViewList(
                     entityLists = mainViewModel.entityLists,
-                    entityListsOrder = mainViewModel.entityListsOrder,
                     entityListFilter = mainViewModel.entityListFilter,
                     onEntityClicked = { entityId, state ->
                         mainViewModel.toggleEntity(entityId, state)
@@ -217,10 +211,8 @@ fun LoadHomePage(
                 )
             ) { backStackEntry ->
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_CAMERA_TILE_ID)
-                val cameraDomains = remember { mutableStateListOf("camera") }
                 val cameraFavorites = remember { mutableStateOf(emptyList<String>()) } // There are no camera favorites
                 ChooseEntityView(
-                    entitiesByDomainOrder = cameraDomains,
                     entitiesByDomain = mainViewModel.cameraEntitiesMap,
                     favoriteEntityIds = cameraFavorites,
                     onNoneClicked = {},
@@ -302,7 +294,6 @@ fun LoadHomePage(
                 val entityIndex = backStackEntry.arguments!!.getInt(ARG_SCREEN_SHORTCUTS_TILE_ENTITY_INDEX)
                 val tileId = backStackEntry.arguments!!.getString(ARG_SCREEN_SHORTCUTS_TILE_ID)!!.toIntOrNull()
                 ChooseEntityView(
-                    entitiesByDomainOrder = mainViewModel.entitiesByDomainOrder,
                     entitiesByDomain = mainViewModel.entitiesByDomain,
                     favoriteEntityIds = mainViewModel.favoriteEntityIds,
                     onNoneClicked = {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -69,8 +69,9 @@ fun LoadHomePage(
                     },
                     onRetryLoadEntitiesClicked = mainViewModel::loadEntities,
                     onSettingsClicked = { swipeDismissableNavController.navigate(SCREEN_SETTINGS) },
-                    onNavigationClicked = { lists, order, filter ->
-                        mainViewModel.prepareToNavigateToEntityListScreen(lists, order, filter)
+                    onNavigationClicked = { entityLists, filter ->
+                        mainViewModel.entityLists = entityLists
+                        mainViewModel.entityListFilter = filter
                         swipeDismissableNavController.navigate(SCREEN_ENTITY_LIST)
                     },
                     isHapticEnabled = mainViewModel.isHapticEnabled.value,
@@ -211,7 +212,10 @@ fun LoadHomePage(
                 )
             ) { backStackEntry ->
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_CAMERA_TILE_ID)
-                val cameraFavorites = remember { mutableStateOf(emptyList<String>()) } // There are no camera favorites
+                // There are no camera favorites
+                val cameraFavorites = remember {
+                    mutableStateOf(emptyList<String>())
+                }
                 ChooseEntityView(
                     entitiesByDomain = mainViewModel.cameraEntitiesMap,
                     favoriteEntityIds = cameraFavorites,

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.foundation.lazy.items
 import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.Chip
 import androidx.wear.compose.material.ChipDefaults
@@ -36,6 +37,7 @@ import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
+import io.homeassistant.companion.android.data.items
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.wearColorPalette
@@ -86,8 +88,8 @@ fun MainView(
                         )
                     }
                     if (expandedFavorites) {
-                        items(favoriteEntityIds.size) { index ->
-                            val favoriteEntityID = favoriteEntityIds[index].split(",")[0]
+                        items(favoriteEntityIds, key = { "favorite-${it}" }) { id ->
+                            val favoriteEntityID = id.split(",")[0]
                             if (mainViewModel.entities.isEmpty()) {
                                 // when we don't have the state of the entity, create a Chip from cache as we don't have the state yet
                                 val cached = mainViewModel.getCachedEntity(favoriteEntityID)
@@ -216,34 +218,31 @@ fun MainView(
                                 item {
                                     ListHeader(id = commonR.string.areas)
                                 }
-                                for (id in mainViewModel.entitiesByAreaOrder) {
-                                    val entities = mainViewModel.entitiesByArea[id]
-                                    val entitiesToShow = entities?.filter {
+                                items(mainViewModel.entitiesByArea, key = { "area-${it}" }) { (id, entities) ->
+                                    val entitiesToShow = entities.filter {
                                         mainViewModel.getCategoryForEntity(it.entityId) == null &&
-                                            mainViewModel.getHiddenByForEntity(it.entityId) == null
+                                                mainViewModel.getHiddenByForEntity(it.entityId) == null
                                     }
-                                    if (!entitiesToShow.isNullOrEmpty()) {
+                                    if (entitiesToShow.isNotEmpty()) {
                                         val area = mainViewModel.areas.first { it.areaId == id }
-                                        item {
-                                            Chip(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                label = {
-                                                    Text(text = area.name)
-                                                },
-                                                onClick = {
-                                                    onNavigationClicked(
-                                                        mapOf(area.name to entities),
-                                                        listOf(area.name)
-                                                    ) {
-                                                        mainViewModel.getCategoryForEntity(it.entityId) == null &&
+                                        Chip(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            label = {
+                                                Text(text = area.name)
+                                            },
+                                            onClick = {
+                                                onNavigationClicked(
+                                                    mapOf(area.name to entities),
+                                                    listOf(area.name)
+                                                ) {
+                                                    mainViewModel.getCategoryForEntity(it.entityId) == null &&
                                                             mainViewModel.getHiddenByForEntity(
-                                                            it.entityId
-                                                        ) == null
-                                                    }
-                                                },
-                                                colors = ChipDefaults.primaryChipColors()
-                                            )
-                                        }
+                                                                it.entityId
+                                                            ) == null
+                                                }
+                                            },
+                                            colors = ChipDefaults.primaryChipColors()
+                                        )
                                     }
                                 }
                             }
@@ -260,36 +259,32 @@ fun MainView(
                                 }
                             }
                             // Buttons for each existing category
-                            for (domain in mainViewModel.entitiesByDomainOrder) {
-                                val domainEntities = mainViewModel.entitiesByDomain[domain]!!
-                                val domainEntitiesToShow =
-                                    domainEntities.filter(domainEntitiesFilter)
+                            items(mainViewModel.entitiesByDomain, key = { "domain-${it}" }) { (domain, domainEntities) ->
+                                val domainEntitiesToShow = domainEntities.filter(domainEntitiesFilter)
                                 if (domainEntitiesToShow.isNotEmpty()) {
-                                    item {
-                                        Chip(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            icon = {
-                                                getIcon(
-                                                    "",
-                                                    domain,
-                                                    context
-                                                ).let { Image(asset = it) }
-                                            },
-                                            label = {
-                                                Text(text = mainViewModel.stringForDomain(domain)!!)
-                                            },
-                                            onClick = {
-                                                onNavigationClicked(
-                                                    mapOf(
-                                                        mainViewModel.stringForDomain(domain)!! to domainEntities
-                                                    ),
-                                                    listOf(mainViewModel.stringForDomain(domain)!!),
-                                                    domainEntitiesFilter
-                                                )
-                                            },
-                                            colors = ChipDefaults.primaryChipColors()
-                                        )
-                                    }
+                                    Chip(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        icon = {
+                                            getIcon(
+                                                "",
+                                                domain,
+                                                context
+                                            ).let { Image(asset = it) }
+                                        },
+                                        label = {
+                                            Text(text = mainViewModel.stringForDomain(domain)!!)
+                                        },
+                                        onClick = {
+                                            onNavigationClicked(
+                                                mapOf(
+                                                    mainViewModel.stringForDomain(domain)!! to domainEntities
+                                                ),
+                                                listOf(mainViewModel.stringForDomain(domain)!!),
+                                                domainEntitiesFilter
+                                            )
+                                        },
+                                        colors = ChipDefaults.primaryChipColors()
+                                    )
                                 }
                             }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -53,10 +53,10 @@ fun SetFavoritesView(
                 item {
                     ListHeader(id = commonR.string.set_favorite)
                 }
-                for (domain in mainViewModel.entitiesByDomainOrder) {
+                for (domain in mainViewModel.entitiesByDomain.orderedKeys) {
                     val entities = mainViewModel.entitiesByDomain[domain].orEmpty()
                     if (entities.isNotEmpty()) {
-                        item {
+                        item(domain) {
                             ExpandableListHeader(
                                 string = mainViewModel.stringForDomain(domain)!!,
                                 key = domain,

--- a/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
@@ -73,7 +73,7 @@ fun ChooseEntityView(
                     )
                 }
                 if (expandedFavorites) {
-                    items(favoriteEntityIds.value, key = { id -> "favorite-${id}" }) { id ->
+                    items(favoriteEntityIds.value, key = { id -> "favorite-$id" }) { id ->
                         val favoriteEntityID = id.split(",")[0]
                         entitiesByDomain.values.flatten()
                             .firstOrNull { it.entityId == favoriteEntityID }
@@ -99,7 +99,7 @@ fun ChooseEntityView(
                         )
                     }
                     if (expandedStates[domain] == true) {
-                        items(entities, key = { "${domain}-${it.entityId}" }) { entity ->
+                        items(entities, key = { "$domain-${it.entityId}" }) { entity ->
                             ChooseEntityChip(
                                 entity = entity,
                                 onEntitySelected = onEntitySelected


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Simplifying the compose state in wear by creating a helper class for the common pattern of associating a map and a list of keys.

This change introduces a new class, `OrderedMap`, that is just a map with an `orderedKeys` property. It also includes some helper functions for creating ordered maps and iterating through them.

## Screenshots
N/A, not user facing change

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->