### PR TITLE
Allow treating ethernet and VPN as home network/for internal URL

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -147,21 +147,10 @@ class ServerSettingsPresenterImpl @Inject constructor(
             }
         }
         mainScope.launch {
-            val ssids = serverManager.getServer(serverId)?.connection?.internalSsids.orEmpty()
-            if (ssids.isEmpty()) {
-                serverManager.getServer(serverId)?.let {
-                    serverManager.updateServer(
-                        it.copy(
-                            connection = it.connection.copy(
-                                internalUrl = null
-                            )
-                        )
-                    )
-                }
-            }
-
-            view.enableInternalConnection(ssids.isNotEmpty())
-            view.updateSsids(ssids)
+            val connection = serverManager.getServer(serverId)?.connection
+            val ssids = connection?.internalSsids.orEmpty()
+            view.enableInternalConnection(ssids.isNotEmpty() || connection?.internalEthernet == true || connection?.internalVpn == true)
+            view.updateHomeNetwork(ssids, connection?.internalEthernet, connection?.internalVpn)
         }
     }
 

--- a/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/server/ServerSettingsView.kt
@@ -4,6 +4,6 @@ interface ServerSettingsView {
     fun updateServerName(name: String)
     fun enableInternalConnection(isEnabled: Boolean)
     fun updateExternalUrl(url: String, useCloud: Boolean)
-    fun updateSsids(ssids: List<String>)
+    fun updateHomeNetwork(ssids: List<String>, ethernet: Boolean?, vpn: Boolean?)
     fun onRemovedServer(success: Boolean, hasAnyRemaining: Boolean)
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/SsidFragment.kt
@@ -1,14 +1,24 @@
 package io.homeassistant.companion.android.settings.ssid
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.util.DisabledLocationHandler
+import io.homeassistant.companion.android.common.util.LocationPermissionInfoHandler
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.ssid.views.SsidView
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
@@ -22,6 +32,12 @@ class SsidFragment : Fragment() {
 
     val viewModel: SsidViewModel by viewModels()
 
+    private val permissionsRequest = registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
+        onPermissionsResult(it)
+    }
+
+    private var canReadWifi by mutableStateOf(false)
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -32,12 +48,18 @@ class SsidFragment : Fragment() {
                 HomeAssistantAppTheme {
                     SsidView(
                         wifiSsids = viewModel.wifiSsids,
+                        canReadWifi = canReadWifi,
+                        ethernet = viewModel.ethernet,
+                        vpn = viewModel.vpn,
                         prioritizeInternal = viewModel.prioritizeInternal,
                         usingWifi = viewModel.usingWifi,
                         activeSsid = viewModel.activeSsid,
                         activeBssid = viewModel.activeBssid,
                         onAddWifiSsid = viewModel::addHomeWifiSsid,
                         onRemoveWifiSsid = viewModel::removeHomeWifiSsid,
+                        onRequestPermission = { onRequestLocationPermission() },
+                        onSetEthernet = viewModel::setInternalWithEthernet,
+                        onSetVpn = viewModel::setInternalWithVpn,
                         onSetPrioritize = viewModel::setPrioritize
                     )
                 }
@@ -51,6 +73,86 @@ class SsidFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        activity?.title = getString(commonR.string.pref_connection_wifi)
+        activity?.title = getString(commonR.string.pref_connection_homenetwork)
+        updateLocationStatus()
+    }
+
+    private fun updateLocationStatus() {
+        val locationEnabled = DisabledLocationHandler.isLocationEnabled(requireContext())
+        if (!locationEnabled) {
+            canReadWifi = false
+            return
+        }
+
+        val permissionsToCheck = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        } else {
+            arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        canReadWifi = checkPermission(permissionsToCheck)
+    }
+
+    private fun onRequestLocationPermission() {
+        val permissionsToCheck: Array<String> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        } else {
+            arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+
+        if (DisabledLocationHandler.isLocationEnabled(requireContext())) {
+            LocationPermissionInfoHandler.showLocationPermInfoDialogIfNeeded(
+                requireContext(),
+                permissionsToCheck,
+                continueYesCallback = {
+                    requestLocationPermission()
+                }
+            )
+        } else {
+            DisabledLocationHandler.showLocationDisabledWarnDialog(
+                requireActivity(),
+                arrayOf(
+                    getString(commonR.string.manage_ssids_wifi)
+                ),
+                showAsNotification = false
+            )
+        }
+    }
+
+    private fun checkPermission(permissions: Array<String>?): Boolean {
+        if (!permissions.isNullOrEmpty()) {
+            for (permission in permissions) {
+                if (ContextCompat.checkSelfPermission(requireContext(), permission) == PackageManager.PERMISSION_DENIED) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    private fun requestLocationPermission() {
+        val permissions = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION) // Background location will be requested later
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+        } else {
+            arrayOf(Manifest.permission.ACCESS_COARSE_LOCATION)
+        }
+        permissionsRequest.launch(permissions)
+    }
+
+    private fun onPermissionsResult(results: Map<String, Boolean>) {
+        if (results.keys.contains(Manifest.permission.ACCESS_FINE_LOCATION) &&
+            results[Manifest.permission.ACCESS_FINE_LOCATION] == true &&
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        ) {
+            // For Android 11+ we MUST NOT request Background Location permission with fine or coarse
+            // permissions as for Android 11 the background location request needs to be done separately
+            // See here: https://developer.android.com/about/versions/11/privacy/location#request-background-location-separately
+            // The separate request of background location is done here
+            permissionsRequest.launch(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+            return
+        }
+        updateLocationStatus()
+        viewModel.updateWifiState()
     }
 }

--- a/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/ssid/views/SsidView.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.settings.ssid.views
 
 import android.net.wifi.WifiManager
 import android.os.Build
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardActions
@@ -27,13 +27,16 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.LocalContentAlpha
-import androidx.compose.material.LocalContentColor
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
+import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.SettingsEthernet
+import androidx.compose.material.icons.filled.VpnKey
 import androidx.compose.material.icons.filled.Wifi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -42,8 +45,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
@@ -51,80 +55,54 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.wifi.WifiHelper
+import io.homeassistant.companion.android.util.compose.HaAlertWarning
 
-@OptIn(
-    ExperimentalComposeUiApi::class,
-    ExperimentalMaterialApi::class,
-    ExperimentalFoundationApi::class
-)
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun SsidView(
     wifiSsids: List<String>,
+    canReadWifi: Boolean,
+    ethernet: Boolean?,
+    vpn: Boolean?,
     prioritizeInternal: Boolean,
     usingWifi: Boolean,
     activeSsid: String?,
     activeBssid: String?,
     onAddWifiSsid: (String) -> Boolean,
     onRemoveWifiSsid: (String) -> Unit,
+    onRequestPermission: () -> Unit,
+    onSetEthernet: (Boolean) -> Unit,
+    onSetVpn: (Boolean) -> Unit,
     onSetPrioritize: (Boolean) -> Unit
 ) {
-    val keyboardController = LocalSoftwareKeyboardController.current
-
     LazyColumn(contentPadding = PaddingValues(vertical = 16.dp)) {
-        item("ssid.intro") {
+        item("intro") {
             Column {
                 Text(
                     text = stringResource(commonR.string.manage_ssids_introduction),
                     modifier = Modifier
                         .padding(horizontal = 16.dp)
-                        .padding(bottom = 8.dp)
+                        .padding(bottom = 16.dp)
                 )
-                Row(modifier = Modifier.padding(horizontal = 16.dp)) {
-                    var ssidInput by remember { mutableStateOf("") }
-                    var ssidError by remember { mutableStateOf(false) }
-
-                    TextField(
-                        value = ssidInput,
-                        singleLine = true,
-                        onValueChange = {
-                            ssidInput = it
-                            ssidError = false
-                        },
-                        label = { Text(stringResource(commonR.string.manage_ssids_input)) },
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                        keyboardActions = KeyboardActions(
-                            onDone = {
-                                keyboardController?.hide()
-                                ssidError = !onAddWifiSsid(ssidInput)
-                                if (!ssidError) ssidInput = ""
-                            }
-                        ),
-                        isError = ssidError,
-                        trailingIcon = if (ssidError) {
-                            {
-                                Icon(
-                                    imageVector = Icons.Default.Error,
-                                    contentDescription = stringResource(commonR.string.manage_ssids_input_exists)
-                                )
-                            }
-                        } else {
-                            null
-                        },
-                        modifier = Modifier.weight(1f)
-                    )
-                    Button(
-                        modifier = Modifier
-                            .height(56.dp) // align with TextField: 56
-                            .padding(start = 8.dp, top = 0.dp),
-                        onClick = {
-                            keyboardController?.hide()
-                            ssidError = !onAddWifiSsid(ssidInput)
-                            if (!ssidError) ssidInput = ""
-                        }
-                    ) {
-                        Text(stringResource(commonR.string.add_ssid))
+                SsidSubheader(
+                    title = stringResource(commonR.string.manage_ssids_wifi),
+                    icon = Icons.Default.Wifi,
+                    checked = null,
+                    onClicked = null
+                )
+                if (canReadWifi) {
+                    SsidInput(onAddWifiSsid)
+                } else {
+                    Box(Modifier.padding(horizontal = 16.dp)) {
+                        HaAlertWarning(
+                            message = stringResource(commonR.string.manage_ssids_permission),
+                            action = stringResource(commonR.string.allow),
+                            onActionClicked = onRequestPermission
+                        )
                     }
                 }
             }
@@ -162,21 +140,18 @@ fun SsidView(
             }
             Row(
                 modifier = Modifier
-                    .heightIn(min = 56.dp)
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-                    .animateItemPlacement(),
+                    .heightIn(min = 48.dp)
+                    .padding(horizontal = 16.dp)
+                    .animateItem(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    imageVector = Icons.Default.Wifi,
-                    contentDescription = null,
-                    tint =
-                    if (connected) {
-                        colorResource(commonR.color.colorAccent)
-                    } else {
-                        LocalContentColor.current.copy(alpha = LocalContentAlpha.current)
-                    }
-                )
+                if (connected) {
+                    Image(
+                        asset = CommunityMaterial.Icon3.cmd_wifi_check,
+                        colorFilter = ColorFilter.tint(colorResource(commonR.color.colorAccent))
+                    )
+                    Spacer(Modifier.width(16.dp))
+                }
                 Text(
                     text =
                     if (it.startsWith(WifiHelper.BSSID_PREFIX)) {
@@ -191,7 +166,7 @@ fun SsidView(
                         null
                     },
                     modifier = Modifier
-                        .padding(horizontal = 16.dp)
+                        .padding(end = 16.dp)
                         .weight(1f)
                 )
                 Icon(
@@ -206,56 +181,185 @@ fun SsidView(
             }
         }
 
-        item("prioritize") {
-            var prioritizeDropdown by remember { mutableStateOf(false) }
+        item("ethernet") {
+            Column {
+                Spacer(Modifier.height(16.dp))
+                SsidSubheader(
+                    title = stringResource(commonR.string.manage_ssids_ethernet),
+                    icon = Icons.Default.SettingsEthernet,
+                    checked = ethernet,
+                    onClicked = { onSetEthernet(it) }
+                )
+            }
+        }
 
+        item("vpn") {
+            SsidSubheader(
+                title = stringResource(commonR.string.manage_ssids_vpn),
+                icon = Icons.Default.VpnKey,
+                checked = vpn,
+                onClicked = { onSetVpn(it) }
+            )
+        }
+
+        item("prioritize") {
             Column {
                 Spacer(modifier = Modifier.height(48.dp))
                 Divider(modifier = Modifier.padding(horizontal = 16.dp))
-                Box {
-                    Column(
-                        modifier = Modifier
-                            .clickable { prioritizeDropdown = true }
-                            .fillMaxWidth()
-                            .padding(all = 16.dp)
-                    ) {
-                        Text(
-                            text = stringResource(commonR.string.prioritize_internal_title),
-                            style = MaterialTheme.typography.body1
-                        )
-                        CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
-                            Text(
-                                text = stringResource(
-                                    if (prioritizeInternal) {
-                                        commonR.string.prioritize_internal_on
-                                    } else {
-                                        commonR.string.prioritize_internal_off
-                                    }
-                                ),
-                                style = MaterialTheme.typography.body2
-                            )
+                SsidPrioritizeInternal(
+                    prioritize = prioritizeInternal,
+                    onChanged = onSetPrioritize
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SsidSubheader(
+    title: String,
+    icon: ImageVector,
+    checked: Boolean?,
+    onClicked: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier
+) {
+    val modifier = if (onClicked != null) {
+        modifier.then(
+            Modifier
+                .clickable { checked?.let { onClicked(!it) } ?: onClicked(true) }
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 16.dp)
+        )
+    } else {
+        modifier.then(
+            Modifier
+                .heightIn(min = 56.dp)
+                .padding(horizontal = 16.dp)
+        )
+    }
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null
+        )
+        Text(
+            text = title,
+            modifier = Modifier.padding(start = 16.dp).weight(1f),
+            style = MaterialTheme.typography.subtitle1
+        )
+        if (onClicked != null) {
+            Switch(
+                checked = checked == true,
+                onCheckedChange = null,
+                colors = SwitchDefaults.colors(uncheckedThumbColor = colorResource(commonR.color.colorSwitchUncheckedThumb))
+            )
+        }
+    }
+}
+
+@Composable
+fun SsidInput(
+    onSubmit: (String) -> Boolean
+) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+    Row(modifier = Modifier.padding(horizontal = 16.dp)) {
+        var ssidInput by remember { mutableStateOf("") }
+        var ssidError by remember { mutableStateOf(false) }
+
+        TextField(
+            value = ssidInput,
+            singleLine = true,
+            onValueChange = {
+                ssidInput = it
+                ssidError = false
+            },
+            label = { Text(stringResource(commonR.string.manage_ssids_input)) },
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    keyboardController?.hide()
+                    ssidError = !onSubmit(ssidInput)
+                    if (!ssidError) ssidInput = ""
+                }
+            ),
+            isError = ssidError,
+            trailingIcon = if (ssidError) {
+                {
+                    Icon(
+                        imageVector = Icons.Default.Error,
+                        contentDescription = stringResource(commonR.string.manage_ssids_input_exists)
+                    )
+                }
+            } else {
+                null
+            },
+            modifier = Modifier.weight(1f)
+        )
+        Button(
+            modifier = Modifier
+                .height(56.dp) // align with TextField: 56
+                .padding(start = 8.dp, top = 0.dp),
+            onClick = {
+                keyboardController?.hide()
+                ssidError = !onSubmit(ssidInput)
+                if (!ssidError) ssidInput = ""
+            }
+        ) {
+            Text(stringResource(commonR.string.add_ssid))
+        }
+    }
+}
+
+@Composable
+fun SsidPrioritizeInternal(
+    prioritize: Boolean,
+    onChanged: (Boolean) -> Unit
+) {
+    var prioritizeDropdown by remember { mutableStateOf(false) }
+    Box {
+        Column(
+            modifier = Modifier
+                .clickable { prioritizeDropdown = true }
+                .fillMaxWidth()
+                .padding(all = 16.dp)
+        ) {
+            Text(
+                text = stringResource(commonR.string.prioritize_internal_title),
+                style = MaterialTheme.typography.body1
+            )
+            CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
+                Text(
+                    text = stringResource(
+                        if (prioritize) {
+                            commonR.string.prioritize_internal_on
+                        } else {
+                            commonR.string.prioritize_internal_off
                         }
-                    }
-                    if (prioritizeDropdown) {
-                        DropdownMenu(
-                            expanded = true,
-                            onDismissRequest = { prioritizeDropdown = false },
-                            modifier = Modifier.fillMaxWidth()
-                        ) {
-                            DropdownMenuItem(onClick = {
-                                onSetPrioritize(false)
-                                prioritizeDropdown = false
-                            }) {
-                                Text(stringResource(commonR.string.prioritize_internal_off))
-                            }
-                            DropdownMenuItem(onClick = {
-                                onSetPrioritize(true)
-                                prioritizeDropdown = false
-                            }) {
-                                Text(stringResource(commonR.string.prioritize_internal_on_expanded))
-                            }
-                        }
-                    }
+                    ),
+                    style = MaterialTheme.typography.body2
+                )
+            }
+        }
+        if (prioritizeDropdown) {
+            DropdownMenu(
+                expanded = true,
+                onDismissRequest = { prioritizeDropdown = false },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                DropdownMenuItem(onClick = {
+                    onChanged(false)
+                    prioritizeDropdown = false
+                }) {
+                    Text(stringResource(commonR.string.prioritize_internal_off))
+                }
+                DropdownMenuItem(onClick = {
+                    onChanged(true)
+                    prioritizeDropdown = false
+                }) {
+                    Text(stringResource(commonR.string.prioritize_internal_on_expanded))
                 }
             }
         }
@@ -267,12 +371,18 @@ fun SsidView(
 private fun PreviewSsidViewEmpty() {
     SsidView(
         wifiSsids = emptyList(),
+        canReadWifi = true,
+        ethernet = null,
+        vpn = null,
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
         activeBssid = "02:00:00:00:00:00",
         usingWifi = true,
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
+        onRequestPermission = {},
+        onSetEthernet = {},
+        onSetVpn = {},
         onSetPrioritize = {}
     )
 }
@@ -282,12 +392,18 @@ private fun PreviewSsidViewEmpty() {
 private fun PreviewSsidViewItems() {
     SsidView(
         wifiSsids = listOf("home-assistant-wifi", "wifi-one", "BSSID:1A:2B:3C:4D:5E:6F"),
+        canReadWifi = true,
+        ethernet = false,
+        vpn = true,
         prioritizeInternal = false,
         activeSsid = "home-assistant-wifi",
         activeBssid = "02:00:00:00:00:00",
         usingWifi = true,
         onAddWifiSsid = { true },
         onRemoveWifiSsid = {},
+        onRequestPermission = {},
+        onSetEthernet = {},
+        onSetVpn = {},
         onSetPrioritize = {}
     )
 }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -934,7 +934,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         val settingsWithLocationPermissions = mutableListOf<String>()
         if (!DisabledLocationHandler.isLocationEnabled(this) && presenter.isSsidUsed()) {
             showLocationDisabledWarning = true
-            settingsWithLocationPermissions.add(getString(commonR.string.pref_connection_wifi))
+            settingsWithLocationPermissions.add(getString(commonR.string.pref_connection_homenetwork))
         }
         for (manager in SensorReceiver.MANAGERS) {
             for (basicSensor in manager.getAvailableSensors(this)) {

--- a/app/src/main/res/xml/preferences_server.xml
+++ b/app/src/main/res/xml/preferences_server.xml
@@ -31,8 +31,7 @@
         <Preference
             android:key="connection_internal_ssids"
             android:icon="@drawable/ic_wifi"
-            android:title="@string/pref_connection_wifi"
-            android:summary="@string/pref_connection_ssids_empty" />
+            android:title="@string/pref_connection_homenetwork"/>
         <EditTextPreference
             android:key="connection_internal"
             android:title="@string/pref_connection_internal"

--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/48.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/48.json
@@ -1,0 +1,1134 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 48,
+    "identityHash": "4054f37ad307a9d9647ed871fa60e5b2",
+    "entities": [
+      {
+        "tableName": "sensor_attributes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "authentication_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`host` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, PRIMARY KEY(`host`))",
+        "fields": [
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "host"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sensors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `enabled` INTEGER NOT NULL, `registered` INTEGER DEFAULT NULL, `state` TEXT NOT NULL, `last_sent_state` TEXT DEFAULT NULL, `last_sent_icon` TEXT DEFAULT NULL, `state_type` TEXT NOT NULL, `type` TEXT NOT NULL, `icon` TEXT NOT NULL, `name` TEXT NOT NULL, `device_class` TEXT, `unit_of_measurement` TEXT, `state_class` TEXT, `entity_category` TEXT, `core_registration` TEXT, `app_registration` TEXT, PRIMARY KEY(`id`, `server_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentState",
+            "columnName": "last_sent_state",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "lastSentIcon",
+            "columnName": "last_sent_icon",
+            "affinity": "TEXT",
+            "notNull": false,
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "stateType",
+            "columnName": "state_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceClass",
+            "columnName": "device_class",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "unitOfMeasurement",
+            "columnName": "unit_of_measurement",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "stateClass",
+            "columnName": "state_class",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "entityCategory",
+            "columnName": "entity_category",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "coreRegistration",
+            "columnName": "core_registration",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "appRegistration",
+            "columnName": "app_registration",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "server_id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "sensor_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `entries` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entries",
+            "columnName": "entries",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "button_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `icon_name` TEXT NOT NULL, `domain` TEXT NOT NULL, `service` TEXT NOT NULL, `service_data` TEXT NOT NULL, `label` TEXT, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, `require_authentication` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "icon_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceData",
+            "columnName": "service_data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "requireAuthentication",
+            "columnName": "require_authentication",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "camera_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `tap_action` TEXT NOT NULL DEFAULT 'REFRESH', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tapAction",
+            "columnName": "tap_action",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'REFRESH'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "media_player_controls_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `label` TEXT, `show_skip` INTEGER NOT NULL, `show_seek` INTEGER NOT NULL, `show_volume` INTEGER NOT NULL, `show_source` INTEGER NOT NULL DEFAULT false, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "showSkip",
+            "columnName": "show_skip",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showSeek",
+            "columnName": "show_seek",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showVolume",
+            "columnName": "show_volume",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showSource",
+            "columnName": "show_source",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "static_widget",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `attribute_ids` TEXT, `label` TEXT, `text_size` REAL NOT NULL, `state_separator` TEXT NOT NULL, `attribute_separator` TEXT NOT NULL, `tap_action` TEXT NOT NULL DEFAULT 'REFRESH', `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeIds",
+            "columnName": "attribute_ids",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateSeparator",
+            "columnName": "state_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeSeparator",
+            "columnName": "attribute_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tapAction",
+            "columnName": "tap_action",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'REFRESH'"
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "template_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `template` TEXT NOT NULL, `text_size` REAL NOT NULL DEFAULT 12.0, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "template",
+            "columnName": "template",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "12.0"
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "notification_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL, `source` TEXT NOT NULL, `server_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received",
+            "columnName": "received",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "location_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `created` INTEGER NOT NULL, `trigger` TEXT NOT NULL, `result` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `location_name` TEXT, `accuracy` INTEGER, `data` TEXT, `server_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": false
+          },
+          {
+            "fieldPath": "locationName",
+            "columnName": "location_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "qs_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tile_id` TEXT NOT NULL, `added` INTEGER NOT NULL DEFAULT 1, `server_id` INTEGER NOT NULL DEFAULT 0, `icon_name` TEXT, `entity_id` TEXT NOT NULL, `label` TEXT NOT NULL, `subtitle` TEXT, `should_vibrate` INTEGER NOT NULL DEFAULT 0, `auth_required` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileId",
+            "columnName": "tile_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "added",
+            "columnName": "added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "icon_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "shouldVibrate",
+            "columnName": "should_vibrate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "authRequired",
+            "columnName": "auth_required",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "favorite_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `friendly_name` TEXT NOT NULL, `icon` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "friendlyName",
+            "columnName": "friendly_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "camera_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT, `refresh_interval` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "refreshInterval",
+            "columnName": "refresh_interval",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "entity_state_complications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT NOT NULL, `show_title` INTEGER NOT NULL DEFAULT 1, `show_unit` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTitle",
+            "columnName": "show_title",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showUnit",
+            "columnName": "show_unit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `_name` TEXT NOT NULL, `name_override` TEXT, `_version` TEXT, `device_registry_id` TEXT, `list_order` INTEGER NOT NULL, `device_name` TEXT, `external_url` TEXT NOT NULL, `internal_url` TEXT, `cloud_url` TEXT, `webhook_id` TEXT, `secret` TEXT, `cloudhook_url` TEXT, `use_cloud` INTEGER NOT NULL, `use_internal_when` TEXT NOT NULL DEFAULT 'SSID', `internal_ssids` TEXT NOT NULL, `prioritize_internal` INTEGER NOT NULL, `access_token` TEXT, `refresh_token` TEXT, `token_expiration` INTEGER, `token_type` TEXT, `install_id` TEXT, `user_id` TEXT, `user_name` TEXT, `user_is_owner` INTEGER, `user_is_admin` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "_name",
+            "columnName": "_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameOverride",
+            "columnName": "name_override",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "_version",
+            "columnName": "_version",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "deviceRegistryId",
+            "columnName": "device_registry_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "listOrder",
+            "columnName": "list_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.externalUrl",
+            "columnName": "external_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.internalUrl",
+            "columnName": "internal_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.cloudUrl",
+            "columnName": "cloud_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.webhookId",
+            "columnName": "webhook_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.secret",
+            "columnName": "secret",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.cloudhookUrl",
+            "columnName": "cloudhook_url",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.useCloud",
+            "columnName": "use_cloud",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.useInternalWhen",
+            "columnName": "use_internal_when",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'SSID'"
+          },
+          {
+            "fieldPath": "connection.internalSsids",
+            "columnName": "internal_ssids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.prioritizeInternal",
+            "columnName": "prioritize_internal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "session.accessToken",
+            "columnName": "access_token",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "session.refreshToken",
+            "columnName": "refresh_token",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "session.tokenExpiration",
+            "columnName": "token_expiration",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "session.tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "session.installId",
+            "columnName": "install_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "user.id",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "user.name",
+            "columnName": "user_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "user.isOwner",
+            "columnName": "user_is_owner",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "user.isAdmin",
+            "columnName": "user_is_admin",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `websocket_setting` TEXT NOT NULL, `sensor_update_frequency` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "websocketSetting",
+            "columnName": "websocket_setting",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorUpdateFrequency",
+            "columnName": "sensor_update_frequency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4054f37ad307a9d9647ed871fa60e5b2')"
+    ]
+  }
+}

--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/48.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/48.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 48,
-    "identityHash": "4054f37ad307a9d9647ed871fa60e5b2",
+    "identityHash": "aef553fa0b2cb5f0ccc508e5908effd2",
     "entities": [
       {
         "tableName": "sensor_attributes",
@@ -923,7 +923,7 @@
       },
       {
         "tableName": "servers",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `_name` TEXT NOT NULL, `name_override` TEXT, `_version` TEXT, `device_registry_id` TEXT, `list_order` INTEGER NOT NULL, `device_name` TEXT, `external_url` TEXT NOT NULL, `internal_url` TEXT, `cloud_url` TEXT, `webhook_id` TEXT, `secret` TEXT, `cloudhook_url` TEXT, `use_cloud` INTEGER NOT NULL, `use_internal_when` TEXT NOT NULL DEFAULT 'SSID', `internal_ssids` TEXT NOT NULL, `prioritize_internal` INTEGER NOT NULL, `access_token` TEXT, `refresh_token` TEXT, `token_expiration` INTEGER, `token_type` TEXT, `install_id` TEXT, `user_id` TEXT, `user_name` TEXT, `user_is_owner` INTEGER, `user_is_admin` INTEGER)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `_name` TEXT NOT NULL, `name_override` TEXT, `_version` TEXT, `device_registry_id` TEXT, `list_order` INTEGER NOT NULL, `device_name` TEXT, `external_url` TEXT NOT NULL, `internal_url` TEXT, `cloud_url` TEXT, `webhook_id` TEXT, `secret` TEXT, `cloudhook_url` TEXT, `use_cloud` INTEGER NOT NULL, `internal_ssids` TEXT NOT NULL, `internal_ethernet` INTEGER, `internal_vpn` INTEGER, `prioritize_internal` INTEGER NOT NULL, `access_token` TEXT, `refresh_token` TEXT, `token_expiration` INTEGER, `token_type` TEXT, `install_id` TEXT, `user_id` TEXT, `user_name` TEXT, `user_is_owner` INTEGER, `user_is_admin` INTEGER)",
         "fields": [
           {
             "fieldPath": "id",
@@ -1010,17 +1010,22 @@
             "notNull": true
           },
           {
-            "fieldPath": "connection.useInternalWhen",
-            "columnName": "use_internal_when",
-            "affinity": "TEXT",
-            "notNull": true,
-            "defaultValue": "'SSID'"
-          },
-          {
             "fieldPath": "connection.internalSsids",
             "columnName": "internal_ssids",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "connection.internalEthernet",
+            "columnName": "internal_ethernet",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "connection.internalVpn",
+            "columnName": "internal_vpn",
+            "affinity": "INTEGER",
+            "notNull": false
           },
           {
             "fieldPath": "connection.prioritizeInternal",
@@ -1128,7 +1133,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '4054f37ad307a9d9647ed871fa60e5b2')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'aef553fa0b2cb5f0ccc508e5908effd2')"
     ]
   }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -192,7 +192,7 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
         val raw = isLockEnabledRaw()
         val bypass = isLockHomeBypassEnabled()
         return if (raw && bypass) {
-            !server.connection.isHomeWifiSsid()
+            !server.connection.isInternal()
         } else {
             raw
         }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelper.kt
@@ -17,4 +17,10 @@ interface WifiHelper {
     fun isUsingSpecificWifi(networks: List<String>): Boolean
     fun getWifiSsid(): String?
     fun getWifiBssid(): String?
+
+    /** Returns if the active data connection is using ethernet */
+    fun isUsingEthernet(): Boolean
+
+    /** Returns if the active data connection is a VPN connection */
+    fun isUsingVpn(): Boolean
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/wifi/WifiHelperImpl.kt
@@ -49,4 +49,28 @@ class WifiHelperImpl @Inject constructor(
 
     override fun getWifiBssid(): String? =
         wifiManager?.connectionInfo?.bssid // Deprecated but callback doesn't provide BSSID info instantly
+
+    override fun isUsingEthernet(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            connectivityManager.activeNetwork?.let {
+                connectivityManager
+                    .getNetworkCapabilities(it)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) == true
+            } == true
+        } else {
+            connectivityManager.activeNetworkInfo?.isConnected == true &&
+                connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_ETHERNET
+        }
+
+    override fun isUsingVpn(): Boolean =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            connectivityManager.activeNetwork?.let {
+                connectivityManager
+                    .getNetworkCapabilities(it)
+                    ?.hasTransport(NetworkCapabilities.TRANSPORT_VPN) == true
+            } == true
+        } else {
+            connectivityManager.activeNetworkInfo?.isConnected == true &&
+                connectivityManager.activeNetworkInfo?.type == ConnectivityManager.TYPE_VPN
+        }
 }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -250,7 +250,7 @@ class BluetoothSensorManager : SensorManager {
         )
     }
 
-    private fun isPermittedOnThisWifiNetwork(context: Context) = serverManager(context).defaultServers.any { it.connection.isHomeWifiSsid() }
+    private fun isPermittedOnThisNetwork(context: Context) = serverManager(context).defaultServers.any { it.connection.isInternal() }
 
     private suspend fun updateBLEDevice(context: Context) {
         val transmitActive = getToggleSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, default = true)
@@ -353,14 +353,14 @@ class BluetoothSensorManager : SensorManager {
         // transmit when BT is on, if we are not already transmitting, or details have changed, and we're permitted on this wifi network
         if (isBtOn(context)) {
             if (bleTransmitterDevice.transmitRequested && (!bleTransmitterDevice.transmitting || bleTransmitterDevice.restartRequired) &&
-                (!bleTransmitterDevice.onlyTransmitOnHomeWifiSetting || isPermittedOnThisWifiNetwork(context))
+                (!bleTransmitterDevice.onlyTransmitOnHomeWifiSetting || isPermittedOnThisNetwork(context))
             ) {
                 TransmitterManager.startTransmitting(context, bleTransmitterDevice)
             }
         }
 
         // BT off, or TransmitToggled off, or not permitted on this network - stop transmitting if we have been
-        if (!isBtOn(context) || !bleTransmitterDevice.transmitRequested || (bleTransmitterDevice.onlyTransmitOnHomeWifiSetting && !isPermittedOnThisWifiNetwork(context))) {
+        if (!isBtOn(context) || !bleTransmitterDevice.transmitRequested || (bleTransmitterDevice.onlyTransmitOnHomeWifiSetting && !isPermittedOnThisNetwork(context))) {
             TransmitterManager.stopTransmitting(bleTransmitterDevice)
         }
 

--- a/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -97,7 +97,7 @@ import kotlinx.coroutines.runBlocking
         Server::class,
         Setting::class
     ],
-    version = 47,
+    version = 48,
     autoMigrations = [
         AutoMigration(from = 24, to = 25),
         AutoMigration(from = 25, to = 26),
@@ -120,7 +120,8 @@ import kotlinx.coroutines.runBlocking
         AutoMigration(from = 43, to = 44),
         AutoMigration(from = 44, to = 45),
         AutoMigration(from = 45, to = 46),
-        AutoMigration(from = 46, to = 47)
+        AutoMigration(from = 46, to = 47),
+        AutoMigration(from = 47, to = 48)
     ]
 )
 @TypeConverters(

--- a/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
@@ -95,8 +95,6 @@ data class ServerConnectionInfo(
 
     fun canUseCloud(): Boolean = !this.cloudUrl.isNullOrBlank()
 
-    fun isHomeWifiSsid(): Boolean = wifiHelper.isUsingSpecificWifi(internalSsids)
-
     fun isInternal(): Boolean {
         if (internalUrl.isNullOrBlank()) return false
 

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -394,7 +394,7 @@
     <string name="location_history_skipped_not_latest">Old location</string>
     <string name="location_history_skipped_old">Very old location</string>
     <string name="location_history_use">Use location history</string>
-    <string name="location_perm_info_message">Android set up restrictions for apps which want to use your WiFi, because WiFi can be theoretically used to determine your location.\n\nAlso to ensure the app can access WiFi in background (URL decision making, sensors) you need to allow location access all the time.\n\nTherefore, to use this option location access all the time is needed.\n\nContinue granting location access?</string>
+    <string name="location_perm_info_message">Android set up restrictions for apps which want to use your WiFi, because WiFi can be theoretically used to determine your location.\n\nATo ensure the app can access WiFi in background (URL decision making, sensors), you must allow location access all the time.\n\nTherefore, to use this option location access all the time is needed.\n\nContinue granting location access?</string>
     <string name="location_perm_info_title">Location access</string>
     <string name="location_tracking">Location tracking</string>
     <string name="location_tracking_summary">View a history of location tracking updates to troubleshoot the device tracker</string>
@@ -402,8 +402,8 @@
     <string name="location">Location</string>
     <string name="lock_summary">Use biometric or screen lock credentials to unlock app</string>
     <string name="lock_title">Lock app</string>
-    <string name="lock_home_bypass_summary">Disable app lock when connected to the home WiFi network</string>
-    <string name="lock_home_bypass_title">Unlock on home WiFi</string>
+    <string name="lock_home_bypass_summary">Disable app lock when connected to the home network</string>
+    <string name="lock_home_bypass_title">Unlock on home network</string>
     <string name="locks">Locks</string>
     <string name="lockscreen_title">App locked!</string>
     <string name="log_file_not_created">Log file could not be created.</string>
@@ -425,10 +425,13 @@
     <string name="manage_all_sensors">Manage all sensors</string>
     <string name="manage_shortcuts_summary">Manage launcher shortcuts</string>
     <string name="manage_shortcuts">Manage shortcuts</string>
-    <string name="manage_ssids_input_exists">This SSID already exists.</string>
+    <string name="manage_ssids_ethernet">Ethernet connected</string>
+    <string name="manage_ssids_input_exists">This SSID already exists</string>
     <string name="manage_ssids_input">New WiFi SSID</string>
-    <string name="manage_ssids_introduction">The internal connection URL will be used when connected to one of the listed SSIDs.</string>
-    <string name="manage_ssids">Manage SSID(s)</string>
+    <string name="manage_ssids_introduction">Indicate when you\'re connected to your home network, based on WiFi, ethernet or VPN. This can be used to, for example, use the internal connection URL or disable the app lock when at home.</string>
+    <string name="manage_ssids_permission">Home Assistant needs additional access to read WiFi information.</string>
+    <string name="manage_ssids_wifi">WiFi network connected</string>
+    <string name="manage_ssids_vpn">VPN connected</string>
     <string name="manage_this_notification">Manage this notification</string>
     <string name="manage_tiles_summary">Set up and manage quick settings tiles here. They will not function until you set them up here.</string>
     <string name="manage_tiles">Manage tiles</string>
@@ -498,6 +501,7 @@
     <string name="none">None</string>
     <string name="none_selected">None selected</string>
     <string name="not_private">Your connection to this site is not private.</string>
+    <string name="not_set">Not set</string>
     <string name="notification_data">Full notification data</string>
     <string name="notification_dismiss_failure">Failed to send event on notification dismissed</string>
     <string name="notification_history_summary">History of notifications</string>
@@ -524,11 +528,10 @@
     <string name="pref_call_tracking_summary">Allow application to detect call occurrence and notify server about it.</string>
     <string name="pref_call_tracking_title">Calls tracking</string>
     <string name="pref_connection_internal">Internal connection URL</string>
-    <string name="pref_connection_ssids_empty">Configure your WiFi SSID(s)</string>
     <string name="pref_connection_title">Connection information</string>
     <string name="pref_connection_url">Home Assistant URL</string>
-    <string name="pref_connection_wifi">Home network WiFi SSID</string>
-    <string name="prioritize_internal_title">When loading dashboard and unknown if connected to home network WiFi</string>
+    <string name="pref_connection_homenetwork">Home network</string>
+    <string name="prioritize_internal_title">When loading dashboard and unknown if connected to home network</string>
     <string name="prioritize_internal_on">Use internal connection URL</string>
     <string name="prioritize_internal_on_expanded">Use internal connection URL (use this if you typically turn location access off)</string>
     <string name="prioritize_internal_off">Use Home Assistant URL (recommended)</string>
@@ -592,7 +595,7 @@
     <string name="sensor_description_battery_level">The current battery level of the device</string>
     <string name="sensor_description_battery_state">The current charging state of the battery</string>
     <string name="sensor_description_battery_temperature">The current battery temperature</string>
-    <string name="sensor_description_bluetooth_ble_emitter">Send BLE iBeacon with configured interval, used to track presence around house, e.g. together with roomassistant, esp32-mqtt-room or espresence projects.\n\nWarning: this can affect battery life, particularly if the \"Transmitter power\" setting is set to High or \"Advertise Mode\" is set to Low latency.\n\nSettings allow for specifying:\n- \"UUID\" (standard UUID format), \"Major\" and \"Minor\" (should be 0 - 65535), to tailor identifiers and groups. The default Minor value 40004 has the special meaning of forcing the beacon to be recognized by the iBeacon Tracker integration\n- \"Transmitter Power\" and \"Advertise Mode\" to help to preserve battery life (use lowest values if possible)\n - \"Measured Power\" to specify power measured at 1m (initial default -59)\n\nIt is also possible to set beacons to only be transmitted when connected to a Home Network WiFi SSID, which may be desirable for privacy and battery life.\n\nNote:\nAdditionally a separate setting exists (\"Enable Transmitter\") to stop or start transmitting.</string>
+    <string name="sensor_description_bluetooth_ble_emitter">Send BLE iBeacon with configured interval, used to track presence around house, e.g. together with roomassistant, esp32-mqtt-room or espresence projects.\n\nWarning: this can affect battery life, particularly if the \"Transmitter power\" setting is set to High or \"Advertise Mode\" is set to Low latency.\n\nSettings allow for specifying:\n- \"UUID\" (standard UUID format), \"Major\" and \"Minor\" (should be 0 - 65535), to tailor identifiers and groups. The default Minor value 40004 has the special meaning of forcing the beacon to be recognized by the iBeacon Tracker integration\n- \"Transmitter Power\" and \"Advertise Mode\" to help to preserve battery life (use lowest values if possible)\n - \"Measured Power\" to specify power measured at 1m (initial default -59)\n\nIt is also possible to set beacons to only be transmitted when connected to a Home network, which may be desirable for privacy and battery life.\n\nNote:\nAdditionally a separate setting exists (\"Enable Transmitter\") to stop or start transmitting.</string>
     <string name="sensor_description_bluetooth_ble_beacon_monitor">Scans for iBeacons and shows the IDs of nearby beacons and their distance in meters. A notification will be shown on the device when scanning is actively running.\n\nWarning: this can affect battery life, especially with a short \"Scan Interval\".\n\nSettings allow for specifying:\n- \"Filter Iterations\" (should be 1 - 100, default: 10), higher values will result in more stable measurements but also less responsiveness.\n- \"Filter RSSI Multiplier\" (should be 1.0 - 2.0, default: 1.05), can be used to achieve more stable measurements when beacons are farther away. This will also affect responsiveness.\n- \"Scan Interval\" (default: 500) milliseconds between scans. Shorter intervals will drain the battery more quickly.\n- \"Scan Period\" (default: 1100) milliseconds to scan for beacons. Most beacons will send a signal every second so this value should be at least 1100ms.\n- \"UUID Filter\" allows to restrict the reported beacons by including (or excluding) those with the selected UUIDs.\n- \"Exclude selected UUIDs\", if false (default) only the beacons with the selected UUIDs are reported. If true all beacons except the selected ones are reported. Not available when \"UUID Filter\" is empty.\n\nNote:\nAdditionally a separate setting exists (\"Enable Beacon Monitor\") to stop or start scanning.</string>
     <string name="sensor_description_bluetooth_connection">Information about currently connected Bluetooth devices</string>
     <string name="sensor_description_bluetooth_state">Whether Bluetooth is enabled on the device</string>
@@ -717,7 +720,7 @@
     <string name="sensor_setting_ble_measured_power_at_1m_title">Measured power</string>
     <string name="sensor_setting_ble_minor_title">Minor</string>
     <string name="sensor_setting_ble_transmit_enabled_title">Enable transmitter</string>
-    <string name="sensor_setting_ble_home_wifi_only_title">Transmit on Home Network WiFi SSID only</string>
+    <string name="sensor_setting_ble_home_wifi_only_title">Transmit on Home network only</string>
     <string name="sensor_setting_ble_transmit_power_high_label">High</string>
     <string name="sensor_setting_ble_transmit_power_low_label">Low</string>
     <string name="sensor_setting_ble_transmit_power_medium_label">Medium</string>
@@ -1081,8 +1084,8 @@
     <string name="shortcut_pinned">Pinned shortcuts</string>
     <string name="remote_debugging">WebView remote debugging</string>
     <string name="remote_debugging_summary">Allow remote debugging of WebView to troubleshoot Home Assistant frontend issues</string>
-    <string name="websocket_setting_home_wifi">On home WiFi only\n\nNotifications will be delivered by Google only when not on home WiFi.</string>
-    <string name="websocket_setting_home_wifi_minimal">On home WiFi only\n\nNotifications will only be received when on home WiFi.</string>
+    <string name="websocket_setting_home_wifi">On home network only\n\nNotifications will be delivered by Google only when not on home network.</string>
+    <string name="websocket_setting_home_wifi_minimal">On home network only\n\nNotifications will only be received when on home network.</string>
     <string name="sensor_update_frequency">Sensor update frequency</string>
     <string name="sensor_update_frequency_description">Sensors will update either instantly or on a defined interval. If the sensor supports instant updates then it will always receive instant updates. View the sensor details to learn which sensors update instantly. Location sensors are not part of the update frequency setting as they have their own interval, consider using High Accuracy mode if you need to adjust the update interval.\n\nIf the sensor does not support instant updates then it will update based on one of the below selected options.\n\nYou must restart the application when you make any changes to this setting.</string>
     <string name="sensor_update_frequency_normal">Normal\n\nSensors will update on a 15 minute interval.</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Add options to also treat ethernet or VPN as home network (for internal URL, app lock, websocket push, BLE monitor). It reads the value from the system, not a specific app, so it matches when the status bar icon shows a <...> for ethernet or key for VPN (no additional details are available).

This should help with users who want internal URL + VPN, which I've seen multiple times on forums/Discord etc., and does not require location access for the app or location services to be on. Addresses:
 - Fixes #2532 
 - Fixes #4852 - "I assume this is because it is not trying to connect using the internal IP but rather the external URL" can now be fixed by enabling VPN
 - Sort of #4866 - it is not pinging but doesn't require location
 - Split tunnel VPN setups

The new values are nullable so we can change defaults and possibly introduce an inverse option in the future.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
The 'home network WiFi SSID' screen is extended with the new options. 
|Light|Dark|
|----|----|
|![image](https://github.com/user-attachments/assets/5ddcdcbb-c0fa-4245-8d28-2b0bdb484b2d)|![image](https://github.com/user-attachments/assets/36b00121-f04a-4b65-8dc5-d4138bcd2344)|

The check for location access is moved to this screen, instead of before the screen, and will display inline next to the WiFi networks setting.
|Light|Dark|
|----|----|
|![image](https://github.com/user-attachments/assets/37007530-2052-43cd-a957-d5f4a4adfae3)|![image](https://github.com/user-attachments/assets/7a81f0f2-8ec7-4cf0-ad5b-2ec67ff5d7f9)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I don't see how adding this advanced information to the basic setup page helps, probably fine to leave it as it is

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
For review purposes: the first two commits include the actual logic. The third commit includes UI.