### PR TITLE
Update Assist dialog state when transitioning locked<>unlocked

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -117,15 +117,23 @@ class AssistViewModel @Inject constructor(
         }
     }
 
-    fun onNewIntent(intent: Intent?) {
+    /**
+     * Update the state of the Assist dialog for a new 'assistant triggered' action
+     * @param intent the updated intent
+     * @param lockedMatches whether the locked state changed and contents should be cleared
+     */
+    fun onNewIntent(intent: Intent?, lockedMatches: Boolean) {
         if (
-            (
-                (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
-                    intent?.action in listOf(Intent.ACTION_ASSIST, "android.intent.action.VOICE_ASSIST")
-                ) &&
-            (inputMode == AssistInputMode.VOICE_ACTIVE || inputMode == AssistInputMode.VOICE_INACTIVE)
+            (intent?.flags != null && intent.flags and Intent.FLAG_ACTIVITY_BROUGHT_TO_FRONT != 0) ||
+            intent?.action in listOf(Intent.ACTION_ASSIST, "android.intent.action.VOICE_ASSIST")
         ) {
-            onMicrophoneInput()
+            if (!lockedMatches && inputMode != AssistInputMode.BLOCKED) {
+                _conversation.clear()
+                _conversation.add(startMessage)
+            }
+            if (inputMode == AssistInputMode.VOICE_ACTIVE || inputMode == AssistInputMode.VOICE_INACTIVE) {
+                onMicrophoneInput()
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #4211 (in later comment), fixes #4231

Update the flags for showing the Assist dialog when locked to:
 - prevent unintentional resuming in a different locked state (= was unlocked and Assist open, lock, keyguard should be on top)
 - clear contents when resumed in a different locked state intentionally (assistant intent action)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->