### PR TITLE
Fix leading zero handling in toJsonType method

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -196,16 +196,22 @@ class WidgetDynamicFieldAdapter(
             return jsonArray.toList()
         }
 
-        // Check if the string starts with a leading zero
-        if (this.trim().startsWith("0") && this.trim().length > 1) {
-            return this.trim() // Treat it as a string to preserve leading zeros
-        }
-
-        // Parse the base types
         this.trim().let { trimmedStr ->
+            // Check if the string is a double (e.g., 0.5)
+            trimmedStr.toDoubleOrNull()?.let {
+                return it
+            }
+
+            // Check if the string starts with a leading zero (but not a decimal number)
+            if (trimmedStr.startsWith("0") && trimmedStr.length > 1 && trimmedStr.toIntOrNull() != null) {
+                return this.trim() // Treat it as a string to preserve leading zeros
+            }
+
+            // Parse the base types
             trimmedStr.toIntOrNull()?.let { return it }
-            trimmedStr.toDoubleOrNull()?.let { return it }
             trimmedStr.toBooleanOrNull()?.let { return it }
+
+            // If none of the above, return the string as-is
             return this
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -195,12 +195,12 @@ class WidgetDynamicFieldAdapter(
 
             return jsonArray.toList()
         }
-        
+
         // Check if the string starts with a leading zero
         if (this.trim().startsWith("0") && this.trim().length > 1) {
             return this.trim() // Treat it as a string to preserve leading zeros
         }
-        
+
         // Parse the base types
         this.trim().let { trimmedStr ->
             trimmedStr.toIntOrNull()?.let { return it }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -195,7 +195,12 @@ class WidgetDynamicFieldAdapter(
 
             return jsonArray.toList()
         }
-
+        
+        // Check if the string starts with a leading zero
+        if (this.trim().startsWith("0") && this.trim().length > 1) {
+            return this.trim() // Treat it as a string to preserve leading zeros
+        }
+        
         // Parse the base types
         this.trim().let { trimmedStr ->
             trimmedStr.toIntOrNull()?.let { return it }

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/common/WidgetDynamicFieldAdapter.kt
@@ -197,19 +197,24 @@ class WidgetDynamicFieldAdapter(
         }
 
         this.trim().let { trimmedStr ->
-            // Check if the string is a double (e.g., 0.5)
-            trimmedStr.toDoubleOrNull()?.let {
-                return it
+            // Check if the string exactly equals "0"
+            if (trimmedStr == "0") {
+                return 0 // Return as Int
             }
 
             // Check if the string starts with a leading zero (but not a decimal number)
-            if (trimmedStr.startsWith("0") && trimmedStr.length > 1 && trimmedStr.toIntOrNull() != null) {
-                return this.trim() // Treat it as a string to preserve leading zeros
+            if (trimmedStr.startsWith("0") && trimmedStr.length > 1) {
+                if (trimmedStr.matches(Regex("0\\.\\d+"))) {
+                    // If the string starts with 0 and contains a point followed by valid digits, return as Double
+                    return trimmedStr.toDoubleOrNull() // could return null
+                }
+                return trimmedStr // Treat it as a string to preserve leading zeros
             }
 
             // Parse the base types
-            trimmedStr.toIntOrNull()?.let { return it }
-            trimmedStr.toBooleanOrNull()?.let { return it }
+            trimmedStr.toIntOrNull()?.let { return it } // Check for Integer first
+            trimmedStr.toDoubleOrNull()?.let { return it } // Then check for Double
+            trimmedStr.toBooleanOrNull()?.let { return it } // Then check for Boolean
 
             // If none of the above, return the string as-is
             return this


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
- Added a check in the `toJsonType` method to preserve leading zeros in strings.
- This ensures that strings starting with a leading zero are treated as strings rather than numbers, preventing unwanted data conversion.