### PR TITLE
add transparent background to media widget

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -29,7 +29,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.google.android.material.color.DynamicColors
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -49,6 +49,7 @@ import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.common.ActionFieldBinder
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetDynamicFieldAdapter
+import io.homeassistant.companion.android.widgets.common.WidgetUtils
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
@@ -225,30 +226,19 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity() {
         }
 
         val buttonWidget = buttonWidgetDao.get(appWidgetId)
-
-        val backgroundTypeValues = mutableListOf(
-            getString(commonR.string.widget_background_type_daynight),
-            getString(commonR.string.widget_background_type_transparent)
-        )
-        if (DynamicColors.isDynamicColorAvailable()) {
-            backgroundTypeValues.add(0, getString(commonR.string.widget_background_type_dynamiccolor))
-        }
+        val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
         binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
 
         if (buttonWidget != null) {
             val actionText = "${buttonWidget.domain}.${buttonWidget.service}"
             binding.widgetTextConfigService.setText(actionText)
             binding.label.setText(buttonWidget.label)
-
             binding.backgroundType.setSelection(
-                when {
-                    buttonWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_dynamiccolor))
-                    buttonWidget.backgroundType == WidgetBackgroundType.TRANSPARENT ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_transparent))
-                    else ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_daynight))
-                }
+                WidgetUtils.getSelectedBackgroundOption(
+                    this,
+                    buttonWidget.backgroundType,
+                    backgroundTypeValues
+                )
             )
             binding.textColor.isVisible = buttonWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
             binding.textColorWhite.isChecked =

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetUtils.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetUtils.kt
@@ -1,0 +1,35 @@
+package io.homeassistant.companion.android.widgets.common
+
+import android.content.Context
+import com.google.android.material.color.DynamicColors
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
+
+/**
+ * Shared helpers for working with widgets.
+ */
+object WidgetUtils {
+
+    /**
+     * Create an adapter for the list of background colour options for a widget.
+     */
+    fun getBackgroundOptionList(context: Context): Array<String> {
+        val backgroundTypeValues = mutableListOf(
+            context.getString(R.string.widget_background_type_daynight),
+            context.getString(R.string.widget_background_type_transparent)
+        )
+        if (DynamicColors.isDynamicColorAvailable()) {
+            backgroundTypeValues.add(0, context.getString(R.string.widget_background_type_dynamiccolor))
+        }
+        return backgroundTypeValues.toTypedArray()
+    }
+
+    fun getSelectedBackgroundOption(context: Context, selectedType: WidgetBackgroundType, options: Array<String>) = when {
+        selectedType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
+            options.indexOf(context.getString(R.string.widget_background_type_dynamiccolor))
+        selectedType == WidgetBackgroundType.TRANSPARENT ->
+            options.indexOf(context.getString(R.string.widget_background_type_transparent))
+        else ->
+            options.indexOf(context.getString(R.string.widget_background_type_daynight))
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
@@ -22,7 +22,6 @@ import androidx.core.content.getSystemService
 import androidx.core.graphics.toColorInt
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -38,6 +37,7 @@ import io.homeassistant.companion.android.util.getHexForColor
 import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
+import io.homeassistant.companion.android.widgets.common.WidgetUtils
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -131,14 +131,7 @@ class EntityWidgetConfigureActivity : BaseWidgetConfigureActivity() {
 
         val tapActionValues = listOf(getString(commonR.string.widget_tap_action_toggle), getString(commonR.string.refresh))
         binding.tapActionList.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, tapActionValues)
-
-        val backgroundTypeValues = mutableListOf(
-            getString(commonR.string.widget_background_type_daynight),
-            getString(commonR.string.widget_background_type_transparent)
-        )
-        if (DynamicColors.isDynamicColorAvailable()) {
-            backgroundTypeValues.add(0, getString(commonR.string.widget_background_type_dynamiccolor))
-        }
+        val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
         binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
 
         if (staticWidget != null) {
@@ -175,17 +168,6 @@ class EntityWidgetConfigureActivity : BaseWidgetConfigureActivity() {
             val toggleable = entity?.domain in EntityExt.APP_PRESS_ACTION_DOMAINS
             binding.tapAction.isVisible = toggleable
             binding.tapActionList.setSelection(if (toggleable && staticWidget.tapAction == WidgetTapAction.TOGGLE) 0 else 1)
-
-            binding.backgroundType.setSelection(
-                when {
-                    staticWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_dynamiccolor))
-                    staticWidget.backgroundType == WidgetBackgroundType.TRANSPARENT ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_transparent))
-                    else ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_daynight))
-                }
-            )
             binding.textColor.visibility = if (staticWidget.backgroundType == WidgetBackgroundType.TRANSPARENT) View.VISIBLE else View.GONE
             binding.textColorWhite.isChecked =
                 staticWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, android.R.color.white) } ?: true

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidget.kt
@@ -5,6 +5,7 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -174,6 +175,10 @@ class MediaPlayerControlsWidget : BaseWidgetProvider() {
                 val title = entity?.attributes?.get("media_title")?.toString()
                 val album = entity?.attributes?.get("media_album_name")?.toString()
                 val icon = entity?.attributes?.get("icon")?.toString()
+
+                if (widget.backgroundType == WidgetBackgroundType.TRANSPARENT) {
+                    setInt(R.id.widgetLayout, "setBackgroundColor", Color.TRANSPARENT)
+                }
 
                 if ((artist != null || album != null) && title != null) {
                     setTextViewText(

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -119,7 +119,8 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
 
         val backgroundTypeValues = mutableListOf(
             getString(commonR.string.widget_background_type_dynamiccolor),
-            getString(commonR.string.widget_background_type_daynight)
+            getString(commonR.string.widget_background_type_daynight),
+            getString(commonR.string.widget_background_type_transparent)
         )
         if (DynamicColors.isDynamicColorAvailable()) {
             binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
@@ -262,6 +263,7 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
                 MediaPlayerControlsWidget.EXTRA_BACKGROUND_TYPE,
                 when (binding.backgroundType.selectedItem as String?) {
                     getString(commonR.string.widget_background_type_dynamiccolor) -> WidgetBackgroundType.DYNAMICCOLOR
+                    getString(commonR.string.widget_background_type_transparent) -> WidgetBackgroundType.TRANSPARENT
                     else -> WidgetBackgroundType.DAYNIGHT
                 }
             )

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -15,7 +15,6 @@ import android.widget.Spinner
 import android.widget.Toast
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
@@ -26,6 +25,7 @@ import io.homeassistant.companion.android.databinding.WidgetMediaControlsConfigu
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
+import io.homeassistant.companion.android.widgets.common.WidgetUtils
 import java.util.LinkedList
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -117,19 +117,8 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
 
         val mediaPlayerWidget = mediaPlayerControlsWidgetDao.get(appWidgetId)
 
-        val backgroundTypeValues = mutableListOf(
-            getString(commonR.string.widget_background_type_dynamiccolor),
-            getString(commonR.string.widget_background_type_daynight),
-            getString(commonR.string.widget_background_type_transparent)
-        )
-        if (DynamicColors.isDynamicColorAvailable()) {
-            binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
-            binding.backgroundType.setSelection(0)
-            binding.backgroundTypeParent.visibility = View.VISIBLE
-        } else {
-            binding.backgroundTypeParent.visibility = View.GONE
-        }
-
+        val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
+        binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
         if (mediaPlayerWidget != null) {
             binding.label.setText(mediaPlayerWidget.label)
             binding.widgetTextConfigEntityId.setText(mediaPlayerWidget.entityId)
@@ -137,6 +126,13 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
             binding.widgetShowSeekButtonsCheckbox.isChecked = mediaPlayerWidget.showSeek
             binding.widgetShowSkipButtonsCheckbox.isChecked = mediaPlayerWidget.showSkip
             binding.widgetShowMediaPlayerSource.isChecked = mediaPlayerWidget.showSource
+            binding.backgroundType.setSelection(
+                WidgetUtils.getSelectedBackgroundOption(
+                    this,
+                    mediaPlayerWidget.backgroundType,
+                    backgroundTypeValues
+                )
+            )
             val entities = runBlocking {
                 try {
                     mediaPlayerWidget.entityId.split(",").map { s ->
@@ -149,14 +145,6 @@ class MediaPlayerControlsWidgetConfigureActivity : BaseWidgetConfigureActivity()
                     null
                 }
             }
-            binding.backgroundType.setSelection(
-                when {
-                    mediaPlayerWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_dynamiccolor))
-                    else ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_daynight))
-                }
-            )
             if (entities != null) {
                 selectedEntities.addAll(entities)
             }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -19,7 +19,6 @@ import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
 import androidx.lifecycle.lifecycleScope
 import com.fasterxml.jackson.databind.JsonMappingException
-import com.google.android.material.color.DynamicColors
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.database.widget.TemplateWidgetDao
@@ -28,6 +27,7 @@ import io.homeassistant.companion.android.databinding.WidgetTemplateConfigureBin
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.util.getHexForColor
 import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
+import io.homeassistant.companion.android.widgets.common.WidgetUtils
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -86,13 +86,7 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
 
         val templateWidget = templateWidgetDao.get(appWidgetId)
 
-        val backgroundTypeValues = mutableListOf(
-            getString(commonR.string.widget_background_type_daynight),
-            getString(commonR.string.widget_background_type_transparent)
-        )
-        if (DynamicColors.isDynamicColorAvailable()) {
-            backgroundTypeValues.add(0, getString(commonR.string.widget_background_type_dynamiccolor))
-        }
+        val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
         binding.backgroundType.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
 
         setupServerSelect(templateWidget?.serverId)
@@ -107,16 +101,12 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
                 binding.renderedTemplate.text = getString(commonR.string.empty_template)
                 binding.addButton.isEnabled = false
             }
-
             binding.backgroundType.setSelection(
-                when {
-                    templateWidget.backgroundType == WidgetBackgroundType.DYNAMICCOLOR && DynamicColors.isDynamicColorAvailable() ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_dynamiccolor))
-                    templateWidget.backgroundType == WidgetBackgroundType.TRANSPARENT ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_transparent))
-                    else ->
-                        backgroundTypeValues.indexOf(getString(commonR.string.widget_background_type_daynight))
-                }
+                WidgetUtils.getSelectedBackgroundOption(
+                    this,
+                    templateWidget.backgroundType,
+                    backgroundTypeValues
+                )
             )
             binding.textColor.isVisible = templateWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
             binding.textColorWhite.isChecked =

--- a/app/src/main/res/layout/widget_media_controls_configure.xml
+++ b/app/src/main/res/layout/widget_media_controls_configure.xml
@@ -129,7 +129,6 @@
             android:layout_height="50dp"
             android:gravity="center"
             android:orientation="horizontal"
-            android:visibility="gone"
             tools:visibility="visible">
 
             <TextView


### PR DESCRIPTION
## Summary
Add support for the media widget to support transparent background. Particularly when nothing is playing the widget is playing it blocks a lot of the wallpaper.

## Screenshots
| Dark Theme  | Light Theme |
| ------------- | ------------- |
| ![Screenshot_20240908_192143](https://github.com/user-attachments/assets/8e0f3fee-b9ea-4c33-9ac4-d156675858c4)  | ![Screenshot_20240908_192224](https://github.com/user-attachments/assets/68803ac2-000a-4d8f-a961-1bb56d6b51b1)  |

## Any other notes
Sometimes the text might not have a high enough contrast ratio with the background.  I considered making the text colour customisable. This may require some additional (I see a number have already been defined) custom attributes for the views as `android.R.attr.textColorPrimary` doesn't appear to be available for the widget.