### PR TITLE
Handle notification permission on Wear

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.runtime.toMutableStateList
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -130,6 +131,8 @@ class MainViewModel @Inject constructor(
         private set
     var isAssistantAppAllowed by mutableStateOf(true)
         private set
+    var areNotificationsAllowed by mutableStateOf(false)
+        private set
 
     fun supportedDomains(): List<String> = HomePresenterImpl.supportedDomains
 
@@ -159,6 +162,8 @@ class MainViewModel @Inject constructor(
             )
             isAssistantAppAllowed =
                 app.packageManager.getComponentEnabledSetting(assistantAppComponent) != PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+
+            refreshNotificationPermission()
         }
     }
 
@@ -544,6 +549,10 @@ class MainViewModel @Inject constructor(
             PackageManager.DONT_KILL_APP
         )
         isAssistantAppAllowed = allowed
+    }
+
+    fun refreshNotificationPermission() {
+        areNotificationsAllowed = NotificationManagerCompat.from(app).areNotificationsEnabled()
     }
 
     fun logout() {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -1,5 +1,9 @@
 package io.homeassistant.companion.android.home.views
 
+import android.content.Intent
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -134,6 +138,9 @@ fun LoadHomePage(
                 )
             }
             composable(SCREEN_SETTINGS) {
+                val notificationLaunch = rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+                    mainViewModel.refreshNotificationPermission()
+                }
                 SettingsView(
                     loadingState = mainViewModel.loadingState.value,
                     favorites = mainViewModel.favoriteEntityIds.value,
@@ -159,6 +166,7 @@ fun LoadHomePage(
                     isToastEnabled = mainViewModel.isToastEnabled.value,
                     isFavoritesOnly = mainViewModel.isFavoritesOnly,
                     isAssistantAppAllowed = mainViewModel.isAssistantAppAllowed,
+                    areNotificationsAllowed = mainViewModel.areNotificationsAllowed,
                     onHapticEnabled = { mainViewModel.setHapticEnabled(it) },
                     onToastEnabled = { mainViewModel.setToastEnabled(it) },
                     setFavoritesOnly = { mainViewModel.setWearFavoritesOnly(it) },
@@ -169,7 +177,14 @@ fun LoadHomePage(
                         mainViewModel.loadTemplateTiles()
                         swipeDismissableNavController.navigate("$ROUTE_TEMPLATE_TILE/$SCREEN_SELECT_TEMPLATE_TILE")
                     },
-                    onAssistantAppAllowed = mainViewModel::setAssistantApp
+                    onAssistantAppAllowed = mainViewModel::setAssistantApp,
+                    onClickNotifications = {
+                        notificationLaunch.launch(
+                            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            }
+                        )
+                    }
                 )
             }
             composable(SCREEN_SET_FAVORITES) {

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SettingsView.kt
@@ -68,12 +68,14 @@ fun SettingsView(
     isToastEnabled: Boolean,
     isFavoritesOnly: Boolean,
     isAssistantAppAllowed: Boolean,
+    areNotificationsAllowed: Boolean,
     onHapticEnabled: (Boolean) -> Unit,
     onToastEnabled: (Boolean) -> Unit,
     setFavoritesOnly: (Boolean) -> Unit,
     onClickCameraTile: () -> Unit,
     onClickTemplateTiles: () -> Unit,
-    onAssistantAppAllowed: (Boolean) -> Unit
+    onAssistantAppAllowed: (Boolean) -> Unit,
+    onClickNotifications: () -> Unit
 ) {
     WearAppTheme {
         ThemeLazyColumn {
@@ -224,6 +226,20 @@ fun SettingsView(
                     colors = getToggleButtonColors()
                 )
             }
+            if (!areNotificationsAllowed) {
+                item {
+                    ListHeader(
+                        id = commonR.string.notifications
+                    )
+                }
+                item {
+                    SecondarySettingsChip(
+                        icon = CommunityMaterial.Icon.cmd_bell_ring,
+                        label = stringResource(commonR.string.suggestion_notifications_title),
+                        onClick = onClickNotifications
+                    )
+                }
+            }
             item {
                 ListHeader(
                     id = commonR.string.account
@@ -268,11 +284,13 @@ private fun PreviewSettingsView() {
         isToastEnabled = false,
         isFavoritesOnly = false,
         isAssistantAppAllowed = true,
+        areNotificationsAllowed = false,
         onHapticEnabled = {},
         onToastEnabled = {},
         setFavoritesOnly = {},
         onClickCameraTile = {},
         onClickTemplateTiles = {},
-        onAssistantAppAllowed = {}
+        onAssistantAppAllowed = {},
+        onClickNotifications = {}
     )
 }

--- a/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationActivity.kt
@@ -57,7 +57,7 @@ class MobileAppIntegrationActivity : AppCompatActivity(), MobileAppIntegrationVi
     }
 
     override fun deviceRegistered() {
-        val intent = HomeActivity.newInstance(this)
+        val intent = HomeActivity.newInstance(this, fromOnboarding = true)
         // empty the back stack
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
         startActivity(intent)

--- a/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -194,7 +194,7 @@ class PhoneSettingsListener : WearableListenerService(), DataClient.OnDataChange
                 updateTiles()
             }
 
-            val intent = HomeActivity.newInstance(applicationContext)
+            val intent = HomeActivity.newInstance(applicationContext, fromOnboarding = true)
             intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(intent)
         } catch (e: Exception) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
To prepare for the API 33 targeting of Wear (#4500), add handling around the notification permission to the Wear app. This should only apply to watch notifications, not bridged notifications*, but it is nice to have if possible so:

 - Ask for notification permission immediately after completing onboarding (Android 13+ only)
 - Add a settings item to open the watch settings to grant permission (any Android version)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Permission prompt after logging in|Settings item if notifications are disabled for the app|Tapping the setting open the system notifications settings**|
|----|----|----|
|![A screenshot of a dialog with the question 'Allow Home Assistant to send you notifications?', a bell icon, an obscured button near the bottom.](https://github.com/user-attachments/assets/9d8eb9e2-78e8-4657-8803-cada5da1df63)|![Settings titled 'Notifications', one option labeled 'Enable notifications'](https://github.com/user-attachments/assets/352e4021-4abe-44e8-b674-ee628bbf2ea7)|![System notification settings for Home Assistant, with a enable everything toggle at the top and individual notification channels below](https://github.com/user-attachments/assets/fc40751d-13f7-42ab-902a-716312509ad3)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
\* At least [that's what Google says](https://developer.android.com/training/wearables/versions/4/changes#:~:text=The%20notification%20permission%20doesn%27t%20apply%20to%20bridged%20notifications), but then you have Samsung making it impossible to change one without the other in their companion app 🤷
\*\* Fun fact: while I can find this in settings app on the emulator, I actually can't find it on my Samsung watch