### PR TITLE
Add support for media players in device controls

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControl.kt
@@ -17,6 +17,8 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.integration.friendlyState
+import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.webview.WebViewActivity
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -73,6 +75,14 @@ interface HaControl {
 
                 iconDrawable.setTint(ContextCompat.getColor(context, colorTint))
                 control.setCustomIcon(iconDrawable.toAndroidIconCompat().toIcon(context))
+            }
+        } else {
+            // Specific override for media_player icons to match HA frontend rather than provided device type
+            if (entity.domain == "media_player") {
+                val icon = IconicsDrawable(context, entity.getIcon(context)).apply { sizeDp = 48 }
+                val tint = if (entity.isActive()) R.color.colorDeviceControlsDefaultOn else R.color.colorDeviceControlsOff
+                icon.setTint(ContextCompat.getColor(context, tint))
+                control.setCustomIcon(icon.toAndroidIconCompat().toIcon(context))
             }
         }
 

--- a/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/HaControlsProviderService.kt
@@ -53,7 +53,7 @@ class HaControlsProviderService : ControlsProviderService() {
             "input_number" to DefaultSliderControl,
             "light" to LightControl,
             "lock" to LockControl,
-            "media_player" to null,
+            "media_player" to MediaPlayerControl,
             "remote" to null,
             "scene" to DefaultButtonControl,
             "script" to DefaultButtonControl,

--- a/app/src/main/java/io/homeassistant/companion/android/controls/MediaPlayerControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/MediaPlayerControl.kt
@@ -17,6 +17,7 @@ import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.getVolumeLevel
 import io.homeassistant.companion.android.common.data.integration.getVolumeStep
+import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.data.integration.supportsVolumeSet
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -29,13 +30,12 @@ object MediaPlayerControl : HaControl {
         entity: Entity<Map<String, Any>>,
         info: HaControlInfo
     ): Control.StatefulBuilder {
-        val isPlaying = entity.state == "playing"
         if (entity.supportsVolumeSet()) {
             val volumeLevel = entity.getVolumeLevel()
             control.setControlTemplate(
                 ToggleRangeTemplate(
                     entity.entityId,
-                    isPlaying,
+                    entity.isActive(),
                     "",
                     RangeTemplate(
                         entity.entityId,
@@ -52,7 +52,7 @@ object MediaPlayerControl : HaControl {
                 ToggleTemplate(
                     entity.entityId,
                     ControlButton(
-                        isPlaying,
+                        entity.isActive(),
                         ""
                     )
                 )

--- a/app/src/main/java/io/homeassistant/companion/android/controls/MediaPlayerControl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/controls/MediaPlayerControl.kt
@@ -1,0 +1,98 @@
+package io.homeassistant.companion.android.controls
+
+import android.content.Context
+import android.os.Build
+import android.service.controls.Control
+import android.service.controls.DeviceTypes
+import android.service.controls.actions.BooleanAction
+import android.service.controls.actions.ControlAction
+import android.service.controls.actions.FloatAction
+import android.service.controls.templates.ControlButton
+import android.service.controls.templates.RangeTemplate
+import android.service.controls.templates.ToggleRangeTemplate
+import android.service.controls.templates.ToggleTemplate
+import androidx.annotation.RequiresApi
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.getVolumeLevel
+import io.homeassistant.companion.android.common.data.integration.getVolumeStep
+import io.homeassistant.companion.android.common.data.integration.supportsVolumeSet
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@RequiresApi(Build.VERSION_CODES.R)
+object MediaPlayerControl : HaControl {
+    override fun provideControlFeatures(
+        context: Context,
+        control: Control.StatefulBuilder,
+        entity: Entity<Map<String, Any>>,
+        info: HaControlInfo
+    ): Control.StatefulBuilder {
+        val isPlaying = entity.state == "playing"
+        if (entity.supportsVolumeSet()) {
+            val volumeLevel = entity.getVolumeLevel()
+            control.setControlTemplate(
+                ToggleRangeTemplate(
+                    entity.entityId,
+                    isPlaying,
+                    "",
+                    RangeTemplate(
+                        entity.entityId,
+                        volumeLevel?.min ?: 0f,
+                        volumeLevel?.max ?: 100f,
+                        volumeLevel?.value ?: 0f,
+                        entity.getVolumeStep(),
+                        "%.0f%%"
+                    )
+                )
+            )
+        } else {
+            control.setControlTemplate(
+                ToggleTemplate(
+                    entity.entityId,
+                    ControlButton(
+                        isPlaying,
+                        ""
+                    )
+                )
+            )
+        }
+        return control
+    }
+
+    override fun getDeviceType(entity: Entity<Map<String, Any>>): Int =
+        DeviceTypes.TYPE_TV
+
+    override fun getDomainString(context: Context, entity: Entity<Map<String, Any>>): String =
+        context.getString(commonR.string.media_player)
+
+    override suspend fun performAction(
+        integrationRepository: IntegrationRepository,
+        action: ControlAction
+    ): Boolean {
+        when (action) {
+            is BooleanAction -> {
+                integrationRepository.callAction(
+                    action.templateId.split(".")[0],
+                    "media_play_pause",
+                    hashMapOf("entity_id" to action.templateId)
+                )
+            }
+            is FloatAction -> {
+                // Convert back to accepted format:
+                // https://github.com/home-assistant/frontend/blob/dev/src/dialogs/more-info/controls/more-info-media_player.ts#L289
+                val volumeLevel = action.newValue.div(100)
+                integrationRepository.callAction(
+                    action.templateId.split(".")[0],
+                    "volume_set",
+                    hashMapOf(
+                        "entity_id" to action.templateId,
+                        "volume_level" to BigDecimal(volumeLevel.toDouble()).setScale(2, RoundingMode.HALF_UP)
+                    )
+                )
+            }
+        }
+        return true
+    }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->

Adds support for media player entities in device controls.

Toggle control will play/pause, active state is only if `playing`

Slider control for volume if media player supports setting the volume

Behavior designed to match frontend as close as possible due to conversions for volume

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

![image](https://github.com/user-attachments/assets/c235b926-a1af-46dd-965d-91c8d7fd7b14)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1149

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Ref: https://community.home-assistant.io/t/wth-why-cant-media-player-entities-be-added-to-android-device-controls/813242

The actions accept any value, we don't particularly need to round things but good to keep things clean i think. Tested with a few of my media players.