### PR TITLE
Support showing all frames of animated gif image in Android 14+

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1255,9 +1255,9 @@ class MessagingManager @Inject constructor(
             }
 
             // delete previous images that are no longer needed
-            val imageCutoff = LocalDateTime.now().minusHours(1)
+            val imageCutoff = LocalDateTime.now().minusDays(2)
             context.externalCacheDir?.listFiles()?.filter { file ->
-                file.endsWith("_animated_notification.gif") &&
+                file.absolutePath.endsWith("_animated_notification.gif") &&
                     imageCutoff.isAfter(LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault()))
             }?.forEach { expired -> expired.delete() }
 

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -87,6 +87,9 @@ import java.io.File
 import java.io.FileOutputStream
 import java.net.URL
 import java.net.URLDecoder
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -100,10 +103,6 @@ import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.util.Calendar
 
 class MessagingManager @Inject constructor(
     @ApplicationContext val context: Context,
@@ -1258,8 +1257,8 @@ class MessagingManager @Inject constructor(
             // delete previous images that are no longer needed
             val imageCutoff = LocalDateTime.now().minusHours(1)
             context.externalCacheDir?.listFiles()?.filter { file ->
-                file.endsWith("_animated_notification.gif")
-                    && imageCutoff.isAfter(LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault()))
+                file.endsWith("_animated_notification.gif") &&
+                    imageCutoff.isAfter(LocalDateTime.ofInstant(Instant.ofEpochMilli(file.lastModified()), ZoneId.systemDefault()))
             }?.forEach { expired -> expired.delete() }
 
             val file = File(context.externalCacheDir, "${System.currentTimeMillis()}_animated_notification.gif")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary

<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This adds support for saving a gif that is sent as a notification image locally so that it can be loaded using a content uri which enables the notification to show the gif as animated including all frames.

Should be noted that this only is only supported on Android 14+, for previous versions the behavior and handling will remain the same where only the first frame of the gif is shown.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

https://github.com/home-assistant/android/assets/14866235/7e3c579a-4a03-440d-b961-9bb05184687c

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: https://github.com/home-assistant/companion.home-assistant/pull/1047

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

closes https://github.com/home-assistant/android/issues/1270