### PR TITLE
Prevent notification attachments failing due to spaces ( ) in url

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1210,9 +1210,10 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         data[ICON_URL]?.let {
+            val dataIcon = it.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
-            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), it)
-            val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(it))
+            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataIcon)
+            val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(dataIcon))
             if (bitmap != null) {
                 builder.setLargeIcon(bitmap)
             }
@@ -1224,9 +1225,10 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         data[IMAGE_URL]?.let {
+            val dataImage = it.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
-            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), it)
-            val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(it))
+            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataImage)
+            val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(dataImage))
             if (bitmap != null) {
                 builder
                     .setLargeIcon(bitmap)
@@ -1270,9 +1272,10 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         data[VIDEO_URL]?.let {
+            val dataVideo = it.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
-            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), it)
-            getVideoFrames(serverId, url, !UrlUtil.isAbsoluteUrl(it))?.let { frames ->
+            val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataVideo)
+            getVideoFrames(serverId, url, !UrlUtil.isAbsoluteUrl(dataVideo))?.let { frames ->
                 Log.d(TAG, "Found ${frames.size} frames for video notification")
                 RemoteViews(context.packageName, R.layout.view_image_flipper).let { remoteViewFlipper ->
                     if (frames.isNotEmpty()) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3926 by automatically replacing ` ` in URLs with the encoded character `%20`. Not replacing any other characters as that might break URLs including already encoded URLs. (This feels like a 'safe' change to automatically handle common user errors.)

Without this change, a notification attachment containing a space will fail the URL validation. Because of that failure it returns the base URL and downloads it (= the login page), which then cannot be processed as an image/video.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->