### PR TITLE
Use the correct unit of measurement for device class volume for the hydration sensor

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -234,7 +234,7 @@ class HealthConnectSensorManager : SensorManager {
             commonR.string.basic_sensor_name_hydration,
             commonR.string.sensor_description_hydration,
             "mdi:cup-water",
-            unitOfMeasurement = "ml",
+            unitOfMeasurement = "mL",
             deviceClass = "volume",
             stateClass = SensorManager.STATE_CLASS_TOTAL_INCREASING,
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

`Entity sensor.dannys_pixel_9_pro_xl_daily_hydration (<class 'homeassistant.components.mobile_app.sensor.MobileAppSensor'>) is using native unit of measurement 'ml' which is not a valid unit for the device class ('volume') it is using; expected one of ['mL', 'gal', 'fl. oz.', 'L', 'CCF', 'ft³', 'm³']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mobile_app%22`

per: https://www.home-assistant.io/integrations/sensor/

`volume: Generic volume in L, mL, gal, fl. oz., m³, ft³, or CCF`

[oops](https://github.com/home-assistant/android/pull/4836#discussion_r1852975198) 🙈 

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->