### PR TITLE
Allow measured power to be updated via notification command

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.common.notifications
 
 import android.content.Context
 import android.util.Log
-import androidx.core.text.isDigitsOnly
 import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.common.sensors.SensorUpdateReceiver
 import io.homeassistant.companion.android.database.sensor.SensorDao
@@ -77,8 +76,7 @@ private fun checkCommandFormat(data: Map<String, String>): Boolean {
                                 (
                                     data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MEASURED_POWER &&
                                         (
-                                            !data[DeviceCommandData.BLE_MEASURED_POWER].isNullOrEmpty() && data[DeviceCommandData.BLE_MEASURED_POWER]?.removePrefix('-'.toString())?.isDigitsOnly() == true &&
-                                                (data[DeviceCommandData.BLE_MEASURED_POWER]?.toIntOrNull() ?: BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M) < 0
+                                            data[DeviceCommandData.BLE_MEASURED_POWER]?.toIntOrNull() != null && data[DeviceCommandData.BLE_MEASURED_POWER]?.toInt()!! < 0
                                             )
                                     )
                             )

--- a/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.notifications
 
 import android.content.Context
 import android.util.Log
+import androidx.core.text.isDigitsOnly
 import io.homeassistant.companion.android.common.sensors.BluetoothSensorManager
 import io.homeassistant.companion.android.common.sensors.SensorUpdateReceiver
 import io.homeassistant.companion.android.database.sensor.SensorDao
@@ -75,7 +76,10 @@ private fun checkCommandFormat(data: Map<String, String>): Boolean {
                                 (data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MINOR && !data[DeviceCommandData.BLE_MINOR].isNullOrEmpty()) ||
                                 (
                                     data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MEASURED_POWER &&
-                                        (!data[DeviceCommandData.BLE_MEASURED_POWER].isNullOrEmpty() && (data[DeviceCommandData.BLE_MEASURED_POWER]?.toIntOrNull() ?: BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M) < 0)
+                                        (
+                                            !data[DeviceCommandData.BLE_MEASURED_POWER].isNullOrEmpty() && data[DeviceCommandData.BLE_MEASURED_POWER]?.removePrefix('-'.toString())?.isDigitsOnly() == true &&
+                                                (data[DeviceCommandData.BLE_MEASURED_POWER]?.toIntOrNull() ?: BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M) < 0
+                                            )
                                     )
                             )
                     )

--- a/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/notifications/DeviceCommands.kt
@@ -24,6 +24,7 @@ object DeviceCommandData {
     // Ble Transmitter Commands
     const val BLE_SET_TRANSMIT_POWER = "ble_set_transmit_power"
     const val BLE_SET_ADVERTISE_MODE = "ble_set_advertise_mode"
+    const val BLE_SET_MEASURED_POWER = "ble_set_measured_power"
     const val BLE_ADVERTISE_LOW_LATENCY = "ble_advertise_low_latency"
     const val BLE_ADVERTISE_BALANCED = "ble_advertise_balanced"
     const val BLE_ADVERTISE_LOW_POWER = "ble_advertise_low_power"
@@ -39,13 +40,15 @@ object DeviceCommandData {
     const val BLE_MINOR = "ble_minor"
     const val BLE_ADVERTISE = "ble_advertise"
     const val BLE_TRANSMIT = "ble_transmit"
+    const val BLE_MEASURED_POWER = "ble_measured_power"
 
     val BLE_COMMANDS = listOf(
         BLE_SET_ADVERTISE_MODE,
         BLE_SET_TRANSMIT_POWER,
         BLE_SET_UUID,
         BLE_SET_MAJOR,
-        BLE_SET_MINOR
+        BLE_SET_MINOR,
+        BLE_SET_MEASURED_POWER
     )
     val BLE_TRANSMIT_COMMANDS =
         listOf(BLE_TRANSMIT_HIGH, BLE_TRANSMIT_LOW, BLE_TRANSMIT_MEDIUM, BLE_TRANSMIT_ULTRA_LOW)
@@ -69,7 +72,11 @@ private fun checkCommandFormat(data: Map<String, String>): Boolean {
                                 (!data[DeviceCommandData.BLE_TRANSMIT].isNullOrEmpty() && data[DeviceCommandData.BLE_TRANSMIT] in DeviceCommandData.BLE_TRANSMIT_COMMANDS) ||
                                 (data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_UUID && !data[DeviceCommandData.BLE_UUID].isNullOrEmpty()) ||
                                 (data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MAJOR && !data[DeviceCommandData.BLE_MAJOR].isNullOrEmpty()) ||
-                                (data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MINOR && !data[DeviceCommandData.BLE_MINOR].isNullOrEmpty())
+                                (data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MINOR && !data[DeviceCommandData.BLE_MINOR].isNullOrEmpty()) ||
+                                (
+                                    data[NotificationData.COMMAND] == DeviceCommandData.BLE_SET_MEASURED_POWER &&
+                                        (!data[DeviceCommandData.BLE_MEASURED_POWER].isNullOrEmpty() && (data[DeviceCommandData.BLE_MEASURED_POWER]?.toIntOrNull() ?: BluetoothSensorManager.DEFAULT_MEASURED_POWER_AT_1M) < 0)
+                                    )
                             )
                     )
         }
@@ -126,6 +133,7 @@ fun commandBleTransmitter(
             when (command) {
                 DeviceCommandData.BLE_SET_ADVERTISE_MODE -> BluetoothSensorManager.SETTING_BLE_ADVERTISE_MODE
                 DeviceCommandData.BLE_SET_TRANSMIT_POWER -> BluetoothSensorManager.SETTING_BLE_TRANSMIT_POWER
+                DeviceCommandData.BLE_SET_MEASURED_POWER -> BluetoothSensorManager.SETTING_BLE_MEASURED_POWER
                 DeviceCommandData.BLE_SET_UUID -> BluetoothSensorManager.SETTING_BLE_ID1
                 DeviceCommandData.BLE_SET_MAJOR -> BluetoothSensorManager.SETTING_BLE_ID2
                 DeviceCommandData.BLE_SET_MINOR -> BluetoothSensorManager.SETTING_BLE_ID3
@@ -145,6 +153,7 @@ fun commandBleTransmitter(
                     ?: BluetoothSensorManager.DEFAULT_BLE_MAJOR
                 DeviceCommandData.BLE_SET_MINOR -> data[DeviceCommandData.BLE_MINOR]
                     ?: BluetoothSensorManager.DEFAULT_BLE_MINOR
+                DeviceCommandData.BLE_SET_MEASURED_POWER -> data[DeviceCommandData.BLE_MEASURED_POWER].toString()
                 else -> {
                     when (data[DeviceCommandData.BLE_TRANSMIT]) {
                         DeviceCommandData.BLE_TRANSMIT_HIGH -> BluetoothSensorManager.BLE_TRANSMIT_HIGH

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -54,7 +54,7 @@ class BluetoothSensorManager : SensorManager {
         private const val DEFAULT_BLE_ADVERTISE_MODE = "lowPower"
         const val DEFAULT_BLE_MAJOR = "100"
         const val DEFAULT_BLE_MINOR = "40004"
-        private const val DEFAULT_MEASURED_POWER_AT_1M = -59
+        const val DEFAULT_MEASURED_POWER_AT_1M = -59
         private var priorBluetoothStateEnabled = false
 
         private const val DEFAULT_BEACON_MONITOR_SCAN_PERIOD = "1100"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implements: #3290

example service call:

```
service: notify.mobile_app_pixel_8_pro
data:
  message: command_ble_transmitter
  data:
    command: ble_set_measured_power
    ble_measured_power: "-10"
```

The field is validated that its not blank and that it is a negative number

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1086

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM PR: https://github.com/home-assistant/mobile-apps-fcm-push/pull/150