### PR TITLE
Update tiles logged out state to prevent cut off overflow, shortcuts tile label

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -126,7 +126,7 @@
     <string name="camera">Camera</string>
     <string name="camera_tile">Camera tile</string>
     <string name="camera_tile_desc">See what\'s on your camera</string>
-    <string name="camera_tile_log_in">Log in to Home Assistant to add a camera tile</string>
+    <string name="camera_tile_log_in">Log in to add a camera tile</string>
     <string name="camera_tile_no_tiles_yet">There are no camera tiles added yet - add one from the watch face to set it up</string>
     <string name="camera_tile_no_entity_yet">Edit the tile settings and select a camera to show</string>
     <string name="camera_tile_n">Camera tile #%d</string>
@@ -774,14 +774,14 @@
     <string name="shortcuts_choose">Choose shortcuts</string>
     <string name="shortcut5_note">Not all launchers support displaying 5 shortcuts, you may not see this shortcut if the above 4 are already added.</string>
     <string name="shortcuts_summary">Add shortcuts to launcher</string>
-    <string name="shortcut_tiles">Shortcut tiles</string>
+    <string name="shortcut_tiles">Shortcuts tiles</string>
     <string name="shortcuts_tile_n">Shortcuts tile #%d</string>
     <string name="shortcuts_tile_select">Select shortcuts tile to manage</string>
     <string name="shortcuts_tile_description">Select up to 7 entities</string>
     <string name="shortcuts_tile_empty">Choose entities in settings</string>
-    <string name="shortcuts_tile_text_setting">Show names on shortcuts tile</string>
-    <string name="shortcuts_tile_log_in">Log in to Home Assistant to add your first shortcut</string>
-    <string name="shortcuts_tile_no_tiles_yet">There are no shortcut tiles added yet</string>
+    <string name="shortcuts_tile_text_setting">Show names on tile</string>
+    <string name="shortcuts_tile_log_in">Log in to add your first shortcut</string>
+    <string name="shortcuts_tile_no_tiles_yet">There are no shortcuts tiles added yet</string>
     <string name="shortcuts">Shortcuts</string>
     <string name="show">Show</string>
     <string name="show_on_map">Show on map</string>
@@ -845,7 +845,7 @@
     <string name="template_tile_content">Template tile content</string>
     <string name="template_tile_desc">Renders and displays a template</string>
     <string name="template_tile_empty">Set template in the phone settings</string>
-    <string name="template_tile_log_in">Log in to Home Assistant to set up a template</string>
+    <string name="template_tile_log_in">Log in to set up a template</string>
     <string name="template_error">Error in template</string>
     <string name="template_render_error">Error rendering template</string>
     <string name="template_tile_help">Provide a template below that will be displayed on the Wear OS template tile. See help for markup options.</string>
@@ -1152,7 +1152,7 @@
     <string name="assist_error">Oops, an error has occurred</string>
     <string name="assist_how_can_i_assist">How can I assist?</string>
     <string name="assist_last_used_pipeline">Last used assistant</string>
-    <string name="assist_log_in">Log in to Home Assistant to start using Assist</string>
+    <string name="assist_log_in">Log in to start using Assist</string>
     <string name="assist_manage_pipelines">Manage assistants</string>
     <string name="assist_permission">To use Assist with your voice, allow Home Assistant to access the microphone</string>
     <string name="assist_pipeline">Assistant</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TileViews.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TileViews.kt
@@ -99,7 +99,7 @@ fun primaryLayoutTimeline(
     builder.setContent(
         Text.Builder(context, context.getString(text))
             .setTypography(Typography.TYPOGRAPHY_BODY1)
-            .setMaxLines(10)
+            .setMaxLines(if (title != null) 3 else 4) // It is highly recommended that main content has [if] 1 label is present: content with max 3 lines
             .setColor(argb(theme.onSurface))
             .build()
     )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
There was another review failure about text sizes on Wear, and after playing with some string lengths I found it was possible to have text cut off on the logged out state for tiles (but only after making strings longer - maybe Google has an extremely small test device?). This PR limits length of logged out state string to the recommendation to prevent text cut off, and shortens strings to help with translations.

(Also a minor related fix for inconsistent shortcuts tile name usage.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Before (forced)|After|
|-----|-----|
|![Tile with a 4th line of text barely visible and cut off by button](https://github.com/home-assistant/android/assets/8148535/dd51e241-9373-45cc-b707-88b8ed561231)|![Tile with only 2 lines of text, all visible](https://github.com/home-assistant/android/assets/8148535/0881cb55-4aee-4f4c-8ba1-130d809eb62f)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->