### PR TITLE
Wear Assist: show login when logged out, scroll first item into view

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt
@@ -17,6 +17,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.conversation.views.LoadAssistView
+import io.homeassistant.companion.android.home.HomeActivity
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -53,6 +54,9 @@ class ConversationActivity : ComponentActivity() {
             val launchIntent = conversationViewModel.onCreate(hasRecordingPermission())
             if (launchIntent) {
                 launchVoiceInputIntent()
+            } else if (!conversationViewModel.isRegistered()) {
+                startActivity(HomeActivity.newInstance(this@ConversationActivity))
+                finish()
             }
         }
 

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -129,6 +129,8 @@ class ConversationViewModel @Inject constructor(
         return false
     }
 
+    fun isRegistered(): Boolean = serverManager.isRegistered()
+
     override fun getInput(): AssistInputMode = inputMode
 
     override fun setInput(inputMode: AssistInputMode) {

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/views/ConversationView.kt
@@ -121,7 +121,7 @@ fun ConversationResultView(
     val scrollState = rememberScalingLazyListState()
     LaunchedEffect(conversation.size) {
         scrollState.scrollToItem(
-            if (inputMode != AssistViewModelBase.AssistInputMode.BLOCKED) conversation.size else (conversation.size - 1)
+            if (inputMode != AssistViewModelBase.AssistInputMode.BLOCKED) (conversation.size + 1) else conversation.size
         )
     }
     if (hapticFeedback) {
@@ -135,6 +135,9 @@ fun ConversationResultView(
     }
 
     ThemeLazyColumn(state = scrollState) {
+        item {
+            Spacer(Modifier.size(1.dp)) // This exists to allow the next item to be centered
+        }
         item {
             if (currentPipeline != null) {
                 val textColor = LocalContentColor.current.copy(alpha = 0.38f) // disabled/hint alpha


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Wear Assist changes to address Google's latest ~~nitpicking~~ review failure:

 - Update Assist on Wear to automatically open the login screen when logged out, instead of asking the user to close and login, to prevent text being cut off issues
 - Add another item at the top of Assist on Wear to allow the pipeline selector to be scrolled into the center of the screen (the first item cannot be scrolled into the center of the screen)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, now more centered possible but contents are the same

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->