### PR TITLE
Hide Favorites header if favorites-only

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/MainView.kt
@@ -64,7 +64,7 @@ fun MainView(
 
     WearAppTheme {
         ThemeLazyColumn {
-            if (favoriteEntityIds.isNotEmpty()) {
+            if (favoriteEntityIds.isNotEmpty() && !mainViewModel.isFavoritesOnly) {
                 item {
                     ExpandableListHeader(
                         string = stringResource(commonR.string.favorites),


### PR DESCRIPTION
## Summary
If favorites-only is on, then favorites is the only thing we'll show, so there's no need to show the "Favorites" header

## Screenshots
Sorry, I don't have Android Studio set up.

## Any other notes
N/A