### PR TITLE
Add car speed sensor

### DIFF
--- a/app/src/full/AndroidManifest.xml
+++ b/app/src/full/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-sdk tools:overrideLibrary="com.google.android.gms.threadnetwork" />
     <uses-permission android:name="com.google.android.gms.permission.CAR_FUEL" />
     <uses-permission android:name="com.google.android.gms.permission.CAR_MILEAGE" />
+    <uses-permission android:name="com.google.android.gms.permission.CAR_SPEED" />
 <!--    <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />-->
 <!--    <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />-->
 <!--    <uses-permission android:name="android.permission.health.READ_WEIGHT" />-->

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -5,7 +5,6 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
 import androidx.annotation.RequiresApi
-import androidx.car.app.hardware.common.CarUnit
 import androidx.car.app.hardware.common.CarValue
 import androidx.car.app.hardware.info.EnergyLevel
 import androidx.car.app.hardware.info.EnergyProfile
@@ -521,8 +520,7 @@ class CarSensorManager :
                 if (speedStatus == "success") data.displaySpeedMetersPerSecond.value!! else STATE_UNKNOWN,
                 carSpeed.sensor.statelessIcon,
                 mapOf(
-                    "status" to speedStatus,
-                    "display_unit" to getSpeedUnit(data.speedDisplayUnit.value)
+                    "status" to speedStatus
                 ),
                 forceUpdate = true
             )
@@ -553,9 +551,5 @@ class CarSensorManager :
             evConnectorList += evTypeMap.getOrDefault(it, STATE_UNKNOWN)
         }
         return evConnectorList.toString()
-    }
-
-    private fun getSpeedUnit(value: Int?): String {
-        return if (value != null) CarUnit.toString(value) else STATE_UNKNOWN
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/CarSensorManager.kt
@@ -522,7 +522,6 @@ class CarSensorManager :
                 carSpeed.sensor.statelessIcon,
                 mapOf(
                     "status" to speedStatus,
-                    "raw_speed" to data.rawSpeedMetersPerSecond.value,
                     "display_unit" to getSpeedUnit(data.speedDisplayUnit.value)
                 ),
                 forceUpdate = true

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -51,6 +51,7 @@
     <uses-permission android:name="android.car.permission.CAR_ENERGY" />
     <uses-permission android:name="android.car.permission.CAR_ENERGY_PORTS" />
     <uses-permission android:name="android.car.permission.READ_CAR_DISPLAY_UNITS" />
+    <uses-permission android:name="android.car.permission.CAR_SPEED" />
 
     <uses-feature android:name="android.hardware.touchscreen" android:required="false"/>
     <uses-feature android:name="android.hardware.telephony" android:required="false"/>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1303,4 +1303,6 @@
     <string name="sensor_description_screen_orientation">Overall orientation of the screen</string>
     <string name="sensor_name_screen_rotation">Screen rotation</string>
     <string name="sensor_description_screen_rotation">The rotation of the screen from its \"natural\" orientation</string>
+    <string name="basic_sensor_name_car_speed">Car speed</string>
+    <string name="sensor_description_car_speed">The current speed of the car</string>
 </resources>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds a car speed sensor whose state will contain display speed in meters per second, Attributes for raw speed and also the display units are supported (untested due to head unit emulator limitations). The values can be either positive, negative or 0 depending on vehicle movement (driving, reverse, stopped)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/user-attachments/assets/93811157-cd32-429f-912e-3031930730dc)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1119

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->