### PR TITLE
Add dialog before prompting for Improv permissions

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovPermissionDialog.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovPermissionDialog.kt
@@ -1,0 +1,93 @@
+package io.homeassistant.companion.android.improv.ui
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.ui.platform.ComposeView
+import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.setFragmentResult
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.improv.ImprovRepository
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+import io.homeassistant.companion.android.util.setLayoutAndExpandedByDefault
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class ImprovPermissionDialog : BottomSheetDialogFragment() {
+
+    @Inject
+    lateinit var improvRepository: ImprovRepository
+
+    @Inject
+    lateinit var prefsRepository: PrefsRepository
+
+    private val requestPermissions =
+        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+            setFragmentResult(RESULT_KEY, bundleOf(RESULT_GRANTED to it.all { result -> result.value }))
+            dismiss()
+        }
+
+    companion object {
+        const val TAG = "ImprovPermissionDialog"
+
+        const val RESULT_KEY = "ImprovPermissionResult"
+        const val RESULT_GRANTED = "granted"
+    }
+
+    private var neededPermissions = arrayOf<String>()
+    private var increasedCount = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val permissions = improvRepository.getRequiredPermissions()
+        context?.let { ctx ->
+            permissions.forEach {
+                val granted = ContextCompat.checkSelfPermission(ctx, it) == PackageManager.PERMISSION_GRANTED
+                if (!granted) neededPermissions += it
+            }
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                HomeAssistantAppTheme {
+                    ImprovPermissionView(
+                        needsBluetooth = neededPermissions.any { it.contains("BLUETOOTH", ignoreCase = true) },
+                        needsLocation = neededPermissions.any { it == Manifest.permission.ACCESS_FINE_LOCATION },
+                        onContinue = { requestPermissions.launch(neededPermissions) },
+                        onSkip = { dismiss() }
+                    )
+                }
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setLayoutAndExpandedByDefault()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (increasedCount) return
+        lifecycleScope.launch {
+            prefsRepository.addImprovPermissionDisplayedCount()
+            increasedCount = true
+        }
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovPermissionView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovPermissionView.kt
@@ -1,0 +1,83 @@
+package io.homeassistant.companion.android.improv.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.onboarding.OnboardingHeaderView
+import io.homeassistant.companion.android.onboarding.OnboardingPermissionBullet
+import io.homeassistant.companion.android.util.compose.ModalBottomSheet
+
+@Composable
+fun ImprovPermissionView(
+    needsBluetooth: Boolean,
+    needsLocation: Boolean,
+    onContinue: () -> Unit,
+    onSkip: () -> Unit
+) {
+    ModalBottomSheet(title = null) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 16.dp)
+                .padding(bottom = 16.dp)
+        ) {
+            OnboardingHeaderView(
+                icon = CommunityMaterial.Icon3.cmd_radar,
+                title = stringResource(commonR.string.improv_permission_title)
+            )
+            Text(
+                text = stringResource(commonR.string.improv_permission_text),
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+                    .align(Alignment.CenterHorizontally)
+            )
+            if (needsBluetooth) {
+                OnboardingPermissionBullet(
+                    icon = CommunityMaterial.Icon.cmd_bluetooth,
+                    text = stringResource(commonR.string.improv_permission_bluetooth)
+                )
+            }
+            if (needsLocation) {
+                OnboardingPermissionBullet(
+                    icon = CommunityMaterial.Icon3.cmd_map_marker,
+                    text = stringResource(commonR.string.improv_permission_location)
+                )
+            }
+            Spacer(Modifier.height(96.dp))
+            Row {
+                TextButton(onClick = onSkip) {
+                    Text(stringResource(id = commonR.string.skip))
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                Button(onClick = onContinue) {
+                    Text(stringResource(id = commonR.string.continue_connect))
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun ImprovPermissionViewPreview() {
+    ImprovPermissionView(
+        needsBluetooth = true,
+        needsLocation = true,
+        onContinue = {},
+        onSkip = {}
+    )
+}

--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSetupDialog.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSetupDialog.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.view.WindowManager
-import android.widget.FrameLayout
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
@@ -13,14 +11,12 @@ import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
-import com.google.android.material.R
-import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.wifi.WifiHelper
 import io.homeassistant.companion.android.improv.ImprovRepository
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+import io.homeassistant.companion.android.util.setLayoutAndExpandedByDefault
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -111,14 +107,7 @@ class ImprovSetupDialog : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        dialog?.setOnShowListener {
-            val dialog = it as BottomSheetDialog
-            dialog.window?.setDimAmount(0.03f)
-            dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-            val bottomSheet = dialog.findViewById<View>(R.id.design_bottom_sheet) as FrameLayout
-            val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
-            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        setLayoutAndExpandedByDefault()
     }
 
     override fun onResume() {

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViews.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/OnboardingViews.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.onboarding
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -70,6 +71,29 @@ fun OnboardingHeaderView(
             modifier = Modifier
                 .padding(vertical = 16.dp)
                 .align(Alignment.CenterHorizontally)
+        )
+    }
+}
+
+@Composable
+fun OnboardingPermissionBullet(
+    icon: IIcon,
+    text: String
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 12.dp)
+    ) {
+        Image(
+            asset = icon,
+            colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
+            contentDescription = null
+        )
+        Text(
+            text = text,
+            modifier = Modifier
+                .padding(start = 16.dp)
+                .fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/onboarding/notifications/NotificationPermissionView.kt
@@ -8,22 +8,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Button
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.mikepenz.iconics.compose.Image
-import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.onboarding.OnboardingHeaderView
+import io.homeassistant.companion.android.onboarding.OnboardingPermissionBullet
 import io.homeassistant.companion.android.onboarding.OnboardingScreen
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
@@ -50,11 +47,11 @@ fun NotificationPermissionView(
                     .padding(bottom = 48.dp)
                     .align(Alignment.CenterHorizontally)
             )
-            NotificationPermissionBullet(
+            OnboardingPermissionBullet(
                 icon = CommunityMaterial.Icon.cmd_alert_decagram,
                 text = stringResource(id = commonR.string.onboarding_notifications_bullet_alert)
             )
-            NotificationPermissionBullet(
+            OnboardingPermissionBullet(
                 icon = CommunityMaterial.Icon3.cmd_text,
                 text = stringResource(id = commonR.string.onboarding_notifications_bullet_commands)
             )
@@ -68,29 +65,6 @@ fun NotificationPermissionView(
                 Text(stringResource(id = commonR.string.continue_connect))
             }
         }
-    }
-}
-
-@Composable
-fun NotificationPermissionBullet(
-    icon: IIcon,
-    text: String
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier.padding(vertical = 12.dp)
-    ) {
-        Image(
-            asset = icon,
-            colorFilter = ColorFilter.tint(MaterialTheme.colors.onSurface),
-            contentDescription = null
-        )
-        Text(
-            text = text,
-            modifier = Modifier
-                .padding(start = 16.dp)
-                .fillMaxWidth()
-        )
     }
 }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
@@ -4,17 +4,14 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.setFragmentResult
-import com.google.android.material.R
-import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+import io.homeassistant.companion.android.util.setLayoutAndExpandedByDefault
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -52,12 +49,6 @@ class ServerChooserFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        dialog?.setOnShowListener {
-            val dialog = it as BottomSheetDialog
-            dialog.window?.setDimAmount(0.03f)
-            val bottomSheet = dialog.findViewById<View>(R.id.design_bottom_sheet) as FrameLayout
-            val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
-            bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
-        }
+        setLayoutAndExpandedByDefault()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/util/FragmentExtensions.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/FragmentExtensions.kt
@@ -1,7 +1,14 @@
 package io.homeassistant.companion.android.util
 
+import android.view.View
+import android.view.WindowManager
+import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
+import com.google.android.material.R
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 /**
  * Check if the state of the fragment is at least started,
@@ -9,3 +16,18 @@ import androidx.lifecycle.Lifecycle
  */
 val Fragment.isStarted: Boolean
     get() = lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+
+/**
+ * Set the layout for a BottomSheetDialogFragment to a shared default for the app,
+ * and expand it to full size by default instead of peek height only.
+ */
+fun BottomSheetDialogFragment.setLayoutAndExpandedByDefault() {
+    dialog?.setOnShowListener {
+        val dialog = it as BottomSheetDialog
+        dialog.window?.setDimAmount(0.03f)
+        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        val bottomSheet = dialog.findViewById<View>(R.id.design_bottom_sheet) as FrameLayout
+        val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+    }
+}

--- a/app/src/main/java/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
@@ -28,7 +28,7 @@ import io.homeassistant.companion.android.common.R as commonR
  */
 @Composable
 fun ModalBottomSheet(
-    title: String,
+    title: String?,
     showHandle: Boolean = true,
     content: @Composable () -> Unit
 ) {
@@ -52,14 +52,16 @@ fun ModalBottomSheet(
                     )
                 }
             }
-            Text(
-                text = title,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 22.dp),
-                style = MaterialTheme.typography.h6,
-                textAlign = TextAlign.Center
-            )
+            if (title != null) {
+                Text(
+                    text = title,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 22.dp),
+                    style = MaterialTheme.typography.h6,
+                    textAlign = TextAlign.Center
+                )
+            }
             content()
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -66,8 +66,10 @@ interface WebViewPresenter {
     fun onMatterThreadIntentResult(context: Context, result: ActivityResult)
     fun finishMatterThreadFlow()
 
+    /** @return `true` if the app should prompt the user for Improv permissions before scanning */
+    suspend fun shouldShowImprovPermissions(): Boolean
+
     /** @return `true` if the app tried starting scanning or `false` if it was missing permissions */
     fun startScanningForImprov(): Boolean
-    fun getImprovPermissions(): Array<String>
     fun stopScanningForImprov(force: Boolean)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -480,6 +480,14 @@ class WebViewPresenterImpl @Inject constructor(
         mutableMatterThreadStep.tryEmit(MatterThreadStep.NOT_STARTED)
     }
 
+    override suspend fun shouldShowImprovPermissions(): Boolean {
+        return if (improvRepository.hasPermission(view as Context)) {
+            true
+        } else {
+            prefsRepository.getImprovPermissionDisplayedCount() < 2
+        }
+    }
+
     override fun startScanningForImprov(): Boolean {
         if (!improvRepository.hasPermission(view as Context)) return false
         improvJobStarted = System.currentTimeMillis()
@@ -493,8 +501,6 @@ class WebViewPresenterImpl @Inject constructor(
         }
         return true
     }
-
-    override fun getImprovPermissions(): Array<String> = improvRepository.getRequiredPermissions()
 
     override fun stopScanningForImprov(force: Boolean) {
         if (improvJob?.isActive == true && (force || System.currentTimeMillis() - improvJobStarted > 1000)) {

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -87,6 +87,10 @@ interface PrefsRepository {
 
     suspend fun setLocationHistoryEnabled(enabled: Boolean)
 
+    suspend fun getImprovPermissionDisplayedCount(): Int
+
+    suspend fun addImprovPermissionDisplayedCount()
+
     /** Clean up any app-level preferences that might reference servers */
     suspend fun removeServer(serverId: Int)
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -36,6 +36,7 @@ class PrefsRepositoryImpl @Inject constructor(
         private const val PREF_IGNORED_SUGGESTIONS = "ignored_suggestions"
         private const val PREF_AUTO_FAVORITES = "auto_favorites"
         private const val PREF_LOCATION_HISTORY_DISABLED = "location_history"
+        private const val PREF_IMPROV_PERMISSION_DISPLAYED = "improv_permission_displayed"
     }
 
     init {
@@ -241,6 +242,13 @@ class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setLocationHistoryEnabled(enabled: Boolean) {
         localStorage.putBoolean(PREF_LOCATION_HISTORY_DISABLED, !enabled)
+    }
+
+    override suspend fun getImprovPermissionDisplayedCount(): Int =
+        localStorage.getInt(PREF_IMPROV_PERMISSION_DISPLAYED) ?: 0
+
+    override suspend fun addImprovPermissionDisplayedCount() {
+        localStorage.putInt(PREF_IMPROV_PERMISSION_DISPLAYED, getImprovPermissionDisplayedCount() + 1)
     }
 
     override suspend fun removeServer(serverId: Int) {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -336,6 +336,10 @@
     <string name="improv_error_unknown">Unknown error, please try again</string>
     <string name="improv_hint">Improv Wi-Fi devices are available to set up</string>
     <string name="improv_list_title">Devices ready to set up</string>
+    <string name="improv_permission_title">Search devices</string>
+    <string name="improv_permission_text">The Home Assistant app can find devices using Bluetooth of this device. Allow access for the following permissions.</string>
+    <string name="improv_permission_bluetooth">Bluetooth</string>
+    <string name="improv_permission_location">Precise location</string>
     <string name="improv_wifi_title">Connect to Wi-Fi</string>
     <string name="improv_wifi_ssid">Network name</string>
     <string name="keep_screen_on_def">Do not lock screen when dashboard is active</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Based on feedback: add a dialog explaining why the app is about to request permissions for scanning for Improv devices. This should prevent users from denying it because it is not understood. Note that the 2nd prompt may not actually result in a system prompt if it is auto-denied.

Moves some code from onboarding views and bottom sheet dialogs to utility files where it is now used in more places.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|-----|-----|
|![Add integration with a bottom dialog sheet titled 'Search devices', light mode](https://github.com/user-attachments/assets/f7e4618b-3436-4e33-ba43-02808059b8cc)|![Add integration with a bottom dialog sheet titled 'Search devices', dark mode](https://github.com/user-attachments/assets/211b13bd-c36f-46cb-bb58-57251433aa39)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
related to home-assistant/iOS#3104