### PR TITLE
Prevent race creating + clean up sensor entries for old/deleted servers

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/sensor/SensorDao.kt
@@ -38,6 +38,9 @@ interface SensorDao {
     @Query("SELECT * FROM Sensors WHERE server_id = :serverId")
     suspend fun getAllServer(serverId: Int): List<Sensor>
 
+    @Query("SELECT * FROM Sensors WHERE NOT(server_id IN (:serverIds))")
+    suspend fun getAllExceptServer(serverIds: List<Int>): List<Sensor>
+
     @Transaction
     @Query("SELECT * FROM sensor_settings WHERE sensor_id = :id")
     fun getSettings(id: String): List<SensorSetting>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #4028's most likely cause (see steps in issue) by preventing a race on logout from the frontend between updating the sensors and deleting the server data, causing stale sensor entries;

and fix it for existing users/create a workaround for any missed cases by cleaning up any orphaned sensor entries there might be during periodic sensor updates.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a; there are no longer toggles for non-existent servers

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->