### PR TITLE
Show sensor state in secondary label in Wear OS sensor UI

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -21,6 +21,7 @@ import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.theme.getToggleButtonColors
 import io.homeassistant.companion.android.util.ToggleSwitch
 import io.homeassistant.companion.android.util.batterySensorManager
+import io.homeassistant.companion.android.views.ThemeLazyColumn
 import kotlinx.coroutines.runBlocking
 
 @SuppressLint("InlinedApi")
@@ -85,6 +86,11 @@ fun SensorUi(
                 overflow = TextOverflow.Ellipsis
             )
         },
+        secondaryLabel = {
+            sensor?.state?.let {
+                Text(if (sensor.unitOfMeasurement != null) "$it ${sensor.unitOfMeasurement}" else it)
+            }
+        },
         selectionControl = { ToggleSwitch(isChecked) },
         colors = getToggleButtonColors()
     )
@@ -95,10 +101,48 @@ fun SensorUi(
 private fun PreviewSensorUI() {
     val context = LocalContext.current
     CompositionLocalProvider {
-        SensorUi(
-            sensor = null,
-            manager = batterySensorManager,
-            basicSensor = runBlocking { batterySensorManager.getAvailableSensors(context).first() }
-        ) { _, _ -> }
+        ThemeLazyColumn {
+            item {
+                SensorUi(
+                    sensor = Sensor(
+                        "battery_level",
+                        0,
+                        true,
+                        state = "80",
+                        unitOfMeasurement = "%"
+                    ),
+                    manager = batterySensorManager,
+                    basicSensor = runBlocking {
+                        batterySensorManager.getAvailableSensors(context).first()
+                    }
+                ) { _, _ -> }
+            }
+
+            item {
+                SensorUi(
+                    sensor = Sensor(
+                        "is_charging",
+                        0,
+                        true,
+                        state = "true"
+                    ),
+                    manager = batterySensorManager,
+                    basicSensor = runBlocking {
+                        batterySensorManager.getAvailableSensors(context)
+                            .first { it.id == "is_charging" }
+                    }
+                ) { _, _ -> }
+            }
+
+            item {
+                SensorUi(
+                    sensor = null,
+                    manager = batterySensorManager,
+                    basicSensor = runBlocking {
+                        batterySensorManager.getAvailableSensors(context).last()
+                    }
+                ) { _, _ -> }
+            }
+        }
     }
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -89,7 +89,7 @@ fun SensorUi(
         secondaryLabel = {
             if (sensor?.enabled == true) {
                 sensor.state.let {
-                    Text(if (!basicSensor.unitOfMeasurement.isNullOrBlank() || sensor.state.toDoubleOrNull() != null) "$it ${sensor.unitOfMeasurement}" else it)
+                    Text(if (basicSensor.unitOfMeasurement.isNullOrBlank() || sensor.state.toDoubleOrNull() == null) it else "$it ${sensor.unitOfMeasurement}")
                 }
             }
         },
@@ -115,7 +115,7 @@ private fun PreviewSensorUI() {
                         unitOfMeasurement = "%"
                     ),
                     manager = batterySensorManager,
-                    basicSensor = runBlocking { batterySensors.first { it.id == "battery_level" } }
+                    basicSensor = batterySensors.first { it.id == "battery_level" }
                 ) { _, _ -> }
             }
 
@@ -128,7 +128,7 @@ private fun PreviewSensorUI() {
                         state = "true"
                     ),
                     manager = batterySensorManager,
-                    basicSensor = runBlocking { batterySensors.first { it.id == "is_charging" } }
+                    basicSensor = batterySensors.first { it.id == "is_charging" }
                 ) { _, _ -> }
             }
 
@@ -136,7 +136,7 @@ private fun PreviewSensorUI() {
                 SensorUi(
                     sensor = null,
                     manager = batterySensorManager,
-                    basicSensor = runBlocking { batterySensors.first { it.id == "battery_power" } }
+                    basicSensor = batterySensors.first { it.id == "battery_power" }
                 ) { _, _ -> }
             }
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -87,8 +87,10 @@ fun SensorUi(
             )
         },
         secondaryLabel = {
-            sensor?.state?.let {
-                Text(if (sensor.unitOfMeasurement != null) "$it ${sensor.unitOfMeasurement}" else it)
+            if (sensor?.enabled == true) {
+                sensor.state.let {
+                    Text(if (!basicSensor.unitOfMeasurement.isNullOrBlank() || sensor.state.toDoubleOrNull() != null) "$it ${sensor.unitOfMeasurement}" else it)
+                }
             }
         },
         selectionControl = { ToggleSwitch(isChecked) },
@@ -100,6 +102,7 @@ fun SensorUi(
 @Composable
 private fun PreviewSensorUI() {
     val context = LocalContext.current
+    val batterySensors = runBlocking { batterySensorManager.getAvailableSensors(context) }
     CompositionLocalProvider {
         ThemeLazyColumn {
             item {
@@ -112,9 +115,7 @@ private fun PreviewSensorUI() {
                         unitOfMeasurement = "%"
                     ),
                     manager = batterySensorManager,
-                    basicSensor = runBlocking {
-                        batterySensorManager.getAvailableSensors(context).first()
-                    }
+                    basicSensor = runBlocking { batterySensors.first { it.id == "battery_level" } }
                 ) { _, _ -> }
             }
 
@@ -127,10 +128,7 @@ private fun PreviewSensorUI() {
                         state = "true"
                     ),
                     manager = batterySensorManager,
-                    basicSensor = runBlocking {
-                        batterySensorManager.getAvailableSensors(context)
-                            .first { it.id == "is_charging" }
-                    }
+                    basicSensor = runBlocking { batterySensors.first { it.id == "is_charging" } }
                 ) { _, _ -> }
             }
 
@@ -138,9 +136,7 @@ private fun PreviewSensorUI() {
                 SensorUi(
                     sensor = null,
                     manager = batterySensorManager,
-                    basicSensor = runBlocking {
-                        batterySensorManager.getAvailableSensors(context).last()
-                    }
+                    basicSensor = runBlocking { batterySensors.first { it.id == "battery_power" } }
                 ) { _, _ -> }
             }
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Show sensor states in the UI to help with troubleshooting states in app compared to what HA core has. Adds more preview data to view different combination of states.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/home-assistant/android/assets/1634145/a1514b7a-29d3-4ef1-a1af-ad88239a7d96)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I am also considering in the future to move to `SplitToggleButton` so we can have a sensor detail screen to show attributes and sensor settings.