### PR TITLE
Allow fan domain to be selected for android auto favorites list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/DomainChecks.kt
@@ -9,6 +9,7 @@ val SUPPORTED_DOMAINS_WITH_STRING = mapOf(
     "alarm_control_panel" to R.string.alarm_control_panels,
     "button" to R.string.buttons,
     "cover" to R.string.covers,
+    "fan" to R.string.fans,
     "input_boolean" to R.string.input_booleans,
     "input_button" to R.string.input_buttons,
     "light" to R.string.lights,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds the fan domain to the supported android auto domains allowing fan entities to be selected for favorites view in android auto
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://github.com/user-attachments/assets/a6f42afd-a491-403e-b38f-fbd4a74c04f4)
![image](https://github.com/user-attachments/assets/213786db-d25d-4cea-82f5-1075592185dc)
![image](https://github.com/user-attachments/assets/308ba5bc-4012-457a-8bcc-5c41446c4d4b)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1129

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->