### PR TITLE
AAOS/Android Auto: Add a button to refresh the main screen entity list

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/util/vehicle/NativeModeActionStrip.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/vehicle/NativeModeActionStrip.kt
@@ -5,20 +5,17 @@ import android.content.pm.PackageManager
 import android.util.Log
 import androidx.car.app.CarContext
 import androidx.car.app.model.Action
-import androidx.car.app.model.ActionStrip
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.launch.LaunchActivity
 
 private const val TAG = "NativeActionStrip"
 
-fun nativeModeActionStrip(carContext: CarContext): ActionStrip {
-    return ActionStrip.Builder().addAction(
-        Action.Builder()
-            .setTitle(carContext.getString(R.string.aa_launch_native))
-            .setOnClickListener {
-                startNativeActivity(carContext)
-            }.build()
-    ).build()
+fun nativeModeAction(carContext: CarContext): Action {
+    return Action.Builder()
+        .setTitle(carContext.getString(R.string.aa_launch_native))
+        .setOnClickListener {
+            startNativeActivity(carContext)
+        }.build()
 }
 
 fun startNativeActivity(carContext: CarContext) {

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.model.Action
+import androidx.car.app.model.ActionStrip
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.Template
 import androidx.lifecycle.lifecycleScope
@@ -18,7 +19,7 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.util.vehicle.SUPPORTED_DOMAINS
 import io.homeassistant.companion.android.util.vehicle.getDomainList
-import io.homeassistant.companion.android.util.vehicle.nativeModeActionStrip
+import io.homeassistant.companion.android.util.vehicle.nativeModeAction
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -80,7 +81,7 @@ class DomainListScreen(
             setTitle(carContext.getString(R.string.all_entities))
             setHeaderAction(Action.BACK)
             if (isAutomotive && !isDrivingOptimized && BuildConfig.FLAVOR != "full") {
-                setActionStrip(nativeModeActionStrip(carContext))
+                setActionStrip(ActionStrip.Builder().addAction(nativeModeAction(carContext)).build())
             }
             val domainBuild = domainList.build()
             if (!domainsAdded) {

--- a/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
@@ -87,8 +87,10 @@ class HaCarAppService : CarAppService() {
                                     serverManager,
                                     serverIdFlow,
                                     entityFlow,
-                                    prefsRepository
-                                ) { loadEntities(lifecycleScope, it) }
+                                    prefsRepository,
+                                    { loadEntities(lifecycleScope, it) },
+                                    { loadEntities(lifecycleScope, serverId.value) }
+                                )
                             )
 
                             push(
@@ -108,8 +110,10 @@ class HaCarAppService : CarAppService() {
                                     serverManager,
                                     serverIdFlow,
                                     entityFlow,
-                                    prefsRepository
-                                ) { loadEntities(lifecycleScope, it) }
+                                    prefsRepository,
+                                    { loadEntities(lifecycleScope, it) },
+                                    { loadEntities(lifecycleScope, serverId.value) }
+                                )
                             )
                         }
                     return LoginScreen(
@@ -129,7 +133,6 @@ class HaCarAppService : CarAppService() {
     private fun loadEntities(scope: CoroutineScope, id: Int) {
         allEntitiesJob?.cancel()
         allEntitiesJob = scope.launch {
-            allEntities.emit(emptyMap())
             serverId.value = id
             val entities: MutableMap<String, Entity<*>>? =
                 if (serverManager.getServer(id) != null) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
If the HA app starts without internet access (e.g., when the car is in an underground garage, as in my case), the list of domains/entities remains empty. Currently, there's no way to refresh it without killing the app. For example, Volvo AAOS doesn't have an option to force-stop apps, so I end up having to restart the car.

This PR adds a refresh button to the main screen header to solve this issue.

## Screenshots
<img width="681" alt="image" src="https://github.com/user-attachments/assets/83a26361-2768-4485-bd01-bb80d02a8c96">
