### PR TITLE
Migrate BuildConfig to Gradle Build Files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
     buildFeatures {
         viewBinding = true
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -75,6 +75,7 @@ android {
     buildFeatures {
         viewBinding = true
         compose = true
+        buildConfig = true
     }
 
     composeOptions {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -28,6 +28,10 @@ android {
         }
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     kotlinOptions {
         jvmTarget = libs.versions.javaVersion.get()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,4 @@ org.gradle.vfs.watch=true
 
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -24,6 +24,7 @@ android {
     buildFeatures {
         viewBinding = true
         compose = true
+        buildConfig = true
     }
 
     composeOptions {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Addresses the following warning during build:

> The option setting 'android.defaults.buildfeatures.buildconfig=true' is deprecated.
> The current default is 'false'.
> It will be removed in version 9.0 of the Android Gradle plugin.
> You can resolve this warning in Android Studio via Refactor > Migrate BuildConfig to Gradle Build Files

Each module uses the `BuildConfig` class so it's added everywhere.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->