### PR TITLE
Provide interface for external bus outside WebViewActivity

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.webview
 
 import android.net.http.SslError
+import io.homeassistant.companion.android.webview.externalbus.ExternalBusMessage
 
 interface WebView {
     enum class ErrorType {
@@ -15,6 +16,8 @@ interface WebView {
     fun setStatusBarAndNavigationBarColor(statusBarColor: Int, navigationBarColor: Int)
 
     fun setExternalAuth(script: String)
+
+    fun sendExternalBusMessage(message: ExternalBusMessage)
 
     fun relaunchApp()
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import kotlinx.coroutines.flow.Flow
+import org.json.JSONObject
 
 interface WebViewPresenter {
 
@@ -40,6 +41,8 @@ interface WebViewPresenter {
     fun isAlwaysShowFirstViewOnAppStartEnabled(): Boolean
 
     fun sessionTimeOut(): Int
+
+    fun onExternalBusMessage(message: JSONObject)
 
     fun onStart(context: Context)
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
@@ -1,0 +1,12 @@
+package io.homeassistant.companion.android.webview.externalbus
+
+import android.webkit.ValueCallback
+
+data class ExternalBusMessage(
+    val id: Any,
+    val type: String,
+    val success: Boolean,
+    val result: Any? = null,
+    val error: Any? = null,
+    val callback: ValueCallback<String>? = null
+)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusModule.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusModule.kt
@@ -1,0 +1,16 @@
+package io.homeassistant.companion.android.webview.externalbus
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ExternalBusModule {
+
+    @Binds
+    @Singleton
+    abstract fun externalBusRepository(externalBusRepositoryImpl: ExternalBusRepositoryImpl): ExternalBusRepository
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusRepository.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusRepository.kt
@@ -1,0 +1,34 @@
+package io.homeassistant.companion.android.webview.externalbus
+
+import kotlinx.coroutines.flow.Flow
+import org.json.JSONObject
+
+/**
+ * A repository to communicate with the external bus which is provided by the frontend,
+ * in contexts where there is no 'line of sight' to the webview (usually: other activity).
+ *
+ * The [WebViewActivity] or listener should be alive for this to work, and the repository
+ * does not guarantee that the the receiver will immediately receive the message as the
+ * system can limit background activity.
+ */
+interface ExternalBusRepository {
+
+    /** Send a message to the external bus (for native) */
+    suspend fun send(message: ExternalBusMessage)
+
+    /**
+     * Register to receive certain messages from the external bus (for native)
+     * @param types List of which message `type`s should be received
+     * @return Flow with received messages for the specified types
+     */
+    fun receive(types: List<String>): Flow<JSONObject>
+
+    /** Send a message from the external bus to registered receivers (for webview) */
+    suspend fun received(message: JSONObject)
+
+    /**
+     * @return Flow with [ExternalBusMessage]s that should be sent on the external
+     * bus (for webview)
+     */
+    fun getSentFlow(): Flow<ExternalBusMessage>
+}

--- a/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusRepositoryImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/externalbus/ExternalBusRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package io.homeassistant.companion.android.webview.externalbus
+
+import android.util.Log
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import org.json.JSONObject
+
+class ExternalBusRepositoryImpl @Inject constructor() : ExternalBusRepository {
+
+    companion object {
+        private const val TAG = "ExternalBusRepo"
+    }
+
+    private val externalBusFlow = MutableSharedFlow<ExternalBusMessage>(
+        // Don't suspend if the WebView is temporarily unavailable
+        extraBufferCapacity = 100
+    )
+    private val receiverFlows = mutableMapOf<List<String>, MutableSharedFlow<JSONObject>>()
+
+    override suspend fun send(message: ExternalBusMessage) {
+        externalBusFlow.emit(message)
+    }
+
+    override fun receive(types: List<String>): Flow<JSONObject> {
+        val flow = receiverFlows[types] ?: MutableSharedFlow()
+        receiverFlows[types] = flow
+        return flow.asSharedFlow()
+    }
+
+    override suspend fun received(message: JSONObject) {
+        if (!message.has("type")) return
+        val type = message.getString("type")
+        val receivers = receiverFlows.filter { it.key.contains(type) }
+        Log.d(TAG, "Sending message of type $type to ${receivers.size} receiver(s)")
+        receivers.forEach { (_, flow) ->
+            flow.emit(message)
+        }
+    }
+
+    override fun getSentFlow(): Flow<ExternalBusMessage> = externalBusFlow.asSharedFlow()
+}


### PR DESCRIPTION
 <!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds an interface to the app to interact with the external bus outside the WebViewActivity. This should make it possible for the frontend to control more native UI of the app.

These changes are required for #4303 because of the flow established in home-assistant/frontend#19743 where the frontend controls some parts of the scanner activity.

In my testing this seems to work relatively well and survives simple configuration changes such as rotating the device. There is no direct reference to the web_view_ to prevent leaks. It is possible that I make minor changes to the `ExternalBusRepository` in the barcode scanner PR, if I find something that hasn't been considered or doesn't work properly after merging this.

Example usage in [this commit](https://github.com/jpelgrom/home-assistant-android/commit/b21492dc29e82cf970c0e5ff391c98be9a6f255b) - note that this is only an example to test, the intended use of the PR is only the barcode scanner messages. You can see the external bus message being posted and a response from the frontend (about the ID not being known) + callback function, with other log lines related to the activity resuming 2s later:

```
2024-04-08 21:52:32.717  8567-8567  NfcSetupActivity        io....stant.companion.android.debug  D  Wrote nfc tag with url: https://www.home-assistant.io/tag/e3b00f1c-40a1-4112-8b15-1c3bcef66112
2024-04-08 21:52:32.752  8567-8567  WebviewActivity         io....stant.companion.android.debug  D  externalBus({"id":4,"type":"result","success":true,"result":{}});
2024-04-08 21:52:32.758  8567-8567  chromium                io....stant.companion.android.debug  I  [INFO:CONSOLE(1)] "Received unknown msg ID 4", source: http://192.168.2.101:8123/frontend_latest/19311.JkgbKuCO63k.js (1)
2024-04-08 21:52:32.758  8567-8567  NfcSetupActivity        io....stant.companion.android.debug  D  NFC Write Complete null
2024-04-08 21:52:34.798  8567-8567  WebviewActivity         io....stant.companion.android.debug  D  Matter/Thread step changed to NOT_STARTED
2024-04-08 21:52:34.805  8567-8567  ServerConnectionInfo    io....stant.companion.android.debug  D  localUrl is: true, usesInternalSsid is: true, usesWifi is: true
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a, no visual changes

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->