### PR TITLE
Add battery voltage divisor setting

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -14,6 +14,8 @@ class BatterySensorManager : SensorManager {
         private const val TAG = "BatterySensor"
         private const val SETTING_BATTERY_CURRENT_DIVISOR = "battery_current_divisor"
         private const val DEFAULT_BATTERY_CURRENT_DIVISOR = 1000000
+        private const val SETTING_BATTERY_VOLTAGE_DIVISOR = "battery_voltage_divisor"
+        private const val DEFAULT_BATTERY_VOLTAGE_DIVISOR = 1000
         private val batteryLevel = SensorManager.BasicSensor(
             "battery_level",
             "sensor",
@@ -281,7 +283,7 @@ class BatterySensorManager : SensorManager {
             return
         }
 
-        val voltage = getBatteryVolts(intent)
+        val voltage = getBatteryVolts(context, intent)
         val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
         val current = getBatteryCurrent(context, batteryManager)
         val wattage = voltage * current
@@ -345,7 +347,13 @@ class BatterySensorManager : SensorManager {
         return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW) / dividerSetting.toFloat()
     }
 
-    private fun getBatteryVolts(intent: Intent): Float {
-        return intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0) / 1000f
+    private fun getBatteryVolts(context: Context, intent: Intent): Float {
+        val dividerSetting = getNumberSetting(
+            context,
+            batteryPower,
+            SETTING_BATTERY_VOLTAGE_DIVISOR,
+            DEFAULT_BATTERY_VOLTAGE_DIVISOR
+        )
+        return intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0) / dividerSetting.toFloat()
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -733,6 +733,7 @@
     <string name="sensor_setting_notification_allow_list_title">Allow list</string>
     <string name="sensor_setting_notification_disable_allow_list_title">Disable allow list requirement</string>
     <string name="sensor_setting_battery_current_divisor_title">Battery current divisor</string>
+    <string name="sensor_setting_battery_voltage_divisor_title">Battery voltage divisor</string>
     <string name="sensor_settings">Sensor settings</string>
     <string name="sensor_summary">Use this to manage what sensors are enabled/disabled.</string>
     <string name="sensor_title">Manage sensors</string>
@@ -1110,7 +1111,7 @@
     <string name="basic_sensor_name_battery_power">Battery power</string>
     <string name="widget_checkbox_require_authentication">Require authentication</string>
     <string name="widget_error_authenticating">Error authenticating - is an authentication method configured?</string>
-    <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting. If your values are not as expected you may need to adjust the \"Battery Current Divisor\" setting to get a proper unit of amperes for the \"current\" attribute. Android is supposed to report microamperes however, some devices may report a different unit. The default will convert microamperes to amperes.</string>
+    <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting.\n\nIf the sensor\'s state or attributes are not as expected, you may need to adjust the current or voltage divisor to get a correct value. Some devices report these values in a different unit.\n- The "Battery current divisor" will convert from microamperes to amperes by default.\n- The "Battery voltage divisor" will convert from millivolts to volts by default.</string>
     <string name="sensor_name_accent_color_sensor">Accent color</string>
     <string name="sensor_description_accent_color_sensor">A hexadecimal color value for the dynamic accent color used in the device theme</string>
     <string name="sensor_name_dynamic_color">Dynamic color</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #4286 by adding a setting to the battery power sensor to set the battery voltage divisor. Like the current, I guess we can't trust anything.

This fix is in line with the existing setting for current, but maybe we can detect this automatically in the future based on expected values? (eg voltage should always be in range x...y, but the tricky part is what to do when it is close to 0)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|----|----|
|![Sensor settings in the Home Assistant app with an option 'Battery voltage divisor', value 1000, light mode](https://github.com/home-assistant/android/assets/8148535/4ec76955-09c0-48aa-983c-29d6b7126b92)|![Sensor settings in the Home Assistant app with an option 'Battery voltage divisor', value 1000, dark mode](https://github.com/home-assistant/android/assets/8148535/97d97e19-668a-496b-a197-ead04074ec6a)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1051

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->