### PR TITLE
Implement relative volume adjustments for the `command_volume_level` notification command

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -136,6 +136,7 @@ class MessagingManager @Inject constructor(
         const val HIGH_ACCURACY_UPDATE_INTERVAL = "high_accuracy_update_interval"
         const val PACKAGE_NAME = "package_name"
         const val CONFIRMATION = "confirmation"
+        const val RELATIVE_VOLUME = "relative_volume"
 
         // special intent constants
         const val INTENT_PACKAGE_NAME = "intent_package_name"
@@ -623,24 +624,20 @@ class MessagingManager @Inject constructor(
                 }
             }
             COMMAND_VOLUME_LEVEL -> {
-                val audioManager =
-                    context.getSystemService<AudioManager>()
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    val notificationManager = context.getSystemService<NotificationManager>()
-                    if (notificationManager?.isNotificationPolicyAccessGranted == false) {
-                        notifyMissingPermission(message.toString(), serverId)
-                    } else {
-                        processStreamVolume(
-                            audioManager!!,
-                            data[NotificationData.MEDIA_STREAM].toString(),
-                            command!!.toInt()
-                        )
-                    }
+                val audioManager = context.getSystemService<AudioManager>()
+                val relative = data[RELATIVE_VOLUME]?.toBoolean() ?: false
+
+                Toast.makeText(context, "$RELATIVE_VOLUME = $relative", Toast.LENGTH_SHORT).show()
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                    context.getSystemService<NotificationManager>()?.isNotificationPolicyAccessGranted == false) {
+                    notifyMissingPermission(message.toString(), serverId)
                 } else {
                     processStreamVolume(
-                        audioManager!!,
-                        data[NotificationData.MEDIA_STREAM].toString(),
-                        command!!.toInt()
+                        audioManager = audioManager!!,
+                        stream = data[NotificationData.MEDIA_STREAM].toString(),
+                        volume = command!!.toInt(),
+                        relative = relative,
                     )
                 }
             }
@@ -1652,29 +1649,34 @@ class MessagingManager @Inject constructor(
         }
     }
 
-    private fun processStreamVolume(audioManager: AudioManager, stream: String, volume: Int) {
-        when (stream) {
-            NotificationData.ALARM_STREAM -> adjustVolumeStream(AudioManager.STREAM_ALARM, volume, audioManager)
-            NotificationData.MUSIC_STREAM -> adjustVolumeStream(AudioManager.STREAM_MUSIC, volume, audioManager)
-            NotificationData.NOTIFICATION_STREAM -> adjustVolumeStream(AudioManager.STREAM_NOTIFICATION, volume, audioManager)
-            NotificationData.RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume, audioManager)
-            NotificationData.CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume, audioManager)
-            NotificationData.SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume, audioManager)
-            NotificationData.DTMF_STREAM -> adjustVolumeStream(AudioManager.STREAM_DTMF, volume, audioManager)
-            else -> Log.d(TAG, "Skipping command due to invalid channel stream")
+    private fun processStreamVolume(
+        audioManager: AudioManager,
+        stream: String,
+        volume: Int,
+        relative: Boolean
+    ) {
+        val streamType = when (stream) {
+            NotificationData.ALARM_STREAM -> AudioManager.STREAM_ALARM
+            NotificationData.MUSIC_STREAM -> AudioManager.STREAM_MUSIC
+            NotificationData.NOTIFICATION_STREAM -> AudioManager.STREAM_NOTIFICATION
+            NotificationData.RING_STREAM -> AudioManager.STREAM_RING
+            NotificationData.CALL_STREAM -> AudioManager.STREAM_VOICE_CALL
+            NotificationData.SYSTEM_STREAM -> AudioManager.STREAM_SYSTEM
+            NotificationData.DTMF_STREAM -> AudioManager.STREAM_DTMF
+            else -> null
         }
-    }
-
-    private fun adjustVolumeStream(stream: Int, volume: Int, audioManager: AudioManager) {
-        var volumeLevel = volume
-        if (volumeLevel > audioManager.getStreamMaxVolume(stream)) {
-            volumeLevel = audioManager.getStreamMaxVolume(stream)
-        } else if (volumeLevel < 0) {
-            volumeLevel = 0
+        if (streamType == null) {
+            Log.d(TAG, "Skipping command due to invalid channel stream")
+            return
         }
+        val newVolume = if (relative) {
+            audioManager.getStreamVolume(streamType) + volume
+        } else {
+            volume
+        }.coerceIn(0..audioManager.getStreamMaxVolume(streamType))
         audioManager.setStreamVolume(
-            stream,
-            volumeLevel,
+            streamType,
+            newVolume,
             AudioManager.FLAG_SHOW_UI
         )
     }

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -630,14 +630,15 @@ class MessagingManager @Inject constructor(
                 Toast.makeText(context, "$RELATIVE_VOLUME = $relative", Toast.LENGTH_SHORT).show()
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
-                    context.getSystemService<NotificationManager>()?.isNotificationPolicyAccessGranted == false) {
+                    context.getSystemService<NotificationManager>()?.isNotificationPolicyAccessGranted == false
+                ) {
                     notifyMissingPermission(message.toString(), serverId)
                 } else {
                     processStreamVolume(
                         audioManager = audioManager!!,
                         stream = data[NotificationData.MEDIA_STREAM].toString(),
                         volume = command!!.toInt(),
-                        relative = relative,
+                        relative = relative
                     )
                 }
             }


### PR DESCRIPTION
## Summary
This PR enhances the `command_volume_level` notification command to support both absolute and relative volume adjustments. Introducing a boolean parameter, `relative_volume`, allows users to specify whether the provided value is an absolute volume level or a relative adjustment to the current volume. Omitting or setting the parameter to `false` preserves the original absolute volume behavior.

The motivation behind these changes is to make changing the volume as responsible as possible. When I tried to set up an automation for [a Zigbee music controller remote](https://www.zigbee2mqtt.io/devices/E2123.html) to control music playback on an Android device through HA using notification commands, I encountered some difficulties: the volume sensors don't update instantly, so if I wanted to handle multiple successive volume change actions from the remote, these steps were required in the automation:
1. read the current value of the volume sensor
2. calculate the new volume by adding or subtracting from it, based on whether the Volume Up or Down button was pressed on the remote
3. fire the `command_volume_level` notification command with the new absolute volume
4. since the volume sensor doesn't update automatically, update the volume sensor's value by firing the `command_update_sensors` notification command, so a potential successive volume change can be handled with the same steps.

And the last step made it pretty slow. It can be much faster if the automation doesn't have to wait for the volume sensor to be updated.

This is how the YAML of a service call using this functionality looks like:

```yaml
service: notify.mobile_app_<device_name>
data:
  message: command_volume_level
  data:
    media_stream: music_stream
    relative_volume / relative / adjust / delta: true # <- which one do you like better?
    command: -2 # this makes the volume decrease 2 steps
```

- [ ] The PR is marked as a draft because I'm not sure which parameter name is the best. I let the maintainers decide it during the review.

## Link to pull request in Documentation repository
Documentation: home-assistant/companion.home-assistant#

- [ ] I'll open the doc update PR when we have the final parameter name :hourglass_flowing_sand: