### PR TITLE
Fix target temperature step attribute name error

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -53,7 +53,7 @@ object ClimateControl : HaControl {
         }
 
         val temperatureUnit = entity.attributes["temperature_unit"] ?: ""
-        val temperatureStepSize = (entity.attributes["target_temperature_step"] as? Number)?.toFloat()
+        val temperatureStepSize = (entity.attributes["target_temp_step"] as? Number)?.toFloat()
             ?: when (temperatureUnit) {
                 "°C" -> 0.5f
                 else -> 1f


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix wrong attribute name for the target temperature step.

Correct one is target_temp_step (which is returned by the API) instead of target_temperature_step.

Currently it is not possible to adjust the temperature of a thermostat in the Android device controls to a step size smaller than 1. 

