### PR TITLE
Suppress system Matter device discovery bottom sheet

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -30,6 +30,11 @@ class MatterManagerImpl @Inject constructor(
         return config != null && config.components.contains("matter")
     }
 
+    override fun suppressDiscoveryBottomSheet(context: Context) {
+        if (!appSupportsCommissioning()) return
+        Matter.getCommissioningClient(context).suppressHalfSheetNotification()
+    }
+
     override fun startNewCommissioningFlow(
         context: Context,
         onSuccess: (IntentSender) -> Unit,

--- a/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -17,6 +17,11 @@ interface MatterManager {
     suspend fun coreSupportsCommissioning(serverId: Int): Boolean
 
     /**
+     * Prevent the bottom sheet for discovered Matter devices from showing up while the app is open.
+     */
+    fun suppressDiscoveryBottomSheet(context: Context)
+
+    /**
      * Start a flow to commission a Matter device that is on the same network as this device.
      * @param onSuccess Callback that receives an intent to launch the commissioning flow
      * @param onFailure Callback for an exception if the commissioning flow cannot be started

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -800,6 +800,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        presenter.onStart(this)
+    }
+
     override fun onResume() {
         super.onResume()
         if (currentAutoplay != presenter.isAutoPlayVideoEnabled()) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -42,6 +42,8 @@ interface WebViewPresenter {
 
     fun sessionTimeOut(): Int
 
+    fun onStart(context: Context)
+
     fun onFinish()
 
     fun isSsidUsed(): Boolean

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -287,6 +287,10 @@ class WebViewPresenterImpl @Inject constructor(
         } ?: 0
     }
 
+    override fun onStart(context: Context) {
+        matterUseCase.suppressDiscoveryBottomSheet(context)
+    }
+
     override fun onFinish() {
         mainScope.cancel()
     }

--- a/app/src/minimal/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -14,6 +14,10 @@ class MatterManagerImpl @Inject constructor() : MatterManager {
 
     override suspend fun coreSupportsCommissioning(serverId: Int): Boolean = false
 
+    override fun suppressDiscoveryBottomSheet(context: Context) {
+        // No support, so nothing to suppress
+    }
+
     override fun startNewCommissioningFlow(
         context: Context,
         onSuccess: (IntentSender) -> Unit,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
By request from the Matter/Thread developers: prevent the system's Matter device discovery bottom sheet from showing up while the Home Assistant app is opened.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
This change will prevent the following from happening:

https://github.com/home-assistant/android/assets/8148535/0a4c732c-71b1-4e36-8cc6-b0052ce41ce4

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->