### PR TITLE
Remove deprecated Accompanist System UI controller

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -179,7 +179,6 @@ dependencies {
     implementation(libs.compose.uiTooling)
     implementation(libs.activity.compose)
     implementation(libs.navigation.compose)
-    implementation(libs.accompanist.systemuicontroller)
 
     implementation(libs.iconics.core)
     implementation(libs.iconics.compose)

--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -5,19 +5,17 @@ import android.app.KeyguardManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.view.WindowCompat
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.assist.ui.AssistSheetView
@@ -63,6 +61,9 @@ class AssistActivity : BaseActivity() {
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge(
+            navigationBarStyle = SystemBarStyle.auto(Color.TRANSPARENT, Color.TRANSPARENT)
+        )
         super.onCreate(savedInstanceState)
         updateShowWhenLocked()
 
@@ -89,15 +90,8 @@ class AssistActivity : BaseActivity() {
 
         val fromFrontend = intent.getBooleanExtra(EXTRA_FROM_FRONTEND, false)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             HomeAssistantAppTheme {
-                val systemUiController = rememberSystemUiController()
-                val useDarkIcons = MaterialTheme.colors.isLight
-                SideEffect {
-                    systemUiController.setSystemBarsColor(Color.Transparent, darkIcons = useDarkIcons)
-                }
-
                 AssistSheetView(
                     conversation = viewModel.conversation,
                     pipelines = viewModel.pipelines,

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -208,7 +208,6 @@ dependencies {
     implementation(libs.compose.uiTooling)
     implementation(libs.activity.compose)
     implementation(libs.navigation.compose)
-    implementation(libs.accompanist.systemuicontroller)
 
     implementation(libs.iconics.core)
     implementation(libs.iconics.compose)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,7 +83,6 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 [libraries]
-accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
 activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activity-compose" }
 android-beacon-library = { module = "org.altbeacon:android-beacon-library", version.ref = "androidBeaconLibrary" }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR removes the [deprecated Accompanist System UI controller](https://google.github.io/accompanist/systemuicontroller/) used to go edge to edge and set system bar appearance, and replaces it with functionality in the core AndroidX libraries to simplify code :)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Tested and I didn't notice any difference - edge to edge works, and the system/Accompanist were already applying a scrim with 3 button nav and on older API versions.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->