### PR TITLE
ListHeader: fix text cut off

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/views/ListHeader.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ListHeader.kt
@@ -1,13 +1,17 @@
 package io.homeassistant.companion.android.views
 
 import androidx.annotation.StringRes
-import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.material.ListHeader
+import androidx.wear.compose.material.LocalTextStyle
 import androidx.wear.compose.material.Text
+import kotlin.math.floor
 import io.homeassistant.companion.android.common.R as commonR
 
 @Composable
@@ -18,12 +22,20 @@ fun ListHeader(@StringRes id: Int, modifier: Modifier = Modifier) {
 @Composable
 fun ListHeader(string: String, modifier: Modifier = Modifier) {
     ListHeader {
-        Row {
-            Text(
-                text = string,
-                modifier = modifier
-            )
+        val maxLines = with(LocalDensity.current) {
+            if (LocalTextStyle.current.fontSize.isSp) {
+                floor(48 / LocalTextStyle.current.fontSize.toDp().value).toInt() // A ListHeader is 48dp
+            } else {
+                1 // Fallback as em cannot be converted
+            }
         }
+        Text(
+            text = string,
+            modifier = modifier,
+            textAlign = TextAlign.Center,
+            maxLines = maxLines,
+            overflow = TextOverflow.Ellipsis
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Prevent text from being cut off abruptly in the `ListHeader`s used in the app (on almost every screen) by calculating the number of lines that fit based on text size + overflow with ellipsis + centering text.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After default size|After very large size (title only)|
|-----|-----|-----|
|![Wear screen with text in title showing 2.5 lines (text cut off)](https://github.com/home-assistant/android/assets/8148535/8ff1f883-21fa-4d85-8d55-0e3791ee8659)|![Wear screen with text in title showing 2 lines, ending in ellipsis](https://github.com/home-assistant/android/assets/8148535/d03d18ec-5898-4c3e-a7e7-167379b47749)|![Wear screen with large text in title showing 1 line, ending in ellipsis](https://github.com/home-assistant/android/assets/8148535/edda4dea-8ec7-430e-9c41-1c8fe93f353a)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->