### PR TITLE
Add intent for assistant headset button to Assist

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -403,6 +403,7 @@
             android:theme="@style/Theme.HomeAssistant.Assist">
             <intent-filter>
                 <action android:name="android.intent.action.ASSIST" />
+                <action android:name="android.intent.action.VOICE_COMMAND" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -421,6 +421,7 @@
             android:theme="@style/Theme.HomeAssistant.Assist">
             <intent-filter>
                 <action android:name="android.intent.action.ASSIST" />
+                <action android:name="android.intent.action.VOICE_COMMAND" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implement #4126 and [this Discord suggestion](https://discord.com/channels/330944238910963714/562408603345092636/1225696592909303899) to allow Assist to respond to headset assistant buttons by adding `android.intent.action.VOICE_COMMAND` to the intent filter. Can't test it myself but two individual reports seems like enough validation and Android should [show a chooser](https://discord.com/channels/330944238910963714/562408603345092636/1225514144917225556) so no need for complicated default assistant app checks.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->