### PR TITLE
Allow only spaces SSID when configuring home network wifi (#3354)

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
@@ -59,7 +59,7 @@ class SsidViewModel @Inject constructor(
      * @return `true` if the SSID was successfully added
      */
     fun addHomeWifiSsid(ssid: String): Boolean {
-        if (ssid.isBlank()) return false
+        if (ssid.isEmpty()) return false
         setHomeWifiSsids((wifiSsids + ssid).sorted())
         return true
     }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidViewModel.kt
@@ -59,8 +59,8 @@ class SsidViewModel @Inject constructor(
      * @return `true` if the SSID was successfully added
      */
     fun addHomeWifiSsid(ssid: String): Boolean {
-        if (ssid.isBlank() || wifiSsids.any { it == ssid.trim() }) return false
-        setHomeWifiSsids((wifiSsids + ssid.trim()).sorted())
+        if (ssid.isBlank()) return false
+        setHomeWifiSsids((wifiSsids + ssid).sorted())
         return true
     }
 


### PR DESCRIPTION
As for issue #3354 this changes allow the use of just spaces in wifi ssid