### PR TITLE
Fix button widget authentication dismissed due to non-foreground window

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetAuthenticationActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetAuthenticationActivity.kt
@@ -15,12 +15,20 @@ class WidgetAuthenticationActivity : AppCompatActivity() {
         private const val TAG = "WidgetAuthenticationA"
     }
 
+    private var authenticating = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         Log.d(TAG, "onCreate in WidgetAuthenticationActivity called")
+    }
 
-        val authenticator = Authenticator(this, this, ::authenticationResult)
-        authenticator.authenticate(getString(R.string.biometric_set_title))
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus && !isFinishing && !authenticating) {
+            val authenticator = Authenticator(this, this, ::authenticationResult)
+            authenticator.authenticate(getString(R.string.biometric_set_title))
+            authenticating = true
+        }
     }
 
     private fun authenticationResult(result: Int) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #3893: prevent the button widget authentication dialog automatically being dismissed when triggered on Android 14 QPR1+, because the window was not in the foreground. It looks like the framework check for this was bugged before QPR1, and the Home Assistant app was showing the authentication dialog before the window (which is transparent) was in the foreground.

More details about how I found this in my last comment on the issue.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
No visual changes except maybe you have to wait 50-100ms longer for the window to get to the foreground compared to older versions?

https://github.com/home-assistant/android/assets/8148535/d526e696-9a98-4a0a-9cfe-47f6bce48ae7

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->