### PR TITLE
Fixed spelling of compound verbs "set up", "log in", and "log out". Fixed "comma splice". Fixed double space.

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_connection_failed_to">Unable to connect to %1$s</string>
     <string name="error_loading_entities">Error loading entities</string>
     <string name="error_onboarding_connection_failed">Unable to connect to Home Assistant.</string>
-    <string name="error_ssl">Unable to communicate with Home Assistant because of a SSL error.  Please ensure your certificate is valid.</string>
+    <string name="error_ssl">Unable to communicate with Home Assistant because of a SSL error. Please ensure your certificate is valid.</string>
     <string name="error_with_registration">The \'Mobile App\' integration is required to use the app, but it is not available on your Home Assistant server. Please check your server configuration and try again.</string>
     <string name="errors">Errors</string>
     <string name="error_http_generic">There was an error loading Home Assistant. Please review the connection settings and try again.\n\nError Code: %1$d \nDescription: %2$s</string>
@@ -390,10 +390,10 @@
     <string name="log">Log</string>
     <string name="logbook">Logbook</string>
     <string name="logged_in">Logged in</string>
-    <string name="login">Login</string>
-    <string name="login_on_phone">Login on your phone</string>
-    <string name="login_wear_os_device">Login Wear OS device</string>
-    <string name="logout">Logout</string>
+    <string name="login">Log in</string>
+    <string name="login_on_phone">Log in on your phone</string>
+    <string name="login_wear_os_device">Log in Wear OS device</string>
+    <string name="logout">Log out</string>
     <string name="lovelace_view_dashboard">Dashboard view or Dashboard</string>
     <string name="lovelace">Dashboard</string>
     <string name="mailbox">Mailbox</string>
@@ -407,10 +407,10 @@
     <string name="manage_ssids_introduction">The internal connection URL will be used when connected to one of the listed SSIDs.</string>
     <string name="manage_ssids">Manage SSID(s)</string>
     <string name="manage_this_notification">Manage this notification</string>
-    <string name="manage_tiles_summary">Setup and manage quick settings tiles here. They will not function until you set them up here.</string>
+    <string name="manage_tiles_summary">Set up and manage quick settings tiles here. They will not function until you set them up here.</string>
     <string name="manage_tiles">Manage tiles</string>
     <string name="manage_wear_device">Manage device %1$s</string>
-    <string name="manage_widgets_summary">Edit your widgets, adding/deleting can only be done from the home screen</string>
+    <string name="manage_widgets_summary">Edit your widgets. Adding/deleting can only be done from the home screen.</string>
     <string name="manage_widgets">Manage widgets</string>
     <string name="manual_desc">Enter the URL of your Home Assistant server. Make sure it includes the protocol and port. For example:\n\nhttp://homeassistant.local:8123 or \nhttps://example.duckdns.org.</string>
     <string name="manual_setup">Enter address manually</string>
@@ -453,7 +453,7 @@
     <string name="nfc_invalid_tag">This tag does not contain Home Assistant data</string>
     <string name="nfc_processing_tag_error">Error while processing NFC tag</string>
     <string name="nfc_read_tag_instructions">Hold your device near an NFC tag</string>
-    <string name="nfc_summary">Setup NFC tags</string>
+    <string name="nfc_summary">Set up NFC tags</string>
     <string name="nfc_tag_identifier">Tag identifier</string>
     <string name="nfc_title_nfc_setup">NFC tags</string>
     <string name="nfc_title_settings">NFC tags</string>
@@ -600,9 +600,9 @@
     <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
     <string name="sensor_description_keyguard_locked">Whether the keyguard is currently locked</string>
     <string name="sensor_description_keyguard_secure">Whether the keyguard is secured by a PIN, pattern or password or a SIM card is currently locked</string>
-    <string name="sensor_description_last_notification">The details of the last notification. You must setup an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
+    <string name="sensor_description_last_notification">The details of the last notification. You must set up an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
     <string name="sensor_description_last_reboot">The date and time of the devices last reboot. The setting below will allow you to adjust the deadband in milliseconds, if you still find the value to jump incorrectly. The default value is 60000 (1 minute).</string>
-    <string name="sensor_description_last_removed_notification">The details of the last removed notification. This can be any notification either cleared by the user or removed by an application. You must setup an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
+    <string name="sensor_description_last_removed_notification">The details of the last removed notification. This can be any notification either cleared by the user or removed by an application. You must set up an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>
     <string name="sensor_description_last_update">The intent action for the last update that was sent, periodic updates will show as \"SensorWorker\".\n\nEnabling the \"Add New Intent\" toggle will create 1 setting to allow you to register for a intent action. The toggle will switch back to off once a new setting is created so you will need to turn it back on to save more intent actions. You can also clear out the setting value to remove the setting in the next update.\n\nIf you are not receiving all intents then you will need to add categories that the intent expects. To do this you will need to add each category after the intent separated by a \",\" repeating until there are no more categories. For example an intent with 2 categories will be: \"intent,category1,category2\" as the setting value.\n\nYou must restart the application after making changes to these settings to take effect.</string>
     <string name="sensor_description_light_sensor">The current level of illuminance</string>
     <string name="sensor_description_location_accurate">Allow Home Assistant to send a notification to request an accurate location along with the application periodically requesting an accurate location.  The Minimum Accuracy setting will allow you to decide how accurate the device location (in meters) has to be in order to send to Home Assistant.  The Minimum time between updates (in milliseconds) keeps the device from sending the accurate location too often. The Include in sensor update setting will make a location request with each sensor update.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixed some common grammatical errors:
a) Compound verbs misspelled as one word: When used as a noun, they are one word (e.g. "Enter your login when prompted"), bus when used as a verb, they are two words (e.g. "Log in to your account").
b) Comma splice: A comma can not be used to join two complete sentences into one sentence (without a conjunction) -- they need to written as two separate sentences.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->