### PR TITLE
Implement native Improv discovery with frontend flow

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSetupDialog.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSetupDialog.kt
@@ -12,11 +12,14 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.wifi.improv.DeviceState
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.wifi.WifiHelper
 import io.homeassistant.companion.android.improv.ImprovRepository
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.setLayoutAndExpandedByDefault
+import io.homeassistant.companion.android.webview.externalbus.ExternalBusMessage
+import io.homeassistant.companion.android.webview.externalbus.ExternalBusRepository
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -30,13 +33,24 @@ class ImprovSetupDialog : BottomSheetDialogFragment() {
     lateinit var improvRepository: ImprovRepository
 
     @Inject
+    lateinit var externalBusRepository: ExternalBusRepository
+
+    @Inject
     lateinit var wifiHelper: WifiHelper
 
     companion object {
         const val TAG = "ImprovSetupDialog"
 
+        private const val ARG_NAME = "name"
+
         const val RESULT_KEY = "ImprovSetupResult"
         const val RESULT_DOMAIN = "domain"
+
+        fun newInstance(deviceName: String?): ImprovSetupDialog {
+            return ImprovSetupDialog().apply {
+                arguments = bundleOf(ARG_NAME to deviceName)
+            }
+        }
     }
 
     private val screenState = MutableStateFlow(
@@ -48,9 +62,20 @@ class ImprovSetupDialog : BottomSheetDialogFragment() {
         )
     )
 
+    private var initialDeviceName: String? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycleScope.launch {
+            if (savedInstanceState == null) {
+                if (arguments?.containsKey(ARG_NAME) == true) {
+                    val name = arguments?.getString(ARG_NAME, "").takeIf { !it.isNullOrBlank() }
+                    name?.let {
+                        initialDeviceName = it
+                        screenState.emit(screenState.value.copy(initialDeviceName = it))
+                    }
+                }
+            }
             repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 screenState.emit(screenState.value.copy(activeSsid = wifiHelper.getWifiSsid()?.removeSurrounding("\"")))
                 launch {
@@ -61,11 +86,23 @@ class ImprovSetupDialog : BottomSheetDialogFragment() {
                 launch {
                     improvRepository.getDevices().collect {
                         screenState.emit(screenState.value.copy(devices = it))
+                        if (initialDeviceName != null) {
+                            it.firstOrNull { device -> device.name == initialDeviceName }
+                                ?.let { foundDevice ->
+                                    screenState.emit(
+                                        screenState.value.copy(
+                                            initialDeviceAddress = foundDevice.address
+                                        )
+                                    )
+                                    initialDeviceName = null
+                                }
+                        }
                     }
                 }
                 launch {
                     improvRepository.getDeviceState().collect {
                         screenState.emit(screenState.value.copy(deviceState = it))
+                        if (it == DeviceState.PROVISIONED) notifyFrontend()
                     }
                 }
                 launch {
@@ -125,6 +162,18 @@ class ImprovSetupDialog : BottomSheetDialogFragment() {
             lifecycleScope.launch(Dispatchers.IO) {
                 improvRepository.startScanning(it)
             }
+        }
+    }
+
+    private fun notifyFrontend() {
+        lifecycleScope.launch {
+            externalBusRepository.send(
+                ExternalBusMessage(
+                    id = -1,
+                    type = "command",
+                    command = "improv/device_setup_done"
+                )
+            )
         }
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetState.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetState.kt
@@ -9,7 +9,9 @@ data class ImprovSheetState(
     val devices: List<ImprovDevice>,
     val deviceState: DeviceState?,
     val errorState: ErrorState?,
-    val activeSsid: String? = null
+    val activeSsid: String? = null,
+    val initialDeviceName: String? = null,
+    val initialDeviceAddress: String? = null
 ) {
     /** @return `true` when [errorState] is not `null` or [ErrorState.NO_ERROR] */
     val hasError

--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetView.kt
@@ -59,14 +59,16 @@ fun ImprovSheetView(
     onRestart: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    var selectedName by rememberSaveable { mutableStateOf<String?>(null) }
-    var selectedAddress by rememberSaveable { mutableStateOf<String?>(null) }
+    var selectedName by rememberSaveable(screenState.initialDeviceName) { mutableStateOf<String?>(screenState.initialDeviceName) }
+    var selectedAddress by rememberSaveable(screenState.initialDeviceAddress) { mutableStateOf<String?>(screenState.initialDeviceAddress) }
     var submittedWifi by rememberSaveable { mutableStateOf(false) }
 
     ModalBottomSheet(
         title = if (screenState.scanning && screenState.deviceState == null && !screenState.hasError) {
             if (selectedAddress != null) {
                 stringResource(commonR.string.improv_wifi_title)
+            } else if (selectedName != null) {
+                ""
             } else {
                 stringResource(commonR.string.improv_list_title)
             }
@@ -142,7 +144,7 @@ fun ImprovSheetView(
                             commonR.string.improv_device_authorized
                         } else if (screenState.deviceState == DeviceState.PROVISIONING) {
                             commonR.string.improv_device_provisioning
-                        } else if (selectedAddress != null) {
+                        } else if (selectedName != null) {
                             commonR.string.improv_device_connecting
                         } else {
                             commonR.string.state_unknown

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebView.kt
@@ -29,6 +29,4 @@ interface WebView {
     fun unlockAppIfNeeded()
 
     fun showError(errorType: ErrorType = ErrorType.TIMEOUT_GENERAL, error: SslError? = null, description: String? = null)
-
-    fun showImprovAvailable()
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -153,7 +153,6 @@
     <string name="complication_entity_state_label">Entity state</string>
     <string name="complication_entity_state_preview">Preview</string>
     <string name="config">Configuration</string>
-    <string name="configure">Configure</string>
     <string name="configure_action">Configure action</string>
     <string name="configure_widget_label">Widget label</string>
     <string name="confirm_delete_all_notification_message">Are you sure? This cannot be undone</string>
@@ -333,7 +332,6 @@
     <string name="improv_error_unable_to_connect">Unable to connect</string>
     <string name="improv_error_unknown_command">Unknown command</string>
     <string name="improv_error_unknown">Unknown error, please try again</string>
-    <string name="improv_hint">Improv Wi-Fi devices are available to set up</string>
     <string name="improv_list_title">Devices ready to set up</string>
     <string name="improv_permission_title">Search devices</string>
     <string name="improv_permission_text">The Home Assistant app can find devices using Bluetooth of this device. Allow access for the following permissions.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
 - Updates how discovered Improv devices are handled to submit info to the frontend so it can show a frontend discovery box, and the frontend can directly trigger the Connect to Wi-Fi screen of the native setup. Requires 2024.12+ / breaks backwards compatibility.
 - Fix permission explanation dialog showing even if all permissions are granted
 - Don't start Improv scanning while the app is in the background

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Short video showing that after tapping on Devices & services, the device is discovered in a frontend discovery box, and tapping Add will trigger the native flow starting from the Wi-Fi step:

https://github.com/user-attachments/assets/211e8327-a6c2-4446-aa53-df393c44c904

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->