### PR TITLE
Add NFC state sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import android.telephony.TelephonyManager
@@ -139,6 +140,12 @@ open class HomeAssistantApplication : Application() {
         registerReceiver(
             sensorReceiver,
             IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        )
+
+        // Listen for NFC state changes
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
         )
 
         // Listen to changes to the audio input/output on the device

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NfcSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NfcSensorManager.kt
@@ -10,7 +10,7 @@ class NfcSensorManager : SensorManager {
     companion object {
         private const val TAG = "NfcSensor"
 
-        val nfcSensor = SensorManager.BasicSensor(
+        val nfcStateSensor = SensorManager.BasicSensor(
             "nfc_state",
             "binary_sensor",
             commonR.string.sensor_name_nfc_sensor,
@@ -27,7 +27,7 @@ class NfcSensorManager : SensorManager {
         get() = commonR.string.sensor_name_nfc_sensor
 
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(nfcSensor)
+        return listOf(nfcStateSensor)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -43,7 +43,7 @@ class NfcSensorManager : SensorManager {
     }
 
     private fun updateNfcState(context: Context) {
-        if (!isEnabled(context, nfcSensor)) {
+        if (!isEnabled(context, nfcStateSensor)) {
             return
         }
 
@@ -52,9 +52,9 @@ class NfcSensorManager : SensorManager {
 
         onSensorUpdated(
             context,
-            nfcSensor,
+            nfcStateSensor,
             nfcEnabled,
-            nfcSensor.statelessIcon,
+            nfcStateSensor.statelessIcon,
             emptyMap() // TODO
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NfcSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NfcSensorManager.kt
@@ -1,0 +1,61 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.nfc.NfcAdapter
+import io.homeassistant.companion.android.common.sensors.SensorManager
+import io.homeassistant.companion.android.common.R as commonR
+
+// TODO move to common
+class NfcSensorManager : SensorManager {
+    companion object {
+        private const val TAG = "NfcSensor"
+
+        val nfcSensor = SensorManager.BasicSensor(
+            "nfc_state",
+            "binary_sensor",
+            commonR.string.sensor_name_nfc_sensor,
+            commonR.string.sensor_description_nfc_sensor,
+            "mdi:nfc",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+        )
+    }
+
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor" // TODO
+    }
+    override val name: Int
+        get() = commonR.string.sensor_name_nfc_sensor
+
+    override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
+        return listOf(nfcSensor)
+    }
+
+    override fun requiredPermissions(sensorId: String): Array<String> {
+        return emptyArray() // TODO ?
+    }
+
+    override fun requestSensorUpdate(context: Context) {
+        updateNfcState(context)
+    }
+
+    override fun hasSensor(context: Context): Boolean {
+        return NfcAdapter.getDefaultAdapter(context) != null
+    }
+
+    private fun updateNfcState(context: Context) {
+        if (!isEnabled(context, nfcSensor)) {
+            return
+        }
+
+        val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+        val nfcEnabled = nfcAdapter?.isEnabled == true
+
+        onSensorUpdated(
+            context,
+            nfcSensor,
+            nfcEnabled,
+            nfcSensor.statelessIcon,
+            emptyMap() // TODO
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -72,6 +72,7 @@ class SensorReceiver : SensorReceiverBase() {
             LocationSensorManager(),
             MobileDataManager(),
             NetworkSensorManager(),
+            NfcSensorManager(),
             NextAlarmManager(),
             NotificationSensorManager(),
             PhoneStateSensorManager(),

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.nfc.NfcAdapter
 import android.os.PowerManager
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
@@ -24,6 +25,7 @@ import io.homeassistant.companion.android.common.sensors.LightSensorManager
 import io.homeassistant.companion.android.common.sensors.MobileDataManager
 import io.homeassistant.companion.android.common.sensors.NetworkSensorManager
 import io.homeassistant.companion.android.common.sensors.NextAlarmManager
+import io.homeassistant.companion.android.common.sensors.NfcSensorManager
 import io.homeassistant.companion.android.common.sensors.PhoneStateSensorManager
 import io.homeassistant.companion.android.common.sensors.PowerSensorManager
 import io.homeassistant.companion.android.common.sensors.PressureSensorManager
@@ -114,7 +116,8 @@ class SensorReceiver : SensorReceiverBase() {
         AudioManager.RINGER_MODE_CHANGED_ACTION to AudioSensorManager.audioSensor.id,
         Intent.ACTION_MANAGED_PROFILE_UNAVAILABLE to DevicePolicyManager.isWorkProfile.id,
         Intent.ACTION_MANAGED_PROFILE_AVAILABLE to DevicePolicyManager.isWorkProfile.id,
-        WifiManager.WIFI_STATE_CHANGED_ACTION to NetworkSensorManager.wifiState.id
+        WifiManager.WIFI_STATE_CHANGED_ACTION to NetworkSensorManager.wifiState.id,
+        NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to NfcSensorManager.nfcStateSensor.id
     )
 
     override fun getSensorSettingsIntent(

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.nfc.NfcAdapter
 import io.homeassistant.companion.android.common.R as commonR
 
-// TODO move to common
 class NfcSensorManager : SensorManager {
     companion object {
         private const val TAG = "NfcSensor"
@@ -20,7 +19,7 @@ class NfcSensorManager : SensorManager {
     }
 
     override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor" // TODO
+        return "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor"
     }
     override val name: Int
         get() = commonR.string.sensor_name_nfc_sensor
@@ -30,7 +29,7 @@ class NfcSensorManager : SensorManager {
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
-        return emptyArray() // TODO ?
+        return emptyArray()
     }
 
     override fun requestSensorUpdate(context: Context) {
@@ -54,7 +53,7 @@ class NfcSensorManager : SensorManager {
             nfcStateSensor,
             nfcEnabled,
             nfcStateSensor.statelessIcon,
-            emptyMap() // TODO
+            emptyMap()
         )
     }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -14,7 +14,8 @@ class NfcSensorManager : SensorManager {
             commonR.string.sensor_name_nfc_sensor,
             commonR.string.sensor_description_nfc_sensor,
             "mdi:nfc",
-            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -19,7 +19,7 @@ class NfcSensorManager : SensorManager {
         )
     }
 
-    override fun docsLink() = "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor"
+    override fun docsLink() = "https://companion.home-assistant.io/docs/core/sensors#nfc-state-sensor"
     override val name = commonR.string.sensor_name_nfc_sensor
 
     override suspend fun getAvailableSensors(context: Context) = listOf(nfcStateSensor)

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -1,8 +1,7 @@
-package io.homeassistant.companion.android.sensors
+package io.homeassistant.companion.android.common.sensors
 
 import android.content.Context
 import android.nfc.NfcAdapter
-import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.R as commonR
 
 // TODO move to common

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -19,23 +19,14 @@ class NfcSensorManager : SensorManager {
         )
     }
 
-    override fun docsLink(): String {
-        return "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor"
-    }
-    override val name: Int
-        get() = commonR.string.sensor_name_nfc_sensor
+    override fun docsLink() = "https://companion.home-assistant.io/docs/core/sensors#nfc-sensor"
+    override val name = commonR.string.sensor_name_nfc_sensor
 
-    override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(nfcStateSensor)
-    }
+    override suspend fun getAvailableSensors(context: Context) = listOf(nfcStateSensor)
 
-    override fun requiredPermissions(sensorId: String): Array<String> {
-        return emptyArray()
-    }
+    override fun requiredPermissions(sensorId: String) = emptyArray<String>()
 
-    override fun requestSensorUpdate(context: Context) {
-        updateNfcState(context)
-    }
+    override fun requestSensorUpdate(context: Context) = updateNfcState(context)
 
     override fun hasSensor(context: Context): Boolean {
         return NfcAdapter.getDefaultAdapter(context) != null

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -11,8 +11,8 @@ class NfcSensorManager : SensorManager {
         val nfcStateSensor = SensorManager.BasicSensor(
             "nfc_state",
             "binary_sensor",
-            commonR.string.sensor_name_nfc_sensor,
-            commonR.string.sensor_description_nfc_sensor,
+            commonR.string.basic_sensor_name_nfc_state,
+            commonR.string.sensor_description_nfc_state,
             "mdi:nfc-variant",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
@@ -20,7 +20,7 @@ class NfcSensorManager : SensorManager {
     }
 
     override fun docsLink() = "https://companion.home-assistant.io/docs/core/sensors#nfc-state-sensor"
-    override val name = commonR.string.sensor_name_nfc_sensor
+    override val name = commonR.string.sensor_name_nfc
 
     override suspend fun getAvailableSensors(context: Context) = listOf(nfcStateSensor)
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NfcSensorManager.kt
@@ -13,7 +13,7 @@ class NfcSensorManager : SensorManager {
             "binary_sensor",
             commonR.string.sensor_name_nfc_sensor,
             commonR.string.sensor_description_nfc_sensor,
-            "mdi:nfc",
+            "mdi:nfc-variant",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1124,6 +1124,8 @@
     <string name="sensor_description_daily_calories">The total number of calories over a day (including both BMR and active calories), where the previous day ends and a new day begins at 12:00 AM local time.</string>
     <string name="sensor_name_daily_steps">Daily steps</string>
     <string name="sensor_description_daily_steps">The total step count over a day, where the previous day ends and a new day begins at 12:00 AM local time.</string>
+    <string name="sensor_name_nfc_sensor">NFC state</string>
+    <string name="sensor_description_nfc_sensor">Whether NFC is enabled on the device</string>
     <string name="thread_debug">Sync Thread credentials</string>
     <string name="thread_debug_active">Syncing…</string>
     <string name="thread_debug_result_error">An unexpected error occurred while syncing</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="basic_sensor_name_mobile_data">Mobile data</string>
     <string name="basic_sensor_name_mobile_rx_gb">Mobile Rx GB</string>
     <string name="basic_sensor_name_mobile_tx_gb">Mobile Tx GB</string>
+    <string name="basic_sensor_name_nfc_state">NFC state</string>
     <string name="basic_sensor_name_phone">Phone state</string>
     <string name="basic_sensor_name_power_save">Power save</string>
     <string name="basic_sensor_name_public_ip">Public IP address</string>
@@ -611,6 +612,7 @@
     <string name="sensor_description_mobile_tx_gb">Total Tx GB on cellular data since last device reboot</string>
     <string name="sensor_description_music_active">Whether music is actively playing on the device</string>
     <string name="sensor_description_next_alarm">The date and time of the next scheduled alarm, any app or manufacturer can override the default behavior. The package attribute will tell you which app set the next scheduled alarm. The setting below will create an Allow List so you can specify what packages you want the alarm event from. This will ignore alarm events for packages not selected and the state will not update until the next scheduled alarm matches one of the selected packages.</string>
+    <string name="sensor_description_nfc_state">Whether NFC is enabled on the device</string>
     <string name="sensor_description_none">No description</string>
     <string name="sensor_description_phone_state">Whether the phone is ringing or in a call, no other caller information is stored</string>
     <string name="sensor_description_power_save">Whether the device is in Power Save mode</string>
@@ -1124,8 +1126,7 @@
     <string name="sensor_description_daily_calories">The total number of calories over a day (including both BMR and active calories), where the previous day ends and a new day begins at 12:00 AM local time.</string>
     <string name="sensor_name_daily_steps">Daily steps</string>
     <string name="sensor_description_daily_steps">The total step count over a day, where the previous day ends and a new day begins at 12:00 AM local time.</string>
-    <string name="sensor_name_nfc_sensor">NFC state</string>
-    <string name="sensor_description_nfc_sensor">Whether NFC is enabled on the device</string>
+    <string name="sensor_name_nfc">NFC sensor</string>
     <string name="thread_debug">Sync Thread credentials</string>
     <string name="thread_debug_active">Syncing…</string>
     <string name="thread_debug_result_error">An unexpected error occurred while syncing</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import dagger.hilt.android.HiltAndroidApp
@@ -98,6 +99,12 @@ open class HomeAssistantApplication : Application() {
         registerReceiver(
             sensorReceiver,
             IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED)
+        )
+
+        // Listen for NFC state changes
+        registerReceiver(
+            sensorReceiver,
+            IntentFilter(NfcAdapter.ACTION_ADAPTER_STATE_CHANGED)
         )
 
         // Update complications when the screen is on

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.media.AudioManager
 import android.net.wifi.WifiManager
+import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import androidx.core.app.TaskStackBuilder
@@ -118,7 +119,8 @@ class SensorReceiver : SensorReceiverBase() {
         "com.google.android.clockwork.actions.WET_MODE_ENDED" to WetModeSensorManager.wetModeSensor.id,
         "android.bluetooth.device.action.ACL_CONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
         "android.bluetooth.device.action.ACL_DISCONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
-        BluetoothAdapter.ACTION_STATE_CHANGED to BluetoothSensorManager.bluetoothState.id
+        BluetoothAdapter.ACTION_STATE_CHANGED to BluetoothSensorManager.bluetoothState.id,
+        NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to NfcSensorManager.nfcStateSensor.id
     )
 
     override fun getSensorSettingsIntent(

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -27,6 +27,7 @@ import io.homeassistant.companion.android.common.sensors.LightSensorManager
 import io.homeassistant.companion.android.common.sensors.MobileDataManager
 import io.homeassistant.companion.android.common.sensors.NetworkSensorManager
 import io.homeassistant.companion.android.common.sensors.NextAlarmManager
+import io.homeassistant.companion.android.common.sensors.NfcSensorManager
 import io.homeassistant.companion.android.common.sensors.PhoneStateSensorManager
 import io.homeassistant.companion.android.common.sensors.PowerSensorManager
 import io.homeassistant.companion.android.common.sensors.PressureSensorManager
@@ -71,6 +72,7 @@ class SensorReceiver : SensorReceiverBase() {
             MobileDataManager(),
             NetworkSensorManager(),
             NextAlarmManager(),
+            NfcSensorManager(),
             OnBodySensorManager(),
             PhoneStateSensorManager(),
             PowerSensorManager(),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Add a new `binary_sensor` which represents whether the device has its NFC sensor enabled or not.

I added the new `NfcSensorManager` class to the `common` module, so it also works on Wear OS! I tested it on Wear OS 3.5.

The sensor reacts to changes immediately by subscribing to `NfcAdapter.ACTION_ADAPTER_STATE_CHANGED`.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#992

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->