### PR TITLE
Support image entity in camera widget (now renamed picture widget)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/views/ManageWidgetsView.kt
@@ -47,7 +47,7 @@ import io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigu
 
 enum class WidgetType(val widgetIcon: IIcon) {
     BUTTON(CommunityMaterial.Icon2.cmd_gesture_tap),
-    CAMERA(CommunityMaterial.Icon.cmd_camera),
+    CAMERA(CommunityMaterial.Icon.cmd_camera_image),
     STATE(CommunityMaterial.Icon3.cmd_shape),
     MEDIA(CommunityMaterial.Icon3.cmd_play_box_multiple),
     TEMPLATE(CommunityMaterial.Icon.cmd_code_braces);

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
@@ -136,7 +136,7 @@ class CameraWidgetConfigureActivity : BaseWidgetConfigureActivity() {
             lifecycleScope.launch {
                 try {
                     val fetchedEntities = serverManager.integrationRepository(server.id).getEntities().orEmpty()
-                        .filter { it.domain == "camera" }
+                        .filter { it.domain == "camera" || it.domain == "image" }
                     entities[server.id] = fetchedEntities
                     if (server.id == selectedServerId) setAdapterEntities(server.id)
                 } catch (e: Exception) {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -132,8 +132,8 @@
     <string name="camera_tile_no_entity_yet">Edit the tile settings and select a camera to show</string>
     <string name="camera_tile_n">Camera tile #%d</string>
     <string name="camera_tiles">Camera tiles</string>
-    <string name="camera_widgets">Camera widgets</string>
-    <string name="camera_widget_desc">Displays the latest image from the camera</string>
+    <string name="camera_widgets">Picture widgets</string>
+    <string name="camera_widget_desc">Displays the latest picture from a camera or image entity</string>
     <string name="cancel">Cancel</string>
     <string name="changelog">View full change log</string>
     <string name="checking_with_home_assistant">Checking with Home Assistant</string>
@@ -974,8 +974,8 @@
     <string name="widget_background_type_dynamiccolor">Dynamic color</string>
     <string name="widget_background_type_transparent">Transparent</string>
     <string name="widget_button_image_description">Service button</string>
-    <string name="widget_camera_description">Camera widget</string>
-    <string name="widget_camera_contentdescription">Camera image</string>
+    <string name="widget_camera_description">Picture widget</string>
+    <string name="widget_camera_contentdescription">Image</string>
     <string name="widget_config_service_error">A custom component is preventing service data from loading.</string>
     <string name="widget_creation_error">Unable to create widget.</string>
     <string name="widget_entity_fetch_error">Unable to fetch data for configured entity.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #4139:

 - Allow selecting image entities in the camera widget
 - Rename camera widget to picture widget to better reflect camera + image entity support

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|    |Light|Dark|
|----|----|----|
|Widget config showing `image` entity|![image](https://github.com/home-assistant/android/assets/8148535/15a960d1-94ff-45a8-acd6-8346450cf824)|![image](https://github.com/home-assistant/android/assets/8148535/f385cdd7-9af5-40a2-9c8a-9af702d0b4fa)|
|App settings list now shows Picture widget|![image](https://github.com/home-assistant/android/assets/8148535/0b50723a-4165-4421-aa22-8da89c9bff9d)|![image](https://github.com/home-assistant/android/assets/8148535/b4eb04e3-0005-46d1-8b0c-c585a5fb9bd1)|

(widget appearance itself did not change)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1023

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->