### PR TITLE
Update shortcut tile add/remove + destroy handling

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -42,7 +42,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.guava.future
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import java.nio.ByteBuffer
 import javax.inject.Inject
 import kotlin.math.min
@@ -146,8 +147,8 @@ class ShortcutsTile : TileService() {
                 .build()
         }
 
-    override fun onTileAddEvent(requestParams: EventBuilders.TileAddEvent) {
-        serviceScope.launch {
+    override fun onTileAddEvent(requestParams: EventBuilders.TileAddEvent): Unit = runBlocking {
+        withContext(Dispatchers.IO) {
             /**
              * When the app is updated from an older version (which only supported a single Shortcut Tile),
              * and the user is adding a new Shortcuts Tile, we can't tell for sure if it's the 1st or 2nd Tile.
@@ -167,8 +168,8 @@ class ShortcutsTile : TileService() {
         }
     }
 
-    override fun onTileRemoveEvent(requestParams: EventBuilders.TileRemoveEvent) {
-        serviceScope.launch {
+    override fun onTileRemoveEvent(requestParams: EventBuilders.TileRemoveEvent): Unit = runBlocking {
+        withContext(Dispatchers.IO) {
             wearPrefsRepository.removeTileShortcuts(requestParams.tileId)
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Follow-up to #3954: updates the shortcut tile's handling of add/remove event + destroying the service, just like the camera tile, to prevent the service scope being cancelled while the app is still storing tile added/removed and ending up with 'ghost tiles'.

(this service already didn't overwrite existing tile data when `onTileAddEvent` was called again)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->