### PR TITLE
Add tag/notify entity icon, add open/opening lock entity icon

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -307,7 +307,7 @@ fun <T> Entity<T>.getIcon(context: Context): IIcon {
     } else {
         /**
          * Return a default icon for the domain that matches the icon used in the frontend, see
-         * https://github.com/home-assistant/frontend/blob/dev/src/common/entity/domain_icon.ts.
+         * icons.json in the component's core integration.
          * Note: for SimplifiedEntity sometimes return a more general icon because we don't have state.
          */
         val compareState =
@@ -386,9 +386,9 @@ fun <T> Entity<T>.getIcon(context: Context): IIcon {
             "lawn_mower" -> CommunityMaterial.Icon3.cmd_robot_mower
             "light" -> CommunityMaterial.Icon2.cmd_lightbulb
             "lock" -> when (compareState) {
-                "unlocked" -> CommunityMaterial.Icon2.cmd_lock_open
+                "unlocked", "open" -> CommunityMaterial.Icon2.cmd_lock_open_variant
                 "jammed" -> CommunityMaterial.Icon2.cmd_lock_alert
-                "locking", "unlocking" -> CommunityMaterial.Icon2.cmd_lock_clock
+                "locking", "unlocking", "opening" -> CommunityMaterial.Icon2.cmd_lock_clock
                 else -> CommunityMaterial.Icon2.cmd_lock
             }
             "mailbox" -> CommunityMaterial.Icon3.cmd_mailbox
@@ -415,7 +415,7 @@ fun <T> Entity<T>.getIcon(context: Context): IIcon {
                     else -> CommunityMaterial.Icon.cmd_cast
                 }
             }
-            "notify" -> CommunityMaterial.Icon.cmd_comment_alert
+            "notify" -> CommunityMaterial.Icon3.cmd_message
             "number" -> CommunityMaterial.Icon3.cmd_ray_vertex
             "persistent_notification" -> CommunityMaterial.Icon.cmd_bell
             "person" -> if (compareState == "not_home") {
@@ -447,6 +447,7 @@ fun <T> Entity<T>.getIcon(context: Context): IIcon {
             } else { // For SimplifiedEntity without state, use a more generic icon
                 CommunityMaterial.Icon2.cmd_light_switch
             }
+            "tag" -> CommunityMaterial.Icon3.cmd_tag_outline
             "text" -> CommunityMaterial.Icon2.cmd_form_textbox
             "timer" -> CommunityMaterial.Icon3.cmd_timer_outline
             "update" -> CommunityMaterial.Icon3.cmd_package


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Updates icons based on entity domain or data in the app with two new ones:
- Added new `tag` and `notify` entity
- Added `open` and `opening` states for the `lock` entity, now matching core icon

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Icons match frontend

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->