### PR TITLE
Prevent socket response continuation being called multiple times (#3338)

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
@@ -1,10 +1,10 @@
 package io.homeassistant.companion.android.common.data.websocket
 
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.SocketResponse
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharedFlow
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A class that holds information about messages that are currently active (sent and no response

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
@@ -4,6 +4,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.So
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.SharedFlow
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * A class that holds information about messages that are currently active (sent and no response
@@ -24,4 +25,6 @@ data class WebSocketRequest(
     val eventTimeout: Long = 0L,
     val onEvent: Channel<Any>? = null,
     var onResponse: CancellableContinuation<SocketResponse>? = null
-)
+) {
+    val hasContinuationBeenInvoked = AtomicBoolean(onResponse == null)
+}

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/WebSocketRequest.kt
@@ -26,5 +26,5 @@ data class WebSocketRequest(
     val onEvent: Channel<Any>? = null,
     var onResponse: CancellableContinuation<SocketResponse>? = null
 ) {
-    val hasContinuationBeenInvoked = AtomicBoolean(onResponse == null)
+    val hasContinuationBeenInvoked = AtomicBoolean(false)
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -707,6 +707,8 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
             it.onResponse?.let { cont ->
                 if (!it.hasContinuationBeenInvoked.getAndSet(true) && cont.isActive) {
                     cont.resumeWith(Result.success(response))
+                } else {
+                    Log.w(TAG, "Response continuation has already been invoked for ${response.id}, ${response.event}")
                 }
             }
             if (it.eventFlow == null) {
@@ -822,6 +824,8 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
                             it.value.onResponse?.let { cont ->
                                 if (!it.value.hasContinuationBeenInvoked.getAndSet(true) && cont.isActive) {
                                     cont.resumeWithException(IOException())
+                                } else {
+                                    Log.w(TAG, "Response continuation has already been invoked, skipping IOException")
                                 }
                             }
                             activeMessages.remove(it.key)

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -52,6 +52,10 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Th
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.TriggerEvent
 import io.homeassistant.companion.android.common.util.toHexString
 import io.homeassistant.companion.android.database.server.ServerUserInfo
+import java.io.IOException
+import java.util.Collections
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -80,10 +84,6 @@ import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import okio.ByteString.Companion.toByteString
-import java.io.IOException
-import java.util.Collections
-import java.util.concurrent.atomic.AtomicLong
-import kotlin.coroutines.resumeWithException
 
 class WebSocketRepositoryImpl @AssistedInject constructor(
     private val okHttpClient: OkHttpClient,
@@ -432,7 +432,7 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
             }
         }
         return synchronized(activeMessages) {
-            activeMessages.values.find { it.message == subscribeMessage }?.eventFlow    as? Flow<T>
+            activeMessages.values.find { it.message == subscribeMessage }?.eventFlow as? Flow<T>
         }
     }
 


### PR DESCRIPTION
## Summary
Prevent the crash outlined in #3338. Coroutines continuations can only be invoke once, see CancellableContinuation. Use atomic boolean to ensure the continuation is called only once in a thread safe way. While this does not fix the underlying cause it will prevent any more crashes. 

## Any other notes
We could log the stack trace whenever the continuation is invoked a second time in order to help identify where the second call comes from.