### PR TITLE
Skip weight records update if empty

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -123,6 +123,9 @@ class HealthConnectSensorManager : SensorManager {
             pageSize = 1
         )
         val response = runBlocking { healthConnectClient.readRecords(weightRequest) }
+        if (response.records.isEmpty()) {
+            return
+        }
         onSensorUpdated(
             context,
             weight,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Noticed that before I got my scale there was an error because we had no records, so like the active calorie sensor we will return if there is no data to avoid the error. I dont have the old error anymore because I now have records.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->