### PR TITLE
Use ksp instead of kapt for Hilt

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ import com.google.gms.googleservices.GoogleServicesPlugin.GoogleServicesPluginCo
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.firebase.appdistribution)
     alias(libs.plugins.google.services)
@@ -117,10 +117,6 @@ android {
         abortOnError = false
         disable += "MissingTranslation"
     }
-
-    kapt {
-        correctErrorTypes = true
-    }
 }
 
 dependencies {
@@ -137,7 +133,7 @@ dependencies {
     "fullImplementation"(libs.kotlinx.coroutines.play.services)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     implementation(libs.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -3,7 +3,7 @@ import com.google.gms.googleservices.GoogleServicesPlugin.GoogleServicesPluginCo
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.google.services)
     alias(libs.plugins.hilt)
@@ -146,10 +146,6 @@ android {
         abortOnError = false
         disable += "MissingTranslation"
     }
-
-    kapt {
-        correctErrorTypes = true
-    }
 }
 
 dependencies {
@@ -166,7 +162,7 @@ dependencies {
     "fullImplementation"(libs.kotlinx.coroutines.play.services)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     implementation(libs.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.google.services).apply(false)
     alias(libs.plugins.firebase.appdistribution).apply(false)
     alias(libs.plugins.hilt).apply(false)
-    alias(libs.plugins.kotlin.kapt).apply(false)
     alias(libs.plugins.kotlin.parcelize).apply(false)
     alias(libs.plugins.ksp).apply(false)
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -45,10 +44,6 @@ android {
         abortOnError = false
         disable += "MissingTranslation"
     }
-
-    kapt {
-        correctErrorTypes = true
-    }
 }
 
 dependencies {
@@ -57,7 +52,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     implementation(libs.appcompat)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -76,7 +76,6 @@ firebase-appdistribution = { id = "com.google.firebase.appdistribution", version
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/wear/build.gradle.kts
+++ b/wear/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.google.services)
 }
@@ -66,10 +66,6 @@ android {
     lint {
         disable += "MissingTranslation"
     }
-
-    kapt {
-        correctErrorTypes = true
-    }
 }
 
 dependencies {
@@ -93,7 +89,7 @@ dependencies {
     implementation(libs.wear.phone.interactions)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.android.compiler)
+    ksp(libs.hilt.android.compiler)
 
     implementation(libs.jackson.module.kotlin)
     implementation(libs.okhttp)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
When building the app with Kotlin 2.0, we get the following warning: `w: Kapt currently doesn't support language version 2.0+. Falling back to 1.9.`. This appears to be harmless, but considering kapt has been in [maintenance mode](https://kotlinlang.org/docs/kapt.html) for a couple of years and even Google samples are now using ksp for Hilt (where it is stable, even though Dagger itself still considers it 'alpha') this seems like a good time to migrate. After migrating Hilt there is nothing left using kapt so it is removed, and the warning resolved.

Did a build + run trying to hit most places where we inject things which seems to work fine. Not seeing any of the promised build speed improvements :(

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->