### PR TITLE
Don't build minimal flavors for Play Publish workflow task

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -187,9 +187,9 @@ jobs:
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
           ./gradlew :common:assemble
-          ./gradlew :app:bundleRelease
+          ./gradlew :app:bundleFullRelease
           ./gradlew :wear:bundleRelease
-          ./gradlew :automotive:bundleRelease
+          ./gradlew :automotive:bundleFullRelease
 
       - name: Deploy to Playstore Internal
         run: bundle exec fastlane deploy_internal


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While watching the CI pushing the latest PR to the Play Store I noticed tasks for building the `minimal` flavor. We don't need those so only build the `full` flavor (there is a different task in the workflow that handles releases with apks, all flavors).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->