### PR TITLE
Support behavior: textInput key on notification action for reply actions

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -139,7 +139,7 @@ class MessagingManager @Inject constructor(
         const val INTENT_CLASS_NAME = "intent_class_name"
         const val URI = "URI"
         const val REPLY = "REPLY"
-        const val TEXT_INPUT = "textInput"
+        const val TEXT_INPUT = "textinput"
         const val HIGH_ACCURACY_UPDATE_INTERVAL = "high_accuracy_update_interval"
         const val PACKAGE_NAME = "package_name"
         const val CONFIRMATION = "confirmation"
@@ -1462,7 +1462,7 @@ class MessagingManager @Inject constructor(
                             )
                         }
                     }
-                    notificationAction.key == REPLY || notificationAction.behavior == TEXT_INPUT -> {
+                    notificationAction.key == REPLY || notificationAction.behavior?.lowercase() == TEXT_INPUT -> {
                         val remoteInput: RemoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).run {
                             setLabel(context.getString(commonR.string.action_reply))
                             build()

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -139,6 +139,7 @@ class MessagingManager @Inject constructor(
         const val INTENT_CLASS_NAME = "intent_class_name"
         const val URI = "URI"
         const val REPLY = "REPLY"
+        const val TEXT_INPUT = "textInput"
         const val HIGH_ACCURACY_UPDATE_INTERVAL = "high_accuracy_update_interval"
         const val PACKAGE_NAME = "package_name"
         const val CONFIRMATION = "confirmation"
@@ -1432,6 +1433,7 @@ class MessagingManager @Inject constructor(
                     data["action_${i}_key"].toString(),
                     data["action_${i}_title"].toString(),
                     data["action_${i}_uri"],
+                    data["action_${i}_behavior"],
                     data
                 )
                 val eventIntent = Intent(context, NotificationActionReceiver::class.java).apply {
@@ -1450,8 +1452,8 @@ class MessagingManager @Inject constructor(
                     )
                 }
 
-                when (notificationAction.key) {
-                    URI -> {
+                when {
+                    notificationAction.key == URI -> {
                         if (!notificationAction.uri.isNullOrBlank()) {
                             builder.addAction(
                                 commonR.drawable.ic_globe,
@@ -1460,7 +1462,7 @@ class MessagingManager @Inject constructor(
                             )
                         }
                     }
-                    REPLY -> {
+                    notificationAction.key == REPLY || notificationAction.behavior == TEXT_INPUT -> {
                         val remoteInput: RemoteInput = RemoteInput.Builder(KEY_TEXT_REPLY).run {
                             setLabel(context.getString(commonR.string.action_reply))
                             build()

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationAction.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationAction.kt
@@ -8,5 +8,6 @@ data class NotificationAction(
     val key: String,
     val title: String,
     val uri: String?,
+    val behavior: String?,
     var data: Map<String, String>
 ) : Parcelable

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
@@ -56,7 +56,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
         val messageId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
         val databaseId = intent.getLongExtra(EXTRA_NOTIFICATION_DB, 0)
 
-        val isReply = notificationAction.key == "REPLY" || notificationAction.behavior == "textInput"
+        val isReply = notificationAction.key == "REPLY" || notificationAction.behavior?.lowercase() == "textinput"
         var replyText: String? = null
 
         val onComplete: () -> Unit = {

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
@@ -56,7 +56,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
         val messageId = intent.getIntExtra(EXTRA_NOTIFICATION_ID, -1)
         val databaseId = intent.getLongExtra(EXTRA_NOTIFICATION_DB, 0)
 
-        val isReply = notificationAction.key == "REPLY"
+        val isReply = notificationAction.key == "REPLY" || notificationAction.behavior == "textInput"
         var replyText: String? = null
 
         val onComplete: () -> Unit = {
@@ -92,7 +92,6 @@ class NotificationActionReceiver : BroadcastReceiver() {
         if (isReply) {
             replyText = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(KEY_TEXT_REPLY).toString()
             notificationAction.data += Pair("reply_text", replyText)
-            notificationAction.data += Pair("reply_title", notificationAction.title)
         }
 
         when (intent.action) {

--- a/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
@@ -92,6 +92,7 @@ class NotificationActionReceiver : BroadcastReceiver() {
         if (isReply) {
             replyText = RemoteInput.getResultsFromIntent(intent)?.getCharSequence(KEY_TEXT_REPLY).toString()
             notificationAction.data += Pair("reply_text", replyText)
+            notificationAction.data += Pair("reply_title", notificationAction.title)
         }
 
         when (intent.action) {

--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -186,7 +186,8 @@ class WebsocketManager(
                             if (action is Map<*, *>) {
                                 flattened["action_${i + 1}_key"] = action["action"].toString()
                                 flattened["action_${i + 1}_title"] = action["title"].toString()
-                                flattened["action_${i + 1}_uri"] = action["uri"].toString()
+                                action["uri"]?.let { uri -> flattened["action_${i + 1}_uri"] = uri.toString() }
+                                action["behavior"]?.let { behavior -> flattened["action_${i + 1}_behavior"] = behavior.toString() }
                             }
                         }
                     } else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #3503 by supporting the use of `behavior: textInput` on a notification action to trigger the reply action. This allows you to use the `action` key to differentiate the different actions, which is already possible on iOS.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1130

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
FCM changes: home-assistant/mobile-apps-fcm-push#170

cc @bgoncal