### PR TITLE
Added a sensor to detect if the hotspot is enabled.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -125,6 +125,7 @@ open class HomeAssistantApplication : Application() {
             IntentFilter().apply {
                 addAction(WifiManager.NETWORK_STATE_CHANGED_ACTION)
                 addAction(WifiManager.WIFI_STATE_CHANGED_ACTION)
+                addAction("android.net.wifi.WIFI_AP_STATE_CHANGED")
             }
         )
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -105,6 +105,7 @@ class SensorReceiver : SensorReceiverBase() {
         "android.bluetooth.device.action.ACL_CONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
         "android.bluetooth.device.action.ACL_DISCONNECTED" to BluetoothSensorManager.bluetoothConnection.id,
         "com.oculus.intent.action.MOUNT_STATE_CHANGED" to QuestSensorManager.headsetMounted.id,
+        "android.net.wifi.WIFI_AP_STATE_CHANGED" to NetworkSensorManager.hotspotState.id,
         BluetoothAdapter.ACTION_STATE_CHANGED to BluetoothSensorManager.bluetoothState.id,
         Intent.ACTION_SCREEN_OFF to PowerSensorManager.interactiveDevice.id,
         Intent.ACTION_SCREEN_ON to PowerSensorManager.interactiveDevice.id,

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -203,8 +203,8 @@ class NetworkSensorManager : SensorManager {
 
     @SuppressLint("PrivateApi")
     private fun hasHotspot(context: Context): Boolean {
-        //Watch doesn't have hotspot.
-        if(context.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)) {
+        // Watch doesn't have hotspot.
+        if (context.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)) {
             return false
         }
         val wifiManager: WifiManager = context.applicationContext.getSystemService()!!

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.sensors
 import android.Manifest
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.pm.PackageManager
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.wifi.WifiInfo
@@ -202,6 +203,10 @@ class NetworkSensorManager : SensorManager {
 
     @SuppressLint("PrivateApi")
     private fun hasHotspot(context: Context): Boolean {
+        //Watch doesn't have hotspot.
+        if(context.packageManager.hasSystemFeature(PackageManager.FEATURE_WATCH)) {
+            return false
+        }
         val wifiManager: WifiManager = context.applicationContext.getSystemService()!!
         return try {
             wifiManager.javaClass.getDeclaredMethod("isWifiApEnabled")
@@ -211,7 +216,7 @@ class NetworkSensorManager : SensorManager {
         }
     }
     private fun updateHotspotEnabledSensor(context: Context) {
-        if (!isEnabled(context, hotspotState) || !hasWifi(context) || !hasHotspot(context)) {
+        if (!isEnabled(context, hotspotState)) {
             return
         }
         val wifiManager: WifiManager = context.getSystemService()!!

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -166,7 +166,7 @@ class NetworkSensorManager : SensorManager {
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return when {
-            sensorId == publicIp.id || sensorId == networkType.id -> {
+            sensorId == hotspotState.id || sensorId == publicIp.id || sensorId == networkType.id -> {
                 arrayOf()
             }
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -36,7 +36,7 @@ class NetworkSensorManager : SensorManager {
             "binary_sensor",
             commonR.string.basic_sensor_name_hotspot_state,
             commonR.string.sensor_description_hotspot,
-            "mdi:wifi",
+            "mdi:access-point",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
@@ -225,7 +225,7 @@ class NetworkSensorManager : SensorManager {
         val method: Method = wifiManager.javaClass.getDeclaredMethod("isWifiApEnabled")
         method.isAccessible = true
         val enabled = method.invoke(wifiManager) as Boolean
-        val icon = if (enabled) "mdi:wifi" else "mdi:wifi-off"
+        val icon = if (enabled) "mdi:access-point" else "mdi:access-point-off"
         onSensorUpdated(
             context,
             hotspotState,

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -113,6 +113,7 @@
     <string name="basic_sensor_name_wifi_signal">WiFi signal strength</string>
     <string name="basic_sensor_name_wifi_state">WiFi state</string>
     <string name="basic_sensor_name_wifi">WiFi connection</string>
+    <string name="basic_sensor_name_hotspot_state">Hotspot state</string>
     <string name="binary_sensor">Binary sensor</string>
     <string name="biometric_message">Unlock using your biometric or screen lock credential</string>
     <string name="biometric_set_title">Confirm to continue</string>
@@ -590,6 +591,7 @@
     <string name="sensor_description_headphone">Whether headphones are plugged into the device</string>
     <string name="sensor_description_headset_mounted">Whether the headset is currently in use</string>
     <string name="sensor_description_high_accuracy_mode">Whether high accuracy mode is active on the device</string>
+    <string name="sensor_description_hotspot">Whether the WIFI hotspot is enabled</string>
     <string name="sensor_description_interactive">Whether the device is in an interactive state</string>
     <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
     <string name="sensor_description_keyguard_locked">Whether the keyguard is currently locked</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This adds a new binary_sensor displaying if the WiFi hotspot is enabled.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1005

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This feature had to use reflection, which usually isn't recommended. But this is the only method to check if a hotspot is enabled.

The sensor will only display if the private function exists, to prevent issues in the future.