### PR TITLE
Add unit of measurement and device class for signal strength sensors

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -57,7 +57,7 @@ class PhoneStateSensorManager : SensorManager {
             commonR.string.basic_sensor_name_sim_1_signal_strength,
             commonR.string.sensor_description_signal_strength,
             "mdi:signal",
-            unitOfMeasurement = "dbm",
+            unitOfMeasurement = "dBm",
             deviceClass = "signal_strength",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -68,7 +68,7 @@ class PhoneStateSensorManager : SensorManager {
             commonR.string.basic_sensor_name_sim_2_signal_strength,
             commonR.string.sensor_description_signal_strength,
             "mdi:signal",
-            unitOfMeasurement = "dbm",
+            unitOfMeasurement = "dBm",
             deviceClass = "signal_strength",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/PhoneStateSensorManager.kt
@@ -57,6 +57,8 @@ class PhoneStateSensorManager : SensorManager {
             commonR.string.basic_sensor_name_sim_1_signal_strength,
             commonR.string.sensor_description_signal_strength,
             "mdi:signal",
+            unitOfMeasurement = "dbm",
+            deviceClass = "signal_strength",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )
 
@@ -66,6 +68,8 @@ class PhoneStateSensorManager : SensorManager {
             commonR.string.basic_sensor_name_sim_2_signal_strength,
             commonR.string.sensor_description_signal_strength,
             "mdi:signal",
+            unitOfMeasurement = "dbm",
+            deviceClass = "signal_strength",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC
         )
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

should've added these initially, oops
 
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

now we get graphs in the UI and the sensor is properly identified

![image](https://github.com/user-attachments/assets/4f846afa-292f-4244-b674-1f832f723510)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->