### PR TITLE
Use deprecated wifi method in case WifiInfo is null

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -532,6 +532,8 @@ class NetworkSensorManager : SensorManager {
             val connectivityManager = context.applicationContext.getSystemService<ConnectivityManager>()
             connectivityManager?.activeNetwork?.let {
                 val info = connectivityManager.getNetworkCapabilities(it)?.transportInfo
+
+                // If WifiInfo is null default to the deprecated method as a fix for some devices that may return null
                 @Suppress("DEPRECATION")
                 return@let info as? WifiInfo ?: context.applicationContext.getSystemService<WifiManager>()?.connectionInfo
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -532,7 +532,8 @@ class NetworkSensorManager : SensorManager {
             val connectivityManager = context.applicationContext.getSystemService<ConnectivityManager>()
             connectivityManager?.activeNetwork?.let {
                 val info = connectivityManager.getNetworkCapabilities(it)?.transportInfo
-                return@let info as? WifiInfo
+                @Suppress("DEPRECATION")
+                return@let info as? WifiInfo ?: context.applicationContext.getSystemService<WifiManager>()?.connectionInfo
             }
         } else {
             @Suppress("DEPRECATION")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #3969 by defaulting to the old deprecated method in case `WifiInfo` returns as null. The 4 sensors mentioned use the new method but Wifi SSID and BSSID use the old method which in this case still works.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->