### PR TITLE
Adds http header check after a GIF File

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1256,7 +1256,7 @@ class MessagingManager @Inject constructor(
         withContext(
             Dispatchers.IO
         ) {
-            if (url == null || url.path.endsWith("gif").not()) {
+            if (url == null || (url.path.endsWith("gif").not() && !isGif(url))) {
                 return@withContext null
             }
 
@@ -1286,6 +1286,20 @@ class MessagingManager @Inject constructor(
             }
             return@withContext FileProvider.getUriForFile(context, "${context.packageName}.provider", file)
         }
+
+    private fun isGif(url: URL): Boolean {
+        val connection = url.openConnection() as? HttpURLConnection ?: return false
+        try {
+            connection.setRequestProperty("User-Agent", "Mozilla/5.0")
+            val contentType = connection.contentType
+            return contentType != null && contentType.startsWith("image/gif")
+        } catch (e: IOException) {
+            Log.e(TAG, "Error checking content type", e)
+            return false
+        } finally {
+            connection.disconnect()
+        }
+    }
 
     private suspend fun handleVideo(
         builder: NotificationCompat.Builder,


### PR DESCRIPTION
Adds a http header check after a GIF File

## Summary
Today I wanted to show a GIF in a notification an Android 14. I saw that this was added befor two weeks, Sadly this only works with URLs that ends with ".gif". Some URL don't have the filename in the url so i added a http header check for that.

## Link to pull request in Documentation repository
The Documentation should be fine. The function is already decribed there.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->