### PR TITLE
Don't reset work profile state on app restart and add "intent only" update type

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
@@ -23,7 +23,7 @@ class DevicePolicyManager : SensorManager {
         return "https://companion.home-assistant.io/docs/core/sensors#work-profile-sensor"
     }
 
-    private var isManagedProfileAvailable: Boolean = false
+    private var isManagedProfileAvailable: Boolean? = null
 
     override val name: Int
         get() = R.string.sensor_name_device_policy
@@ -56,12 +56,14 @@ class DevicePolicyManager : SensorManager {
             return
         }
 
-        onSensorUpdated(
-            context,
-            isWorkProfile,
-            isManagedProfileAvailable,
-            isWorkProfile.statelessIcon,
-            mapOf()
-        )
+        isManagedProfileAvailable?.let { state ->
+            onSensorUpdated(
+                context,
+                isWorkProfile,
+                state,
+                isWorkProfile.statelessIcon,
+                mapOf()
+            )
+        }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/DevicePolicyManager.kt
@@ -15,7 +15,7 @@ class DevicePolicyManager : SensorManager {
             R.string.sensor_name_work_profile,
             R.string.sensor_description_work_profile,
             "mdi:briefcase",
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT_ONLY
         )
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -37,7 +37,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             commonR.string.sensor_description_last_notification,
             "mdi:bell-ring",
             docsLink = "https://companion.home-assistant.io/docs/core/sensors#last-notification",
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT_ONLY
         )
         val lastRemovedNotification = SensorManager.BasicSensor(
             "last_removed_notification",
@@ -46,7 +46,7 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
             commonR.string.sensor_description_last_removed_notification,
             "mdi:bell-ring",
             docsLink = "https://companion.home-assistant.io/docs/core/sensors#last-removed-notification",
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT_ONLY
         )
         val activeNotificationCount = SensorManager.BasicSensor(
             "active_notification_count",

--- a/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -166,6 +166,7 @@ fun SensorDetailView(
                         text = stringResource(
                             when (viewModel.basicSensor.updateType) {
                                 SensorManager.BasicSensor.UpdateType.INTENT -> commonR.string.sensor_update_type_chip_intent
+                                SensorManager.BasicSensor.UpdateType.INTENT_ONLY -> commonR.string.sensor_update_type_chip_intent_only
                                 SensorManager.BasicSensor.UpdateType.WORKER -> {
                                     when (viewModel.settingUpdateFrequency) {
                                         SensorUpdateFrequencySetting.FAST_ALWAYS -> commonR.string.sensor_update_type_chip_worker_fast_always
@@ -577,6 +578,9 @@ fun SensorDetailUpdateInfoDialog(
         content = {
             var infoString = when (basicSensor.updateType) {
                 SensorManager.BasicSensor.UpdateType.INTENT -> stringResource(commonR.string.sensor_update_type_info_intent)
+                SensorManager.BasicSensor.UpdateType.INTENT_ONLY -> {
+                    "${stringResource(commonR.string.sensor_update_type_info_intent)}\n\n${stringResource(commonR.string.sensor_update_type_info_intent_only)}"
+                }
                 SensorManager.BasicSensor.UpdateType.WORKER -> {
                     "${stringResource(
                         when (userSetting) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/SensorManager.kt
@@ -50,6 +50,7 @@ interface SensorManager {
     ) {
         enum class UpdateType {
             INTENT,
+            INTENT_ONLY,
             WORKER,
             LOCATION,
             CUSTOM

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1100,7 +1100,7 @@
     <string name="sensor_update_type_info_title">About sensor updates</string>
     <string name="sensor_update_type_info_enable">Enable this sensor to send updates to Home Assistant.\n\n</string>
     <string name="sensor_update_type_info_intent">This sensor is updated instantly whenever the state changes.</string>
-    <string name="sensor_update_type_info_intent_only">Note: the sensor can only detect changes, it cannot read the current state. If the state changes if the device is restarted or while the app is not running, the sensor may not have the correct state.</string>
+    <string name="sensor_update_type_info_intent_only">Note: the sensor can only listen for changes, it cannot get the current state. If the state changes when the device is restarted or while the app is not running, the sensor may not have the correct state.</string>
     <string name="sensor_update_type_info_worker_fast_always">This sensor\'s state is updated every minute and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_fast_charging">This sensor\'s state is updated every minute while charging, every 15 minutes when not charging, and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_normal">This sensor\'s state is updated every 15 minutes and when a sensor that updates instantly is updated.</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1091,6 +1091,7 @@
     <string name="sensor_worker_sync_missing_permissions">To enable this sensor, turn it on in the app settings</string>
     <string name="sensor_update_frequency_summary">Change the frequency of updates for sensors that do not update instantly.</string>
     <string name="sensor_update_type_chip_intent">Updates instantly</string>
+    <string name="sensor_update_type_chip_intent_only">Updates instantly, only on changes</string>
     <string name="sensor_update_type_chip_worker_fast_always">Updates every minute</string>
     <string name="sensor_update_type_chip_worker_fast_charging">Updates every 1 / 15 min</string>
     <string name="sensor_update_type_chip_worker_normal">Updates every 15 min</string>
@@ -1099,6 +1100,7 @@
     <string name="sensor_update_type_info_title">About sensor updates</string>
     <string name="sensor_update_type_info_enable">Enable this sensor to send updates to Home Assistant.\n\n</string>
     <string name="sensor_update_type_info_intent">This sensor is updated instantly whenever the state changes.</string>
+    <string name="sensor_update_type_info_intent_only">Note: the sensor can only detect changes. If the state changes if the device is restarted or while the app is not running, the sensor may not have the correct state.</string>
     <string name="sensor_update_type_info_worker_fast_always">This sensor\'s state is updated every minute and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_fast_charging">This sensor\'s state is updated every minute while charging, every 15 minutes when not charging, and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_normal">This sensor\'s state is updated every 15 minutes and when a sensor that updates instantly is updated.</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1100,7 +1100,7 @@
     <string name="sensor_update_type_info_title">About sensor updates</string>
     <string name="sensor_update_type_info_enable">Enable this sensor to send updates to Home Assistant.\n\n</string>
     <string name="sensor_update_type_info_intent">This sensor is updated instantly whenever the state changes.</string>
-    <string name="sensor_update_type_info_intent_only">Note: the sensor can only detect changes. If the state changes if the device is restarted or while the app is not running, the sensor may not have the correct state.</string>
+    <string name="sensor_update_type_info_intent_only">Note: the sensor can only detect changes, it cannot read the current state. If the state changes if the device is restarted or while the app is not running, the sensor may not have the correct state.</string>
     <string name="sensor_update_type_info_worker_fast_always">This sensor\'s state is updated every minute and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_fast_charging">This sensor\'s state is updated every minute while charging, every 15 minutes when not charging, and when a sensor that updates instantly is updated.</string>
     <string name="sensor_update_type_info_worker_normal">This sensor\'s state is updated every 15 minutes and when a sensor that updates instantly is updated.</string>

--- a/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/sensors/WetModeSensorManager.kt
@@ -15,8 +15,7 @@ class WetModeSensorManager : SensorManager {
             commonR.string.sensor_description_wet_mode,
             "mdi:water-off",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
-            updateType = SensorManager.BasicSensor.UpdateType.INTENT
-
+            updateType = SensorManager.BasicSensor.UpdateType.INTENT_ONLY
         )
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Closes #4755 by:
 - setting the default tracking value for the work profile sensor to `null`, and only updating the sensor if the value is not `null`, so it is not overwritten if we have not received the intent
 - adding a new "intent only" update type for sensors which we cannot read the state for or reliably expect to receive a value in the callback quickly after registering, which mentions in the UI that we need updates from the system and the state may get out of sync

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|     |Light|Dark|
|-----|-----|-----|
|Chip for new update type|![A chip with the text 'Updates instantly, only on changes', light mode](https://github.com/user-attachments/assets/599ef49f-fb80-466f-8398-e269cd2e91a2)|![A chip with the text 'Updates instantly, only on changes', dark mode](https://github.com/user-attachments/assets/b7a8e6f4-5915-4f61-b16c-597b8c965cf7)|
|Dialog text after tapping the chip|![A dialog with new text 'Note: the sensor can only listen for changes, it cannot get the current state. If the state changes when the device is restarted or while the app is not running, the sensor may not have the correct state.', light mode](https://github.com/user-attachments/assets/8e1d6bcb-733b-4178-83f0-5fa853bd0550)|![A dialog with new text 'Note: the sensor can only listen for changes, it cannot get the current state. If the state changes when the device is restarted or while the app is not running, the sensor may not have the correct state.', dark mode](https://github.com/user-attachments/assets/407b623c-9308-4752-b554-208d9e90836c)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->