### PR TITLE
Correct null check to avoid errors in pip

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1187,16 +1187,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         newConfig: Configuration
     ) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
-        if (exoPlayerView.visibility != View.VISIBLE) {
+        if (exoPlayerView.visibility != View.VISIBLE && decor.getChildAt(3) != null) {
             if (isInPictureInPictureMode) {
                 (decor.getChildAt(3) as FrameLayout).layoutParams.height =
                     FrameLayout.LayoutParams.MATCH_PARENT
                 decor.requestLayout()
             } else {
-                if (decor.getChildAt(3) != null) {
-                    (decor.getChildAt(3) as FrameLayout).layoutParams.height = videoHeight
-                    decor.requestLayout()
-                }
+                (decor.getChildAt(3) as FrameLayout).layoutParams.height = videoHeight
+                decor.requestLayout()
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Fixes the below play console error by applying the null check to the entire condition.

```
Exception java.lang.NullPointerException: null cannot be cast to non-null type android.widget.FrameLayout
  at io.homeassistant.companion.android.webview.WebViewActivity.onPictureInPictureModeChanged (WebViewActivity.kt:1192)
  at android.app.Activity.dispatchPictureInPictureModeChanged (Activity.java:9320)
  at android.app.ActivityThread.handleWindowingModeChangeIfNeeded (ActivityThread.java:6799)
  at android.app.ActivityThread.performActivityConfigurationChanged (ActivityThread.java:6599)
  at android.app.ActivityThread.performConfigurationChangedForActivity (ActivityThread.java:6574)
  at android.app.ActivityThread.handleActivityConfigurationChanged (ActivityThread.java:6966)
  at android.app.ActivityThread.handleActivityConfigurationChanged (ActivityThread.java:6899)
  at android.app.servertransaction.ActivityConfigurationChangeItem.execute (ActivityConfigurationChangeItem.java:55)
  at android.app.servertransaction.ActivityTransactionItem.execute (ActivityTransactionItem.java:45)
  at android.app.servertransaction.TransactionExecutor.executeCallbacks (TransactionExecutor.java:139)
  at android.app.servertransaction.TransactionExecutor.execute (TransactionExecutor.java:96)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2685)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:8919)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:578)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
I have not been able to reproduce this but this should avoid the crash as the check should've been applied to the entire condition.