### PR TITLE
Fire an event when a navigation entity is selected while driving

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
@@ -118,6 +118,14 @@ class MapVehicleScreen(
                         )
                         .setOnClickListener {
                             Log.i(TAG, "${pair.first.entityId} clicked")
+                            lifecycleScope.launch {
+                                integrationRepository.fireEvent(
+                                    "android.navigation_started",
+                                    mapOf(
+                                        "entity_id" to pair.first.entityId
+                                    )
+                                )
+                            }
                             val intent = Intent(
                                 CarContext.ACTION_NAVIGATE,
                                 Uri.parse("geo:${pair.second[0]},${pair.second[1]}")


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes: #4315 by adding a new event `android.navigation_started` which only occurs for navigation entities in the driving interface.

which provides the following example event data:

```
event_type: android.navigation_started
data:
  entity_id: zone.test
  device_id: DEVICE_ID
origin: REMOTE
time_fired: "2024-09-13T23:10:24.304583+00:00"
context:
  id: ID
  parent_id: null
  user_id: USER_ID

```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#pending

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->