### PR TITLE
Controls: prevent individual server error from blocking all others

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -94,11 +94,11 @@ class HaControlsProviderService : ControlsProviderService() {
                     return@launch
                 }
 
-                try {
-                    val entities = mutableMapOf<Int, List<Entity<Any>>?>()
-                    val areaForEntity = mutableMapOf<Int, Map<String, AreaRegistryResponse?>>()
-                    serverManager.defaultServers.map { server ->
-                        async {
+                val entities = mutableMapOf<Int, List<Entity<Any>>?>()
+                val areaForEntity = mutableMapOf<Int, Map<String, AreaRegistryResponse?>>()
+                serverManager.defaultServers.map { server ->
+                    async {
+                        try {
                             val getAreaRegistry = async { serverManager.webSocketRepository(server.id).getAreaRegistry() }
                             val getDeviceRegistry = async { serverManager.webSocketRepository(server.id).getDeviceRegistry() }
                             val getEntityRegistry = async { serverManager.webSocketRepository(server.id).getEntityRegistry() }
@@ -119,9 +119,13 @@ class HaControlsProviderService : ControlsProviderService() {
                             }
                             entities[server.id] = entities[server.id].orEmpty()
                                 .sortedWith(compareBy(nullsLast()) { areaForEntity[server.id]?.get(it.entityId)?.name })
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Unable to load entities/registries for server ${server.id} (${server.friendlyName}), skipping", e)
                         }
-                    }.awaitAll()
+                    }
+                }.awaitAll()
 
+                try {
                     val allEntities = mutableListOf<Pair<Int, Entity<Any>>>()
                     entities.forEach { serverEntities ->
                         serverEntities.value?.forEach { allEntities += Pair(serverEntities.key, it) }
@@ -158,7 +162,7 @@ class HaControlsProviderService : ControlsProviderService() {
                             subscriber.onNext(it)
                         }
                 } catch (e: Exception) {
-                    Log.e(TAG, "Error getting list of entities", e)
+                    Log.e(TAG, "Error building list of entities", e)
                 }
                 subscriber.onComplete()
             }


### PR DESCRIPTION
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Catch exceptions thrown while loading all available controls (= adding a new control) on a server level, instead on a higher level/all servers, to make sure that an issue with one server doesn't prevent data from other servers from showing.

This should fix #4246 - I've not been able to reproduce the issue but based on the description and that it was 'fixed' by removing the offline server, this suggests one server throwing an unexpected exception before the service returned controls, resulting in the error shown by the system in the screenshot.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->