### PR TITLE
Show server name in "Unable to connect to Home Assistant" dialog

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1215,8 +1215,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
         isShowingError = true
 
+        val serverName = if (serverManager.defaultServers.size > 1) presenter.getActiveServerName() else null
         val alert = AlertDialog.Builder(this)
-            .setTitle(commonR.string.error_connection_failed)
+            .setTitle(
+                getString(
+                    commonR.string.error_connection_failed_to,
+                    serverName ?: getString(commonR.string.app_name)
+                )
+            )
             .setOnDismissListener {
                 isShowingError = false
                 alertDialog = null

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -11,6 +11,7 @@ interface WebViewPresenter {
     fun onViewReady(path: String?)
 
     fun getActiveServer(): Int
+    fun getActiveServerName(): String?
     fun updateActiveServer()
     fun setActiveServer(id: Int)
     fun switchActiveServer(id: Int)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -117,6 +117,13 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun getActiveServer(): Int = serverId
 
+    override fun getActiveServerName(): String? =
+        if (serverManager.isRegistered()) {
+            serverManager.getServer(serverId)?.friendlyName
+        } else {
+            null
+        }
+
     override fun updateActiveServer() {
         if (serverManager.isRegistered()) {
             serverManager.getServer()?.let {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -244,6 +244,7 @@
     <string name="entity_widget_desc">View any entity\'s current state and toggle it</string>
     <string name="error_auth_revoked">It appears that your authorization was revoked, please reconnect to Home Assistant.</string>
     <string name="error_connection_failed">Unable to connect to Home Assistant.</string>
+    <string name="error_connection_failed_to">Unable to connect to %1$s</string>
     <string name="error_loading_entities">Error loading entities</string>
     <string name="error_onboarding_connection_failed">Unable to connect to Home Assistant.</string>
     <string name="error_ssl">Unable to communicate with Home Assistant because of a SSL error.  Please ensure your certificate is valid.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
[By suggestion](https://github.com/home-assistant/android/issues/3979#issuecomment-1792538021): show the server name instead of a generic "Home Assistant" to prevent confusion when the app cannot connect in the `WebViewActivity`, when using multiserver.

Adding a button to switch servers here would probably also be a nice improvement, but that doesn't fit and this dialog currently is used for a lot of things so let's not try to do everything in one PR. (Switching now requires going to Settings or dismissing the dialog and using swipe gestures.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Server name: Home

|Light|Dark|
|-----|-----|
|![Dialog for connection issues titled 'Unable to connect to Home', light mode](https://github.com/home-assistant/android/assets/8148535/2a6a65b5-bae8-4372-af9c-071a40ec968c)|![Dialog for connection issues titled 'Unable to connect to Home', dark mode](https://github.com/home-assistant/android/assets/8148535/cdaa04c1-8d6a-4aac-8151-988a0b1b4458)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->