### PR TITLE
Allow multiple tasks for `command_webview`

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1789,7 +1789,8 @@ class MessagingManager @Inject constructor(
             } else {
                 WebViewActivity.newInstance(context, title, serverId)
             }
-            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
             intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
             context.startActivity(intent)
         } catch (e: Exception) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
'Fix' #3343 by allowing `command_webview` to create multiple, new tasks. This allows launching the webview to work reliably irrespective of how the app was originally started.

While this behavior may not be perfect in my opinion (you end up with hidden tasks which can be unpredictable), all app features that allow you to navigate to a specific page the webview such as shortcuts, tapping on notifications, device controls long press, etc. use this to reliably load the frontend with a specific page. Different behavior for this specific feature (which as a result didn't always work) doesn't make a lot of sense.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Docs don't mention anything about tasks/recents so let's not complicate things

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Based on [these specific reproduction steps](https://github.com/home-assistant/android/issues/3343#issuecomment-2016581587), without this change:
- If the initial task was from the launcher, it seems to create a new activity (which will load the page)
- If the initial task was from `command_webview`, it seems to bring the existing activity to the front and that's it

There must be something here with task stacks/affinity different for launch vs webview as the 'root' that allowed it to work without requiring the multiple tasks flag. I've also tried checking the intent extras in `onNewIntent` for the second point, but it didn't call the function.
