### PR TITLE
Check controls while locked setting when using panel

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -1,15 +1,36 @@
 package io.homeassistant.companion.android.controls
 
+import android.annotation.SuppressLint
+import android.app.KeyguardManager
 import android.os.Bundle
+import android.service.controls.ControlsProviderService
 import android.util.Log
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
+import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
 class HaControlsPanelActivity : AppCompatActivity() {
@@ -22,10 +43,22 @@ class HaControlsPanelActivity : AppCompatActivity() {
 
     private var launched = false
 
+    @SuppressLint("InlinedApi") // This activity will only be launched on Android 14+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setShowWhenLocked(true)
         if (!serverManager.isRegistered()) {
             finish()
+            return
+        }
+
+        val disallowLocked =
+            intent?.hasExtra(ControlsProviderService.EXTRA_LOCKSCREEN_ALLOW_TRIVIAL_CONTROLS) != true ||
+                intent?.getBooleanExtra(ControlsProviderService.EXTRA_LOCKSCREEN_ALLOW_TRIVIAL_CONTROLS, false) != true
+        val keyguardManager = getSystemService<KeyguardManager>()
+        val isLocked = keyguardManager?.isKeyguardLocked ?: true
+        if (disallowLocked && isLocked) {
+            setContent { LockedPanelView() }
             return
         }
 
@@ -53,5 +86,26 @@ class HaControlsPanelActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         if (launched) finish()
+    }
+
+    @Composable
+    fun LockedPanelView() {
+        MdcTheme {
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Lock,
+                    contentDescription = null
+                )
+                Text(
+                    text = stringResource(commonR.string.tile_auth_required),
+                    style = MaterialTheme.typography.h6,
+                    modifier = Modifier.padding(top = 16.dp)
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When using the device controls panel instead of individual/native controls on Android 14, also check the system setting for using device controls while the device is locked and if not allowed, block the panel (as the frontend doesn't have a read only mode).

I tried requesting unlocking the device when the panel is opened by using [`KeyguardManager.requestDismissKeyguard`](https://developer.android.com/reference/kotlin/android/app/KeyguardManager?hl=en#requestdismisskeyguard) to make the experience smoother, but that doesn't play nice with the activity transition used by the app and will result in the user seeing their home screen/last app instead of Home Assistant after unlocking.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light mode|Dark mode|
|-----|-----|
|![White screen with a lock icon and the text 'Requires unlocked device'](https://github.com/home-assistant/android/assets/8148535/e6ce36df-8520-45de-b9c4-814aa13e390a)|![Dark grey screen with a lock icon and the text 'Requires unlocked device'](https://github.com/home-assistant/android/assets/8148535/d6c81eee-cd80-47d3-bb79-20a611d0ece8)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->