### PR TITLE
Always send sensor registration device class + entity category to prevent errors due to old registration

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -20,7 +20,8 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceRequest
-import io.homeassistant.companion.android.common.data.integration.impl.entities.SensorRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.SensorRegistrationRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.SensorUpdateRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.ServiceCallRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.Template
 import io.homeassistant.companion.android.common.data.integration.impl.entities.UpdateLocationRequest
@@ -702,7 +703,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         val canRegisterDeviceClassDistance = server.version?.isAtLeast(2022, 10, 0) == true
         val integrationRequest = IntegrationRequest(
             "register_sensor",
-            SensorRequest(
+            SensorRegistrationRequest(
                 sensorRegistration.uniqueId,
                 if (canRegisterEntityDisabledState && sensorRegistration.disabled) {
                     null
@@ -751,7 +752,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         val integrationRequest = IntegrationRequest(
             "update_sensor_states",
             sensors.map {
-                SensorRequest(
+                SensorUpdateRequest(
                     it.uniqueId,
                     if (it.state is String) it.state.ifBlank { null } else it.state,
                     it.type,

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
@@ -11,7 +11,29 @@ data class SensorRegistrationRequest<T>(
     val icon: String,
     val attributes: Map<String, Any>,
     val name: String? = null,
+    @JsonInclude(JsonInclude.Include.ALWAYS) // Always to override incorrect value from old registration
+    val deviceClass: String? = null,
+    val unitOfMeasurement: String? = null,
+    val stateClass: String? = null,
+    @JsonInclude(JsonInclude.Include.ALWAYS) // Always to override incorrect value from old registration
+    val entityCategory: String? = null,
+    val disabled: Boolean? = null
+) {
+    /** @return [SensorRegistrationRequestLegacy] for core < 2023.2 which doesn't accept null properties */
+    fun toLegacy(): SensorRegistrationRequestLegacy<T> = SensorRegistrationRequestLegacy(
+        uniqueId, state, type, icon, attributes, name, deviceClass, unitOfMeasurement, stateClass, entityCategory, disabled
+    )
+}
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class SensorRegistrationRequestLegacy<T>(
+    val uniqueId: String,
     @JsonInclude(JsonInclude.Include.ALWAYS)
+    val state: T,
+    val type: String,
+    val icon: String,
+    val attributes: Map<String, Any>,
+    val name: String? = null,
     val deviceClass: String? = null,
     val unitOfMeasurement: String? = null,
     val stateClass: String? = null,

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/entities/SensorRequest.kt
@@ -3,7 +3,7 @@ package io.homeassistant.companion.android.common.data.integration.impl.entities
 import com.fasterxml.jackson.annotation.JsonInclude
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-data class SensorRequest<T>(
+data class SensorRegistrationRequest<T>(
     val uniqueId: String,
     @JsonInclude(JsonInclude.Include.ALWAYS)
     val state: T,
@@ -11,9 +11,18 @@ data class SensorRequest<T>(
     val icon: String,
     val attributes: Map<String, Any>,
     val name: String? = null,
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     val deviceClass: String? = null,
     val unitOfMeasurement: String? = null,
     val stateClass: String? = null,
     val entityCategory: String? = null,
     val disabled: Boolean? = null
+)
+
+data class SensorUpdateRequest<T>(
+    val uniqueId: String,
+    val state: T,
+    val type: String,
+    val icon: String,
+    val attributes: Map<String, Any>
 )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3202, fixes home-assistant/core#102853

Always send the values for `device_class` and `entity_category` when registering sensors to make sure they match the app value. Some sensors were changed in the past based on feedback, but users with existing registrations wouldn't have seen this updated in core as the app didn't send `null` values instead of sending that it should be `null`. To make this possible, registrations and updates need to be split as the app currently depends on using `null` as "don't send".

Example before/after payloads:
```
{"type":"register_sensor","data":{"unique_id":"battery_state","state":"discharging","type":"sensor","icon":"mdi:battery-minus","attributes":{},"name":"Battery state","entity_category":"diagnostic","disabled":false}}
{"type":"register_sensor","data":{"unique_id":"battery_state","state":"discharging","type":"sensor","icon":"mdi:battery-minus","attributes":{},"name":"Battery state","device_class":null,"entity_category":"diagnostic","disabled":false}}

{"type":"register_sensor","data":{"unique_id":"audio_sensor","state":"normal","type":"sensor","icon":"mdi:volume-high","attributes":{},"name":"Ringer mode","disabled":false}}
{"type":"register_sensor","data":{"unique_id":"audio_sensor","state":"normal","type":"sensor","icon":"mdi:volume-high","attributes":{},"name":"Ringer mode","device_class":null,"entity_category":null,"disabled":false}}
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Requires home-assistant/core#86965, which was first included in 2023.2.0.