### PR TITLE
WearOS: Add app activities to ShortcutsTile

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
@@ -39,8 +39,7 @@ class TileActionReceiver : BroadcastReceiver() {
                     it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     context.startActivity(it)
                 }
-            }
-            else {
+            } else {
                 runBlocking {
                     if (wearPrefsRepository.getWearHapticFeedback() && context != null) hapticClick(context)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
@@ -8,6 +8,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.onEntityPressedWithoutState
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.conversation.ConversationActivity
+import io.homeassistant.companion.android.home.HomeActivity
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 
@@ -28,16 +30,28 @@ class TileActionReceiver : BroadcastReceiver() {
         val entityId: String? = intent?.getStringExtra("entity_id")
 
         if (entityId != null) {
-            runBlocking {
-                if (wearPrefsRepository.getWearHapticFeedback() && context != null) hapticClick(context)
+            if (entityId.split(".")[0] == "app_shortcut" && context != null) {
+                val m = mapOf(
+                    "assist" to ConversationActivity.newInstance(context),
+                    "home_assistant" to HomeActivity.newInstance(context)
+                )
+                m[entityId.split(".")[1]]?.let {
+                    it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    context.startActivity(it)
+                }
+            }
+            else {
+                runBlocking {
+                    if (wearPrefsRepository.getWearHapticFeedback() && context != null) hapticClick(context)
 
-                try {
-                    onEntityPressedWithoutState(
-                        entityId = entityId,
-                        integrationRepository = serverManager.integrationRepository()
-                    )
-                } catch (e: Exception) {
-                    Log.e(TAG, "Cannot call tile service", e)
+                    try {
+                        onEntityPressedWithoutState(
+                            entityId = entityId,
+                            integrationRepository = serverManager.integrationRepository()
+                        )
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Cannot call tile service", e)
+                    }
                 }
             }
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
@@ -52,6 +52,7 @@ fun ChooseEntityView(
     // Remember expanded state of each header
     val expandedStates = rememberExpandedStates(entitiesByDomainOrder)
     var expandedFavorites: Boolean by rememberSaveable { mutableStateOf(false) }
+    var expandedAppShortcuts: Boolean by rememberSaveable { mutableStateOf(false) }
 
     WearAppTheme {
         ThemeLazyColumn {
@@ -116,6 +117,65 @@ fun ChooseEntityView(
                             )
                         }
                     }
+                }
+            }
+
+            // App Shortcuts
+            item {
+                ExpandableListHeader(
+                    string = stringResource(commonR.string.shortcuts),
+                    expanded = expandedAppShortcuts,
+                    onExpandChanged = { expandedAppShortcuts = it }
+                )
+            }
+            if (expandedAppShortcuts) {
+                // HomeAssistant app shortcut
+                item {     
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        icon = { 
+                            Image(
+                                asset = CommunityMaterial.Icon2.cmd_home_assistant,
+                                colorFilter = ColorFilter.tint(Color.White)
+                            )
+                        },
+                        label = { Text(stringResource(id = commonR.string.app_name)) },
+                        onClick = {
+                            onEntitySelected(
+                                SimplifiedEntity(
+                                    "app_shortcut.home_assistant",
+                                    "Home Assistant",
+                                    "mdi:home-assistant"
+                                )
+                            )
+                        },
+                        colors = getFilledTonalButtonColors()
+                    )
+                }
+                // Assist shortcut
+                item {     
+                    Button(
+                        modifier = Modifier
+                            .fillMaxWidth(),
+                        icon = { 
+                            Image(
+                                asset = CommunityMaterial.Icon.cmd_comment_processing_outline,
+                                colorFilter = ColorFilter.tint(Color.White)
+                            )
+                        },
+                        label = { Text(stringResource(id = commonR.string.assist)) },
+                        onClick = {
+                            onEntitySelected(
+                                SimplifiedEntity(
+                                    "app_shortcut.assist",
+                                    "Assist",
+                                    "mdi:comment-processing-outline"
+                                )
+                            )
+                        },
+                        colors = getFilledTonalButtonColors()
+                    )
                 }
             }
         }

--- a/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/views/ChooseEntityView.kt
@@ -130,11 +130,11 @@ fun ChooseEntityView(
             }
             if (expandedAppShortcuts) {
                 // HomeAssistant app shortcut
-                item {     
+                item {
                     Button(
                         modifier = Modifier
                             .fillMaxWidth(),
-                        icon = { 
+                        icon = {
                             Image(
                                 asset = CommunityMaterial.Icon2.cmd_home_assistant,
                                 colorFilter = ColorFilter.tint(Color.White)
@@ -154,11 +154,11 @@ fun ChooseEntityView(
                     )
                 }
                 // Assist shortcut
-                item {     
+                item {
                     Button(
                         modifier = Modifier
                             .fillMaxWidth(),
-                        icon = { 
+                        icon = {
                             Image(
                                 asset = CommunityMaterial.Icon.cmd_comment_processing_outline,
                                 colorFilter = ColorFilter.tint(Color.White)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This adds the option to add buttons to launch either the Companion app, or the Assist dialog to the ShortcutsTile. 
See #4550

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

Shortcut tile with newly added buttons;
<img width="267" alt="ShortcutTile" src="https://github.com/user-attachments/assets/740610e0-802a-4c18-b24c-e89d75166b03">

Config for this example;
<img width="270" alt="ShortcutTileConfig" src="https://github.com/user-attachments/assets/2b335051-2e4b-4c2c-878b-2aba0eba2b8b">

New button options are added at the bottom of the entity selection list under the `shortcuts` section;
<img width="266" alt="ShortcutActivityOptions" src="https://github.com/user-attachments/assets/a48b384c-d4ed-4d0b-8142-5243250d1d53">


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->

1. This implementation has been tested only on an AndroidStudio emulator.
2. It seems that the HA Icon included in the `CommunityMaterial.Icon` library has not yet been updated.
3. I'm not fluent in Kotlin / Android app development, so if there's any improvements to be made I'm happy to learn :)
