### PR TITLE
Fix data URI download notification on Android 14+

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/DataUriDownloadManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/DataUriDownloadManager.kt
@@ -60,7 +60,7 @@ object DataUriDownloadManager {
                     context,
                     0,
                     sendIntent,
-                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
                 )
             )
         } else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes the following crash for data URI downloads (= automation traces from frontend) on Android 14+ devices. The download itself actually still works, but the app crashes when creating a notification to tell you it's done. I've done a quick check and think this is the only instance of an implicit intent that was mutable.

```
2024-10-02 20:01:23.453 12827-12827 AndroidRuntime          io....stant.companion.android.debug  E  FATAL EXCEPTION: main
                                                                                                    Process: io.homeassistant.companion.android.debug, PID: 12827
                                                                                                    java.lang.IllegalArgumentException: io.homeassistant.companion.android.debug: Targeting U+ (version 34 and above) disallows creating or retrieving a PendingIntent with FLAG_MUTABLE, an implicit Intent within and without FLAG_NO_CREATE and FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT for security reasons. To retrieve an already existing PendingIntent, use FLAG_NO_CREATE, however, to create a new PendingIntent with an implicit Intent use FLAG_IMMUTABLE.
                                                                                                    	at android.os.Parcel.createExceptionOrNull(Parcel.java:3187)
                                                                                                    	at android.os.Parcel.createException(Parcel.java:3167)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3150)
                                                                                                    	at android.os.Parcel.readException(Parcel.java:3092)
                                                                                                    	at android.app.IActivityManager$Stub$Proxy.getIntentSenderWithFeature(IActivityManager.java:6767)
                                                                                                    	at android.app.PendingIntent.getActivityAsUser(PendingIntent.java:582)
                                                                                                    	at android.app.PendingIntent.getActivity(PendingIntent.java:563)
                                                                                                    	at android.app.PendingIntent.getActivity(PendingIntent.java:527)
                                                                                                    	at io.homeassistant.companion.android.util.DataUriDownloadManager.saveDataUri(DataUriDownloadManager.kt:59)
                                                                                                    	at io.homeassistant.companion.android.util.DataUriDownloadManager$saveDataUri$1.invokeSuspend(Unknown Source:15)
                                                                                                    	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
                                                                                                    	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
                                                                                                    	at android.os.Handler.handleCallback(Handler.java:959)
                                                                                                    	at android.os.Handler.dispatchMessage(Handler.java:100)
                                                                                                    	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                                    	at android.os.Looper.loop(Looper.java:317)
                                                                                                    	at android.app.ActivityThread.main(ActivityThread.java:8592)
                                                                                                    	at java.lang.reflect.Method.invoke(Native Method)
                                                                                                    	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                                    	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
                                                                                                    	Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@8d4c760, Dispatchers.Main.immediate]
                                                                                                    Caused by: android.os.RemoteException: Remote stack trace:
                                                                                                    	at com.android.server.am.ActivityManagerService.getIntentSenderWithFeatureAsApp(ActivityManagerService.java:5479)
                                                                                                    	at com.android.server.am.ActivityManagerService.getIntentSenderWithFeature(ActivityManagerService.java:5422)
                                                                                                    	at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:3349)
                                                                                                    	at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:2822)
                                                                                                    	at android.os.Binder.execTransactInternal(Binder.java:1505)
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->