### PR TITLE
Notification: "when_relative" for "chronometer"

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -128,6 +128,7 @@ class MessagingManager @Inject constructor(
         const val PERSISTENT = "persistent"
         const val CHRONOMETER = "chronometer"
         const val WHEN = "when"
+        const val WHEN_RELATIVE = "when_relative"
         const val CAR_UI = "car_ui"
         const val KEY_TEXT_REPLY = "key_text_reply"
         const val INTENT_CLASS_NAME = "intent_class_name"
@@ -980,10 +981,15 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         try { // Without this, a non-numeric when value will crash the app
-            val notificationWhen = data[WHEN]?.toLongOrNull()?.times(1000) ?: 0
+            var notificationWhen = data[WHEN]?.toLongOrNull()?.times(1000) ?: 0
+            val isRelative = data[WHEN_RELATIVE]?.toBoolean() ?: false
             val usesChronometer = data[CHRONOMETER]?.toBoolean() ?: false
 
             if (notificationWhen != 0L) {
+                if (isRelative) {
+                    notificationWhen += System.currentTimeMillis()
+                }
+
                 builder.setWhen(notificationWhen)
                 builder.setUsesChronometer(usesChronometer)
 


### PR DESCRIPTION
"timeout" is relative, but "when" is absolute by default.

It is now possible to synchronize timers in seconds without time difference:
```yaml
timeout: 120
chronometer: "true"
when: 120
when_relative: "true"
```
