### PR TITLE
Add energy device class to (kilo)calories sensors

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -31,6 +31,7 @@ class HealthConnectSensorManager : SensorManager {
             commonR.string.basic_sensor_name_active_calories_burned,
             commonR.string.sensor_description_active_calories_burned,
             "mdi:fire",
+            "energy",
             unitOfMeasurement = "kcal",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.WORKER
@@ -43,6 +44,7 @@ class HealthConnectSensorManager : SensorManager {
             commonR.string.basic_sensor_name_total_calories_burned,
             commonR.string.sensor_description_total_calories_burned,
             "mdi:fire",
+            "energy",
             unitOfMeasurement = "kcal",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.WORKER

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -704,6 +704,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         val canRegisterDeviceClassDistance = server.version?.isAtLeast(2022, 10, 0) == true
         val canRegisterNullProperties = server.version?.isAtLeast(2023, 2, 0) == true
         val canRegisterDeviceClassEnum = server.version?.isAtLeast(2023, 1, 0) == true
+        val canRegisterDeviceClassEnergyCalories = server.version?.isAtLeast(2024, 10, 0) == true
 
         val registrationData = SensorRegistrationRequest(
             sensorRegistration.uniqueId,
@@ -721,6 +722,13 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
             when (sensorRegistration.deviceClass) {
                 "distance" -> if (canRegisterDeviceClassDistance) sensorRegistration.deviceClass else null
                 "enum" -> if (canRegisterDeviceClassEnum) sensorRegistration.deviceClass else null
+                "energy" -> if (
+                    canRegisterDeviceClassEnergyCalories || sensorRegistration.unitOfMeasurement !in listOf("cal", "kcal")
+                ) {
+                    sensorRegistration.deviceClass
+                } else {
+                    null
+                }
                 else -> sensorRegistration.deviceClass
             },
             sensorRegistration.unitOfMeasurement,

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/HealthServicesSensorManager.kt
@@ -70,7 +70,8 @@ class HealthServicesSensorManager : SensorManager {
             commonR.string.sensor_name_daily_calories,
             commonR.string.sensor_description_daily_calories,
             "mdi:fire",
-            unitOfMeasurement = "kcal",
+            "energy",
+            unitOfMeasurement = "cal",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
             updateType = SensorManager.BasicSensor.UpdateType.WORKER
         )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Add energy device class to sensors which report calories, which was[ added in core 2024.10](https://www.home-assistant.io/blog/2024/10/02/release-202410/#:~:text=We%20now%20have%20a%20new%20unit%20of%20measurement%20for%20energy%20entities%3A%20calories.)
 - Fix Wear daily calories [unit](https://developer.android.com/reference/kotlin/androidx/health/services/client/data/DataType#CALORIES_DAILY()) - it looks like core will just accept the new unit without messing up the history

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->