### PR TITLE
Catch potential play services errors

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -194,7 +194,12 @@ class HighAccuracyLocationService : Service() {
             .setPriority(Priority.PRIORITY_HIGH_ACCURACY)
             .build()
 
-        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+        fusedLocationProviderClient = try {
+            LocationServices.getFusedLocationProviderClient(this)
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to get fused location provider client", e)
+            null
+        }
         fusedLocationProviderClient?.requestLocationUpdates(request, getLocationUpdateIntent())
     }
 }

--- a/app/src/full/java/io/homeassistant/companion/android/onboarding/WearOnboardingListener.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/onboarding/WearOnboardingListener.kt
@@ -16,6 +16,10 @@ import javax.inject.Inject
 @SuppressLint("VisibleForTests") // https://issuetracker.google.com/issues/239451111
 class WearOnboardingListener : WearableListenerService() {
 
+    companion object {
+        private const val TAG = "WearOnboardingListener"
+    }
+
     @Inject
     lateinit var serverManager: ServerManager
 
@@ -41,8 +45,16 @@ class WearOnboardingListener : WearableListenerService() {
                 setUrgent()
                 asPutDataRequest()
             }
-            Wearable.getDataClient(this@WearOnboardingListener).putDataItem(putDataReq).addOnCompleteListener {
-                Log.d("WearOnboardingListener", "sendHomeAssistantInstance: ${if (it.isSuccessful) "success" else "failed"}")
+            try {
+                Wearable.getDataClient(this@WearOnboardingListener).putDataItem(putDataReq)
+                    .addOnCompleteListener {
+                        Log.d(
+                            TAG,
+                            "sendHomeAssistantInstance: ${if (it.isSuccessful) "success" else "failed"}"
+                        )
+                    }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to send home assistant instance", e)
             }
         }
     }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.sensors
 
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.car.app.connection.CarConnection
 import androidx.lifecycle.Observer
 import io.homeassistant.companion.android.common.sensors.SensorManager
@@ -56,7 +57,12 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
         }
         CoroutineScope(Dispatchers.Main + Job()).launch {
             if (carConnection == null) {
-                carConnection = CarConnection(context.applicationContext)
+                carConnection = try {
+                    CarConnection(context.applicationContext)
+                } catch (e: Exception) {
+                    Log.e(TAG, "Failed to get car connection", e)
+                    null
+                }
             }
             carConnection?.type?.observeForever(this@AndroidAutoSensorManager)
         }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/GeocodeSensorManager.kt
@@ -75,7 +75,12 @@ class GeocodeSensorManager : SensorManager {
             return
         }
 
-        val location = LocationServices.getFusedLocationProviderClient(context).lastLocation.await()
+        val location = try {
+            LocationServices.getFusedLocationProviderClient(context).lastLocation.await()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to get fused location provider client", e)
+            null
+        }
         var address: Address? = null
         try {
             if (location == null) {
@@ -128,7 +133,13 @@ class GeocodeSensorManager : SensorManager {
 
         val prettyAddress = address?.getAddressLine(0)
 
-        HighAccuracyLocationService.updateNotificationAddress(context, location, if (!prettyAddress.isNullOrEmpty()) prettyAddress else context.getString(commonR.string.unknown_address))
+        if (location != null) {
+            HighAccuracyLocationService.updateNotificationAddress(
+                context,
+                location,
+                if (!prettyAddress.isNullOrEmpty()) prettyAddress else context.getString(commonR.string.unknown_address)
+            )
+        }
 
         onSensorUpdated(
             context,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

This is an attempt to fix #3060 based on the [recent comment](https://github.com/home-assistant/android/issues/3060#issuecomment-1813814320) and linked [internal issue](https://issuetracker.google.com/issues/257765160)

The idea is that any play services call that involves settings up the client like `getNodeClient` or `getFusedLocationProviderClient` can all fail and crash the app if there was a connection error. So now I have done a wide range search to look for all potential errors. We did not have try/catch blocks everywhere but we did in a few places.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
