### PR TITLE
Catch AssertionError when loading certificates/private key (mTLS)

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/keychain/KeyChainRepositoryImpl.kt
@@ -63,16 +63,24 @@ class KeyChainRepositoryImpl @Inject constructor(
             if (chain == null) {
                 chain = try {
                     KeyChain.getCertificateChain(context, alias!!)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Exception getting certificate chain", e)
+                } catch (t: Throwable) {
+                    when (t) {
+                        is AssertionError,
+                        is Exception -> Log.e(TAG, "Issue getting certificate chain", t)
+                        else -> throw t
+                    }
                     null
                 }
             }
             if (key == null) {
                 key = try {
                     KeyChain.getPrivateKey(context, alias!!)
-                } catch (e: Exception) {
-                    Log.e(TAG, "Exception getting private key", e)
+                } catch (t: Throwable) {
+                    when (t) {
+                        is AssertionError,
+                        is Exception -> Log.e(TAG, "Issue getting private key", t)
+                        else -> throw t
+                    }
                     null
                 }
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Closes #4449 by catching `AssertionError`s for the KeyChain, as we want it to transparently fail (prompt the user again if required, or give an error message in the WebView). Looking at the source for [KeyChain](https://cs.android.com/android/platform/superproject/+/main:frameworks/base/keystore/java/android/security/KeyChain.java) it can also wrap `CertificateException`s in these `AssertionError`s so this may be relevant for more use cases.

Note this does not fix why the KeyChain is unavailable, I believe that is outside the scope of the app.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->