### PR TITLE
Add padding to refresh interval to avoid text getting cut off

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.home.views
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -46,7 +47,7 @@ fun RefreshIntervalPickerView(
     )
 
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.padding(12.dp).fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ListHeader(R.string.refresh_interval)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

We got a review failure from Google with a screenshot this time!

![image](https://github.com/home-assistant/android/assets/1634145/4f5b3604-a41c-49f0-9523-adcf49940180)

Adding padding to this screen to prevent the text from getting cut off like that. I tried to move to `ThemeLazyColumn` however the rotary input does not play nice so the best option seemed to be adding some sane padding

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

After fix using largest font size in Pixel Watch (one side effect of this change is that not many elements are visible in the picker however we do need to push things down a bit so this might be expected in larger screen sizes):

![image](https://github.com/home-assistant/android/assets/1634145/06ebc1ee-4314-4ff2-b763-cff99470a324)

Still behaves fine in default text size:

![image](https://github.com/home-assistant/android/assets/1634145/404778c9-fe94-465f-bda7-bbf5b471bde6)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->