### PR TITLE
Hide widgets from automotive build and prevent intent registration too

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -5,6 +5,7 @@ import android.app.NotificationManager
 import android.bluetooth.BluetoothAdapter
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.net.wifi.WifiManager
 import android.nfc.NfcAdapter
@@ -282,19 +283,21 @@ open class HomeAssistantApplication : Application() {
             ContextCompat.RECEIVER_EXPORTED
         )
 
-        // Update widgets when the screen turns on, updates are skipped if widgets were not added
-        val buttonWidget = ButtonWidget()
-        val entityWidget = EntityWidget()
-        val mediaPlayerWidget = MediaPlayerControlsWidget()
-        val templateWidget = TemplateWidget()
+        if (!this.packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)) {
+            // Update widgets when the screen turns on, updates are skipped if widgets were not added
+            val buttonWidget = ButtonWidget()
+            val entityWidget = EntityWidget()
+            val mediaPlayerWidget = MediaPlayerControlsWidget()
+            val templateWidget = TemplateWidget()
 
-        val screenIntentFilter = IntentFilter()
-        screenIntentFilter.addAction(Intent.ACTION_SCREEN_ON)
-        screenIntentFilter.addAction(Intent.ACTION_SCREEN_OFF)
+            val screenIntentFilter = IntentFilter()
+            screenIntentFilter.addAction(Intent.ACTION_SCREEN_ON)
+            screenIntentFilter.addAction(Intent.ACTION_SCREEN_OFF)
 
-        ContextCompat.registerReceiver(this, buttonWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
-        ContextCompat.registerReceiver(this, entityWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
-        ContextCompat.registerReceiver(this, mediaPlayerWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
-        ContextCompat.registerReceiver(this, templateWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+            ContextCompat.registerReceiver(this, buttonWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+            ContextCompat.registerReceiver(this, entityWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+            ContextCompat.registerReceiver(this, mediaPlayerWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+            ContextCompat.registerReceiver(this, templateWidget, screenIntentFilter, ContextCompat.RECEIVER_NOT_EXPORTED)
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -176,7 +176,7 @@ class SettingsFragment(
         val isAutomotive =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
-        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest" || isAutomotive
+        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest" || !isAutomotive
         findPreference<Preference>("manage_widgets")?.setOnPreferenceClickListener {
             parentFragmentManager.commit {
                 replace(R.id.content, ManageWidgetsSettingsFragment::class.java, null)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -176,7 +176,7 @@ class SettingsFragment(
         val isAutomotive =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
-        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest" || !isAutomotive
+        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest" && !isAutomotive
         findPreference<Preference>("manage_widgets")?.setOnPreferenceClickListener {
             parentFragmentManager.commit {
                 replace(R.id.content, ManageWidgetsSettingsFragment::class.java, null)

--- a/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -173,7 +173,10 @@ class SettingsFragment(
             it.entryValues = percentages.map { pct -> pct.toString() }.toTypedArray()
         }
 
-        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest"
+        val isAutomotive =
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
+
+        findPreference<PreferenceCategory>("widgets")?.isVisible = Build.MODEL != "Quest" || isAutomotive
         findPreference<Preference>("manage_widgets")?.setOnPreferenceClickListener {
             parentFragmentManager.commit {
                 replace(R.id.content, ManageWidgetsSettingsFragment::class.java, null)
@@ -181,9 +184,6 @@ class SettingsFragment(
             }
             return@setOnPreferenceClickListener true
         }
-
-        val isAutomotive =
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && requireContext().packageManager.hasSystemFeature(PackageManager.FEATURE_AUTOMOTIVE)
 
         if (Build.MODEL != "Quest") {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/BaseWidgetProvider.kt
@@ -142,9 +142,8 @@ abstract class BaseWidgetProvider : AppWidgetProvider() {
         context: Context
     ) {
         val widgetProvider = getWidgetProvider(context)
-        val systemWidgetIds = AppWidgetManager.getInstance(context)
-            .getAppWidgetIds(widgetProvider)
-            .toSet()
+        val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+        val systemWidgetIds = appWidgetManager.getAppWidgetIds(widgetProvider).toSet()
         val dbWidgetIds = getAllWidgetIdsWithEntities(context).keys
 
         val invalidWidgetIds = dbWidgetIds.minus(systemWidgetIds)

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -93,7 +93,7 @@ class ButtonWidget : AppWidgetProvider() {
 
     private fun updateAllWidgets(context: Context) {
         mainScope.launch {
-            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val appWidgetManager = AppWidgetManager.getInstance(context) ?: return@launch
             val systemWidgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, ButtonWidget::class.java))
             val dbWidgetList = buttonWidgetDao.getAll()
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -86,7 +86,7 @@ class CameraWidget : AppWidgetProvider() {
 
     private fun updateAllWidgets(context: Context) {
         mainScope.launch {
-            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val appWidgetManager = AppWidgetManager.getInstance(context) ?: return@launch
             val systemWidgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, CameraWidget::class.java))
             val dbWidgetList = cameraWidgetDao.getAll()
 

--- a/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/widgets/template/TemplateWidget.kt
@@ -176,9 +176,8 @@ class TemplateWidget : AppWidgetProvider() {
     private suspend fun updateAllWidgets(
         context: Context
     ) {
-        val systemWidgetIds = AppWidgetManager.getInstance(context)
-            .getAppWidgetIds(ComponentName(context, TemplateWidget::class.java))
-            .toSet()
+        val appWidgetManager = AppWidgetManager.getInstance(context) ?: return
+        val systemWidgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, TemplateWidget::class.java)).toSet()
         val dbWidgetIds = templateWidgetDao.getAll().map { it.id }
 
         val invalidWidgetIds = dbWidgetIds.minus(systemWidgetIds)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

As normal app widgets dont exist in automotive we should not register the screen on intent nor should we show the widget option in settings.

Should prevent below crash from unsupported device:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'int[] android.appwidget.AppWidgetManager.getAppWidgetIds(android.content.ComponentName)' on a null object reference
    at io.homeassistant.companion.android.widgets.button.ButtonWidget$updateAllWidgets$1.invokeSuspend(ButtonWidget.kt:97)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288
```

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->