### PR TITLE
Fix Picker rotary input on some devices and update design

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.home.views
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.runtime.Composable
@@ -10,15 +9,17 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.wear.compose.material.Picker
 import androidx.wear.compose.material.rememberPickerState
 import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.ButtonDefaults
 import androidx.wear.compose.material3.Icon
+import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
@@ -39,8 +40,7 @@ fun RefreshIntervalPickerView(
     val initialIndex = options.indexOf(currentInterval)
     val state = rememberPickerState(
         initialNumberOfOptions = options.size,
-        initiallySelectedOption = if (initialIndex != -1) initialIndex else 0,
-        repeatItems = true
+        initiallySelectedOption = if (initialIndex != -1) initialIndex else 0
     )
 
     Column(
@@ -53,13 +53,17 @@ fun RefreshIntervalPickerView(
             contentDescription = stringResource(R.string.refresh_interval),
             modifier = Modifier
                 .weight(1f)
-                .padding(all = 8.dp)
                 .rotaryWithSnap(state.toRotaryScrollAdapter())
         ) {
             Text(
-                intervalToString(LocalContext.current, options[it]),
-                fontSize = 24.sp,
-                color = if (it != this.selectedOption) wearColorScheme.onBackground else wearColorScheme.primary
+                text = intervalToString(LocalContext.current, options[it]),
+                style = with(LocalDensity.current) {
+                    MaterialTheme.typography.displayMedium.copy(
+                        fontWeight = FontWeight.Medium,
+                        fontSize = MaterialTheme.typography.displayMedium.fontSize.value.dp.toSp() // Ignore text scaling
+                    )
+                },
+                color = wearColorScheme.primary
             )
         }
         Button(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
On some devices with imprecise rotary input, such as the Galaxy Watch 4 I personally use, the picker items were too small resulting in skipping every other item which is impractical (you could only select odd-indexed items using touch). This PR updates the picker design to [the design guidelines](https://developer.android.com/design/ui/wear/guides/components/pickers), which fixes this issue as the items are now larger. Code for style based on Horologist's DatePicker.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before|After|
|-----|----|
|![A Picker with smaller text, normal font weight and different color depending on position](https://github.com/home-assistant/android/assets/8148535/0e053e23-3e4c-43e8-b7f3-fc9d788935d6)|![A Picker with larger text, bold and all the same color](https://github.com/home-assistant/android/assets/8148535/78f1f5b6-ea60-4fce-8313-45b3299d6bb1)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->