### PR TITLE
Remove "No unique cases found to override" log (not specific enough)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -470,7 +470,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                 startActivity(browserIntent)
                                 return true
                             } else {
-                                Log.d(TAG, "No unique cases found to override")
+                                // Do nothing.
                             }
                         } catch (e: Exception) {
                             Log.e(TAG, "Unable to override the URL", e)


### PR DESCRIPTION
![bug](https://github.com/home-assistant/android/assets/38705255/b87de5cf-6b1c-447e-b911-17b568f4d4d1)

Problem-Error:
```
'if' must have both main and 'else' branches if used as an expression :467
```

