### PR TITLE
Adds Device Class "Connectivity" to the AndroidAuto Sensor

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -24,6 +24,7 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
             commonR.string.basic_sensor_name_android_auto,
             commonR.string.sensor_description_android_auto,
             "mdi:car",
+            deviceClass = "connectivity"
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
     }

--- a/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/AndroidAutoSensorManager.kt
@@ -24,7 +24,7 @@ class AndroidAutoSensorManager : SensorManager, Observer<Int> {
             commonR.string.basic_sensor_name_android_auto,
             commonR.string.sensor_description_android_auto,
             "mdi:car",
-            deviceClass = "connectivity"
+            deviceClass = "connectivity",
             updateType = SensorManager.BasicSensor.UpdateType.INTENT
         )
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
This PR will add the Device Class 'Connectivity' to the Android Auto Sensor and therefore, will then use the correct state translation

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->