### PR TITLE
Use recommended splash screen library for Wear OS

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ compose-compiler = "1.5.3"
 constraintlayout = "2.1.4"
 converterJackson = "2.9.0"
 coreKtx = "1.12.0"
+core-splashscreen = "1.1.0-alpha02"
 cronet-embedded = "113.5672.61"
 emojiJava = "5.1.1"
 firebase-bom = "32.2.3"
@@ -114,6 +115,7 @@ compose-uiTooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 converter-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "converterJackson" }
 core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
+core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "core-splashscreen" }
 cronet-embedded = { module = "org.chromium.net:cronet-embedded", version.ref = "cronet-embedded" }
 emojiJava = { module = "com.vdurmont:emoji-java", version.ref = "emojiJava" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebase-bom" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
 
     implementation(libs.wear)
     implementation(libs.core.ktx)
+    implementation(libs.core.splashscreen)
     implementation(libs.play.services.wearable)
     implementation(libs.wear.input)
     implementation(libs.wear.remote.interactions)

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -107,7 +107,7 @@
             android:icon="@mipmap/ic_assist_launcher"
             android:label="@string/ha_assist"
             android:launchMode="singleTask"
-            android:theme="@style/Theme.HomeAssistant.SplashTheme"
+            android:theme="@style/Theme.HomeAssistant.SplashThemeAssist"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -107,6 +107,7 @@
             android:icon="@mipmap/ic_assist_launcher"
             android:label="@string/ha_assist"
             android:launchMode="singleTask"
+            android:theme="@style/Theme.HomeAssistant.SplashTheme"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
 
         <activity android:name=".home.HomeActivity" />
         <activity android:name=".splash.SplashActivity"
-            android:theme="@style/SplashTheme"
+            android:theme="@style/Theme.HomeAssistant.SplashTheme"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.conversation.views.LoadAssistView
@@ -45,6 +46,7 @@ class ConversationActivity : ComponentActivity() {
     ) { conversationViewModel.onPermissionResult(it, this::launchVoiceInputIntent) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         lifecycleScope.launch {

--- a/wear/src/main/java/io/homeassistant/companion/android/splash/SplashActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/splash/SplashActivity.kt
@@ -2,11 +2,13 @@ package io.homeassistant.companion.android.splash
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import io.homeassistant.companion.android.home.HomeActivity
 
 class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        installSplashScreen()
         super.onCreate(savedInstanceState)
 
         val intent = HomeActivity.newInstance(this)

--- a/wear/src/main/res/drawable/splash_background.xml
+++ b/wear/src/main/res/drawable/splash_background.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:drawable="@drawable/app_icon"
+        android:drawable="@mipmap/ic_launcher_round"
         android:width="@dimen/splash_screen_icon_size"
         android:height="@dimen/splash_screen_icon_size"
         android:gravity="center"/>

--- a/wear/src/main/res/drawable/splash_background.xml
+++ b/wear/src/main/res/drawable/splash_background.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item android:drawable="@android:color/black" />
-
     <item
         android:drawable="@drawable/app_icon"
-        android:width="48dp"
-        android:height="48dp"
+        android:width="@dimen/splash_screen_icon_size"
+        android:height="@dimen/splash_screen_icon_size"
         android:gravity="center"/>
 
 </layer-list>

--- a/wear/src/main/res/drawable/splash_background_assist.xml
+++ b/wear/src/main/res/drawable/splash_background_assist.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@mipmap/ic_assist_launcher"
+        android:width="@dimen/splash_screen_icon_size"
+        android:height="@dimen/splash_screen_icon_size"
+        android:gravity="center"/>
+
+</layer-list>

--- a/wear/src/main/res/values/dimens.xml
+++ b/wear/src/main/res/values/dimens.xml
@@ -12,4 +12,9 @@
     inner_frame_layout_padding (below variable) on round screens.
     -->
     <dimen name="inner_frame_layout_padding">5dp</dimen>
+    
+    <!--
+    Dimensions for splash screen icon size.
+    -->
+    <dimen name="splash_screen_icon_size">48dp</dimen>
 </resources>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -30,9 +30,9 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.SplashScreen">
+    <style name="Theme.HomeAssistant.SplashTheme" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@android:color/black</item>
-        <item name="windowSplashScreenAnimatedIcon">@drawable/app_icon</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_background</item>
         <item name="postSplashScreenTheme">@style/Theme.HomeAssistant</item>
     </style>
 </resources>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -35,4 +35,10 @@
         <item name="windowSplashScreenAnimatedIcon">@drawable/splash_background</item>
         <item name="postSplashScreenTheme">@style/Theme.HomeAssistant</item>
     </style>
+
+    <style name="Theme.HomeAssistant.SplashThemeAssist" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@android:color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/splash_background_assist</item>
+        <item name="postSplashScreenTheme">@style/Theme.HomeAssistant</item>
+    </style>
 </resources>

--- a/wear/src/main/res/values/styles.xml
+++ b/wear/src/main/res/values/styles.xml
@@ -30,7 +30,9 @@
         <item name="android:fontFamily">sans-serif-medium</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:windowBackground">@drawable/splash_background</item>
+    <style name="SplashTheme" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@android:color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/app_icon</item>
+        <item name="postSplashScreenTheme">@style/Theme.HomeAssistant</item>
     </style>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We had another review failure for the splash screen this time. Turns out there is a new library and recommendation to follow. This PR implements: https://developer.android.com/training/wearables/apps/splash-screen

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

BEFORE
![image](https://github.com/home-assistant/android/assets/1634145/cdb574c3-b134-409c-8006-9bba154db544)

AFTER
![image](https://github.com/home-assistant/android/assets/1634145/6f542142-70db-4677-8595-7dde1420e157)

ASSIST
![image](https://github.com/home-assistant/android/assets/1634145/ee6169d5-d76a-4816-ab54-d7b5a5a01816)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Side Note: I dont quite notice a difference 🤷‍♂️ 