### PR TITLE
Open onboarding when Assist is launched when not registered

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -21,6 +21,7 @@ import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.assist.ui.AssistSheetView
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 
@@ -68,6 +69,12 @@ class AssistActivity : BaseActivity() {
         updateShowWhenLocked()
 
         if (savedInstanceState == null) {
+            if (!viewModel.isRegistered()) {
+                startActivity(Intent(this, LaunchActivity::class.java))
+                finish()
+                return
+            }
+
             viewModel.onCreate(
                 hasPermission = hasRecordingPermission(),
                 serverId = if (intent.hasExtra(EXTRA_SERVER)) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -52,6 +52,8 @@ abstract class AssistViewModelBase(
     private var binaryHandlerId: Int? = null
     private var conversationId: String? = null
 
+    fun isRegistered(): Boolean = serverManager.isRegistered()
+
     abstract fun getInput(): AssistInputMode?
     abstract fun setInput(inputMode: AssistInputMode)
 

--- a/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -129,8 +129,6 @@ class ConversationViewModel @Inject constructor(
         return false
     }
 
-    fun isRegistered(): Boolean = serverManager.isRegistered()
-
     override fun getInput(): AssistInputMode = inputMode
 
     override fun setInput(inputMode: AssistInputMode) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
If Assist is opened (via the default assistant app shortcut), but the app is not yet registered, send the user to onboarding to skip having to close + open app manually. This matches [the app's Wear OS behavior](https://github.com/home-assistant/android/blob/2279d5d7dfb6151a0b4c3ac4ccdb60f251bc2056/wear/src/main/java/io/homeassistant/companion/android/conversation/ConversationActivity.kt#L57).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Setting HA as the assistant app while not logged in, then triggering it by holding the power button on my device:

https://github.com/user-attachments/assets/8d7ca092-e13a-4ce6-8cc2-16a439715734

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->