### PR TITLE
Update Wear more details screen to prevent cut off

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -2,13 +2,11 @@ package io.homeassistant.companion.android.home.views
 
 import android.content.Context
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -23,25 +21,29 @@ import androidx.wear.compose.foundation.lazy.rememberScalingLazyListState
 import androidx.wear.compose.material.Icon
 import androidx.wear.compose.material.InlineSlider
 import androidx.wear.compose.material.InlineSliderDefaults
+import androidx.wear.compose.material.MaterialTheme
 import androidx.wear.compose.material.PositionIndicator
 import androidx.wear.compose.material.Scaffold
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.ToggleButton
 import androidx.wear.compose.material.ToggleButtonDefaults
-import androidx.wear.compose.material.ToggleChipDefaults
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.common.data.integration.domain
+import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.getFanSpeed
 import io.homeassistant.companion.android.common.data.integration.getFanSteps
+import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.integration.getLightBrightness
+import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
 import io.homeassistant.companion.android.common.data.integration.supportsLightColorTemperature
 import io.homeassistant.companion.android.theme.WearAppTheme
+import io.homeassistant.companion.android.theme.wearColorPalette
 import io.homeassistant.companion.android.util.getColorTemperature
 import io.homeassistant.companion.android.util.onEntityClickedFeedback
 import io.homeassistant.companion.android.util.onEntityFeedback
@@ -77,41 +79,41 @@ fun DetailsPanelView(
                 val attributes = entity.attributes as Map<*, *>
 
                 item {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        val friendlyName = attributes["friendly_name"].toString()
-                        Text(friendlyName)
-
-                        if (entity.domain in EntityExt.DOMAINS_TOGGLE) {
-                            val isChecked = entity.state in listOf("on", "locked", "open", "opening")
-                            ToggleButton(
-                                checked = isChecked,
-                                onCheckedChange = {
-                                    onEntityToggled(entity.entityId, entity.state)
-                                    onEntityClickedFeedback(
-                                        isToastEnabled,
-                                        isHapticEnabled,
-                                        context,
-                                        friendlyName,
-                                        haptic
-                                    )
-                                },
-                                modifier = Modifier
-                                    .padding(start = 16.dp)
-                                    .size(ToggleButtonDefaults.SmallToggleButtonSize)
-                            ) {
-                                Icon(
-                                    imageVector = ToggleChipDefaults.switchIcon(isChecked),
-                                    contentDescription = if (isChecked) {
-                                        stringResource(R.string.enabled)
-                                    } else {
-                                        stringResource(R.string.disabled)
-                                    }
+                    // Style similar to icon on frontend tile card
+                    val isChecked = entity.isActive()
+                    if (entity.domain in EntityExt.DOMAINS_TOGGLE) {
+                        ToggleButton(
+                            checked = isChecked,
+                            onCheckedChange = {
+                                onEntityToggled(entity.entityId, entity.state)
+                                onEntityClickedFeedback(
+                                    isToastEnabled,
+                                    isHapticEnabled,
+                                    context,
+                                    entity.friendlyName,
+                                    haptic
                                 )
-                            }
+                            },
+                            colors = ToggleButtonDefaults.toggleButtonColors(checkedBackgroundColor = MaterialTheme.colors.secondary.copy(alpha = 0.2f)),
+                            modifier = Modifier.size(ToggleButtonDefaults.SmallToggleButtonSize)
+                        ) {
+                            Image(
+                                asset = entity.getIcon(LocalContext.current),
+                                colorFilter = ColorFilter.tint(
+                                    if (isChecked) MaterialTheme.colors.secondary else wearColorPalette.onSurface
+                                ),
+                                contentDescription = stringResource(if (isChecked) R.string.enabled else R.string.disabled)
+                            )
                         }
+                    } else {
+                        Image(
+                            asset = entity.getIcon(LocalContext.current),
+                            colorFilter = ColorFilter.tint(wearColorPalette.onSurface)
+                        )
                     }
+                }
+                item {
+                    ListHeader(entity.friendlyName)
                 }
 
                 if (entity.domain == "fan") {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Updates the more details screen on a watch to prevent content from being cut off. The entity title and toggle were forced onto one line, so with longer entity names and/or larger text sizes it would get cut off.

New design prominently shows the entity icon, which can be tapped to toggle, and the entity title on another line (which can wrap / limit length). Design is very similar to the frontend tile card and default Wear round buttons with icons, so hopefully familiar to users. Colors are not dynamic - on is always yellow, matching the vehicle interface.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After, off|After, on|After, no toggle*|
|-----|-----|-----|-----|
|![More details screen with text and toggle immediately at the top cut off by the round screen](https://github.com/home-assistant/android/assets/8148535/2c89bdac-caa7-4bb3-95d3-29697037b241)|![More details screen with a lightbulb icon in a circle that can be tapped, grey for off](https://github.com/home-assistant/android/assets/8148535/341de68d-360a-4cc6-b3d5-46f064e7f742)|![More details screen with a lightbulb icon in a circle that can be tapped, yellow for on](https://github.com/home-assistant/android/assets/8148535/0445d2a7-6277-4621-adf8-bf916100d56d)|![More details screen with a palette icon for a scene, which is not in a circle indicating it cannot be tapped](https://github.com/home-assistant/android/assets/8148535/3653ca88-990d-45f8-aac4-2e84363fc49e)|

\* and default text size

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->