### PR TITLE
Add mobile network cell sensor

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -149,11 +149,11 @@ class NetworkSensorManager : SensorManager {
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
-        val cellTowerConnection = SensorManager.BasicSensor(
-            "cell_tower_connection",
+        val cellConnection = SensorManager.BasicSensor(
+            "cell_connection",
             "sensor",
-            commonR.string.basic_sensor_name_cell_tower,
-            commonR.string.sensor_description_cell_tower,
+            commonR.string.basic_sensor_name_cell,
+            commonR.string.sensor_description_cell,
             "mdi:radio-tower",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
@@ -189,7 +189,7 @@ class NetworkSensorManager : SensorManager {
         }
 
         val list = if (hasTelephony(context)) {
-            listWithWifi.plus(cellTowerConnection)
+            listWithWifi.plus(cellConnection)
         } else {
             listWithWifi
         }
@@ -230,7 +230,7 @@ class NetworkSensorManager : SensorManager {
         updateWifiFrequencySensor(context)
         updateWifiSignalStrengthSensor(context)
         updatePublicIpSensor(context)
-        updateCellTowerConnectionSensor(context)
+        updateCellConnectionSensor(context)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             updateNetworkType(context)
@@ -601,22 +601,16 @@ class NetworkSensorManager : SensorManager {
     }
 
     @SuppressLint("MissingPermission")
-    private fun updateCellTowerConnectionSensor(context: Context) {
-        if (!isEnabled(context, cellTowerConnection) || !hasTelephony(context)) {
+    private fun updateCellConnectionSensor(context: Context) {
+        if (!isEnabled(context, cellConnection) || !hasTelephony(context)) {
             return
         }
 
         val telephonyManager = context.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
 
-        val cellInfoList = telephonyManager.getAllCellInfo()
+        val cell = telephonyManager.getAllCellInfo().findLast { cell -> cell.isRegistered } ?: return
 
-        val cell = cellInfoList.findLast { cell -> cell.isRegistered } //cell.cellConnectionStatus == CellInfo.CONNECTION_PRIMARY_SERVING
-
-        if(cell == null){
-            return
-        }
-
-        val cellTowerStr : String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val cellId : String = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             when (cell) {
                 is CellInfoNr -> {
                     "nr:" + (cell.cellIdentity as CellIdentityNr).nci
@@ -671,9 +665,9 @@ class NetworkSensorManager : SensorManager {
 
         onSensorUpdated(
             context,
-            cellTowerConnection,
-            cellTowerStr,
-            cellTowerConnection.statelessIcon,
+            cellConnection,
+            cellId,
+            cellConnection.statelessIcon,
             mapOf()
         )
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/NetworkSensorManager.kt
@@ -141,6 +141,16 @@ class NetworkSensorManager : SensorManager {
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
+        val cellTowerConnection = SensorManager.BasicSensor(
+            "cell_tower_connection",
+            "sensor",
+            commonR.string.basic_sensor_name_cell_tower,
+            commonR.string.sensor_description_cell_tower,
+            "mdi:radio-tower",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+        )
+
         private const val SETTING_GET_CURRENT_BSSID = "network_get_current_bssid"
     }
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1090,6 +1090,8 @@
     <string name="undo">Undo</string>
     <string name="basic_sensor_name_network_type">Network type</string>
     <string name="sensor_description_network_type">The type of transport the current active network is using</string>
+    <string name="basic_sensor_name_cell_tower">Cell tower connection</string>
+    <string name="sensor_description_cell_tower">The id of the cell tower the device is currently connected to</string>
     <string name="sensor_name_volume_notification">Volume level notification</string>
     <string name="sensor_description_volume_notification">Volume level for notifications on the device</string>
     <string name="sensor_name_volume_system">Volume level system</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1090,8 +1090,8 @@
     <string name="undo">Undo</string>
     <string name="basic_sensor_name_network_type">Network type</string>
     <string name="sensor_description_network_type">The type of transport the current active network is using</string>
-    <string name="basic_sensor_name_cell_tower">Cell tower connection</string>
-    <string name="sensor_description_cell_tower">The id of the cell tower the device is currently connected to</string>
+    <string name="basic_sensor_name_cell">Cell connection</string>
+    <string name="sensor_description_cell">The id of the mobile network cell the device is currently connected to</string>
     <string name="sensor_name_volume_notification">Volume level notification</string>
     <string name="sensor_description_volume_notification">Volume level for notifications on the device</string>
     <string name="sensor_name_volume_system">Volume level system</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Fixes: #4368 by adding a mobile network cell sensor. 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I tried to follow the same convention for cell ids as the "Automate" app https://llamalab.com/automate/doc/block/cell_site_near.html . However I lack knowledge to implement it perfectly :
- the UTMS network type could not be implemented because there is no corresponding `CellInfo` class
- for GSM i did not implement the `RNC` value because it is not available in the `CellInfoGsm` object (in the "Automate" app example it is also empty) 
I don't know much in mobile networks, someone more knowledgeable in mobile networks could help to improve this. 

Currently the sensor is not instantaneously updated. 
I couldn't find a way to get updates with intents. I found a way to do it with a callback (https://developer.android.com/reference/kotlin/android/telephony/TelephonyCallback.CellInfoListener) but I am still figuring out how to implement it.
Therefore, this PR is not yet ready but I would happily receive some feedback regarding what I did and ways to do improve the code.

In the emulator the APIs always return the same values for cell towers regardless of the device settings so I tested my code on two physical phones.
I could only test the following scenarios (because of phone settings limitations, availability of network types in my location and my cell plan)  : 
- on SDK level 35:
  -  lte (4G) 
  - wcdma (3G)
- on SDK level 28
  - lte (4G)
  - wcdma (4G)
  - gsm (2G)

Thanks to @dshokouhi for the suggestion to use the `CellIdentity` class.