### PR TITLE
Unlink saving crash stacktrace from Sentry

### DIFF
--- a/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/full/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -1,25 +1,14 @@
 package io.homeassistant.companion.android
 
 import android.content.Context
-import android.util.Log
-import io.sentry.SentryOptions
 import io.sentry.android.core.SentryAndroid
-import java.io.File
-import java.io.PrintWriter
 import java.net.ConnectException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLHandshakeException
 import javax.net.ssl.SSLPeerUnverifiedException
 import javax.net.ssl.SSLProtocolException
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
-private const val FATAL_CRASH_FILE = "/fatalcrash/last_crash"
 
 fun initCrashReporting(context: Context, enabled: Boolean) {
     // Don't init on debug builds or when disabled
@@ -30,27 +19,6 @@ fun initCrashReporting(context: Context, enabled: Boolean) {
     SentryAndroid.init(context) { options ->
         options.isEnableAutoSessionTracking = true
         options.isEnableNdk = false
-
-        options.beforeSend = SentryOptions.BeforeSendCallback { event, _ ->
-            if (event.isCrashed && event.throwable != null) {
-                try {
-                    val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
-                    if (!crashFile.exists()) {
-                        crashFile.parentFile?.mkdirs()
-                        crashFile.createNewFile()
-                    }
-                    val stacktraceWriter = PrintWriter(crashFile)
-                    val timestamp = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault()).format(event.timestamp)
-                    stacktraceWriter.print("$timestamp: ")
-                    event.throwable?.printStackTrace(stacktraceWriter)
-                    stacktraceWriter.close()
-                } catch (e: Exception) {
-                    Log.i("CrashHandling", "Tried saving fatal crash but encountered exception", e)
-                }
-            }
-
-            return@BeforeSendCallback event
-        }
 
         val ignoredEvents = arrayOf(
             ConnectException::class.java,
@@ -64,25 +32,6 @@ fun initCrashReporting(context: Context, enabled: Boolean) {
 
         options.ignoredExceptionsForType.addAll(ignoredEvents)
     }
-}
-
-suspend fun getLatestFatalCrash(context: Context, enabled: Boolean): String? = withContext(Dispatchers.IO) {
-    if (!shouldEnableCrashHandling(enabled)) {
-        return@withContext null
-    }
-
-    var toReturn: String? = null
-    try {
-        val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
-        if (crashFile.exists() &&
-            crashFile.lastModified() >= (System.currentTimeMillis() - TimeUnit.HOURS.toMillis(12))
-        ) { // Existing, recent file
-            toReturn = crashFile.readText().trim().ifBlank { null }
-        }
-    } catch (e: Exception) {
-        Log.e("CrashHandling", "Encountered exception while reading crash log file", e)
-    }
-    return@withContext toReturn
 }
 
 private fun shouldEnableCrashHandling(enabled: Boolean) = !BuildConfig.DEBUG && enabled

--- a/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -23,6 +23,7 @@ import io.homeassistant.companion.android.database.settings.SensorUpdateFrequenc
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.settings.language.LanguagesManager
 import io.homeassistant.companion.android.util.LifecycleHandler
+import io.homeassistant.companion.android.util.initCrashSaving
 import io.homeassistant.companion.android.websocket.WebsocketBroadcastReceiver
 import io.homeassistant.companion.android.widgets.button.ButtonWidget
 import io.homeassistant.companion.android.widgets.entity.EntityWidget
@@ -60,6 +61,7 @@ open class HomeAssistantApplication : Application() {
                 applicationContext,
                 prefsRepository.isCrashReporting()
             )
+            initCrashSaving(applicationContext)
         }
 
         languagesManager.applyCurrentLang()

--- a/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/settings/log/LogFragment.kt
@@ -31,8 +31,8 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
-import io.homeassistant.companion.android.getLatestFatalCrash
 import io.homeassistant.companion.android.util.LogcatReader
+import io.homeassistant.companion.android.util.getLatestFatalCrash
 import java.io.File
 import java.util.Calendar
 import javax.inject.Inject
@@ -115,7 +115,7 @@ class LogFragment : Fragment() {
 
             // Runs with Dispatcher IO
             processLog = LogcatReader.readLog()
-            crashLog = getLatestFatalCrash(requireContext(), prefsRepository.isCrashReporting())
+            crashLog = getLatestFatalCrash(requireContext())
 
             showLog()
             showHideLogLoader(false)

--- a/app/src/main/java/io/homeassistant/companion/android/util/CrashSaving.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/util/CrashSaving.kt
@@ -1,0 +1,54 @@
+package io.homeassistant.companion.android.util
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val FATAL_CRASH_FILE = "/fatalcrash/last_crash"
+
+fun initCrashSaving(context: Context) {
+    val handler = Thread.getDefaultUncaughtExceptionHandler()
+    Thread.setDefaultUncaughtExceptionHandler { thread, exception ->
+        // Try saving the crash in a file
+        try {
+            val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
+            if (!crashFile.exists()) {
+                crashFile.parentFile?.mkdirs()
+                crashFile.createNewFile()
+            }
+
+            crashFile.writeText(
+                """|Timestamp: ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault()).format(Date())}
+                    |Thread: ${thread.name}
+                    |Exception: ${exception.stackTraceToString()}
+                """.trimMargin()
+            )
+        } catch (e: Exception) {
+            Log.i("CrashSaving", "Tried saving fatal crash but encountered exception", e)
+        }
+
+        // Send to crash handling and/or system (and crash)
+        handler?.uncaughtException(thread, exception)
+    }
+}
+
+suspend fun getLatestFatalCrash(context: Context): String? = withContext(Dispatchers.IO) {
+    var toReturn: String? = null
+    try {
+        val crashFile = File(context.applicationContext.cacheDir.absolutePath + FATAL_CRASH_FILE)
+        if (crashFile.exists() &&
+            crashFile.lastModified() >= (System.currentTimeMillis() - TimeUnit.HOURS.toMillis(12))
+        ) { // Existing, recent file
+            toReturn = crashFile.readText().trim().ifBlank { null }
+        }
+    } catch (e: Exception) {
+        Log.e("CrashSaving", "Encountered exception while reading crash log file", e)
+    }
+    return@withContext toReturn
+}

--- a/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/minimal/java/io/homeassistant/companion/android/CrashHandling.kt
@@ -1,14 +1,7 @@
 package io.homeassistant.companion.android
 
 import android.content.Context
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 fun initCrashReporting(context: Context, enabled: Boolean) {
     // Noop
-}
-
-suspend fun getLatestFatalCrash(context: Context, enabled: Boolean): String? = withContext(Dispatchers.IO) {
-    // Noop
-    return@withContext null
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
A couple of years ago I added saving uncaught fatal exceptions to the app to display them to the user, using a hook provided by Sentry. Turns out it is not too difficult to do it without Sentry, so this PR changes that.

It will still pass exceptions on to Sentry if initialized (tested). Saving the crash is always on now because it no longer involves Sentry/a 3rd party you might want to switch off.

(Maybe it will also catch more stuff now that it is simpler, because I feel like recently it hasn't worked very well.)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
I did code an exception to test but actually got a real crash :)

|Light|Dark|
|-----|----|
|![App log screen with 'recent crash' tab selected and a crash stacktrace, light mode](https://github.com/user-attachments/assets/2b31250e-8bc2-4952-85da-4d76176eff48)|![App log screen with 'recent crash' tab selected and a crash stacktrace, dark mode](https://github.com/user-attachments/assets/aa5263aa-c7bd-4d0d-ae1d-869efd33e753)|

<details>

<summary>Crash text (note that I switched timestamp/thread after taking the screenshot)</summary>

```
Timestamp: 2024-12-10 19:04:54.070
Thread: main
Exception: java.lang.IllegalStateException: Testing
	at io.homeassistant.companion.android.settings.SettingsFragment.onCreatePreferences$lambda$46$lambda$45(SettingsFragment.kt:355)
	at io.homeassistant.companion.android.settings.SettingsFragment.$r8$lambda$0g-zfgYjQ-VCcAfvQ5UjEk4dvso(Unknown Source:0)
	at io.homeassistant.companion.android.settings.SettingsFragment$$ExternalSyntheticLambda1.onPreferenceClick(D8$$SyntheticClass:0)
	at androidx.preference.Preference.performClick(Preference.java:1200)
	at androidx.preference.Preference.performClick(Preference.java:1182)
	at androidx.preference.Preference$1.onClick(Preference.java:182)
	at android.view.View.performClick(View.java:8033)
	at android.view.View.performClickInternal(View.java:8010)
	at android.view.View.-$$Nest$mperformClickInternal(Unknown Source:0)
	at android.view.View$PerformClick.run(View.java:31336)
	at android.os.Handler.handleCallback(Handler.java:991)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8787)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:591)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:871)
```

</details>

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->