### PR TITLE
Add Wear OS TLS client certificate authentication (TLS CCA) support

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearMainView.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.wearable.Node
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.HomeAssistantApplication
 import io.homeassistant.companion.android.onboarding.OnboardApp
 import io.homeassistant.companion.android.settings.wear.SettingsWearViewModel
 import kotlinx.coroutines.cancel
@@ -71,15 +72,16 @@ class SettingsWearMainView : AppCompatActivity() {
                 locationTrackingPossible = false,
                 notificationsPossible = false,
                 isWatch = true,
-                discoveryOptions = OnboardApp.DiscoveryOptions.ADD_EXISTING_EXTERNAL
+                discoveryOptions = OnboardApp.DiscoveryOptions.ADD_EXISTING_EXTERNAL,
+                mayRequireTlsClientCertificate = (application as HomeAssistantApplication).keyChainRepository.getPrivateKey() != null
             ) // While notifications are technically possible, the app can't handle this for the Wear device
         )
     }
 
     private fun onOnboardingComplete(result: OnboardApp.Output?) {
         if (result != null) {
-            val (url, authCode, deviceName, deviceTrackingEnabled, _) = result
-            settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled, true)
+            val (url, authCode, deviceName, deviceTrackingEnabled, _, tlsCertificateUri, tlsCertificatePassword) = result
+            settingsWearViewModel.sendAuthToWear(url, authCode, deviceName, deviceTrackingEnabled, true, tlsCertificateUri, tlsCertificatePassword)
         } else {
             Log.e(TAG, "onOnboardingComplete: Activity result returned null intent data")
         }

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltAndroidApp
 open class HomeAssistantApplication : Application() {
@@ -40,6 +41,7 @@ open class HomeAssistantApplication : Application() {
     lateinit var prefsRepository: PrefsRepository
 
     @Inject
+    @Named("keyChainRepository")
     lateinit var keyChainRepository: KeyChainRepository
 
     @Inject

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingActivity.kt
@@ -44,6 +44,7 @@ class OnboardingActivity : BaseActivity() {
         }
         viewModel.deviceIsWatch = input.isWatch
         viewModel.discoveryOptions = input.discoveryOptions
+        viewModel.mayRequireTlsClientCertificate = input.mayRequireTlsClientCertificate
 
         if (savedInstanceState == null) {
             supportFragmentManager.commit {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.onboarding
 
 import android.app.Application
+import android.net.Uri
 import android.util.Log
 import android.webkit.URLUtil
 import android.widget.Toast
@@ -52,6 +53,11 @@ class OnboardingViewModel @Inject constructor(
     var locationTrackingEnabled by mutableStateOf(false)
     val notificationsPossible = mutableStateOf(true)
     var notificationsEnabled by mutableStateOf(false)
+    var mayRequireTlsClientCertificate by mutableStateOf(false)
+    var tlsClientCertificateUri: Uri? by mutableStateOf(null)
+    var tlsClientCertificateFilename by mutableStateOf("")
+    var tlsClientCertificatePassword by mutableStateOf("")
+    var tlsClientCertificatePasswordCorrect by mutableStateOf(false)
 
     private var authCode = ""
 
@@ -81,7 +87,9 @@ class OnboardingViewModel @Inject constructor(
         authCode = authCode,
         deviceName = deviceName.value,
         deviceTrackingEnabled = locationTrackingEnabled,
-        notificationsEnabled = notificationsEnabled
+        notificationsEnabled = notificationsEnabled,
+        tlsClientCertificateUri = tlsClientCertificateUri?.toString() ?: "",
+        tlsClientCertificatePassword = tlsClientCertificatePassword
     )
 
     fun onDiscoveryActive() {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -36,6 +36,7 @@ import io.homeassistant.companion.android.util.isStarted
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import javax.inject.Inject
+import javax.inject.Named
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -54,6 +55,7 @@ class AuthenticationFragment : Fragment() {
     lateinit var themesManager: ThemesManager
 
     @Inject
+    @Named("keyChainRepository")
     lateinit var keyChainRepository: KeyChainRepository
 
     @SuppressLint("SetJavaScriptEnabled")

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.PowerManager
+import android.provider.OpenableColumns
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
@@ -25,6 +26,8 @@ import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
 import io.homeassistant.companion.android.onboarding.notifications.NotificationPermissionFragment
 import io.homeassistant.companion.android.sensors.LocationSensorManager
+import java.io.IOException
+import java.security.KeyStore
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -32,6 +35,9 @@ class MobileAppIntegrationFragment : Fragment() {
 
     private val requestLocationPermissions = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
         onLocationPermissionResult(it)
+    }
+    private val getContent = registerForActivityResult(ActivityResultContracts.GetContent()) {
+        onGetContentResult(it)
     }
 
     private var dialog: AlertDialog? = null
@@ -49,6 +55,8 @@ class MobileAppIntegrationFragment : Fragment() {
                         onboardingViewModel = viewModel,
                         openPrivacyPolicy = this@MobileAppIntegrationFragment::openPrivacyPolicy,
                         onLocationTrackingChanged = this@MobileAppIntegrationFragment::onLocationTrackingChanged,
+                        onSelectTLSCertificateClicked = this@MobileAppIntegrationFragment::onSelectTLSCertificateClicked,
+                        onCheckPassword = this@MobileAppIntegrationFragment::onCheckTLSCertificatePassword,
                         onFinishClicked = this@MobileAppIntegrationFragment::onComplete
                     )
                 }
@@ -86,6 +94,39 @@ class MobileAppIntegrationFragment : Fragment() {
         }
 
         viewModel.setLocationTracking(checked)
+    }
+
+    private fun onSelectTLSCertificateClicked() {
+        getContent.launch("*/*")
+    }
+
+    private fun onCheckTLSCertificatePassword(password: String) {
+        var ok: Boolean
+        context?.contentResolver?.openInputStream(viewModel.tlsClientCertificateUri!!)!!.buffered().use {
+            val keystore = KeyStore.getInstance("PKCS12")
+            ok = try {
+                keystore.load(it, password.toCharArray())
+                true
+            } catch (e: IOException) {
+                // we cannot determine if it failed due to wrong password or other reasons, since e.cause is not set to UnrecoverableKeyException
+                false
+            }
+        }
+        viewModel.tlsClientCertificatePasswordCorrect = ok
+    }
+
+    @SuppressLint("Range")
+    private fun onGetContentResult(uri: Uri?) {
+        if (uri != null) {
+            context?.contentResolver?.query(uri, null, null, null, null)?.use { cursor ->
+                cursor.moveToFirst()
+
+                viewModel.tlsClientCertificateUri = uri
+                viewModel.tlsClientCertificateFilename = cursor.getString(cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME))
+            }
+            // check with empty password
+            onCheckTLSCertificatePassword("")
+        }
     }
 
     private fun requestPermissions(sensorId: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
@@ -153,11 +153,19 @@ fun MobileAppIntegrationView(
                                 }
                             ),
                             trailingIcon = {
-                                Icon(
-                                    imageVector = if (onboardingViewModel.tlsClientCertificatePasswordCorrect) Icons.Filled.CheckCircle else Icons.Filled.Error,
-                                    tint = if (!onboardingViewModel.tlsClientCertificatePasswordCorrect) colorResource(commonR.color.colorWarning) else colorResource(commonR.color.colorOnBackground),
-                                    contentDescription = null
-                                )
+                                if (onboardingViewModel.tlsClientCertificatePasswordCorrect) {
+                                    Icon(
+                                        imageVector = Icons.Filled.CheckCircle,
+                                        tint = colorResource(commonR.color.colorOnBackground),
+                                        contentDescription = stringResource(id = commonR.string.password_correct)
+                                    )
+                                } else {
+                                    Icon(
+                                        imageVector = Icons.Filled.Error,
+                                        tint = colorResource(commonR.color.colorWarning),
+                                        contentDescription = stringResource(id = commonR.string.password_incorrect)
+                                    )
+                                }
                             },
                             isError = !onboardingViewModel.tlsClientCertificatePasswordCorrect,
                             modifier = Modifier
@@ -179,7 +187,7 @@ fun MobileAppIntegrationView(
         ) {
             Button(
                 onClick = onFinishClicked,
-                enabled = !onboardingViewModel.deviceIsWatch || !onboardingViewModel.mayRequireTlsClientCertificate || onboardingViewModel.mayRequireTlsClientCertificate && onboardingViewModel.tlsClientCertificatePasswordCorrect
+                enabled = !onboardingViewModel.deviceIsWatch || onboardingViewModel.tlsClientCertificateUri == null || onboardingViewModel.tlsClientCertificatePasswordCorrect
             ) {
                 Text(stringResource(id = commonR.string.continue_connect))
             }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
@@ -133,45 +133,42 @@ fun MobileAppIntegrationView(
                     )
                 }
                 if (onboardingViewModel.tlsClientCertificateUri != null) {
-                    Row {
-                        TextField(
-                            value = onboardingViewModel.tlsClientCertificatePassword,
-                            onValueChange = {
-                                onboardingViewModel.tlsClientCertificatePassword = it
-                                onCheckPassword(onboardingViewModel.tlsClientCertificatePassword)
-                            },
-                            label = { Text(text = stringResource(id = commonR.string.password)) },
-                            singleLine = true,
-                            visualTransformation = PasswordVisualTransformation(),
-                            keyboardOptions = KeyboardOptions(
-                                keyboardType = KeyboardType.Password,
-                                imeAction = ImeAction.Done
-                            ),
-                            keyboardActions = KeyboardActions(
-                                onDone = {
-                                    keyboardController?.hide()
-                                }
-                            ),
-                            trailingIcon = {
-                                if (onboardingViewModel.tlsClientCertificatePasswordCorrect) {
-                                    Icon(
-                                        imageVector = Icons.Filled.CheckCircle,
-                                        tint = colorResource(commonR.color.colorOnBackground),
-                                        contentDescription = stringResource(id = commonR.string.password_correct)
-                                    )
-                                } else {
-                                    Icon(
-                                        imageVector = Icons.Filled.Error,
-                                        tint = colorResource(commonR.color.colorWarning),
-                                        contentDescription = stringResource(id = commonR.string.password_incorrect)
-                                    )
-                                }
-                            },
-                            isError = !onboardingViewModel.tlsClientCertificatePasswordCorrect,
-                            modifier = Modifier
-                                .weight(1f)
-                        )
-                    }
+                    TextField(
+                        value = onboardingViewModel.tlsClientCertificatePassword,
+                        onValueChange = {
+                            onboardingViewModel.tlsClientCertificatePassword = it
+                            onCheckPassword(onboardingViewModel.tlsClientCertificatePassword)
+                        },
+                        label = { Text(text = stringResource(id = commonR.string.password)) },
+                        singleLine = true,
+                        visualTransformation = PasswordVisualTransformation(),
+                        keyboardOptions = KeyboardOptions(
+                            keyboardType = KeyboardType.Password,
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                keyboardController?.hide()
+                            }
+                        ),
+                        trailingIcon = {
+                            if (onboardingViewModel.tlsClientCertificatePasswordCorrect) {
+                                Icon(
+                                    imageVector = Icons.Filled.CheckCircle,
+                                    tint = colorResource(commonR.color.colorOnBackground),
+                                    contentDescription = stringResource(id = commonR.string.password_correct)
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Filled.Error,
+                                    tint = colorResource(commonR.color.colorWarning),
+                                    contentDescription = stringResource(id = commonR.string.password_incorrect)
+                                )
+                            }
+                        },
+                        isError = !onboardingViewModel.tlsClientCertificatePasswordCorrect,
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
             }
             TextButton(onClick = openPrivacyPolicy) {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationView.kt
@@ -3,19 +3,26 @@ package io.homeassistant.companion.android.onboarding.integration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Switch
 import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.material.TextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -26,6 +33,8 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.onboarding.OnboardingHeaderView
@@ -38,6 +47,8 @@ fun MobileAppIntegrationView(
     onboardingViewModel: OnboardingViewModel,
     openPrivacyPolicy: () -> Unit,
     onLocationTrackingChanged: (Boolean) -> Unit,
+    onSelectTLSCertificateClicked: () -> Unit,
+    onCheckPassword: (String) -> Unit,
     onFinishClicked: () -> Unit
 ) {
     val scrollState = rememberScrollState()
@@ -97,6 +108,64 @@ fun MobileAppIntegrationView(
                     fontWeight = FontWeight.Light
                 )
             }
+            if (onboardingViewModel.deviceIsWatch && onboardingViewModel.mayRequireTlsClientCertificate) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(id = commonR.string.tls_cert_onboarding_title),
+                    style = MaterialTheme.typography.h6
+                )
+                Text(
+                    text = stringResource(id = commonR.string.tls_cert_onboarding_description),
+                    fontWeight = FontWeight.Light
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Button(onClick = onSelectTLSCertificateClicked) {
+                        Text(text = stringResource(id = commonR.string.select_file))
+                    }
+                    Text(
+                        text = onboardingViewModel.tlsClientCertificateFilename,
+                        modifier = Modifier
+                            .align(Alignment.CenterVertically)
+                    )
+                }
+                if (onboardingViewModel.tlsClientCertificateUri != null) {
+                    Row {
+                        TextField(
+                            value = onboardingViewModel.tlsClientCertificatePassword,
+                            onValueChange = {
+                                onboardingViewModel.tlsClientCertificatePassword = it
+                                onCheckPassword(onboardingViewModel.tlsClientCertificatePassword)
+                            },
+                            label = { Text(text = stringResource(id = commonR.string.password)) },
+                            singleLine = true,
+                            visualTransformation = PasswordVisualTransformation(),
+                            keyboardOptions = KeyboardOptions(
+                                keyboardType = KeyboardType.Password,
+                                imeAction = ImeAction.Done
+                            ),
+                            keyboardActions = KeyboardActions(
+                                onDone = {
+                                    keyboardController?.hide()
+                                }
+                            ),
+                            trailingIcon = {
+                                Icon(
+                                    imageVector = if (onboardingViewModel.tlsClientCertificatePasswordCorrect) Icons.Filled.CheckCircle else Icons.Filled.Error,
+                                    tint = if (!onboardingViewModel.tlsClientCertificatePasswordCorrect) colorResource(commonR.color.colorWarning) else colorResource(commonR.color.colorOnBackground),
+                                    contentDescription = null
+                                )
+                            },
+                            isError = !onboardingViewModel.tlsClientCertificatePasswordCorrect,
+                            modifier = Modifier
+                                .weight(1f)
+                        )
+                    }
+                }
+            }
             TextButton(onClick = openPrivacyPolicy) {
                 Text(stringResource(id = commonR.string.privacy_url))
             }
@@ -108,7 +177,10 @@ fun MobileAppIntegrationView(
                 .fillMaxWidth(),
             horizontalArrangement = Arrangement.End
         ) {
-            Button(onClick = onFinishClicked) {
+            Button(
+                onClick = onFinishClicked,
+                enabled = !onboardingViewModel.deviceIsWatch || !onboardingViewModel.mayRequireTlsClientCertificate || onboardingViewModel.mayRequireTlsClientCertificate && onboardingViewModel.tlsClientCertificatePasswordCorrect
+            ) {
                 Text(stringResource(id = commonR.string.continue_connect))
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/util/TLSWebViewClient.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/TLSWebViewClient.kt
@@ -19,8 +19,9 @@ import java.security.PrivateKey
 import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import javax.inject.Inject
+import javax.inject.Named
 
-open class TLSWebViewClient @Inject constructor(private var keyChainRepository: KeyChainRepository) : WebViewClient() {
+open class TLSWebViewClient @Inject constructor(@Named("keyChainRepository") private var keyChainRepository: KeyChainRepository) : WebViewClient() {
 
     var isTLSClientAuthNeeded = false
         private set

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -116,6 +116,7 @@ import org.chromium.net.CronetEngine
 import org.json.JSONObject
 import java.util.concurrent.Executors
 import javax.inject.Inject
+import javax.inject.Named
 import io.homeassistant.companion.android.common.R as commonR
 
 @OptIn(androidx.media3.common.util.UnstableApi::class)
@@ -189,6 +190,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     lateinit var authenticationDao: AuthenticationDao
 
     @Inject
+    @Named("keyChainRepository")
     lateinit var keyChainRepository: KeyChainRepository
 
     private lateinit var binding: ActivityWebviewBinding

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
@@ -18,6 +18,7 @@ import io.homeassistant.companion.android.common.data.authentication.impl.Authen
 import io.homeassistant.companion.android.common.data.integration.impl.IntegrationService
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepositoryImpl
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
@@ -159,7 +160,13 @@ abstract class DataModule {
 
     @Binds
     @Singleton
+    @Named("keyChainRepository")
     abstract fun bindKeyChainRepository(keyChainRepository: KeyChainRepositoryImpl): KeyChainRepository
+
+    @Binds
+    @Singleton
+    @Named("keyStore")
+    abstract fun bindKeyStore(keyStore: KeyStoreImpl): KeyChainRepository
 
     @Binds
     @Singleton

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/DataModule.kt
@@ -18,7 +18,7 @@ import io.homeassistant.companion.android.common.data.authentication.impl.Authen
 import io.homeassistant.companion.android.common.data.integration.impl.IntegrationService
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepositoryImpl
-import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreRepositoryImpl
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
@@ -166,7 +166,7 @@ abstract class DataModule {
     @Binds
     @Singleton
     @Named("keyStore")
-    abstract fun bindKeyStore(keyStore: KeyStoreImpl): KeyChainRepository
+    abstract fun bindKeyStore(keyStore: KeyStoreRepositoryImpl): KeyChainRepository
 
     @Binds
     @Singleton

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/TLSHelper.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/TLSHelper.kt
@@ -9,12 +9,16 @@ import java.security.Principal
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import javax.inject.Inject
+import javax.inject.Named
 import javax.net.ssl.SSLContext
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509ExtendedKeyManager
 import javax.net.ssl.X509TrustManager
 
-class TLSHelper @Inject constructor(private val keyChainRepository: KeyChainRepository) {
+class TLSHelper @Inject constructor(
+    @Named("keyChainRepository") private val keyChainRepository: KeyChainRepository,
+    @Named("keyStore") private val keyStore: KeyChainRepository
+) {
 
     fun setupOkHttpClientSSLSocketFactory(builder: OkHttpClient.Builder) {
         val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
@@ -64,7 +68,7 @@ class TLSHelper @Inject constructor(private val keyChainRepository: KeyChainRepo
 
                 // block until a chain is provided via the TLSWebView
                 runBlocking {
-                    chain = keyChainRepository.getCertificateChain()
+                    chain = keyChainRepository.getCertificateChain() ?: keyStore.getCertificateChain()
                 }
 
                 return chain
@@ -75,7 +79,7 @@ class TLSHelper @Inject constructor(private val keyChainRepository: KeyChainRepo
 
                 // block until a key is provided via the TLSWebView
                 runBlocking {
-                    key = keyChainRepository.getPrivateKey()
+                    key = keyChainRepository.getPrivateKey() ?: keyStore.getPrivateKey()
                 }
 
                 return key

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepository.kt
@@ -12,6 +12,8 @@ interface KeyChainRepository {
 
     suspend fun load(context: Context)
 
+    suspend fun setData(alias: String, privateKey: PrivateKey, certificateChain: Array<X509Certificate>)
+
     fun getAlias(): String?
 
     fun getPrivateKey(): PrivateKey?

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.lang.UnsupportedOperationException
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
 import javax.inject.Inject
@@ -38,6 +39,10 @@ class KeyChainRepositoryImpl @Inject constructor(
         }
 
         doLoad(context)
+    }
+
+    override suspend fun setData(alias: String, privateKey: PrivateKey, certificateChain: Array<X509Certificate>) {
+        throw UnsupportedOperationException("setData not supported for KeyChainRepositoryImpl")
     }
 
     override fun getAlias(): String? {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyStoreImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyStoreImpl.kt
@@ -13,6 +13,7 @@ import javax.inject.Inject
 class KeyStoreImpl @Inject constructor() : KeyChainRepository {
     companion object {
         private const val TAG = "KeyStoreRepository"
+        const val ALIAS = "TLSClientCertificate"
     }
 
     private var alias: String? = null

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyStoreImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyStoreImpl.kt
@@ -1,0 +1,102 @@
+package io.homeassistant.companion.android.common.data.keychain
+
+import android.content.Context
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.security.KeyStore
+import java.security.KeyStore.PrivateKeyEntry
+import java.security.PrivateKey
+import java.security.cert.X509Certificate
+import javax.inject.Inject
+
+class KeyStoreImpl @Inject constructor() : KeyChainRepository {
+    companion object {
+        private const val TAG = "KeyStoreRepository"
+    }
+
+    private var alias: String? = null
+    private var key: PrivateKey? = null
+    private var chain: Array<X509Certificate>? = null
+
+    override suspend fun clear() {
+        alias = null
+        key = null
+        chain = null
+    }
+
+    override suspend fun load(context: Context, alias: String) = withContext(Dispatchers.IO) {
+        this@KeyStoreImpl.alias = alias
+        doLoad()
+    }
+
+    override suspend fun load(context: Context) {
+        throw IllegalArgumentException("Key alias cannot be null.")
+    }
+
+    override suspend fun setData(alias: String, privateKey: PrivateKey, certificateChain: Array<X509Certificate>) = withContext(Dispatchers.IO) {
+        clear()
+        doStore(alias, privateKey, certificateChain)
+        this@KeyStoreImpl.alias = alias
+        doLoad()
+    }
+
+    override fun getAlias(): String? {
+        return alias
+    }
+
+    override fun getPrivateKey(): PrivateKey? {
+        return key
+    }
+
+    override fun getCertificateChain(): Array<X509Certificate>? {
+        return chain
+    }
+
+    @Synchronized
+    private fun doLoad() {
+        if (alias != null && alias?.isNotEmpty() == true) {
+            val aks = KeyStore.getInstance("AndroidKeyStore").apply {
+                load(null)
+                if (!containsAlias(alias)) return
+            }
+            val entry = try {
+                aks.getEntry(alias, null) as PrivateKeyEntry
+            } catch (e: Exception) {
+                Log.e(TAG, "Exception getting KeyStore.Entry", e)
+                null
+            }
+            if (entry != null) {
+                if (chain == null) {
+                    chain = try {
+                        entry.certificateChain as Array<X509Certificate>
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Exception getting certificate chain", e)
+                        null
+                    }
+                }
+                if (key == null) {
+                    key = try {
+                        entry.privateKey
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Exception getting private key", e)
+                        null
+                    }
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    private fun doStore(alias: String, key: PrivateKey, chain: Array<X509Certificate>) {
+        try {
+            KeyStore.getInstance("AndroidKeyStore").apply {
+                load(null)
+                setEntry(alias, PrivateKeyEntry(key, chain), null)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Exception storing KeyStore.Entry", e)
+            return
+        }
+    }
+}

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -490,6 +490,8 @@
     <string name="other_settings">Other settings</string>
     <string name="other">Other</string>
     <string name="password">Password</string>
+    <string name="password_correct">Correct password</string>
+    <string name="password_incorrect">Incorrect password</string>
     <string name="permission_explanation_calls">In order to track incoming and outgoing call\'s occurrence we need access to your phone state. No phone numbers or other call details will be stored.</string>
     <string name="permission_explanation">In order to use location tracking features or different connection urls based on WiFi SSID we need access to your location. If you want consistent background updates you will also need to allow background processing</string>
     <string name="persistent_notification">Persistent notification</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -551,6 +551,7 @@
     <string name="security">Security</string>
     <string name="select">Select</string>
     <string name="select_entity_to_display">Select entity to display</string>
+    <string name="select_file">Select file</string>
     <string name="select_instance">Select your Home Assistant server</string>
     <string name="sensor_description_active_notification_count">Total count of active notifications that are visible to the user including silent, persistent and the Sensor Worker notifications.</string>
     <string name="sensor_description_app_importance">If the app is in the foreground, background or any other state it can be</string>
@@ -1093,6 +1094,8 @@
     <string name="tls_cert_title">TLS client certificate error</string>
     <string name="tls_cert_not_found_message">The remote site requires a client certificate.\nPlease install the required credential on your phone and try again.</string>
     <string name="tls_cert_expired_message">The certificate is not yet or no longer valid.\nPlease install a new credential on your phone and try again.</string>
+    <string name="tls_cert_onboarding_description">If your Home Assistant instance requires TLS client certificate authentication, select a TLS client certificate file to install it on your Wear OS device.</string>
+    <string name="tls_cert_onboarding_title">TLS client certificate</string>
     <string name="basic_sensor_name_battery_power">Battery power</string>
     <string name="widget_checkbox_require_authentication">Require authentication</string>
     <string name="widget_error_authenticating">Error authenticating - is an authentication method configured?</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.PowerManager
 import dagger.hilt.android.HiltAndroidApp
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
 import io.homeassistant.companion.android.complications.ComplicationReceiver
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import kotlinx.coroutines.CoroutineScope
@@ -33,7 +34,7 @@ open class HomeAssistantApplication : Application() {
         super.onCreate()
 
         ioScope.launch {
-            keyStore.load(applicationContext, "TLSClientCertificate")
+            keyStore.load(applicationContext, KeyStoreImpl.ALIAS)
         }
 
         val sensorReceiver = SensorReceiver()

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -11,13 +11,30 @@ import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import dagger.hilt.android.HiltAndroidApp
+import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.complications.ComplicationReceiver
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
 
 @HiltAndroidApp
 open class HomeAssistantApplication : Application() {
+    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + Job())
+
+    @Inject
+    @Named("keyStore")
+    lateinit var keyStore: KeyChainRepository
+
     override fun onCreate() {
         super.onCreate()
+
+        ioScope.launch {
+            keyStore.load(applicationContext, "TLSClientCertificate")
+        }
 
         val sensorReceiver = SensorReceiver()
         // This will cause the sensor to be updated every time the OS broadcasts that a cable was plugged/unplugged.

--- a/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -12,7 +12,7 @@ import android.os.Build
 import android.os.PowerManager
 import dagger.hilt.android.HiltAndroidApp
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
-import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreRepositoryImpl
 import io.homeassistant.companion.android.complications.ComplicationReceiver
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +34,7 @@ open class HomeAssistantApplication : Application() {
         super.onCreate()
 
         ioScope.launch {
-            keyStore.load(applicationContext, KeyStoreImpl.ALIAS)
+            keyStore.load(applicationContext, KeyStoreRepositoryImpl.ALIAS)
         }
 
         val sensorReceiver = SensorReceiver()

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
-import java.io.IOException
 import java.security.KeyStore
 import java.security.PrivateKey
 import java.security.cert.X509Certificate
@@ -156,20 +155,16 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
             // load TLS key
             if (tlsClientCertificateData != null && tlsClientCertificateData.isNotEmpty()) {
                 KeyStore.getInstance("PKCS12").apply {
-                    try {
-                        load(tlsClientCertificateData.inputStream(), tlsClientCertificatePassword)
+                    load(tlsClientCertificateData.inputStream(), tlsClientCertificatePassword)
 
-                        val alias = aliases().nextElement()
-                        val certificateChain = getCertificateChain(alias).filterIsInstance<X509Certificate>().toTypedArray()
-                        val privateKey = getKey(alias, tlsClientCertificatePassword) as PrivateKey
+                    val alias = aliases().nextElement()
+                    val certificateChain = getCertificateChain(alias).filterIsInstance<X509Certificate>().toTypedArray()
+                    val privateKey = getKey(alias, tlsClientCertificatePassword) as PrivateKey
 
-                        // we store the TLS Client key under a static alias because there is currently
-                        // no way to ask the user for the correct alias
-                        keyStore.setData(KeyStoreRepositoryImpl.ALIAS, privateKey, certificateChain)
-                        keyChainRepository.load(applicationContext)
-                    } catch (e: IOException) {
-                        Log.e(TAG, "Cannot load TLS client certificate", e)
-                    }
+                    // we store the TLS Client key under a static alias because there is currently
+                    // no way to ask the user for the correct alias
+                    keyStore.setData(KeyStoreRepositoryImpl.ALIAS, privateKey, certificateChain)
+                    keyChainRepository.load(applicationContext)
                 }
             }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -19,7 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
-import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreRepositoryImpl
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.WearDataMessages
@@ -165,7 +165,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
 
                         // we store the TLS Client key under a static alias because there is currently
                         // no way to ask the user for the correct alias
-                        keyStore.setData(KeyStoreImpl.ALIAS, privateKey, certificateChain)
+                        keyStore.setData(KeyStoreRepositoryImpl.ALIAS, privateKey, certificateChain)
                         keyChainRepository.load(applicationContext)
                     } catch (e: IOException) {
                         Log.e(TAG, "Cannot load TLS client certificate", e)

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -19,6 +19,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
+import io.homeassistant.companion.android.common.data.keychain.KeyStoreImpl
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.WearDataMessages
@@ -164,7 +165,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
 
                         // we store the TLS Client key under a static alias because there is currently
                         // no way to ask the user for the correct alias
-                        keyStore.setData("TLSClientCertificate", privateKey, certificateChain)
+                        keyStore.setData(KeyStoreImpl.ALIAS, privateKey, certificateChain)
                         keyChainRepository.load(applicationContext)
                     } catch (e: IOException) {
                         Log.e(TAG, "Cannot load TLS client certificate", e)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Wear OS does not currently allow the user to install certificates to the system-wide KeyChain for TLS CCA support. This commit adds support for using certificates from the app-specific Android KeyStore with UI for setting up a certificate during the Wear OS onboarding process. The manual step in the onboarding process is required since we cannot transmit certificates of the Android KeyChain because they are not extractable.

In particular, this commit adds the following changes:
* KeyStoreImpl as an additional KeyChainRepository interface implementation for loading and storing keys to the application's KeyStore. TLSHelper uses KeyStoreImpl as a fallback key manager.
* UI for selecting a certificate file with GET_CONTENT intent during Wear OS onboarding in OnboardingActivity if it is detected that the Home Assistant may require TLS CCA. The UI includes a password check for the PKCS12 container.
* During onboarding the app sends the raw PKCS12 data to Wear OS together with the container password. The connection is assumed to be encrypted and trusted so that no additional encryption is necessary.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Onboarding with certificate selection (light mode):
<img src ="https://github.com/home-assistant/android/assets/6516878/d2b05f71-1494-4f13-9f04-a0e6c1f0cf91" width="30%" title="Screenshot_20231008_163611" /><img src ="https://github.com/home-assistant/android/assets/6516878/90cba7ad-f28c-4b7a-9ded-5791e9ba65c4" width="30%" title="Screenshot_20231008_163659" /><img src ="https://github.com/home-assistant/android/assets/6516878/8998418a-119b-4671-a3b0-ad4db5b259ea" width="30%" title="Screenshot_20231008_163710" /><img src ="https://github.com/home-assistant/android/assets/6516878/14d1bbc5-657d-4d4b-9826-844228a09825" width="30%" title="Screenshot_20231008_163725" />

Onboarding with certificate selection (dark mode):
<img src ="https://github.com/home-assistant/android/assets/6516878/d2ac7473-a304-45b1-8e47-0d69f5f8470c" width="30%" title="Screenshot_20231008_171321" /><img src ="https://github.com/home-assistant/android/assets/6516878/5b3fe2bb-b6e7-438d-a3a4-45bdb2051708" width="30%" title="Screenshot_20231008_171330" />


Onboarding without certificate selection (no changes):
<img src ="https://github.com/home-assistant/android/assets/6516878/4703cb7d-2a0b-4d78-b796-163e92b40339" width="30%" title="Screenshot_20231008_165508" />



## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#995


## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This is a fix #2771. The linked issues also contains the idea to generate a certificate signing request on the Wear OS device, however, this PR does not add support for this feature.