### PR TITLE
add new sensor for ip6 addresses

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -126,7 +126,7 @@ class NetworkSensorManager : SensorManager {
             commonR.string.basic_sensor_name_ip6_addresses,
             commonR.string.sensor_description_ip6_addresses,
             "mdi:ip",
-            unitOfMeasurement = "connection(s)",
+            unitOfMeasurement = "address(es)",
             stateClass = SensorManager.STATE_CLASS_MEASUREMENT,
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -384,7 +384,7 @@ class NetworkSensorManager : SensorManager {
             if (!ipAddresses.isNullOrEmpty()) {
                 val ip6Addresses = ipAddresses.filter { linkAddress -> linkAddress.address is Inet6Address }
                 if (ip6Addresses.isNotEmpty()) {
-                    ipAddressList = ipAddressList.plus(elements = ipAddresses.map { linkAddress -> linkAddress.toString() })
+                    ipAddressList = ipAddressList.plus(elements = ip6Addresses.map { linkAddress -> linkAddress.toString() })
                     totalAddresses += ip6Addresses.size
                 }
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -19,6 +19,7 @@ import io.homeassistant.companion.android.database.AppDatabase
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import java.lang.reflect.Method
+import java.net.Inet6Address
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.OkHttpClient
@@ -27,7 +28,6 @@ import okhttp3.Response
 import okio.IOException
 import org.json.JSONException
 import org.json.JSONObject
-import java.net.Inet6Address
 
 class NetworkSensorManager : SensorManager {
     companion object {
@@ -394,8 +394,10 @@ class NetworkSensorManager : SensorManager {
             ip6Addresses,
             totalAddresses,
             ip6Addresses.statelessIcon,
-            mapOf("ip6_addresses" to ipAddressList))
-
+            mapOf(
+                "ip6_addresses" to ipAddressList
+            )
+        )
     }
 
     private fun updateWifiLinkSpeedSensor(context: Context) {
@@ -633,5 +635,4 @@ class NetworkSensorManager : SensorManager {
             @Suppress("DEPRECATION")
             context.applicationContext.getSystemService<WifiManager>()?.connectionInfo
         }
-
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -126,8 +126,11 @@ class NetworkSensorManager : SensorManager {
             commonR.string.basic_sensor_name_ip6_addresses,
             commonR.string.sensor_description_ip6_addresses,
             "mdi:ip",
-            docsLink = "TODO",
-            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
+            unitOfMeasurement = "connection(s)",
+            stateClass = SensorManager.STATE_CLASS_MEASUREMENT,
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#connection-type-sensor",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
         val networkType = SensorManager.BasicSensor(
             "network_type",
@@ -371,7 +374,7 @@ class NetworkSensorManager : SensorManager {
         if (!isEnabled(context, ip6Addresses) || !hasWifi(context)) {
             return
         }
-        var ipAddressList: List<String> = ArrayList()
+        val ipAddressList: List<String> = ArrayList()
         var totalAddresses = 0
 
         if (checkPermission(context, ip6Addresses.id)) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -374,7 +374,7 @@ class NetworkSensorManager : SensorManager {
         if (!isEnabled(context, ip6Addresses)) {
             return
         }
-        val ipAddressList: List<String> = ArrayList()
+        var ipAddressList: List<String> = ArrayList()
         var totalAddresses = 0
 
         if (checkPermission(context, ip6Addresses.id)) {
@@ -383,8 +383,8 @@ class NetworkSensorManager : SensorManager {
             val ipAddresses = connectivityManager?.getLinkProperties(activeNetwork)?.linkAddresses
             if (!ipAddresses.isNullOrEmpty()) {
                 val ip6Addresses = ipAddresses.filter { linkAddress -> linkAddress.address is Inet6Address }
-                if (!ip6Addresses.isEmpty()) {
-                    ipAddressList.plus(ipAddresses.map { linkAddress -> linkAddress.address.toString() })
+                if (ip6Addresses.isNotEmpty()) {
+                    ipAddressList = ipAddressList.plus(elements = ipAddresses.map { linkAddress -> linkAddress.toString() })
                     totalAddresses += ip6Addresses.size
                 }
             }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -384,7 +384,7 @@ class NetworkSensorManager : SensorManager {
             if (!ipAddresses.isNullOrEmpty()) {
                 val ip6Addresses = ipAddresses.filter { linkAddress -> linkAddress.address is Inet6Address }
                 if (!ip6Addresses.isEmpty()) {
-                    ipAddressList.plus(ipAddresses.map { toString() })
+                    ipAddressList.plus(ipAddresses.map { linkAddress -> linkAddress.address.toString() })
                     totalAddresses += ip6Addresses.size
                 }
             }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="basic_sensor_name_high_accuracy_mode">High accuracy mode</string>
     <string name="basic_sensor_name_interactive">Interactive</string>
     <string name="basic_sensor_name_internal_storage">Internal storage</string>
+    <string name="basic_sensor_name_ip6_addresses">IPv6 addresses</string>
     <string name="basic_sensor_name_keyguard_locked">Keyguard locked</string>
     <string name="basic_sensor_name_keyguard_secure">Keyguard secure</string>
     <string name="basic_sensor_name_last_notification">Last notification</string>
@@ -598,6 +599,7 @@
     <string name="sensor_description_hotspot">Whether the WIFI hotspot is enabled</string>
     <string name="sensor_description_interactive">Whether the device is in an interactive state</string>
     <string name="sensor_description_internal_storage">Information about the total and available storage space internally</string>
+    <string name="sensor_description_ip6_addresses">The IPv6 addresses bound to the currently active network interface</string>
     <string name="sensor_description_keyguard_locked">Whether the keyguard is currently locked</string>
     <string name="sensor_description_keyguard_secure">Whether the keyguard is secured by a PIN, pattern or password or a SIM card is currently locked</string>
     <string name="sensor_description_last_notification">The details of the last notification. You must setup an allow list or explicitly allow all notifications to be sent.\n\nNote: Sending all notification data will result in heavy battery usage.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR is intended to address #4198: Adds a new network sensor to detect ipv6 addresses and list them as attributes

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1031

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

I'm still trying to figure out how best to test this. As such I'm leaving this as a draft for now