### PR TITLE
Fix Active Notification Count sensor showing 0 notifications when upd…

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -99,7 +99,6 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
 
     override fun requestSensorUpdate(context: Context) {
         updateMediaSession(context)
-        updateActiveNotificationCount()
     }
 
     override fun onListenerConnected() {


### PR DESCRIPTION
## Summary
I noticed that after my previous changes (#4516) were merged, this error log showed up in Logcat:

```
SensorReceiver  io.homeassistant.companion.android   E  Issue requesting updates for Notification sensors
java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.Context android.content.Context.getApplicationContext()' on a null object reference
    at android.content.ContextWrapper.getApplicationContext(ContextWrapper.java:154)
    at io.homeassistant.companion.android.sensors.NotificationSensorManager.updateActiveNotificationCount(NotificationSensorManager.kt:236)
    at io.homeassistant.companion.android.sensors.NotificationSensorManager.requestSensorUpdate(NotificationSensorManager.kt:102)
    at io.homeassistant.companion.android.common.sensors.SensorManager$DefaultImpls.requestSensorUpdate(SensorManager.kt:138)
    at io.homeassistant.companion.android.sensors.NotificationSensorManager.requestSensorUpdate(NotificationSensorManager.kt:25)
    at io.homeassistant.companion.android.common.sensors.SensorReceiverBase.updateSensors(SensorReceiverBase.kt:184)
    at io.homeassistant.companion.android.common.sensors.SensorWorkerBase$doWork$2.invokeSuspend(SensorWorkerBase.kt:67)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
    at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
```

And also, the Active Notification Count sensor always shows `0 notifications` when the sensor update was triggered through `requestSensorUpdate()`. I noticed that there are two instances created from `NotificationSensorManager`: one which is instantiated [here from the code](https://github.com/home-assistant/android/blob/e36d38843d180e3ee6cc4025878e50e0e7705a9c/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt#L79), and the other is instantiated by the Android framework because it is a `Service`. The problematic case was when it was instantiated from the code because that instance was added to `SensorReceiver.MANAGERS`, and `requestSensorUpdate()` is usually called on instances from that list.

[Related discussion from the previous PR](https://github.com/home-assistant/android/pull/4516/files#r1677876942).

I added the `updateActiveNotificationCount()` call to make the newly added setting appear earlier. A long-term solution for this could be [this refactor idea](https://github.com/home-assistant/android/pull/4516/files#r1678020269). (Also, I think it would be good not to have multiple instances of a single `SensorManager`. Every `SensorManager` that inherits from `BroadcastReceiver` or `Service` (and thus instantiated by Android) is prone to errors like this.)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->