### PR TITLE
Update manual onboarding screens to prevent the button from overlapping elements

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
@@ -10,6 +10,7 @@ import androidx.wear.activity.ConfirmationActivity
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.databinding.ActivityIntegrationBinding
 import io.homeassistant.companion.android.home.HomeActivity
+import io.homeassistant.companion.android.util.adjustInset
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -44,6 +45,8 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
         binding.finish.setOnClickListener {
             presenter.onRegistrationAttempt(serverId, binding.deviceName.text.toString())
         }
+
+        adjustInset(applicationContext, binding, null)
     }
 
     override fun onResume() {

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
@@ -39,10 +39,10 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
         binding = ActivityIntegrationBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.serverUrl.setText(Build.MODEL)
+        binding.deviceName.setText(Build.MODEL)
 
         binding.finish.setOnClickListener {
-            presenter.onRegistrationAttempt(serverId, binding.serverUrl.text.toString())
+            presenter.onRegistrationAttempt(serverId, binding.deviceName.text.toString())
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
@@ -53,6 +53,7 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
         super.onResume()
 
         binding.loadingView.visibility = View.GONE
+        binding.constraintLayout.visibility = View.VISIBLE
     }
 
     override fun deviceRegistered() {
@@ -64,6 +65,7 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
 
     override fun showLoading() {
         binding.loadingView.visibility = View.VISIBLE
+        binding.constraintLayout.visibility = View.GONE
     }
 
     override fun showError() {
@@ -77,6 +79,7 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
         }
         startActivity(intent)
         binding.loadingView.visibility = View.GONE
+        binding.constraintLayout.visibility = View.VISIBLE
     }
 
     override fun onDestroy() {

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
@@ -36,7 +36,7 @@ class ManualSetupActivity : AppCompatActivity(), ManualSetupView {
         setContentView(binding.root)
 
         binding.buttonNext.setOnClickListener {
-            presenter.onNextClicked(this, findViewById<EditText>(R.id.server_url).text.toString())
+            presenter.onNextClicked(this, findViewById<EditText>(R.id.device_name).text.toString())
         }
     }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.databinding.ActivityManualSetupBinding
 import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationActivity
+import io.homeassistant.companion.android.util.adjustInset
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -38,6 +39,8 @@ class ManualSetupActivity : AppCompatActivity(), ManualSetupView {
         binding.buttonNext.setOnClickListener {
             presenter.onNextClicked(this, findViewById<EditText>(R.id.device_name).text.toString())
         }
+
+        adjustInset(applicationContext, null, binding)
     }
 
     override fun startIntegration(serverId: Int) {

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupActivity.kt
@@ -49,6 +49,7 @@ class ManualSetupActivity : AppCompatActivity(), ManualSetupView {
 
     override fun showLoading() {
         binding.loadingView.visibility = View.VISIBLE
+        binding.constraintLayout.visibility = View.GONE
     }
 
     override fun showContinueOnPhone() {
@@ -62,6 +63,7 @@ class ManualSetupActivity : AppCompatActivity(), ManualSetupView {
         }
         startActivity(confirmation)
         binding.loadingView.visibility = View.GONE
+        binding.constraintLayout.visibility = View.VISIBLE
     }
 
     override fun showError(@StringRes message: Int) {
@@ -75,12 +77,14 @@ class ManualSetupActivity : AppCompatActivity(), ManualSetupView {
         }
         startActivity(intent)
         binding.loadingView.visibility = View.GONE
+        binding.constraintLayout.visibility = View.VISIBLE
     }
 
     override fun onResume() {
         super.onResume()
 
         binding.loadingView.visibility = View.GONE
+        binding.constraintLayout.visibility = View.VISIBLE
     }
 
     override fun onDestroy() {

--- a/wear/src/main/java/io/homeassistant/companion/android/util/OnboardingPadding.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/OnboardingPadding.kt
@@ -1,0 +1,20 @@
+package io.homeassistant.companion.android.util
+
+import android.content.Context
+import android.content.res.Resources
+import io.homeassistant.companion.android.databinding.ActivityIntegrationBinding
+import io.homeassistant.companion.android.databinding.ActivityManualSetupBinding
+
+private const val FACTOR = 0.146467f // c = a * sqrt(2)
+
+fun adjustInset(
+    context: Context,
+    integrationBinding: ActivityIntegrationBinding? = null,
+    manualSetupBinding: ActivityManualSetupBinding? = null
+) {
+    if (context.resources.configuration.isScreenRound) {
+        val inset = (FACTOR * Resources.getSystem().displayMetrics.widthPixels).toInt()
+        val binding = integrationBinding ?: manualSetupBinding
+        binding?.root?.setPadding(inset, inset, inset, inset)
+    }
+}

--- a/wear/src/main/java/io/homeassistant/companion/android/util/OnboardingPadding.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/util/OnboardingPadding.kt
@@ -14,7 +14,10 @@ fun adjustInset(
 ) {
     if (context.resources.configuration.isScreenRound) {
         val inset = (FACTOR * Resources.getSystem().displayMetrics.widthPixels).toInt()
-        val binding = integrationBinding ?: manualSetupBinding
-        binding?.root?.setPadding(inset, inset, inset, inset)
+        if (integrationBinding != null) {
+            integrationBinding.linearLayout.setPadding(inset, inset, inset, inset)
+        } else {
+            manualSetupBinding?.linearLayout?.setPadding(inset, inset, inset, inset)
+        }
     }
 }

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -7,6 +7,7 @@
 
     <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/linear_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
@@ -17,6 +18,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:id="@+id/constraint_layout"
             android:padding="@dimen/inner_frame_layout_padding"
             app:layout_boxedEdges="all">
 

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -2,8 +2,7 @@
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="8dp">
+    android:layout_height="match_parent">
     <requestFocus />
 
     <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -1,64 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.wear.widget.BoxInsetLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/box_inset_layout_padding"
-    tools:context=".onboarding.integration.MobileAppIntegrationActivity"
-    tools:deviceIds="wear">
+    android:padding="8dp">
+    <requestFocus />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingTop="@dimen/inner_frame_layout_padding"
-        android:paddingStart="@dimen/inner_frame_layout_padding"
-        android:paddingEnd="@dimen/inner_frame_layout_padding"
-        app:layout_boxedEdges="top|left|right">
-        <requestFocus />
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        tools:context=".onboarding.integration.MobileAppIntegrationActivity"
+        tools:deviceIds="wear"
+        android:orientation="vertical">
 
-        <EditText
-            android:id="@+id/server_url"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:ems="10"
-            android:hint="@string/device_name"
-            android:inputType="textPersonName"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView"
-            android:importantForAutofill="no" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/inner_frame_layout_padding"
+            app:layout_boxedEdges="all">
 
-        <TextView
-            android:id="@+id/textView"
-            style="@style/HeaderText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/registerDevice"
-            android:maxLines="2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <EditText
+                android:id="@+id/device_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:ems="10"
+                android:minHeight="48dp"
+                android:hint="@string/device_name"
+                android:inputType="textPersonName"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView"
+                android:importantForAutofill="no" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/finish"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:contentDescription="@string/button_forward"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/server_url"
-            app:srcCompat="@drawable/ic_button_check" />
+            <TextView
+                android:id="@+id/textView"
+                style="@style/HeaderText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/registerDevice"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/finish"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/button_forward"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/device_name"
+                app:srcCompat="@drawable/ic_button_check" />
 
-    <io.homeassistant.companion.android.util.LoadingView
-        android:id="@+id/loading_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:loading_text="@string/attempting_registration"
-        android:visibility="gone" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.wear.widget.BoxInsetLayout>
+        <io.homeassistant.companion.android.util.LoadingView
+            android:id="@+id/loading_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:loading_text="@string/attempting_registration"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</ScrollView>

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -11,8 +11,11 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/inner_frame_layout_padding"
-        app:layout_boxedEdges="all">
+        android:paddingTop="@dimen/inner_frame_layout_padding"
+        android:paddingStart="@dimen/inner_frame_layout_padding"
+        android:paddingEnd="@dimen/inner_frame_layout_padding"
+        app:layout_boxedEdges="top|left|right">
+        <requestFocus />
 
         <EditText
             android:id="@+id/server_url"
@@ -41,11 +44,11 @@
             android:id="@+id/finish"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="4dp"
             android:contentDescription="@string/button_forward"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/server_url"
             app:srcCompat="@drawable/ic_button_check" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/wear/src/main/res/layout/activity_integration.xml
+++ b/wear/src/main/res/layout/activity_integration.xml
@@ -36,6 +36,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/registerDevice"
+            android:maxLines="2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -35,6 +35,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/choose_server"
+            android:maxLines="2"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -3,8 +3,7 @@
 <ScrollView xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:padding="8dp">
+    android:layout_height="match_parent">
     <requestFocus />
 
     <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -9,6 +9,7 @@
     <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:id="@+id/linear_layout"
         android:gravity="center"
         tools:deviceIds="wear"
         android:orientation="vertical">
@@ -16,6 +17,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:id="@+id/constraint_layout"
             android:padding="@dimen/inner_frame_layout_padding"
             app:layout_boxedEdges="all">
 

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -1,63 +1,70 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.wear.widget.BoxInsetLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+
+<ScrollView xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:padding="@dimen/box_inset_layout_padding"
-    tools:deviceIds="wear">
+    android:padding="8dp">
+    <requestFocus />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:paddingTop="@dimen/inner_frame_layout_padding"
-        android:paddingStart="@dimen/inner_frame_layout_padding"
-        android:paddingEnd="@dimen/inner_frame_layout_padding"
-        app:layout_boxedEdges="top|left|right">
-        <requestFocus />
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        tools:deviceIds="wear"
+        android:orientation="vertical">
 
-        <EditText
-            android:id="@+id/server_url"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:ems="10"
-            android:hint="@string/input_url_hint"
-            android:inputType="textNoSuggestions"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView"
-            android:importantForAutofill="no" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:padding="@dimen/inner_frame_layout_padding"
+            app:layout_boxedEdges="all">
 
-        <TextView
-            android:id="@+id/textView"
-            style="@style/HeaderText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/choose_server"
-            android:maxLines="2"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            <EditText
+                android:id="@+id/device_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:ems="10"
+                android:minHeight="48dp"
+                android:hint="@string/input_url_hint"
+                android:inputType="textNoSuggestions"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView"
+                android:importantForAutofill="no"
+                tools:ignore="TextFields" />
 
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/button_next"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:contentDescription="@string/button_forward"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/server_url"
-            app:srcCompat="@drawable/ic_button_arrow_forward" />
+            <TextView
+                android:id="@+id/textView"
+                style="@style/HeaderText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/manual_title"
+                android:textAlignment="center"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/button_next"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:contentDescription="@string/button_forward"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/device_name"
+                app:srcCompat="@drawable/ic_button_arrow_forward" />
 
-    <io.homeassistant.companion.android.util.LoadingView
-        android:id="@+id/loading_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:loading_text="@string/attempting_connection"
-        android:visibility="gone" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.wear.widget.BoxInsetLayout>
+        <io.homeassistant.companion.android.util.LoadingView
+            android:id="@+id/loading_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            app:loading_text="@string/attempting_connection"
+            android:visibility="gone" />
+
+    </LinearLayout>
+</ScrollView>

--- a/wear/src/main/res/layout/activity_manual_setup.xml
+++ b/wear/src/main/res/layout/activity_manual_setup.xml
@@ -10,8 +10,11 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:padding="@dimen/inner_frame_layout_padding"
-        app:layout_boxedEdges="all">
+        android:paddingTop="@dimen/inner_frame_layout_padding"
+        android:paddingStart="@dimen/inner_frame_layout_padding"
+        android:paddingEnd="@dimen/inner_frame_layout_padding"
+        app:layout_boxedEdges="top|left|right">
+        <requestFocus />
 
         <EditText
             android:id="@+id/server_url"
@@ -40,10 +43,11 @@
             android:id="@+id/button_next"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
             android:contentDescription="@string/button_forward"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/server_url"
             app:srcCompat="@drawable/ic_button_arrow_forward" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed when largest font size is used and user attempts to manually enter the URL using Advanced option when app is not installed the next button overlaps the text field.

Moved to `ScrollView` to allow the screen to be scrollable.

Increased min height so the tap area is larger per recommendation in android studio

Used the same manual URL string as the phone app as the current string was odd

Add padding if the device is round based on: https://stackoverflow.com/a/49338298


## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

BEFORE
![image](https://github.com/home-assistant/android/assets/1634145/58165c4d-447e-4e90-bedf-1c9548c2199c)

![image](https://github.com/home-assistant/android/assets/1634145/2328db35-0f71-4a63-9722-9c97b3f677a1)

AFTER

![image](https://github.com/home-assistant/android/assets/1634145/3fb0722f-9782-4c74-82e3-1db610e824b3)

![image](https://github.com/home-assistant/android/assets/1634145/a7c18170-91ca-4224-9171-d00c7f14d267)

![image](https://github.com/home-assistant/android/assets/1634145/07f0d39c-c25c-4467-8cca-405a78a3a504)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->