### PR TITLE
Skip ranker_group notifications as they are meaningless and system generated and prevent valid notification data from sending

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/sensors/NotificationSensorManager.kt
@@ -144,6 +144,10 @@ class NotificationSensorManager : NotificationListenerService(), SensorManager {
                 return@launch
             }
 
+            if (sbn.notification.group == "ranker_group") {
+                return@launch
+            }
+
             val attr = mappedBundle(sbn.notification.extras).orEmpty()
                 .plus("package" to sbn.packageName)
                 .plus("post_time" to sbn.postTime)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Skip the system generated `ranker_group` from sending a meaningless update to HA as it prevents the actual notification data needed.

In my own data I can see that this "special" group is quite meaningless as it has no text or anything other than the app posted a notification

![image](https://github.com/user-attachments/assets/b9e69c91-01ed-4a68-a8dc-bf74161816f3)

we can see the previous notification had no group however the notification that was desired got skipped due to the `ranker_group` superseding the update

![image](https://github.com/user-attachments/assets/2d61c087-ed2f-4fad-8f9f-204d8333ab5e)

testing locally with the HA prod and debug app side by side with each app listening for the others notification. Sending a message with "test" followed by "test2" results in "test" being sent and then the ranker_group for prod. The debug build with this change shows the expected sequence of "test" followed by "test2" instead of the ranker_group.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
this behavior was also called out in https://github.com/home-assistant/android/issues/4585 where we can see the system generated group is just unwanted.