### PR TITLE
Add setting to control inclusion of all notification contents as attributes in the Active Notification Count sensor

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -27,6 +27,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
         private const val TAG = "NotificationManager"
         private const val SETTING_ALLOW_LIST = "notification_allow_list"
         private const val SETTING_DISABLE_ALLOW_LIST = "notification_disable_allow_list"
+        private const val SETTING_INCLUDE_CONTENTS_AS_ATTRS = "active_notification_count_content_attrs"
 
         private var listenerConnected = false
         val lastNotification = SensorManager.BasicSensor(
@@ -98,6 +99,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
 
     override fun requestSensorUpdate(context: Context) {
         updateMediaSession(context)
+        updateActiveNotificationCount()
     }
 
     override fun onListenerConnected() {
@@ -237,16 +239,19 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
 
         try {
             val attr: MutableMap<String, Any?> = mutableMapOf()
-            for (item in activeNotifications) {
-                attr += mappedBundle(item.notification.extras, "_${item.packageName}_${item.id}").orEmpty()
-                    .plus("${item.packageName}_${item.id}_post_time" to item.postTime)
-                    .plus("${item.packageName}_${item.id}_is_ongoing" to item.isOngoing)
-                    .plus("${item.packageName}_${item.id}_is_clearable" to item.isClearable)
-                    .plus("${item.packageName}_${item.id}_group_id" to item.notification.group)
-                    .plus("${item.packageName}_${item.id}_category" to item.notification.category)
+            val includeContentsAsAttrsSetting = getToggleSetting(applicationContext, activeNotificationCount, SETTING_INCLUDE_CONTENTS_AS_ATTRS, default = true)
+            if (includeContentsAsAttrsSetting) {
+                for (item in activeNotifications) {
+                    attr += mappedBundle(item.notification.extras, "_${item.packageName}_${item.id}").orEmpty()
+                        .plus("${item.packageName}_${item.id}_post_time" to item.postTime)
+                        .plus("${item.packageName}_${item.id}_is_ongoing" to item.isOngoing)
+                        .plus("${item.packageName}_${item.id}_is_clearable" to item.isClearable)
+                        .plus("${item.packageName}_${item.id}_group_id" to item.notification.group)
+                        .plus("${item.packageName}_${item.id}_category" to item.notification.category)
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                    attr["${item.packageName}_${item.id}_channel_id"] = item.notification.channelId
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        attr["${item.packageName}_${item.id}_channel_id"] = item.notification.channelId
+                    }
                 }
             }
             onSensorUpdated(

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -734,7 +734,7 @@
     <string name="sensor_setting_nextalarm_allow_list_title">Allow list</string>
     <string name="sensor_setting_notification_allow_list_title">Allow list</string>
     <string name="sensor_setting_notification_disable_allow_list_title">Disable allow list requirement</string>
-    <string name="sensor_setting_active_notification_count_content_attrs_title">Include content from all notifications as sensor attributes</string>
+    <string name="sensor_setting_active_notification_count_content_attrs_title">Include content from all notifications as attributes</string>
     <string name="sensor_setting_battery_current_divisor_title">Battery current divisor</string>
     <string name="sensor_setting_battery_voltage_divisor_title">Battery voltage divisor</string>
     <string name="sensor_settings">Sensor settings</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -559,7 +559,7 @@
     <string name="select_entity_to_display">Select entity to display</string>
     <string name="select_file">Select file</string>
     <string name="select_instance">Select your Home Assistant server</string>
-    <string name="sensor_description_active_notification_count">Total count of active notifications that are visible to the user including silent, persistent and the Sensor Worker notifications.</string>
+    <string name="sensor_description_active_notification_count">Total count of active notifications that are visible to the user including silent, persistent and the Sensor Worker notifications. Attributes will include the contents of all notifications if the corresponding setting is enabled. It\'s enabled by default.</string>
     <string name="sensor_description_app_importance">If the app is in the foreground, background or any other state it can be</string>
     <string name="sensor_description_android_auto">If the phone is currently connected to an Android Auto head unit</string>
     <string name="sensor_description_android_os_version">Android OS version</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -734,6 +734,7 @@
     <string name="sensor_setting_nextalarm_allow_list_title">Allow list</string>
     <string name="sensor_setting_notification_allow_list_title">Allow list</string>
     <string name="sensor_setting_notification_disable_allow_list_title">Disable allow list requirement</string>
+    <string name="sensor_setting_active_notification_count_content_attrs_title">Include content from all notifications as sensor attributes</string>
     <string name="sensor_setting_battery_current_divisor_title">Battery current divisor</string>
     <string name="sensor_setting_battery_voltage_divisor_title">Battery voltage divisor</string>
     <string name="sensor_settings">Sensor settings</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently, the Active Notification Sensor attaches the content of all notifications in the sensor attributes. I think this has two problems:

1. The fact that, this sensor also includes all notification content in addition to the count is not intuitive judging only based on the sensor's name, and can surprise users (including myself).
2. It can increase power and data consumption.

And these could surprise the user, maybe in a negative way.

So here comes a new toggle setting for the Active Notification Count sensor to the rescue: `Include content from all notifications as sensor attributes`

## Link to pull request in Documentation repository
Documentation: https://github.com/home-assistant/companion.home-assistant/pull/1077

## Any other notes
Please check [this comment](https://github.com/home-assistant/android/pull/4516/files#r1677876942).

## Screenshots
![Screenshot_20240715_190818_Home Assistant](https://github.com/user-attachments/assets/a6f8f925-8f19-40fa-860b-11136fb60906)