### PR TITLE
Replace deprecated MdcTheme with 'normal' theme matching XML theme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,7 +180,6 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
-    implementation(libs.accompanist.themeadapter.material)
 
     implementation(libs.iconics.core)
     implementation(libs.iconics.compose)

--- a/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningActivity.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/MatterCommissioningActivity.kt
@@ -12,13 +12,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.google.android.gms.home.matter.Matter
 import com.google.android.gms.home.matter.commissioning.SharedDeviceData
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.matter.views.MatterCommissioningView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -47,7 +47,7 @@ class MatterCommissioningActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 MatterCommissioningView(
                     step = viewModel.step,
                     deviceName = deviceName,

--- a/app/src/full/java/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt
@@ -32,13 +32,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.themeadapter.material.MdcTheme
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import io.homeassistant.companion.android.database.server.ServerSessionInfo
 import io.homeassistant.companion.android.database.server.ServerUserInfo
 import io.homeassistant.companion.android.matter.MatterCommissioningViewModel.CommissioningFlowStep
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlin.math.min
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -217,7 +217,7 @@ fun MatterCommissioningViewHeader() {
 fun PreviewMatterCommissioningView(
     @PreviewParameter(MatterCommissioningViewPreviewStates::class) step: CommissioningFlowStep
 ) {
-    MdcTheme {
+    HomeAssistantAppTheme {
         MatterCommissioningView(
             step = step,
             deviceName = "Manufacturer Matter Light",

--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
@@ -16,10 +16,10 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.settings.wear.SettingsWearViewModel
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 const val WEAR_DOCS_LINK = "https://companion.home-assistant.io/docs/wear-os/"
@@ -31,7 +31,7 @@ fun LoadSettingsHomeView(
     loginWearOs: () -> Unit,
     onStartBackClicked: () -> Unit
 ) {
-    MdcTheme {
+    HomeAssistantAppTheme {
         val navController = rememberNavController()
         NavHost(navController = navController, startDestination = SettingsWearMainView.LANDING) {
             composable(SettingsWearMainView.FAVORITES) {

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -18,12 +18,12 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.view.WindowCompat
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.assist.ui.AssistSheetView
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 
 @AndroidEntryPoint
@@ -97,7 +97,7 @@ class AssistActivity : BaseActivity() {
 
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 val systemUiController = rememberSystemUiController()
                 val useDarkIcons = MaterialTheme.colors.isLight
                 SideEffect {

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -23,10 +23,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -90,7 +90,7 @@ class HaControlsPanelActivity : AppCompatActivity() {
 
     @Composable
     fun LockedPanelView() {
-        MdcTheme {
+        HomeAssistantAppTheme {
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
@@ -31,6 +30,7 @@ import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.settings.SettingViewModel
 import io.homeassistant.companion.android.settings.server.ServerChooserFragment
 import io.homeassistant.companion.android.util.UrlUtil
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -71,7 +71,7 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
         super.onCreate(savedInstanceState)
         setContent {
             Box(modifier = Modifier.fillMaxSize()) {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     CircularProgressIndicator(
                         modifier = Modifier.align(Alignment.Center)
                     )

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/NfcSetupActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/NfcSetupActivity.kt
@@ -11,11 +11,11 @@ import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.nfc.views.LoadNfcView
 import io.homeassistant.companion.android.util.UrlUtil
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.launch
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -62,7 +62,7 @@ class NfcSetupActivity : BaseActivity() {
         }
 
         setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 LoadNfcView(
                     viewModel = viewModel,
                     startDestination = if (simpleWrite) NAV_WRITE else NAV_WELCOME,

--- a/app/src/main/java/io/homeassistant/companion/android/nfc/TagReaderActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/nfc/TagReaderActivity.kt
@@ -8,12 +8,12 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.nfc.views.TagReaderView
 import io.homeassistant.companion.android.util.UrlUtil
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
@@ -34,7 +34,7 @@ class TagReaderActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 TagReaderView()
             }
         }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.HomeAssistantApis
@@ -32,6 +31,7 @@ import io.homeassistant.companion.android.onboarding.OnboardingViewModel
 import io.homeassistant.companion.android.onboarding.integration.MobileAppIntegrationFragment
 import io.homeassistant.companion.android.themes.ThemesManager
 import io.homeassistant.companion.android.util.TLSWebViewClient
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.isStarted
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -66,7 +66,7 @@ class AuthenticationFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     AndroidView({
                         WebView(requireContext()).apply {
                             themesManager.setThemeForWebView(requireContext(), settings)

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
@@ -10,12 +10,12 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupFragment
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -42,7 +42,7 @@ class DiscoveryFragment @Inject constructor() : Fragment() {
 
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     DiscoveryView(
                         onboardingViewModel = viewModel,
                         manualSetupClicked = { navigateToManualSetup() },

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -20,13 +20,13 @@ import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
 import io.homeassistant.companion.android.onboarding.notifications.NotificationPermissionFragment
 import io.homeassistant.companion.android.sensors.LocationSensorManager
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.launch
 import java.io.IOException
 import java.security.KeyStore
@@ -52,7 +52,7 @@ class MobileAppIntegrationFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     MobileAppIntegrationView(
                         onboardingViewModel = viewModel,
                         openPrivacyPolicy = this@MobileAppIntegrationFragment::openPrivacyPolicy,

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/manual/ManualSetupFragment.kt
@@ -7,11 +7,11 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
 import io.homeassistant.companion.android.onboarding.authentication.AuthenticationFragment
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
 @AndroidEntryPoint
 class ManualSetupFragment : Fragment() {
@@ -25,7 +25,7 @@ class ManualSetupFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     ManualSetupView(
                         onboardingViewModel = viewModel,
                         connectedClicked = { connectClicked() }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionFragment.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.app.NotificationManagerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import io.homeassistant.companion.android.onboarding.OnboardingViewModel
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 class NotificationPermissionFragment : Fragment() {
@@ -44,7 +44,7 @@ class NotificationPermissionFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     NotificationPermissionView(
                         onSetNotificationsEnabled = ::setNotifications
                     )

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.onboarding.OnboardingHeaderView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @Composable
@@ -102,7 +102,7 @@ fun NotificationPermissionBullet(
 @Preview(showSystemUi = true)
 @Composable
 fun NotificationPermissionViewPreview() {
-    MdcTheme {
+    HomeAssistantAppTheme {
         NotificationPermissionView(
             onSetNotificationsEnabled = {}
         )

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/welcome/WelcomeFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/welcome/WelcomeFragment.kt
@@ -7,10 +7,10 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
-import com.google.accompanist.themeadapter.material.MdcTheme
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.onboarding.discovery.DiscoveryFragment
 import io.homeassistant.companion.android.onboarding.manual.ManualSetupFragment
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
 class WelcomeFragment : Fragment() {
 
@@ -21,7 +21,7 @@ class WelcomeFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     WelcomeView(
                         onContinue = { welcomeNavigation() }
                     )

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/welcome/WelcomeView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/welcome/WelcomeView.kt
@@ -27,8 +27,8 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.google.accompanist.themeadapter.material.MdcTheme
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @Composable
@@ -103,7 +103,7 @@ fun WelcomeView(
 @Preview(showSystemUi = true)
 @Preview(showSystemUi = true, uiMode = UI_MODE_NIGHT_YES)
 private fun PreviewWelcome() {
-    MdcTheme {
+    HomeAssistantAppTheme {
         WelcomeView(onContinue = {})
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/controls/ManageControlsSettingsFragment.kt
@@ -9,12 +9,12 @@ import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.controls.views.ManageControlsView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -34,7 +34,7 @@ class ManageControlsSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     ManageControlsView(
                         panelEnabled = viewModel.panelEnabled,
                         authSetting = viewModel.authRequired,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/developer/location/LocationTrackingFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/developer/location/LocationTrackingFragment.kt
@@ -15,11 +15,11 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.settings.developer.location.views.LocationTrackingView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -38,7 +38,7 @@ class LocationTrackingFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     LocationTrackingView(
                         useHistory = viewModel.historyEnabled,
                         onSetHistory = viewModel::enableHistory,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationChannelFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationChannelFragment.kt
@@ -9,10 +9,10 @@ import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.notification.views.NotificationChannelView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -28,7 +28,7 @@ class NotificationChannelFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     NotificationChannelView(notificationViewModel = viewModel)
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/notification/NotificationDetailFragment.kt
@@ -12,12 +12,12 @@ import androidx.core.view.MenuHost
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.database.notification.NotificationDao
 import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.settings.notification.views.LoadNotification
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
@@ -51,7 +51,7 @@ class NotificationDetailFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     LoadNotification(notification)
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/qs/ManageTilesFragment.kt
@@ -12,12 +12,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.typeface.IIcon
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.EntityExt
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.qs.views.ManageTilesView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.icondialog.IconDialog
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -38,7 +38,7 @@ class ManageTilesFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     var showingDialog by remember { mutableStateOf(false) }
 
                     if (showingDialog) {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorDetailFragment.kt
@@ -21,12 +21,12 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.common.util.LocationPermissionInfoHandler
 import io.homeassistant.companion.android.settings.sensor.views.SensorDetailView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -71,7 +71,7 @@ class SensorDetailFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     SensorDetailView(
                         viewModel = viewModel,
                         onSetEnabled = { enable, serverId -> viewModel.setEnabled(enable, serverId) },

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorSettingsFragment.kt
@@ -17,10 +17,10 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.settings.sensor.views.SensorListView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -35,7 +35,7 @@ class SensorSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     SensorListView(
                         viewModel = viewModel,
                         onSensorClicked = { sensor ->

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorUpdateFrequencyFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/SensorUpdateFrequencyFragment.kt
@@ -8,11 +8,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.SettingViewModel
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.sensor.views.SensorUpdateFrequencyView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -27,7 +27,7 @@ class SensorUpdateFrequencyFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     val settings = viewModel.getSettingFlow(0)
                         .collectAsState(initial = viewModel.getSetting(0))
                     SensorUpdateFrequencyView(

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
@@ -8,13 +8,13 @@ import android.widget.FrameLayout
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -37,7 +37,7 @@ class ServerChooserFragment : BottomSheetDialogFragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     ServerChooserView(
                         servers = serverManager.defaultServers,
                         onServerSelected = { serverId ->

--- a/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsSettingsFragment.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.typeface.IIcon
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.shortcuts.views.ManageShortcutsView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.icondialog.IconDialog
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -41,7 +41,7 @@ class ManageShortcutsSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     var showingTag by remember { mutableStateOf<String?>(null) }
                     showingTag?.let { tag ->
                         IconDialog(

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.ssid.views.SsidView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -29,7 +29,7 @@ class SsidFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     SsidView(
                         wifiSsids = viewModel.wifiSsids,
                         prioritizeInternal = viewModel.prioritizeInternal,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/url/ExternalUrlFragment.kt
@@ -7,9 +7,9 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.url.views.ExternalUrlView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -28,7 +28,7 @@ class ExternalUrlFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     ExternalUrlView(
                         canUseCloud = viewModel.canUseCloud,
                         useCloud = viewModel.useCloud,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/vehicle/ManageAndroidAutoSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/vehicle/ManageAndroidAutoSettingsFragment.kt
@@ -10,11 +10,11 @@ import androidx.annotation.RequiresApi
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.vehicle.views.AndroidAutoFavoritesSettings
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -34,7 +34,7 @@ class ManageAndroidAutoSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     AndroidAutoFavoritesSettings(
                         androidAutoViewModel = viewModel,
                         serversList = serverManager.defaultServers,

--- a/app/src/main/java/io/homeassistant/companion/android/settings/websocket/WebsocketSettingFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/websocket/WebsocketSettingFragment.kt
@@ -18,12 +18,12 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.getSystemService
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.wifi.WifiHelper
 import io.homeassistant.companion.android.settings.SettingViewModel
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.websocket.views.WebsocketSettingView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import javax.inject.Inject
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -61,7 +61,7 @@ class WebsocketSettingFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     val settings = viewModel.getSettingFlow(serverId)
                         .collectAsState(initial = viewModel.getSetting(serverId))
                     WebsocketSettingView(

--- a/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/widgets/ManageWidgetsSettingsFragment.kt
@@ -7,10 +7,10 @@ import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.widgets.views.ManageWidgetsView
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.common.R as commonR
 
 @AndroidEntryPoint
@@ -25,7 +25,7 @@ class ManageWidgetsSettingsFragment : Fragment() {
     ): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                MdcTheme {
+                HomeAssistantAppTheme {
                     ManageWidgetsView(viewModel = viewModel)
                 }
             }

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/Theme.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/Theme.kt
@@ -1,0 +1,51 @@
+package io.homeassistant.companion.android.util.compose
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material.LocalContentColor
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.darkColors
+import androidx.compose.material.lightColors
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.Color
+
+val colorPrimary = Color(0xFF03A9F4)
+val colorPrimaryDark = Color(0xFF0288D1)
+val darkColorBackground = Color(0xFF1C1C1C)
+
+private val haLightColors = lightColors(
+    primary = colorPrimary,
+    primaryVariant = colorPrimaryDark,
+    secondary = colorPrimary,
+    secondaryVariant = colorPrimary,
+    onPrimary = Color.White,
+    onSecondary = Color.White
+)
+private val haDarkColors = darkColors(
+    primary = colorPrimary,
+    primaryVariant = colorPrimaryDark,
+    secondary = colorPrimary,
+    secondaryVariant = colorPrimary,
+    background = darkColorBackground,
+    onPrimary = Color.White,
+    onSecondary = Color.White
+)
+
+/**
+ * A Compose [MaterialTheme] version of the app's XML theme. This achieves the same goal as the
+ * (now deprecated) [com.google.accompanist.themeadapter.material.MdcTheme].
+ */
+@Composable
+fun HomeAssistantAppTheme(
+    content: @Composable () -> Unit
+) {
+    MaterialTheme(
+        colors = if (isSystemInDarkTheme()) haDarkColors else haLightColors
+    ) {
+        // Copied from MdcTheme:
+        CompositionLocalProvider(
+            LocalContentColor provides MaterialTheme.colors.onBackground,
+            content = content
+        )
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialog.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialog.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
 @Composable
 fun IconDialogContent(
@@ -56,7 +56,7 @@ fun IconDialog(
 @Preview
 @Composable
 private fun IconDialogPreview() {
-    MdcTheme {
+    HomeAssistantAppTheme {
         Surface(
             modifier = Modifier
                 .width(480.dp)

--- a/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogFragment.kt
@@ -7,8 +7,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.DialogFragment
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.typeface.IIcon
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlin.math.min
 
 class IconDialogFragment(callback: (IIcon) -> Unit) : DialogFragment() {
@@ -33,7 +33,7 @@ class IconDialogFragment(callback: (IIcon) -> Unit) : DialogFragment() {
         super.onViewCreated(view, savedInstanceState)
 
         (view as ComposeView).setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 IconDialogContent(
                     onSelect = onSelect
                 )

--- a/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogGrid.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogGrid.kt
@@ -20,11 +20,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.themeadapter.material.MdcTheme
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.ITypeface
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -82,7 +82,7 @@ fun IconDialogGrid(
 @Preview
 @Composable
 private fun IconDialogGridPreview() {
-    MdcTheme {
+    HomeAssistantAppTheme {
         Surface(
             modifier = Modifier
                 .width(480.dp)

--- a/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogSearch.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/icondialog/IconDialogSearch.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.accompanist.themeadapter.material.MdcTheme
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
 @Composable
 fun IconDialogSearch(
@@ -52,7 +52,7 @@ fun IconDialogSearch(
 @Preview
 @Composable
 private fun IconDialogSearchPreview() {
-    MdcTheme {
+    HomeAssistantAppTheme {
         Surface {
             IconDialogSearch(value = "account", onValueChange = {})
         }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/assist/AssistShortcutActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/assist/AssistShortcutActivity.kt
@@ -8,11 +8,11 @@ import androidx.activity.viewModels
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
-import com.google.accompanist.themeadapter.material.MdcTheme
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.assist.AssistActivity
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import java.util.UUID
 
 @AndroidEntryPoint
@@ -28,7 +28,7 @@ class AssistShortcutActivity : BaseActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MdcTheme {
+            HomeAssistantAppTheme {
                 AssistShortcutView(
                     selectedServerId = viewModel.serverId,
                     servers = viewModel.servers,

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -209,7 +209,6 @@ dependencies {
     implementation(libs.activity.compose)
     implementation(libs.navigation.compose)
     implementation(libs.accompanist.systemuicontroller)
-    implementation(libs.accompanist.themeadapter.material)
 
     implementation(libs.iconics.core)
     implementation(libs.iconics.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,6 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 [libraries]
-accompanist-themeadapter-material = { module = "com.google.accompanist:accompanist-themeadapter-material", version.ref = "accompanist" }
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity-compose" }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
MdcTheme appears to [have been deprecated](https://google.github.io/accompanist/themeadapter-material/) in the latest release. Also see: lint warnings have increased significantly 😅. Replace it with our own theme everywhere it is used. Thankfully, because the modifications for the HA (XML) theme are very minor compared to a default Material theme there's not a lot to define/duplicate.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
I checked most screens and didn't notice a difference or issues.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->