### PR TITLE
Downgrade Retrofit to 2.9.0

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -70,7 +70,6 @@ dependencies {
 
     api(libs.androidx.work.runtime.ktx)
 
-    api(platform(libs.retrofit.bom))
     api(libs.retrofit)
     implementation(libs.retrofit.converter.jackson)
     implementation(libs.okhttp)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ play-services-wearable = "18.1.0"
 preference-ktx = "1.2.1"
 recyclerview = "1.3.2"
 reorderable = "0.9.6"
-retrofit = "2.10.0"
+retrofit = "2.9.0"
 room = "2.6.1"
 sentry-android = "7.6.0"
 tools-desugar-jdk-libs = "2.0.4"
@@ -152,9 +152,8 @@ play-services-wearable = { module = "com.google.android.gms:play-services-wearab
 preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "preference-ktx" }
 recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
 reorderable = { module = "org.burnoutcrew.composereorderable:reorderable", version.ref = "reorderable" }
-retrofit-bom = { module = "com.squareup.retrofit2:retrofit-bom", version.ref = "retrofit" }
-retrofit = { module = "com.squareup.retrofit2:retrofit" }
-retrofit-converter-jackson = { module = "com.squareup.retrofit2:converter-jackson" }
+retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit-converter-jackson = { module = "com.squareup.retrofit2:converter-jackson", version.ref = "retrofit"  }
 sentry-android = { module = "io.sentry:sentry-android", version.ref = "sentry-android" }
 tools-desugar-jdk = { module = "com.android.tools:desugar_jdk_libs", version.ref = "tools-desugar-jdk-libs" }
 wear = { module = "androidx.wear:wear", version.ref = "wear" }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Downgrade as the Retrofit update unintentionally bumps Jackson which in turn results in the minimum SDK level required being 26. Fixes #4323. Reverts the bump in #4293. See [this issue comment for details](https://github.com/home-assistant/android/issues/4323#issuecomment-2040533565).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->