### PR TITLE
Add Page zoom setting

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -163,6 +163,16 @@ class SettingsFragment(
             }
         }
 
+        findPreference<ListPreference>("page_zoom")?.let {
+            // The list of percentages for iOS/Android should match
+            // https://github.com/home-assistant/iOS/blob/ff66bbf2e3f9add0abb0b492499b81e824db36ed/Sources/Shared/Settings/SettingsStore.swift#L108
+            val percentages = listOf(50, 75, 85, 100, 115, 125, 150, 175, 200)
+            it.entries = percentages.map { pct ->
+                getString(if (pct == 100) commonR.string.page_zoom_default else commonR.string.page_zoom_pct, pct)
+            }.toTypedArray()
+            it.entryValues = percentages.map { pct -> pct.toString() }.toTypedArray()
+        }
+
         findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest"
         findPreference<Preference>("manage_widgets")?.setOnPreferenceClickListener {
             parentFragmentManager.commit {

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -110,6 +110,7 @@ class SettingsPresenterImpl @Inject constructor(
         when (key) {
             "themes" -> themesManager.getCurrentTheme()
             "languages" -> langsManager.getCurrentLang()
+            "page_zoom" -> prefsRepository.getPageZoomLevel().toString()
             "screen_orientation" -> prefsRepository.getScreenOrientation()
             else -> throw IllegalArgumentException("No string found by this key: $key")
         }
@@ -120,6 +121,7 @@ class SettingsPresenterImpl @Inject constructor(
             when (key) {
                 "themes" -> themesManager.saveTheme(value)
                 "languages" -> langsManager.saveLang(value)
+                "page_zoom" -> prefsRepository.setPageZoomLevel(value?.toIntOrNull())
                 "screen_orientation" -> prefsRepository.saveScreenOrientation(value)
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -346,7 +346,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                         webView.clearHistory()
                         clearHistory = false
                     }
-                    enablePinchToZoom()
+                    setWebViewZoom()
                     if (moreInfoEntity != "" && view?.progress == 100 && isConnected) {
                         ioScope.launch {
                             val owner = "onPageFinished:$moreInfoEntity"
@@ -880,7 +880,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         appLocked = presenter.isAppLocked()
         binding.blurView.setBlurEnabled(appLocked)
 
-        enablePinchToZoom()
+        setWebViewZoom()
 
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
 
@@ -1610,7 +1610,10 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         return super.dispatchKeyEvent(event)
     }
 
-    private fun enablePinchToZoom() {
+    private fun setWebViewZoom() {
+        // Set base zoom level (percentage must be scaled to device density/percentage)
+        webView.setInitialScale((resources.displayMetrics.density * presenter.getPageZoomLevel()).toInt())
+
         // Enable pinch to zoom
         webView.settings.builtInZoomControls = presenter.isPinchToZoomEnabled()
         // Use idea from https://github.com/home-assistant/iOS/pull/1472 to filter viewport

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -30,6 +30,7 @@ interface WebViewPresenter {
 
     fun isKeepScreenOnEnabled(): Boolean
 
+    fun getPageZoomLevel(): Int
     fun isPinchToZoomEnabled(): Boolean
     fun isWebViewDebugEnabled(): Boolean
 

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -252,6 +252,10 @@ class WebViewPresenterImpl @Inject constructor(
         prefsRepository.isKeepScreenOnEnabled()
     }
 
+    override fun getPageZoomLevel(): Int = runBlocking {
+        prefsRepository.getPageZoomLevel()
+    }
+
     override fun isPinchToZoomEnabled(): Boolean = runBlocking {
         prefsRepository.isPinchToZoomEnabled()
     }

--- a/app/src/main/res/drawable/ic_zoom_in.xml
+++ b/app/src/main/res/drawable/ic_zoom_in.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="@color/colorAccent"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,10h-2v2H9v-2H7V9h2V7h1v2h2v1z" />
+</vector>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -55,6 +55,11 @@
             android:icon="@drawable/ic_phone_check"
             android:title="@string/keep_screen_on"
             android:summary="@string/keep_screen_on_def"/>
+        <ListPreference
+            android:key="page_zoom"
+            android:icon="@drawable/ic_zoom_in"
+            android:title="@string/page_zoom"
+            app:useSimpleSummaryProvider="true"/>
         <SwitchPreference
             android:key="pinch_to_zoom"
             android:icon="@drawable/ic_gesture_pinch"

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -47,6 +47,10 @@ interface PrefsRepository {
 
     suspend fun saveScreenOrientation(orientation: String?)
 
+    suspend fun getPageZoomLevel(): Int
+
+    suspend fun setPageZoomLevel(level: Int?)
+
     suspend fun isPinchToZoomEnabled(): Boolean
 
     suspend fun setPinchToZoomEnabled(enabled: Boolean)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -26,6 +26,7 @@ class PrefsRepositoryImpl @Inject constructor(
         private const val CONTROLS_PANEL_PATH = "controls_panel_path"
         private const val PREF_FULLSCREEN_ENABLED = "fullscreen_enabled"
         private const val PREF_KEEP_SCREEN_ON_ENABLED = "keep_screen_on_enabled"
+        private const val PREF_PAGE_ZOOM_LEVEL = "page_zoom_level"
         private const val PREF_PINCH_TO_ZOOM_ENABLED = "pinch_to_zoom_enabled"
         private const val PREF_AUTOPLAY_VIDEO = "autoplay_video"
         private const val PREF_ALWAYS_SHOW_FIRST_VIEW_ON_APP_START = "always_show_first_view_on_app_start"
@@ -162,6 +163,13 @@ class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setKeepScreenOnEnabled(enabled: Boolean) {
         localStorage.putBoolean(PREF_KEEP_SCREEN_ON_ENABLED, enabled)
+    }
+
+    override suspend fun getPageZoomLevel(): Int =
+        localStorage.getInt(PREF_PAGE_ZOOM_LEVEL) ?: 100
+
+    override suspend fun setPageZoomLevel(level: Int?) {
+        localStorage.putInt(PREF_PAGE_ZOOM_LEVEL, level)
     }
 
     override suspend fun isPinchToZoomEnabled(): Boolean {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -324,6 +324,9 @@
     <string name="interval_in_view">In view</string>
     <string name="keep_screen_on_def">Do not lock screen when dashboard is active</string>
     <string name="keep_screen_on">Keep screen on</string>
+    <string name="page_zoom_default">%1$d%% (default)</string>
+    <string name="page_zoom_pct">%1$d%%</string>
+    <string name="page_zoom">Page zoom</string>
     <string name="pinch_to_zoom_def">Allow pinch-to-zoom gesture to zoom app window</string>
     <string name="pinch_to_zoom">Pinch-to-zoom</string>
     <string name="label_attribute">Attribute:</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Implements #4571 - allow overriding the default WebView zoom level.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|---|---|
|![Settings row titled 'Page zoom', '100% (default', magnifying glass with plus icon, light mode](https://github.com/user-attachments/assets/52ca67fa-f58b-4494-9e13-1d4d4cc4a73f)|![Settings row titled 'Page zoom', '100% (default', magnifying glass with plus icon, dark mode](https://github.com/user-attachments/assets/b2ef94ee-a841-44e6-936e-6eef8d8b31a9)|
|![Dialog with options for 50%, 75%, 85%, 100% (default), 115%, 125%, 150%, 175%, 200% page zoom options, light mode](https://github.com/user-attachments/assets/833ffe85-07a7-4075-a74e-18b1f847f641)|![Dialog with options for 50%, 75%, 85%, 100% (default), 115%, 125%, 150%, 175%, 200% page zoom options, dark mode](https://github.com/user-attachments/assets/8b8811dc-266a-403e-93ee-89dc9c72ec7b)|

(it scales the frontend, as you can imagine)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I'm not sure we need this. There is a webview page but the same feature exists on iOS (name/values were copied) and it isn't documented.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->