### PR TITLE
Revert "Bump softprops/action-gh-release from 2.1.0 to 2.2.0 (#4896)"

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Create Github Pre-Release
         if: github.event.inputs.beta == 'true'
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@v2.1.0
         with:
           tag_name: ${{ steps.rel_number.outputs.version }}
           body_path: ./app/build/outputs/changelogGithub


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Currently releases don't include artifacts and fail with ([example](https://github.com/home-assistant/android/actions/runs/12471370823/job/34808200161)):

```
 👩‍🏭 Creating new GitHub release for tag 2024.12.5...
⬆️ Uploading app-full-release.apk...
⬆️ Uploading app-minimal-release.apk...
⬆️ Uploading version_code.txt...
⬆️ Uploading wear-release.apk...
⬆️ Uploading automotive-full-release.apk...
⬆️ Uploading automotive-minimal-release.apk...
##[error***Request body length does not match content-length header
```

Needs softprops/action-gh-release#562 for fix so revert while it is not released.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->