### PR TITLE
Migrate setup-java action to use Temurin (two more)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4.4.0
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
 
       - uses: actions/cache@v4
@@ -88,7 +88,7 @@ jobs:
     - name: Set up JDK 17
       uses: actions/setup-java@v4.4.0
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '17'
 
     - name: Setup Gradle


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
GitHub Actions is currently failing for steps:
```yml
name: Set up JDK 17
uses: actions/setup-java@v4.4.0
with:
  distribution: 'adopt'
  java-version: '17'
```
with:
```
Run actions/setup-java@v4.4.0
Installed distributions
  Trying to resolve the latest version from remote
  Error: Could not find satisfied version for SemVer '17'. 
```

These were migrated to use a supported distribution in #3172 but it looks like we missed two jobs. This PR fixes that. (The failure is probably temporary but still a good idea to migrate those as well.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->