### PR TITLE
Remove Thread credential sync from start of Matter commissioning flow

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.matter
 
 import android.app.Application
 import android.content.IntentSender
-import android.util.Log
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -91,24 +90,12 @@ class MatterCommissioningViewModel @Inject constructor(
         }
     }
 
-    suspend fun syncThreadIfNecessary(): IntentSender? {
+    fun syncThreadIfNecessary(): IntentSender? {
         step = CommissioningFlowStep.Working
-        return try {
-            val result = threadManager.syncPreferredDataset(
-                getApplication<Application>().applicationContext,
-                serverId,
-                false,
-                viewModelScope
-            )
-            when (result) {
-                is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
-                is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
-                else -> null
-            }
-        } catch (e: Exception) {
-            Log.w(TAG, "Unable to sync preferred Thread dataset, continuing", e)
-            null
-        }
+        // The app used to sync Thread credentials here until commit 26a472a, but it was
+        // (temporarily?) removed due to slowing down the Matter commissioning flow for the user
+        // and limited usefulness of the result (because of API limitations)
+        return null
     }
 
     fun onThreadPermissionResult(result: ActivityResult, code: String) {

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -345,24 +345,11 @@ class WebViewPresenterImpl @Inject constructor(
         if (_matterThreadStep.value != MatterThreadStep.REQUESTED) {
             _matterThreadStep.tryEmit(MatterThreadStep.REQUESTED)
 
-            mainScope.launch {
-                val deviceThreadIntent = try {
-                    when (val result = threadUseCase.syncPreferredDataset(context, serverId, false, CoroutineScope(coroutineContext + SupervisorJob()))) {
-                        is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
-                        is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
-                        else -> null
-                    }
-                } catch (e: Exception) {
-                    Log.w(TAG, "Unable to sync preferred Thread dataset, continuing", e)
-                    null
-                }
-                if (deviceThreadIntent != null) {
-                    matterThreadIntentSender = deviceThreadIntent
-                    _matterThreadStep.tryEmit(MatterThreadStep.THREAD_EXPORT_TO_SERVER_MATTER)
-                } else {
-                    startMatterCommissioningFlow(context)
-                }
-            }
+            // The app used to sync Thread credentials here until commit 26a472a, but it was
+            // (temporarily?) removed due to slowing down the Matter commissioning flow for the user
+            // and limited usefulness of the result (because of API limitations)
+
+            startMatterCommissioningFlow(context)
         } // else already waiting for a result, don't send another request
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After discussion with @agners, remove Thread credential syncing from the start of the Matter commissioning flow. There are 2 major reasons for this:

* it significantly slows down the flow while only being useful some of the time (initially, and on Thread network/BR changes)
* the results have limited usefulness because the API limits how much Home Assistant can influence the device data
 
The alternative for the user is to use the manual 'import credentials' button in the frontend (matching iOS), or access the sync option in the app settings > troubleshooting menu.

This should result in a more reliable user experience when using Matter and prevents unstable/unfinished Thread work on the core and app side 'polluting a real device'. Adding a comment in the code in case/when we revisit this in the future.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a / the Thread permission dialog will no longer show up when doing Matter commissioning

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a, this behavior wasn't documented, general Thread companion app import/export documentation to be done independently

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->