### PR TITLE
Improve usability when external url is behind a reverse proxy

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/authentication/AuthenticationFragment.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.webkit.CookieManager
 import android.webkit.SslErrorHandler
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -158,6 +159,11 @@ class AuthenticationFragment : Fragment() {
                                     showError(requireContext().getString(commonR.string.error_ssl), error, null)
                                 }
                             }
+
+                            val cookieManager = CookieManager.getInstance()
+                            cookieManager.setAcceptCookie(true)
+                            cookieManager.setAcceptThirdPartyCookies(this, true)
+
                             authUrl = buildAuthUrl(viewModel.manualUrl.value)
                             loadUrl(authUrl!!)
                         }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -463,7 +463,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                     startActivity(intent)
                                 }
                                 return true
-                            } else if (!webView.url.toString().contains(it.toString())) {
+                            } else if (isConnected && !webView.url.toString().contains(it.toString())) {
                                 Log.d(TAG, "Launching browser")
                                 val browserIntent = Intent(Intent.ACTION_VIEW, it)
                                 startActivity(browserIntent)


### PR DESCRIPTION
## Summary
Just a few quality of life bug fixes that make it easier to use the app when home assistant is hosted behind a reverse proxy.

- Store cookies during the onboarding phase. This is already common behavior for the remainder of the app. Usually a reverse proxy stores a cookie, but this is lost after the onboarding which causes the app to fail on next startup.
- Don't launch the browser in the WebViewActivity when the url changes while the app is not connected yet. Sometimes a reverse proxy wants to show a different page before accepting the connection. This gives the proxy the opportunity to do so. Otherwise the app can launch the browser over 15 times (the app is confused and gets stuck in a loop)

## Screenshots
N/A

## Link to pull request in Documentation repository
Is this necessary for bug fixes?

## Any other notes
Relevant issue: #1438