### PR TITLE
Breaking change: Improve sensor mobile_data

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/MobileDataManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/MobileDataManager.kt
@@ -34,6 +34,7 @@ class MobileDataManager : SensorManager {
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#mobile-data-sensors"
     }
+
     override val name: Int
         get() = commonR.string.sensor_name_mobile_data
 
@@ -42,7 +43,7 @@ class MobileDataManager : SensorManager {
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
-        return if (sensorId == mobileDataRoaming.id) {
+        return if (sensorId == mobileDataRoaming.id || Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             arrayOf(Manifest.permission.READ_PHONE_STATE)
         } else {
             arrayOf()
@@ -75,6 +76,8 @@ class MobileDataManager : SensorManager {
         if (telephonyManager?.simState == TelephonyManager.SIM_STATE_READY) {
             enabled = if (sensor.id == mobileDataRoaming.id && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 telephonyManager.isDataRoamingEnabled
+            } else if (sensor.id == mobileDataState.id && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                telephonyManager.isDataEnabled
             } else {
                 getInt(context.contentResolver, settingKey, 0) == 1
             }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
Improve gathering data for sensor mobile_data. 
The currently used API for the mobile_data sensor is marked as  ```@UnsupportedAppUsage``` and is therefore not supported on newer devices (e.g. Pixel 9).
As of SDK 26 there is an API ```TelephonyManager#isDataEnabled``` that is supported on all devices.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Frontend not affected due to this change.

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#435
The existing documentation introduced with above pull request is still fully valid.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->