### PR TITLE
Support for Thread "import credentials" from frontend

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
@@ -97,6 +97,7 @@ class MatterCommissioningViewModel @Inject constructor(
             val result = threadManager.syncPreferredDataset(
                 getApplication<Application>().applicationContext,
                 serverId,
+                false,
                 viewModelScope
             )
             when (result) {

--- a/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -7,10 +7,12 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.activity.result.ActivityResult
+import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.threadnetwork.IsPreferredCredentialsResult
 import com.google.android.gms.threadnetwork.ThreadBorderAgent
 import com.google.android.gms.threadnetwork.ThreadNetwork
 import com.google.android.gms.threadnetwork.ThreadNetworkCredentials
+import com.google.android.gms.threadnetwork.ThreadNetworkStatusCodes
 import io.homeassistant.companion.android.common.data.HomeAssistantVersion
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.ThreadDatasetResponse
@@ -49,11 +51,52 @@ class ThreadManagerImpl @Inject constructor(
     override suspend fun syncPreferredDataset(
         context: Context,
         serverId: Int,
+        exportOnly: Boolean,
         scope: CoroutineScope
     ): ThreadManager.SyncResult {
         if (!appSupportsThread()) return ThreadManager.SyncResult.AppUnsupported
         if (!coreSupportsThread(serverId)) return ThreadManager.SyncResult.ServerUnsupported
 
+        return if (exportOnly) { // Limited sync, only export non-app dataset
+            exportSyncPreferredDataset(context)
+        } else { // Full sync
+            fullSyncPreferredDataset(context, serverId, scope)
+        }
+    }
+
+    private suspend fun exportSyncPreferredDataset(
+        context: Context
+    ): ThreadManager.SyncResult {
+        val getDeviceDataset = try {
+            getPreferredDatasetFromDevice(context)
+        } catch (e: ApiException) {
+            Log.e(TAG, "Thread: export cannot be started", e)
+            if (e.statusCode == ThreadNetworkStatusCodes.LOCAL_NETWORK_NOT_CONNECTED) {
+                return ThreadManager.SyncResult.NotConnected
+            } else {
+                throw e
+            }
+        }
+
+        return if (getDeviceDataset == null) {
+            ThreadManager.SyncResult.NoneHaveCredentials
+        } else {
+            val appIsDevicePreferred = appAddedIsPreferredCredentials(context)
+            Log.d(TAG, "Thread: device ${if (appIsDevicePreferred) "prefers" else "doesn't prefer" } dataset from app")
+
+            return if (appIsDevicePreferred) {
+                ThreadManager.SyncResult.OnlyOnServer(imported = false)
+            } else {
+                ThreadManager.SyncResult.OnlyOnDevice(exportIntent = getDeviceDataset)
+            }
+        }
+    }
+
+    private suspend fun fullSyncPreferredDataset(
+        context: Context,
+        serverId: Int,
+        scope: CoroutineScope
+    ): ThreadManager.SyncResult {
         deleteOrphanedThreadCredentials(context, serverId)
 
         val getDeviceDataset = scope.async { getPreferredDatasetFromDevice(context) }

--- a/app/src/main/java/io/homeassistant/companion/android/matter/MatterFrontendCommissioningStatus.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/matter/MatterFrontendCommissioningStatus.kt
@@ -3,7 +3,12 @@ package io.homeassistant.companion.android.matter
 enum class MatterFrontendCommissioningStatus {
     NOT_STARTED,
     REQUESTED,
-    THREAD_EXPORT_TO_SERVER,
+    THREAD_EXPORT_TO_SERVER_MATTER,
+    THREAD_EXPORT_TO_SERVER_ONLY,
     IN_PROGRESS,
-    ERROR
+    THREAD_SENT,
+    THREAD_NONE,
+    ERROR_MATTER,
+    ERROR_THREAD_LOCAL_NETWORK,
+    ERROR_THREAD_OTHER
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -63,7 +63,7 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
     override fun runThreadDebug(context: Context, serverId: Int) {
         mainScope.launch {
             try {
-                when (val syncResult = threadManager.syncPreferredDataset(context, serverId, CoroutineScope(coroutineContext + SupervisorJob()))) {
+                when (val syncResult = threadManager.syncPreferredDataset(context, serverId, false, CoroutineScope(coroutineContext + SupervisorJob()))) {
                     is ThreadManager.SyncResult.ServerUnsupported ->
                         view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_unsupported_server), false)
                     is ThreadManager.SyncResult.OnlyOnServer -> {

--- a/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -11,6 +11,7 @@ interface ThreadManager {
     sealed class SyncResult {
         object AppUnsupported : SyncResult()
         object ServerUnsupported : SyncResult()
+        object NotConnected : SyncResult()
         class OnlyOnServer(val imported: Boolean) : SyncResult()
         class OnlyOnDevice(val exportIntent: IntentSender?) : SyncResult()
         class AllHaveCredentials(val matches: Boolean?, val fromApp: Boolean?, val updated: Boolean?, val exportIntent: IntentSender?) : SyncResult()
@@ -28,15 +29,21 @@ interface ThreadManager {
     suspend fun coreSupportsThread(serverId: Int): Boolean
 
     /**
-     * Try to sync the preferred Thread dataset with the device and server. If one has a preferred
-     * dataset while the other one doesn't, it will sync. If both have preferred datasets, it will
-     * send updated data to the server if needed. If neither has a preferred dataset, skip syncing.
+     * Try to sync the preferred Thread dataset.
+     * @param exportOnly Controls the synchronization direction.
+     *  - If set to `true`, only get the device preferred dataset and sync to the server if it
+     *    wasn't added by the app.
+     *  - If set to `false`, try to get the device and server in sync. This will clean up old/stale
+     *    app datasets. If one has a preferred dataset while the other one doesn't, it will sync to
+     *    the other. If both have preferred datasets, it will send updated data to the server if
+     *    needed. If neither has a preferred dataset, skip syncing.
      * @return [SyncResult] with details of the sync operation, which may include an [IntentSender]
      * if permission is required to import the device dataset
      */
     suspend fun syncPreferredDataset(
         context: Context,
         serverId: Int,
+        exportOnly: Boolean,
         scope: CoroutineScope
     ): SyncResult
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/MatterThreadStep.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/MatterThreadStep.kt
@@ -1,11 +1,11 @@
-package io.homeassistant.companion.android.matter
+package io.homeassistant.companion.android.webview
 
-enum class MatterFrontendCommissioningStatus {
+enum class MatterThreadStep {
     NOT_STARTED,
     REQUESTED,
     THREAD_EXPORT_TO_SERVER_MATTER,
     THREAD_EXPORT_TO_SERVER_ONLY,
-    IN_PROGRESS,
+    MATTER_IN_PROGRESS,
     THREAD_SENT,
     THREAD_NONE,
     ERROR_MATTER,

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.webview
 import android.content.Context
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
-import io.homeassistant.companion.android.matter.MatterFrontendCommissioningStatus
 import kotlinx.coroutines.flow.Flow
 
 interface WebViewPresenter {
@@ -54,12 +53,12 @@ interface WebViewPresenter {
 
     fun appCanCommissionMatterDevice(): Boolean
     fun startCommissioningMatterDevice(context: Context)
-    fun getMatterCommissioningStatusFlow(): Flow<MatterFrontendCommissioningStatus>
-    fun getMatterCommissioningIntent(): IntentSender?
-    fun onMatterCommissioningIntentResult(context: Context, result: ActivityResult)
-    fun confirmMatterCommissioningError()
 
     /** @return `true` if the app can send this device's preferred Thread credential to the server */
     fun appCanExportThreadCredentials(): Boolean
     fun exportThreadCredentials(context: Context)
+    fun getMatterThreadStepFlow(): Flow<MatterThreadStep>
+    fun getMatterThreadIntent(): IntentSender?
+    fun onMatterThreadIntentResult(context: Context, result: ActivityResult)
+    fun finishMatterThreadFlow()
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -58,4 +58,8 @@ interface WebViewPresenter {
     fun getMatterCommissioningIntent(): IntentSender?
     fun onMatterCommissioningIntentResult(context: Context, result: ActivityResult)
     fun confirmMatterCommissioningError()
+
+    /** @return `true` if the app can send this device's preferred Thread credential to the server */
+    fun appCanExportThreadCredentials(): Boolean
+    fun exportThreadCredentials(context: Context)
 }

--- a/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -19,6 +19,7 @@ class ThreadManagerImpl @Inject constructor() : ThreadManager {
     override suspend fun syncPreferredDataset(
         context: Context,
         serverId: Int,
+        exportOnly: Boolean,
         scope: CoroutineScope
     ): ThreadManager.SyncResult = ThreadManager.SyncResult.AppUnsupported
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1145,6 +1145,10 @@
     <string name="thread_debug_result_unsupported_server">The Home Assistant server does not support Thread</string>
     <string name="thread_debug_result_updated">Updated network from Home Assistant on this device</string>
     <string name="thread_debug_summary">Manually update device and server Thread credentials and verify results</string>
+    <string name="thread_export_success">Imported credential</string>
+    <string name="thread_export_none">You don\'t have any credentials to import.</string>
+    <string name="thread_export_not_connected">You are not connected to a local network. Connect to Wi-Fi or ethernet to import Thread credentials.</string>
+    <string name="thread_export_unavailable">Thread is currently unavailable</string>
     <string name="tile_vibrate">Vibrate when clicked</string>
     <string name="tile_auth_required">Requires unlocked device</string>
     <string name="no_results">No results yet</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Support the frontend `thread/import_credentials` action, shown as a button on the Thread config page, which will export the preferred Thread credential from the device (if the device doesn't prefer a HA credential) to the server.

This partially re-uses the existing Thread credential sync logic from Matter commissioning.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Video showing the flow, first denying the permission/failure and then success:

https://github.com/home-assistant/android/assets/8148535/183adc05-837f-4db1-8512-5815032f4af9

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->