### PR TITLE
Update text for go to first view in onStop setting

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -23,7 +23,7 @@
     <string name="all_entities">All entities</string>
     <string name="all_results">All results</string>
     <string name="allow">Allow</string>
-    <string name="always_show_first_view_on_app_start">Always show first view on app start</string>
+    <string name="always_show_first_view_on_app_start">Always show first view when opening app</string>
     <string name="always_show_first_view_on_app_start_summary">The first view of the default dashboard is shown as soon as the app is opened</string>
     <string name="app_name">Home Assistant</string>
     <string name="app_version_info">App version info</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #4840 (people didn't use the tag :( ). Note that the event is called in `onStop` and it depends on the system whether or not it is triggered, so start and open are both not 100% correct but at least the setting title is now the same as the description.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
...

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->