### PR TITLE
Improve onboarding discovery feedback

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViewModel.kt
@@ -4,7 +4,6 @@ import android.app.Application
 import android.net.Uri
 import android.util.Log
 import android.webkit.URLUtil
-import android.widget.Toast
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -13,7 +12,6 @@ import androidx.core.content.getSystemService
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LifecycleObserver
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import io.homeassistant.companion.android.onboarding.discovery.HomeAssistantInstance
@@ -34,15 +32,15 @@ class OnboardingViewModel @Inject constructor(
     private val _homeAssistantSearcher = HomeAssistantSearcher(
         nsdManager = app.getSystemService()!!,
         wifiManager = app.getSystemService(),
+        onStart = { discoveryActive = true },
         onInstanceFound = ::onInstanceFound,
-        onError = {
-            Toast.makeText(app, R.string.failed_scan, Toast.LENGTH_LONG).show()
-            // TODO: Go to manual setup?
-        }
+        onError = { discoveryActive = false }
     )
     val homeAssistantSearcher: LifecycleObserver = _homeAssistantSearcher
 
     val foundInstances = mutableStateListOf<HomeAssistantInstance>()
+    var discoveryActive by mutableStateOf(true)
+        private set
     val manualUrl = mutableStateOf("")
     var discoveryOptions: OnboardApp.DiscoveryOptions? = null
     var manualContinueEnabled by mutableStateOf(false)

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryFragment.kt
@@ -44,6 +44,7 @@ class DiscoveryFragment @Inject constructor() : Fragment() {
             setContent {
                 HomeAssistantAppTheme {
                     DiscoveryView(
+                        discoveryActive = viewModel.discoveryActive,
                         foundInstances = viewModel.foundInstances,
                         manualSetupClicked = { navigateToManualSetup() },
                         instanceClicked = { onInstanceClicked(it) }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/DiscoveryView.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.onboarding.discovery
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -14,17 +15,24 @@ import androidx.compose.material.Divider
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
 import androidx.compose.material.LocalContentAlpha
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,13 +42,21 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.onboarding.OnboardingHeaderView
 import io.homeassistant.companion.android.util.homeAssistantInstance1
 import io.homeassistant.companion.android.util.homeAssistantInstance2
+import kotlinx.coroutines.delay
 
 @Composable
 fun DiscoveryView(
+    discoveryActive: Boolean,
     foundInstances: SnapshotStateList<HomeAssistantInstance>,
     manualSetupClicked: () -> Unit,
     instanceClicked: (instance: HomeAssistantInstance) -> Unit
 ) {
+    var discoveryTimeout by remember { mutableStateOf(false) }
+    LaunchedEffect("discoveryTimeout") {
+        delay(10_000L)
+        discoveryTimeout = true
+    }
+
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -50,13 +66,20 @@ fun DiscoveryView(
             icon = CommunityMaterial.Icon2.cmd_home_search,
             title = stringResource(id = commonR.string.select_instance)
         )
-        LinearProgressIndicator(
-            modifier = Modifier
-                .fillMaxWidth(0.25f)
-                .padding(vertical = 16.dp)
-                .height(2.dp)
-                .align(Alignment.CenterHorizontally)
-        )
+        val indicatorModifier = Modifier
+            .fillMaxWidth(0.25f)
+            .padding(vertical = 16.dp)
+            .height(2.dp)
+            .align(Alignment.CenterHorizontally)
+        if (discoveryActive) {
+            LinearProgressIndicator(modifier = indicatorModifier)
+        } else {
+            LinearProgressIndicator(progress = 0f, modifier = indicatorModifier)
+        }
+
+        val discoveryHasError by remember(discoveryActive, foundInstances.size, discoveryTimeout) {
+            mutableStateOf(!discoveryActive || (foundInstances.size == 0 && discoveryTimeout))
+        }
         LazyColumn(
             modifier = Modifier
                 .fillMaxWidth()
@@ -64,49 +87,96 @@ fun DiscoveryView(
         ) {
             items(foundInstances.size, { foundInstances[it].url }) { index ->
                 val instance = foundInstances[index]
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(min = 56.dp)
-                        .clickable(onClick = { instanceClicked(instance) })
-                ) {
-                    Column {
-                        Text(instance.name)
-                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                            Text(
-                                text = instance.url.toString(),
-                                fontSize = 14.sp
-                            )
-                        }
-                    }
-                    Icon(
-                        painter = painterResource(R.drawable.navigate_next),
-                        contentDescription = null
+                DiscoveredInstanceRow(
+                    instance = instance,
+                    onClick = { instanceClicked(instance) }
+                )
+            }
+            item("discovery.error") {
+                AnimatedVisibility(discoveryHasError) {
+                    Text(
+                        text = stringResource(if (!discoveryActive) commonR.string.failed_scan else commonR.string.slow_scan),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.body2,
+                        modifier = Modifier.fillMaxWidth()
                     )
                 }
-                Divider(Modifier.padding(8.dp))
             }
         }
-        TextButton(
-            onClick = manualSetupClicked,
+        Column(
             modifier = Modifier
                 .align(Alignment.CenterHorizontally)
-                .padding(top = 16.dp)
+                .padding(top = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Text(text = stringResource(commonR.string.manual_setup))
+            if (discoveryHasError && discoveryActive) {
+                Text(
+                    text = stringResource(commonR.string.manual_setup_hint),
+                    style = MaterialTheme.typography.body2
+                )
+            }
+            if (discoveryHasError) {
+                OutlinedButton(onClick = manualSetupClicked) {
+                    Text(text = stringResource(commonR.string.manual_setup))
+                }
+            } else {
+                TextButton(onClick = manualSetupClicked) {
+                    Text(text = stringResource(commonR.string.manual_setup))
+                }
+            }
         }
     }
 }
 
+@Composable
+private fun DiscoveredInstanceRow(
+    instance: HomeAssistantInstance,
+    onClick: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(min = 56.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Column {
+            Text(instance.name)
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                Text(
+                    text = instance.url.toString(),
+                    fontSize = 14.sp
+                )
+            }
+        }
+        Icon(
+            painter = painterResource(R.drawable.navigate_next),
+            contentDescription = null
+        )
+    }
+    Divider(Modifier.padding(8.dp))
+}
+
 @Preview(showSystemUi = true)
 @Composable
-fun DiscoveryViewPreview() {
+fun DiscoveryViewActivePreview() {
     DiscoveryView(
+        discoveryActive = true,
         foundInstances = remember {
             mutableStateListOf(homeAssistantInstance1, homeAssistantInstance2)
         },
+        manualSetupClicked = { },
+        instanceClicked = {}
+    )
+}
+
+@Preview(showSystemUi = true)
+@Composable
+fun DiscoveryViewErrorPreview() {
+    DiscoveryView(
+        discoveryActive = false,
+        foundInstances = remember { mutableStateListOf() },
         manualSetupClicked = { },
         instanceClicked = {}
     )

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/HomeAssistantSearcher.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/discovery/HomeAssistantSearcher.kt
@@ -15,6 +15,7 @@ import okio.internal.commonToUtf8String
 class HomeAssistantSearcher constructor(
     private val nsdManager: NsdManager,
     private val wifiManager: WifiManager?,
+    private val onStart: () -> Unit,
     private val onInstanceFound: (instance: HomeAssistantInstance) -> Unit,
     private val onError: () -> Unit
 ) : NsdManager.DiscoveryListener, DefaultLifecycleObserver {
@@ -44,6 +45,7 @@ class HomeAssistantSearcher constructor(
             onError()
             return
         }
+        onStart()
         try {
             if (wifiManager != null && multicastLock == null) {
                 multicastLock = wifiManager.createMulticastLock(TAG)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -415,6 +415,7 @@
     <string name="manage_widgets">Manage widgets</string>
     <string name="manual_desc">Enter the URL of your Home Assistant server. Make sure it includes the protocol and port. For example:\n\nhttp://homeassistant.local:8123 or \nhttps://example.duckdns.org.</string>
     <string name="manual_setup">Enter address manually</string>
+    <string name="manual_setup_hint">Not finding your server?</string>
     <string name="manual_title">What is your Home Assistant address?</string>
     <string name="map">Map</string>
     <string name="matter_commissioning_unavailable">Matter is currently unavailable</string>
@@ -808,6 +809,7 @@
     <string name="slider_fan_speed">Fan speed</string>
     <string name="slider_light_brightness">Brightness</string>
     <string name="slider_light_colortemp">Color temperature</string>
+    <string name="slow_scan">Scanning… Make sure your server is on and you\'re connected to the same network.</string>
     <string name="skip">Skip</string>
     <string name="speed">Speed: %1$d%%</string>
     <string name="state_auto">Auto</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Based on a failed automotive review, two improvements to the discovery screen during onboarding:
 - If discovery is taking longer than expected, add a message to check power/network and emphasize the manual option (the text and placement of 'Not finding your server?' is taken from iOS, but a bit less obvious because discovery is strongly preferred and generally works)
 - If discovery fails show a persistent error instead of a toast with no changes in the discovery UI

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Video showing change 1 (longer than expected means: 10 seconds)

https://github.com/user-attachments/assets/dbaad84a-19da-4849-aea9-3979ed6f4df6

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->