### PR TITLE
Add option to update camera & template tile when 'in view'

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearTemplateTile.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/settings/wear/views/SettingsWearTemplateTile.kt
@@ -88,7 +88,7 @@ fun SettingsWearTemplateTile(
                         expanded = dropdownExpanded,
                         onDismissRequest = { dropdownExpanded = false }
                     ) {
-                        val options = listOf(0, 60, 2 * 60, 5 * 60, 10 * 60, 15 * 60, 30 * 60, 60 * 60, 2 * 60 * 60, 5 * 60 * 60, 10 * 60 * 60, 24 * 60 * 60)
+                        val options = listOf(0, 1, 60, 2 * 60, 5 * 60, 10 * 60, 15 * 60, 30 * 60, 60 * 60, 2 * 60 * 60, 5 * 60 * 60, 10 * 60 * 60, 24 * 60 * 60)
                         for (option in options) {
                             DropdownMenuItem(onClick = {
                                 onRefreshIntervalChanged(option)

--- a/common/src/main/java/io/homeassistant/companion/android/util/IntervalToString.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/IntervalToString.kt
@@ -6,7 +6,7 @@ import io.homeassistant.companion.android.common.R
 fun intervalToString(context: Context, interval: Int): String {
     return when {
         interval == 0 -> context.getString(R.string.interval_manual)
-        interval == 1 -> context.getString(R.string.interval_on_view)
+        interval == 1 -> context.getString(R.string.interval_in_view)
         interval >= 60 * 60 -> context.resources.getQuantityString(R.plurals.interval_hours, interval / 60 / 60, interval / 60 / 60)
         interval >= 60 -> context.resources.getQuantityString(R.plurals.interval_minutes, interval / 60, interval / 60)
         else -> context.resources.getQuantityString(R.plurals.interval_seconds, interval, interval)

--- a/common/src/main/java/io/homeassistant/companion/android/util/IntervalToString.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/util/IntervalToString.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.common.R
 fun intervalToString(context: Context, interval: Int): String {
     return when {
         interval == 0 -> context.getString(R.string.interval_manual)
+        interval == 1 -> context.getString(R.string.interval_on_view)
         interval >= 60 * 60 -> context.resources.getQuantityString(R.plurals.interval_hours, interval / 60 / 60, interval / 60 / 60)
         interval >= 60 -> context.resources.getQuantityString(R.plurals.interval_minutes, interval / 60, interval / 60)
         else -> context.resources.getQuantityString(R.plurals.interval_seconds, interval, interval)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -317,6 +317,7 @@
         <item quantity="one">%d second</item>
         <item quantity="other">%d seconds</item>
     </plurals>
+    <string name="interval_on_view">On view</string>
     <string name="keep_screen_on_def">Do not lock screen when dashboard is active</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="pinch_to_zoom_def">Allow pinch-to-zoom gesture to zoom app window</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -317,7 +317,7 @@
         <item quantity="one">%d second</item>
         <item quantity="other">%d seconds</item>
     </plurals>
-    <string name="interval_on_view">On view</string>
+    <string name="interval_in_view">In view</string>
     <string name="keep_screen_on_def">Do not lock screen when dashboard is active</string>
     <string name="keep_screen_on">Keep screen on</string>
     <string name="pinch_to_zoom_def">Allow pinch-to-zoom gesture to zoom app window</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/RefreshIntervalPickerView.kt
@@ -15,6 +15,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.wear.compose.material.ListHeader
@@ -43,7 +45,8 @@ fun RefreshIntervalPickerView(
     currentInterval: Int,
     onSelectInterval: (Int) -> Unit
 ) {
-    val options = listOf(0, 60, 2 * 60, 5 * 60, 10 * 60, 15 * 60, 30 * 60, 60 * 60, 2 * 60 * 60, 5 * 60 * 60, 10 * 60 * 60, 24 * 60 * 60)
+    // Refresh interval options: never, when viewed, every x time
+    val options = listOf(0, 1, 60, 2 * 60, 5 * 60, 10 * 60, 15 * 60, 30 * 60, 60 * 60, 2 * 60 * 60, 5 * 60 * 60, 10 * 60 * 60, 24 * 60 * 60)
     val initialIndex = options.indexOf(currentInterval)
     val state = rememberPickerState(
         initialNumberOfOptions = options.size,
@@ -76,7 +79,10 @@ fun RefreshIntervalPickerView(
                         fontSize = MaterialTheme.typography.displayMedium.fontSize.value.dp.toSp() // Ignore text scaling
                     )
                 },
-                color = wearColorScheme.primary
+                color = wearColorScheme.primary,
+                textAlign = TextAlign.Center, // In case of overflow, minimize weird layout behavior
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 2
             )
         }
         FilledIconButton(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implements #4007: use the `onTileEnterEvent` callback to request an update to the tile once it enters the view. Considering that this callback exists it's probably safe to assume an update that is requested in this callback won't be throttled (at least it appears to work during testing).

Includes a minor edit to the refresh interval picker to ensure strings that are more than one line look a bit nicer - originally the string I used was 2 lines but I made it shorter to fit in one instead.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Setting:
![Refresh interval picker with the option 'On view' centered](https://github.com/home-assistant/android/assets/8148535/15e1c15a-b83c-435f-a3db-da9f96c2d5b8)

Demo video:

https://github.com/home-assistant/android/assets/8148535/fade8c77-d4bb-4d4d-b1d3-ba3eb484d767

('On view' was changed to 'In view' after taking the screenshot and video)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Coming soon
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->