### PR TITLE
Add ability for ClimateControl Card to cycle through entity states

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CameraControl.kt
@@ -15,7 +15,6 @@ import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import java.net.URL
 import java.util.concurrent.TimeUnit
@@ -32,11 +31,10 @@ object CameraControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
-        val image = if (baseUrl != null && (entity.attributes["entity_picture"] as? String)?.isNotBlank() == true) {
-            getThumbnail(baseUrl + entity.attributes["entity_picture"] as String)
+        val image = if (info.baseUrl != null && (entity.attributes["entity_picture"] as? String)?.isNotBlank() == true) {
+            getThumbnail(info.baseUrl + entity.attributes["entity_picture"] as String)
         } else {
             null
         }

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -76,7 +76,8 @@ object ClimateControl : HaControl {
             val toggleRangeTemplate = ToggleRangeTemplate(
                 entity.entityId + "_range",
                 entity.state != "off",
-                "Toggle climate", rangeTemplate
+                "Toggle climate",
+                rangeTemplate
             )
             var modesFlag = 0
             this.currentMode = entity.state

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -75,7 +75,7 @@ object ClimateControl : HaControl {
             supportedModes.clear()
             val toggleRangeTemplate = ToggleRangeTemplate(
                 entity.entityId + "_range",
-                entity.state != "off",
+                true,
                 "Toggle climate",
                 rangeTemplate
             )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -144,6 +144,7 @@ object ClimateControl : HaControl {
             }
             is BooleanAction -> {
                 val nextMode = (this.supportedModes.indexOf(currentMode) + 1) % this.supportedModes.count()
+                this.currentMode = this.supportedModes[nextMode]
                 integrationRepository.callService(
                     action.templateId.split(".")[0],
                     "set_hvac_mode",

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -74,6 +74,7 @@ object ClimateControl : HaControl {
             val state = ClimateState(entity.state, ArrayList())
             val toggleRangeTemplate = ToggleRangeTemplate(
                 info.systemId + "_range",
+                // Set checked to true to always show the temperature indicator, regardless of climate mode
                 true,
                 context.getString(commonR.string.widget_tap_action_toggle),
                 rangeTemplate

--- a/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/ClimateControl.kt
@@ -76,7 +76,7 @@ object ClimateControl : HaControl {
             val toggleRangeTemplate = ToggleRangeTemplate(
                 entity.entityId + "_range",
                 true,
-                "Toggle climate",
+                context.getString(commonR.string.widget_tap_action_toggle),
                 rangeTemplate
             )
             var modesFlag = 0

--- a/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/CoverControl.kt
@@ -17,7 +17,6 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.getCoverPosition
 import io.homeassistant.companion.android.common.data.integration.isActive
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
 object CoverControl : HaControl {
@@ -26,8 +25,7 @@ object CoverControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         val position = entity.getCoverPosition()
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultButtonControl.kt
@@ -11,7 +11,6 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.util.capitalize
 import java.util.Locale
 
@@ -21,8 +20,7 @@ object DefaultButtonControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         control.setStatusText("")
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSliderControl.kt
@@ -11,7 +11,6 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import kotlinx.coroutines.runBlocking
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -20,8 +19,7 @@ object DefaultSliderControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         control.setStatusText("")
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/DefaultSwitchControl.kt
@@ -14,7 +14,6 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.isActive
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.util.capitalize
 import java.util.Locale
 
@@ -24,8 +23,7 @@ object DefaultSwitchControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         control.setControlTemplate(
             ToggleTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/FanControl.kt
@@ -18,7 +18,6 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.integration.getFanSpeed
 import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
 object FanControl : HaControl {
@@ -26,8 +25,7 @@ object FanControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         if (entity.supportsFanSetSpeed()) {
             val position = entity.getFanSpeed()

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -17,7 +17,6 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.friendlyState
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.webview.WebViewActivity
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -77,15 +76,14 @@ interface HaControl {
             }
         }
 
-        return provideControlFeatures(context, control, entity, info.area, info.baseUrl).build()
+        return provideControlFeatures(context, control, entity, info).build()
     }
 
     fun provideControlFeatures(
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder
 
     fun getDeviceType(entity: Entity<Map<String, Any>>): Int

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaFailedControl.kt
@@ -10,7 +10,6 @@ import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.util.capitalize
 import java.util.Locale
 
@@ -20,8 +19,7 @@ object HaFailedControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         control.setStatus(if (entity.state == "notfound") Control.STATUS_NOT_FOUND else Control.STATUS_ERROR)
         control.setStatusText("")

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LightControl.kt
@@ -18,7 +18,6 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationRep
 import io.homeassistant.companion.android.common.data.integration.getLightBrightness
 import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
 object LightControl : HaControl {
@@ -26,8 +25,7 @@ object LightControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         val position = entity.getLightBrightness()
         control.setControlTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/LockControl.kt
@@ -13,7 +13,6 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.isActive
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
 object LockControl : HaControl {
@@ -21,8 +20,7 @@ object LockControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         control.setControlTemplate(
             ToggleTemplate(

--- a/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/VacuumControl.kt
@@ -13,7 +13,6 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.isActive
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 
 @RequiresApi(Build.VERSION_CODES.R)
 object VacuumControl : HaControl {
@@ -24,8 +23,7 @@ object VacuumControl : HaControl {
         context: Context,
         control: Control.StatefulBuilder,
         entity: Entity<Map<String, Any>>,
-        area: AreaRegistryResponse?,
-        baseUrl: String?
+        info: HaControlInfo
     ): Control.StatefulBuilder {
         entitySupportedFeatures = entity.attributes["supported_features"] as Int
         control.setControlTemplate(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The ClimateControl right now doesn't cycle through modes (toggle in case it's a normal heating) when clicking on it within "Device controls" on Android which means more hassle when trying to change modes, as I would have to go into the app and in general it requires more clicks.

## Screenshots/Screencast
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://github.com/home-assistant/android/assets/16007727/e36608f3-3a89-4fe9-8f2a-569ba47ff814)

[Screencast from 2024-01-17 20-23-47.webm](https://github.com/home-assistant/android/assets/16007727/bc6be879-4084-4d85-8475-78842b3c55b5)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
None so far. If that is needed, please come back to me.
<!-- Documentation: home-assistant/companion.home-assistant# -->

## Any other notes
Didn't know whether I should create an issue for that just to have the implementation directly around and decided against that. In case I missed some workflow feel free to reach out to me. Would be happy to see this change merged