### PR TITLE
Check protocol/port when determining reload for WebView

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -100,7 +100,12 @@ class WebViewPresenterImpl @Inject constructor(
             loosing wifi signal and reopening app. Without this we would still be trying to use the
             internal url externally.
              */
-            if (oldUrlForServer != urlForServer || oldUrl?.host != url?.host) {
+            if (
+                oldUrlForServer != urlForServer ||
+                oldUrl?.protocol != url?.protocol ||
+                oldUrl?.host != url?.host ||
+                oldUrl?.port != url?.port
+            ) {
                 view.loadUrl(
                     url = Uri.parse(url.toString())
                         .buildUpon()


### PR DESCRIPTION
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When determining whether the WebView should be reloaded with the current server URL, also check that the protocol (http/https) and port (8123, 443, ...) match and if not reload.

Should fix #4294 as the only difference between the user's URLs is the port and it works correctly when closing/reopening the app which forces a reload with the current URL to use for the webview. This has nothing to do with Cloudflare or the needlessly complicated network setup.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->