### PR TITLE
Replace 'Refresh interval' title with icon

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
@@ -10,12 +10,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.ListHeader
+import androidx.wear.compose.material.LocalContentColor
 import androidx.wear.compose.material.Picker
 import androidx.wear.compose.material.rememberPickerState
 import androidx.wear.compose.material3.FilledIconButton
@@ -28,9 +31,10 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.google.android.horologist.annotations.ExperimentalHorologistApi
 import com.google.android.horologist.composables.picker.toRotaryScrollAdapter
 import com.google.android.horologist.compose.rotaryinput.rotaryWithSnap
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.theme.wearColorScheme
 import io.homeassistant.companion.android.util.intervalToString
-import io.homeassistant.companion.android.views.ListHeader
 import io.homeassistant.companion.android.common.R as R
 
 @OptIn(ExperimentalHorologistApi::class)
@@ -50,7 +54,13 @@ fun RefreshIntervalPickerView(
         modifier = Modifier.padding(horizontal = 12.dp).fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        ListHeader(R.string.refresh_interval)
+        ListHeader {
+            Image(
+                asset = CommunityMaterial.Icon3.cmd_timer_cog,
+                contentDescription = stringResource(R.string.refresh_interval),
+                colorFilter = ColorFilter.tint(LocalContentColor.current)
+            )
+        }
         Picker(
             state = state,
             contentDescription = stringResource(R.string.refresh_interval),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To (hopefully) finally address review failures about text being cut off on round screens replace it with an icon. Same icon as used in the previous screen so should be pretty clear.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![Picker with a clock with cog icon above it](https://github.com/home-assistant/android/assets/8148535/c9453d8a-68e8-40fe-9d2a-24b727e13653)

As a reminder, the preference chip:
![Refresh interval: Manual, with the same icon](https://github.com/home-assistant/android/assets/8148535/1dd4f82a-2c89-426d-9f9f-0797cd267b8d)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->