### PR TITLE
Send IP address of Matter device for on network commissioning

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningService.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningService.kt
@@ -58,7 +58,7 @@ class MatterCommissioningService : Service(), CommissioningService.Callback {
                 commissioningServiceDelegate.sendCommissioningError(CommissioningError.OTHER)
                 return@launch
             }
-            val result = matterManager.commissionOnNetworkDevice(metadata.passcode, serverId)
+            val result = matterManager.commissionOnNetworkDevice(metadata.passcode, metadata.networkLocation.formattedIpAddress, serverId)
             Log.d(TAG, "Server commissioning was ${if (result?.success == true) "successful" else "not successful (${result?.errorCode})"}")
 
             if (result?.success == true) {

--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -58,9 +58,9 @@ class MatterManagerImpl @Inject constructor(
         }
     }
 
-    override suspend fun commissionOnNetworkDevice(pin: Long, serverId: Int): MatterCommissionResponse? {
+    override suspend fun commissionOnNetworkDevice(pin: Long, ip: String, serverId: Int): MatterCommissionResponse? {
         return try {
-            serverManager.webSocketRepository(serverId).commissionMatterDeviceOnNetwork(pin)
+            serverManager.webSocketRepository(serverId).commissionMatterDeviceOnNetwork(pin, ip)
         } catch (e: Exception) {
             Log.e(TAG, "Error while executing server commissioning request", e)
             null

--- a/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -37,5 +37,5 @@ interface MatterManager {
      * Send a request to the server to commission an "on network" Matter device
      * @return [MatterCommissionResponse], or `null` if it wasn't possible to complete the request
      */
-    suspend fun commissionOnNetworkDevice(pin: Long, serverId: Int): MatterCommissionResponse?
+    suspend fun commissionOnNetworkDevice(pin: Long, ip: String, serverId: Int): MatterCommissionResponse?
 }

--- a/app/src/minimal/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -24,5 +24,5 @@ class MatterManagerImpl @Inject constructor() : MatterManager {
 
     override suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse? = null
 
-    override suspend fun commissionOnNetworkDevice(pin: Long, serverId: Int): MatterCommissionResponse? = null
+    override suspend fun commissionOnNetworkDevice(pin: Long, ip: String, serverId: Int): MatterCommissionResponse? = null
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -60,7 +60,7 @@ interface WebSocketRepository {
      * @return [MatterCommissionResponse] detailing the server's response, or `null` if the server
      * did not return a response.
      */
-    suspend fun commissionMatterDeviceOnNetwork(pin: Long): MatterCommissionResponse?
+    suspend fun commissionMatterDeviceOnNetwork(pin: Long, ip: String): MatterCommissionResponse?
 
     /**
      * Return a list of all Thread datasets known to the server.

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -474,13 +474,13 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
     }
 
     override suspend fun commissionMatterDeviceOnNetwork(pin: Long, ip: String): MatterCommissionResponse? {
+        val data = mapOf(
+            "type" to "matter/commission_on_network",
+            "pin" to pin
+        )
         val response = sendMessage(
             WebSocketRequest(
-                message = mapOf(
-                    "type" to "matter/commission_on_network",
-                    "pin" to pin,
-                    "ipaddr" to ip
-                ),
+                message = if (server?.version?.isAtLeast(2024, 1) == true) data.plus("ip_addr" to ip) else data,
                 timeout = 120000L // Matter commissioning takes at least 60 seconds + interview
             )
         )

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -473,12 +473,13 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
         }
     }
 
-    override suspend fun commissionMatterDeviceOnNetwork(pin: Long): MatterCommissionResponse? {
+    override suspend fun commissionMatterDeviceOnNetwork(pin: Long, ip: String): MatterCommissionResponse? {
         val response = sendMessage(
             WebSocketRequest(
                 message = mapOf(
                     "type" to "matter/commission_on_network",
-                    "pin" to pin
+                    "pin" to pin,
+                    "ipaddr" to ip
                 ),
                 timeout = 120000L // Matter commissioning takes at least 60 seconds + interview
             )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Requires: home-assistant/core#106237

When using `matter/commission_on_network` (commissioning started from the frontend), also send the IP address returned by the system to the server in order to fix home-assistant-libs/python-matter-server#463. Read the issue + linked PR for more details.

The websocket message will now look like this:

```
{
    "id": 3,
    "type": "matter/commission_on_network",
    "pin": 1234,
    "ip_addr": "fd82:c9e9:5cb7:1:2c5c:ed99:ecf:4460"
}
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->