### PR TITLE
Breaking Change: Update heart rate sensor for Wear OS 4+ target

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.BODY_SENSORS" />
+    <uses-permission android:name="android.permission.BODY_SENSORS_BACKGROUND" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.google.android.clockwork.settings.WATCH_TOUCH" />
     <uses-permission android:name="android.permission.BLUETOOTH"

--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SensorUi.kt
@@ -43,11 +43,19 @@ fun SensorUi(
         var allGranted = true
         isGranted.forEach {
             if (
+                it.key == Manifest.permission.ACCESS_FINE_LOCATION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
                 manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_FINE_LOCATION) &&
-                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION) &&
-                it.key == Manifest.permission.ACCESS_FINE_LOCATION && Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
             ) {
                 backgroundRequest.launch(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                return@forEach
+            }
+            if (
+                it.key == Manifest.permission.BODY_SENSORS && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.BODY_SENSORS) &&
+                manager.requiredPermissions(basicSensor.id).contains(Manifest.permission.BODY_SENSORS_BACKGROUND)
+            ) {
+                backgroundRequest.launch(Manifest.permission.BODY_SENSORS_BACKGROUND)
                 return@forEach
             }
             if (!it.value) {
@@ -68,10 +76,17 @@ fun SensorUi(
                 onSensorClicked(basicSensor.id, enabled)
             } else {
                 permissionLaunch.launch(
-                    if (permissions.size == 1 && permissions[0] == Manifest.permission.ACCESS_BACKGROUND_LOCATION) {
+                    if (permissions.size == 1 &&
+                        (
+                            permissions[0] == Manifest.permission.ACCESS_BACKGROUND_LOCATION ||
+                                permissions[0] == Manifest.permission.BODY_SENSORS_BACKGROUND
+                            )
+                    ) {
                         permissions
                     } else {
-                        permissions.toSet().minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                        permissions.toSet()
+                            .minus(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                            .minus(Manifest.permission.BODY_SENSORS_BACKGROUND)
                             .toTypedArray()
                     }
                 )

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -54,16 +54,16 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
-        return arrayOf(Manifest.permission.BODY_SENSORS)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.BODY_SENSORS, Manifest.permission.BODY_SENSORS_BACKGROUND)
+        } else {
+            arrayOf(Manifest.permission.BODY_SENSORS)
+        }
     }
 
     override fun hasSensor(context: Context): Boolean {
-        // Starting with Android 13 (T), background access requires BODY_SENSORS_BACKGROUND permission
-        // which must be allowlisted by OEMs. Because Home Assistant isn't allowlisted, the sensor only
-        // works while the app is visible and is practically useless, so don't make it available on 13+.
         val packageManager: PackageManager = context.packageManager
-        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
-            packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_HEART_RATE)
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_HEART_RATE)
     }
 
     private lateinit var latestContext: Context

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HeartRateSensorManager.kt
@@ -12,6 +12,7 @@ import android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_LOW
 import android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM
 import android.hardware.SensorManager.SENSOR_STATUS_NO_CONTACT
 import android.hardware.SensorManager.SENSOR_STATUS_UNRELIABLE
+import android.os.Build
 import android.util.Log
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.R as commonR
@@ -57,8 +58,12 @@ class HeartRateSensorManager : SensorManager, SensorEventListener {
     }
 
     override fun hasSensor(context: Context): Boolean {
+        // Starting with Android 13 (T), background access requires BODY_SENSORS_BACKGROUND permission
+        // which must be allowlisted by OEMs. Because Home Assistant isn't allowlisted, the sensor only
+        // works while the app is visible and is practically useless, so don't make it available on 13+.
         val packageManager: PackageManager = context.packageManager
-        return packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_HEART_RATE)
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU &&
+            packageManager.hasSystemFeature(PackageManager.FEATURE_SENSOR_HEART_RATE)
     }
 
     private lateinit var latestContext: Context


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Update the permission requirements for the heart rate sensor on Wear OS 4+ to handle the new behavior when targeting it. These permissions need to be requested in two stages like background location. Any user with the sensor currently enabled on Wear OS 4+, will need to re-enable it after updating.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
~~Documentation: home-assistant/companion.home-assistant#1087~~ n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->