### PR TITLE
Fix pipeline badge in the header of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# :iphone: Home Assistant Companion for Android  ![Beta Deploy](https://github.com/home-assistant/android/workflows/Beta%20Deploy/badge.svg)
+# :iphone: Home Assistant Companion for Android  [![Build](https://github.com/home-assistant/android/actions/workflows/onPush.yml/badge.svg)](https://github.com/home-assistant/android/actions/workflows/onPush.yml)
 
 ## Documentation
 If you are looking for documentation around the companion applications check out the [Home Assistant Companion Documentation](https://companion.home-assistant.io/).  This will provide you instructions on using the applications.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
I noticed that the title/header in the README looks weird:
![image](https://github.com/user-attachments/assets/5699a350-6987-4e66-8353-25ef7a75773c)

In this PR I propose to show the status of the [On Push](https://github.com/home-assistant/android/actions/workflows/onPush.yml) pipeline instead (which seemed to match the old "Beta Deploy" the closest):
![image](https://github.com/user-attachments/assets/13eb2b46-35a0-4418-b891-09a280996838)

## Screenshots
N/A

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
~~Documentation: home-assistant/companion.home-assistant#~~

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->