### PR TITLE
Add 2 different display sensors around various screen states

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -279,7 +279,7 @@ open class HomeAssistantApplication : Application() {
             this,
             sensorReceiver,
             IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED),
-            ContextCompat.RECEIVER_NOT_EXPORTED
+            ContextCompat.RECEIVER_EXPORTED
         )
 
         // Update widgets when the screen turns on, updates are skipped if widgets were not added

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -274,6 +274,14 @@ open class HomeAssistantApplication : Application() {
             )
         }
 
+        // Register for changes to the configuration
+        ContextCompat.registerReceiver(
+            this,
+            sensorReceiver,
+            IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
+
         // Update widgets when the screen turns on, updates are skipped if widgets were not added
         val buttonWidget = ButtonWidget()
         val entityWidget = EntityWidget()

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -130,7 +130,10 @@ class SensorReceiver : SensorReceiverBase() {
         Intent.ACTION_MANAGED_PROFILE_AVAILABLE to listOf(DevicePolicyManager.isWorkProfile.id),
         WifiManager.WIFI_STATE_CHANGED_ACTION to listOf(NetworkSensorManager.wifiState.id),
         NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to listOf(NfcSensorManager.nfcStateSensor.id),
-        Intent.ACTION_CONFIGURATION_CHANGED to listOf(DisplaySensorManager.screenOrientation.id)
+        Intent.ACTION_CONFIGURATION_CHANGED to listOf(
+            DisplaySensorManager.screenOrientation.id,
+            DisplaySensorManager.screenRotation.id
+        )
     )
 
     override fun getSensorSettingsIntent(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -130,10 +130,7 @@ class SensorReceiver : SensorReceiverBase() {
         Intent.ACTION_MANAGED_PROFILE_AVAILABLE to listOf(DevicePolicyManager.isWorkProfile.id),
         WifiManager.WIFI_STATE_CHANGED_ACTION to listOf(NetworkSensorManager.wifiState.id),
         NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to listOf(NfcSensorManager.nfcStateSensor.id),
-        Intent.ACTION_CONFIGURATION_CHANGED to listOf(
-            DisplaySensorManager.screenRotation.id,
-            DisplaySensorManager.screenOrientation.id
-        )
+        Intent.ACTION_CONFIGURATION_CHANGED to listOf(DisplaySensorManager.screenOrientation.id)
     )
 
     override fun getSensorSettingsIntent(

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -129,7 +129,11 @@ class SensorReceiver : SensorReceiverBase() {
         Intent.ACTION_MANAGED_PROFILE_UNAVAILABLE to listOf(DevicePolicyManager.isWorkProfile.id),
         Intent.ACTION_MANAGED_PROFILE_AVAILABLE to listOf(DevicePolicyManager.isWorkProfile.id),
         WifiManager.WIFI_STATE_CHANGED_ACTION to listOf(NetworkSensorManager.wifiState.id),
-        NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to listOf(NfcSensorManager.nfcStateSensor.id)
+        NfcAdapter.ACTION_ADAPTER_STATE_CHANGED to listOf(NfcSensorManager.nfcStateSensor.id),
+        Intent.ACTION_CONFIGURATION_CHANGED to listOf(
+            DisplaySensorManager.screenRotation.id,
+            DisplaySensorManager.screenOrientation.id
+        )
     )
 
     override fun getSensorSettingsIntent(

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
@@ -201,15 +201,19 @@ class DisplaySensorManager : SensorManager, SensorEventListener {
 
         val display = getRotationString(dm.getDisplay(Display.DEFAULT_DISPLAY).rotation)
 
-        val hasMultipleDisplays = dm.displays.size > 1
         val multiple = dm.displays.associate { it.name to getRotationString(it.rotation) }
-
+        val possibleStates = listOf("0", "90", "180", "270")
+        val attrs = if (dm.displays.size > 1) {
+            multiple.plus("options" to possibleStates)
+        } else {
+            mapOf("options" to possibleStates)
+        }
         onSensorUpdated(
             context,
             screenRotation,
             display,
             screenRotation.statelessIcon,
-            if (hasMultipleDisplays) multiple else mapOf()
+            attrs
         )
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
@@ -1,27 +1,18 @@
 package io.homeassistant.companion.android.common.sensors
 
 import android.content.Context
-import android.content.pm.PackageManager.FEATURE_SENSOR_ACCELEROMETER
 import android.content.res.Configuration
-import android.hardware.Sensor
-import android.hardware.SensorEvent
-import android.hardware.SensorEventListener
-import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
 import android.hardware.display.DisplayManager
 import android.provider.Settings
 import android.util.Log
 import android.view.Display
 import android.view.Surface
-import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 
-class DisplaySensorManager : SensorManager, SensorEventListener {
+class DisplaySensorManager : SensorManager {
     companion object {
         private const val TAG = "DisplaySensors"
-        private var hasAccelerometer = false
-        private var isListenerRegistered = false
-        private var listenerLastRegistered = 0
 
         val screenBrightness = SensorManager.BasicSensor(
             "screen_brightness",
@@ -60,26 +51,13 @@ class DisplaySensorManager : SensorManager, SensorEventListener {
             docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-rotation-sensor",
             unitOfMeasurement = "°"
         )
-
-        val isFaceDownOrUp = SensorManager.BasicSensor(
-            "is_face_down_or_up",
-            "sensor",
-            commonR.string.sensor_name_is_face_down_or_up,
-            commonR.string.sensor_description_is_face_down_or_up,
-            "mdi:hand-pointing-down",
-            docsLink = "https://companion.home-assistant.io/docs/core/sensors#is-face-down-or-up-sensor"
-        )
     }
+
     override val name: Int
         get() = commonR.string.sensor_name_display_sensors
 
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        hasAccelerometer = context.packageManager.hasSystemFeature(FEATURE_SENSOR_ACCELEROMETER)
-        return if (hasAccelerometer) {
-            listOf(screenBrightness, screenOffTimeout, screenOrientation, screenRotation, isFaceDownOrUp)
-        } else {
-            listOf(screenBrightness, screenOffTimeout, screenOrientation, screenRotation)
-        }
+        return listOf(screenBrightness, screenOffTimeout, screenOrientation, screenRotation)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -90,20 +68,13 @@ class DisplaySensorManager : SensorManager, SensorEventListener {
         return "https://companion.home-assistant.io/docs/core/sensors#display-sensors"
     }
 
-    private lateinit var latestContext: Context
-    private lateinit var mySensorManager: android.hardware.SensorManager
-
     override fun requestSensorUpdate(
         context: Context
     ) {
-        latestContext = context
         updateScreenBrightness(context)
         updateScreenTimeout(context)
         updateScreenOrientation(context)
         updateScreenRotation(context)
-        if (hasAccelerometer) {
-            updateIsFaceDownOrUp(context)
-        }
     }
 
     private fun updateScreenBrightness(context: Context) {
@@ -215,67 +186,6 @@ class DisplaySensorManager : SensorManager, SensorEventListener {
             screenRotation.statelessIcon,
             attrs
         )
-    }
-
-    private fun updateIsFaceDownOrUp(context: Context) {
-        if (!isEnabled(context, isFaceDownOrUp)) {
-            return
-        }
-        val now = System.currentTimeMillis()
-        if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
-            Log.d(TAG, "Re-registering listener as it appears to be stuck")
-            mySensorManager.unregisterListener(this)
-            isListenerRegistered = false
-        }
-        mySensorManager = latestContext.getSystemService()!!
-
-        val accelerometerSensor = mySensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
-        if (accelerometerSensor != null && !isListenerRegistered) {
-            mySensorManager.registerListener(
-                this,
-                accelerometerSensor,
-                SENSOR_DELAY_NORMAL
-            )
-            Log.d(TAG, "Accelerometer sensor listener registered")
-            isListenerRegistered = true
-            listenerLastRegistered = now.toInt()
-        }
-    }
-
-    override fun onSensorChanged(event: SensorEvent?) {
-        if (event?.sensor?.type == Sensor.TYPE_ACCELEROMETER) {
-            // Following the example from: https://developer.android.com/reference/android/hardware/SensorEvent#values
-            // When the device is lying flat with the screen down the value is inverted
-            val state = when {
-                event.values[2] < -9 -> "down"
-                event.values[2] > 9 -> "up"
-                else -> STATE_UNKNOWN
-            }
-            val icon = when (state) {
-                "down" -> "mdi:hand-pointing-down"
-                "up" -> "mdi:hand-pointing-up"
-                else -> "mdi:crosshairs-question"
-            }
-            onSensorUpdated(
-                latestContext,
-                isFaceDownOrUp,
-                state,
-                icon,
-                mapOf(
-                    "x" to event.values[0],
-                    "y" to event.values[1],
-                    "z" to event.values[2]
-                )
-            )
-        }
-
-        mySensorManager.unregisterListener(this)
-        Log.d(TAG, "Accelerometer sensor listener unregistered")
-        isListenerRegistered = false
-    }
-
-    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
-        // No op
     }
 
     private fun getRotationString(rotate: Int): String = when (rotate) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
@@ -186,7 +186,9 @@ class DisplaySensorManager : SensorManager, SensorEventListener {
             screenOrientation,
             orientation,
             icon,
-            mapOf()
+            mapOf(
+                "options" to listOf("portrait", "landscape", "square", STATE_UNKNOWN)
+            )
         )
     }
 

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/DisplaySensorManager.kt
@@ -1,13 +1,24 @@
 package io.homeassistant.companion.android.common.sensors
 
 import android.content.Context
+import android.content.res.Configuration
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager.SENSOR_DELAY_NORMAL
 import android.provider.Settings
 import android.util.Log
+import android.view.Surface
+import android.view.WindowManager
+import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 
-class DisplaySensorManager : SensorManager {
+class DisplaySensorManager : SensorManager, SensorEventListener {
     companion object {
-        private const val TAG = "ScreenBrightness"
+        private const val TAG = "DisplaySensors"
+        private var isListenerRegistered = false
+        private var listenerLastRegistered = 0
 
         val screenBrightness = SensorManager.BasicSensor(
             "screen_brightness",
@@ -26,23 +37,63 @@ class DisplaySensorManager : SensorManager {
             "mdi:cellphone-off",
             docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-off-timeout-sensor"
         )
+
+        val screenOrientation = SensorManager.BasicSensor(
+            "screen_orientation",
+            "sensor",
+            commonR.string.sensor_name_screen_orientation,
+            commonR.string.sensor_description_screen_orientation,
+            "mdi:screen-rotation",
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-orientation-sensor",
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+        )
+
+        val screenRotation = SensorManager.BasicSensor(
+            "screen_rotation",
+            "sensor",
+            commonR.string.sensor_name_screen_rotation,
+            commonR.string.sensor_description_screen_rotation,
+            "mdi:screen-rotation",
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#screen-rotation-sensor",
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+        )
+
+        val isFaceDown = SensorManager.BasicSensor(
+            "is_face_down",
+            "binary_sensor",
+            commonR.string.sensor_name_is_face_down,
+            commonR.string.sensor_description_is_face_down,
+            "mdi:hand-pointing-down",
+            docsLink = "https://companion.home-assistant.io/docs/core/sensors#is-face-down-sensor"
+        )
     }
     override val name: Int
         get() = commonR.string.sensor_name_display_sensors
 
     override suspend fun getAvailableSensors(context: Context): List<SensorManager.BasicSensor> {
-        return listOf(screenBrightness, screenOffTimeout)
+        return listOf(screenBrightness, screenOffTimeout, screenOrientation, screenRotation, isFaceDown)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
         return emptyArray()
     }
 
+    override fun docsLink(): String {
+        return "https://companion.home-assistant.io/docs/core/sensors#display-sensors"
+    }
+
+    private lateinit var latestContext: Context
+    private lateinit var mySensorManager: android.hardware.SensorManager
+
     override fun requestSensorUpdate(
         context: Context
     ) {
+        latestContext = context
         updateScreenBrightness(context)
         updateScreenTimeout(context)
+        updateScreenOrientation(context)
+        updateScreenRotation(context)
+        updateIsFaceDown(context)
     }
 
     private fun updateScreenBrightness(context: Context) {
@@ -97,5 +148,105 @@ class DisplaySensorManager : SensorManager {
             screenOffTimeout.statelessIcon,
             mapOf()
         )
+    }
+
+    private fun updateScreenOrientation(context: Context) {
+        if (!isEnabled(context, screenOrientation)) {
+            return
+        }
+
+        @Suppress("DEPRECATION")
+        val orientation = when (context.resources.configuration.orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> "portrait"
+            Configuration.ORIENTATION_LANDSCAPE -> "landscape"
+            Configuration.ORIENTATION_SQUARE -> "square"
+            Configuration.ORIENTATION_UNDEFINED -> STATE_UNKNOWN
+            else -> STATE_UNKNOWN
+        }
+
+        val icon = when (orientation) {
+            "portrait" -> "mdi:phone-rotate-portrait"
+            "landscape" -> "mdi:phone-rotate-landscape"
+            "square" -> "mdi:crop-square"
+            else -> screenOrientation.statelessIcon
+        }
+
+        onSensorUpdated(
+            context,
+            screenOrientation,
+            orientation,
+            icon,
+            mapOf()
+        )
+    }
+
+    private fun updateScreenRotation(context: Context) {
+        if (!isEnabled(context, screenRotation)) {
+            return
+        }
+
+        val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+        @Suppress("DEPRECATION")
+        val display = when (wm.defaultDisplay.rotation) {
+            Surface.ROTATION_0 -> "0°"
+            Surface.ROTATION_90 -> "90°"
+            Surface.ROTATION_180 -> "180°"
+            Surface.ROTATION_270 -> "270°"
+            else -> STATE_UNKNOWN
+        }
+
+        onSensorUpdated(
+            context,
+            screenRotation,
+            display,
+            screenRotation.statelessIcon,
+            mapOf()
+        )
+    }
+
+    private fun updateIsFaceDown(context: Context) {
+        if (!isEnabled(context, isFaceDown)) {
+            return
+        }
+        val now = System.currentTimeMillis()
+        if (listenerLastRegistered + SensorManager.SENSOR_LISTENER_TIMEOUT < now && isListenerRegistered) {
+            Log.d(TAG, "Re-registering listener as it appears to be stuck")
+            mySensorManager.unregisterListener(this)
+            isListenerRegistered = false
+        }
+        mySensorManager = latestContext.getSystemService()!!
+
+        val accelerometerSensor = mySensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        if (accelerometerSensor != null && !isListenerRegistered) {
+            mySensorManager.registerListener(
+                this,
+                accelerometerSensor,
+                SENSOR_DELAY_NORMAL
+            )
+            Log.d(TAG, "Accelerometer sensor listener registered")
+            isListenerRegistered = true
+            listenerLastRegistered = now.toInt()
+        }
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type == Sensor.TYPE_ACCELEROMETER) {
+            onSensorUpdated(
+                latestContext,
+                isFaceDown,
+                event.values[2] < -9,
+                isFaceDown.statelessIcon,
+                mapOf()
+            )
+        }
+
+        mySensorManager.unregisterListener(this)
+        Log.d(TAG, "Accelerometer sensor listener unregistered")
+        isListenerRegistered = false
+    }
+
+    override fun onAccuracyChanged(p0: Sensor?, p1: Int) {
+        // No op
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1283,10 +1283,10 @@
     <string name="basic_sensor_name_sim_1_data_network_type">Data network type (SIM 1)</string>
     <string name="basic_sensor_name_sim_2_data_network_type">Data network type (SIM 2)</string>
     <string name="sensor_description_data_network_type">The radio technology (network type) currently in use on the device for data transmission</string>
-    <string name="sensor_name_screen_orientation">Screen Orientation</string>
+    <string name="sensor_name_screen_orientation">Screen orientation</string>
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
-    <string name="sensor_name_screen_rotation">Screen Rotation</string>
+    <string name="sensor_name_screen_rotation">Screen rotation</string>
     <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation</string>
-    <string name="sensor_name_is_face_down">Is Face Down</string>
+    <string name="sensor_name_is_face_down">Is face down</string>
     <string name="sensor_description_is_face_down">If the device screen is facing down at the ground</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1283,4 +1283,10 @@
     <string name="basic_sensor_name_sim_1_data_network_type">Data network type (SIM 1)</string>
     <string name="basic_sensor_name_sim_2_data_network_type">Data network type (SIM 2)</string>
     <string name="sensor_description_data_network_type">The radio technology (network type) currently in use on the device for data transmission</string>
+    <string name="sensor_name_screen_orientation">Screen Orientation</string>
+    <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
+    <string name="sensor_name_screen_rotation">Screen Rotation</string>
+    <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation</string>
+    <string name="sensor_name_is_face_down">Is Face Down</string>
+    <string name="sensor_description_is_face_down">If the device screen is facing down at the ground</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1287,6 +1287,6 @@
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
     <string name="sensor_name_screen_rotation">Screen rotation</string>
     <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation. If the device has multiple displays the state will be for the default display. Attributes will exist for additional detected displays with the display name and its rotation angle.</string>
-    <string name="sensor_name_is_face_down">Is face down</string>
-    <string name="sensor_description_is_face_down">If the device screen is facing down at the ground</string>
+    <string name="sensor_name_is_face_down_or_up">Is face down or up</string>
+    <string name="sensor_description_is_face_down_or_up">If the device screen is facing down at the ground, up at the air or unknown</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1286,7 +1286,7 @@
     <string name="sensor_name_screen_orientation">Screen orientation</string>
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
     <string name="sensor_name_screen_rotation">Screen rotation</string>
-    <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation</string>
+    <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation. If the device has multiple displays the state will be for the default display. Attributes will exist for additional detected displays with the display name and its rotation angle.</string>
     <string name="sensor_name_is_face_down">Is face down</string>
     <string name="sensor_description_is_face_down">If the device screen is facing down at the ground</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1287,6 +1287,4 @@
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
     <string name="sensor_name_screen_rotation">Screen rotation</string>
     <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation. If the device has multiple displays the state will be for the default display. Attributes will exist for additional detected displays with the display name and its rotation angle.</string>
-    <string name="sensor_name_is_face_down_or_up">Is face down or up</string>
-    <string name="sensor_description_is_face_down_or_up">If the device screen is facing down at the ground, up at the air or unknown</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1286,5 +1286,5 @@
     <string name="sensor_name_screen_orientation">Screen orientation</string>
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
     <string name="sensor_name_screen_rotation">Screen rotation</string>
-    <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation. If the device has multiple displays the state will be for the default display. Attributes will exist for additional detected displays with the display name and its rotation angle.</string>
+    <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #2440 by adding 2 different sensors to capture the various states.

- Orientation sensor - Displays orientation typically portrait vs landscape
- Rotation sensor - Displays device rotation degree angle based on the natural orientation (i.e. a phone will be portrait 0 while a tablet will be landscape 0)

2 different sensors because the states can all be independent of each other.

Originally I tried to be fancy with reverse portrait states however I realized the angles are dependent on the device in question and theres too much for account for when you consider all the different types of screens like on a watch, car etc...

The intent that is added only fires while the screen is on and if the screen has to redraw teh UI so battery impact is very minimal  here.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->


![image](https://github.com/user-attachments/assets/2e71b183-8825-414d-a63c-b4af0338b24f)


## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1102

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
