### PR TITLE
Add clear_notification support to Wear OS

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
@@ -22,6 +22,7 @@ import com.mikepenz.iconics.utils.colorFilter
 import com.mikepenz.iconics.utils.toAndroidIconCompat
 import com.vdurmont.emoji.EmojiParser
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.util.cancel
 import io.homeassistant.companion.android.common.util.generalChannel
 import java.util.Locale
 
@@ -51,6 +52,9 @@ object NotificationData {
 
     const val MEDIA_STREAM = "media_stream"
     val ALARM_STREAMS = listOf(ALARM_STREAM, ALARM_STREAM_MAX)
+
+    // special action constants
+    const val CLEAR_NOTIFICATION = "clear_notification"
 }
 
 fun createChannelID(
@@ -278,4 +282,11 @@ fun handleText(
         builder.setContentText(text)
         builder.setStyle(NotificationCompat.BigTextStyle().bigText(text))
     }
+}
+
+fun clearNotification(context: Context, tag: String) {
+    Log.d(NotificationData.TAG, "Clearing notification with tag: $tag")
+    val notificationManagerCompat = NotificationManagerCompat.from(context)
+    val messageId = tag.hashCode()
+    notificationManagerCompat.cancel(tag, messageId, true)
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.notifications.DeviceCommandData
 import io.homeassistant.companion.android.common.notifications.NotificationData
+import io.homeassistant.companion.android.common.notifications.clearNotification
 import io.homeassistant.companion.android.common.notifications.commandBeaconMonitor
 import io.homeassistant.companion.android.common.notifications.commandBleTransmitter
 import io.homeassistant.companion.android.common.notifications.getGroupNotificationBuilder
@@ -64,6 +65,9 @@ class MessagingManager @Inject constructor(
             val allowCommands = serverManager.integrationRepository(serverId).isTrusted()
             val message = notificationData[NotificationData.MESSAGE]
             when {
+                message == NotificationData.CLEAR_NOTIFICATION && !notificationData["tag"].isNullOrBlank() -> {
+                    clearNotification(context, notificationData["tag"]!!)
+                }
                 message == DeviceCommandData.COMMAND_BEACON_MONITOR && allowCommands -> {
                     if (!commandBeaconMonitor(context, notificationData)) {
                         sendNotification(notificationData, now)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Move the `clear_notification` command to common extensions and add support in the Wear OS app. 'Fixes' #3952.

Tested it with a simple notification message + tag, followed by `clear_notification` + tag, and it seems to work correctly - not sure why it wasn't added before.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Existing notifications with the tag will now be cleared instead of receiving a notification with the `clear_notification` message on the watch.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1000 (🎉)

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->