### PR TITLE
Update github-script action to latest version everywhere

### DIFF
--- a/.github/actions/create-release-notes/action.yml
+++ b/.github/actions/create-release-notes/action.yml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Get Previous Release Tag
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: latest-release-tag
       with:
         github-token: ${{ inputs.gh-token }}
@@ -23,7 +23,7 @@ runs:
           })
           return data.tag_name
     - name: Get Generated Release Notes
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: generate-notes
       with:
         github-token: ${{ inputs.gh-token }}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Addresses the warning about an old github-script action as we were using v6 in release notes but v7 for the weekly workflow, so dependabot didn't tell us about updates as it was up-to-date in one place.

```
Play Publish
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

Github, Firebase, and Sentry Release
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/github-script@v6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->