### PR TITLE
Improve camera tile add/remove event handling

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/CameraTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/CameraTile.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.guava.future
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -185,16 +185,17 @@ class CameraTile : TileService() {
             builder.build()
         }
 
-    override fun onTileAddEvent(requestParams: EventBuilders.TileAddEvent) {
-        serviceScope.launch {
-            AppDatabase.getInstance(this@CameraTile)
-                .cameraTileDao()
-                .add(CameraTile(id = requestParams.tileId))
+    override fun onTileAddEvent(requestParams: EventBuilders.TileAddEvent) = runBlocking {
+        withContext(Dispatchers.IO) {
+            val dao = AppDatabase.getInstance(this@CameraTile).cameraTileDao()
+            if (dao.get(requestParams.tileId) == null) {
+                dao.add(CameraTile(id = requestParams.tileId))
+            } // else already existing, don't overwrite existing tile data
         }
     }
 
-    override fun onTileRemoveEvent(requestParams: EventBuilders.TileRemoveEvent) {
-        serviceScope.launch {
+    override fun onTileRemoveEvent(requestParams: EventBuilders.TileRemoveEvent) = runBlocking {
+        withContext(Dispatchers.IO) {
             AppDatabase.getInstance(this@CameraTile)
                 .cameraTileDao()
                 .delete(requestParams.tileId)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Following reports by @dshokouhi in chats and [on Discord](https://discord.com/channels/330944238910963714/562408603345092636/1162095891210063883) of camera tiles resetting unexpectedly or not being removed from the app, I tested adding/removing camera tiles again.

For camera tiles resetting, this can be caused by `onTileAddEvent` or `onTileRemoveEvent`. This PR updates `onTileAddEvent` to not overwrite tile data if it already exists, hopefully fixing this (remove+add is annoying, the app would have to add soft delete).

For camera tiles sticking around, during testing I noticed that the system was often destroying the service almost immediately after the add/remove events were sent. As a result, code started in the service's coroutine was cancelled before completing, and a camera tile wasn't added to the database or not removed from the database. I could semi-reliably get it to destroy the service within several milliseconds of adding/removing.
![Logcat example showing 10ms between event and destroy](https://github.com/home-assistant/android/assets/8148535/082363ab-1b7d-4a9a-8899-db624ecaa563)
To prevent this, making sure the database work is completed before completing the callback function seems to be the only reliable way (`runBlocking`). This PR changes it for the camera tiles, during testing it still finishes in <100ms and the app isn't visible at the time (system plays animation) so blocking isn't an issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
If accepted I intend to update other tile services to do the same later (there haven't been any complaints yet, but they use other storage  which may behave differently on cancellation).