### PR TITLE
Log action for external bus improv/scan command

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1677,8 +1677,14 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
     }
 
     private fun scanForImprov() {
-        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) return
-        if (!hasWindowFocus()) return
+        if (!packageManager.hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE)) {
+            Log.d(TAG, "Improv scan request ignored because device doesn't have Bluetooth")
+            return
+        }
+        if (!hasWindowFocus()) {
+            Log.d(TAG, "Improv scan request ignored because webview doesn't have focus")
+            return
+        }
         lifecycleScope.launch {
             if (presenter.shouldShowImprovPermissions()) {
                 supportFragmentManager.setFragmentResultListener(ImprovPermissionDialog.RESULT_KEY, this@WebViewActivity) { _, bundle ->

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -490,7 +490,12 @@ class WebViewPresenterImpl @Inject constructor(
     }
 
     override fun startScanningForImprov(): Boolean {
-        if (!improvRepository.hasPermission(view as Context)) return false
+        if (!improvRepository.hasPermission(view as Context)) {
+            Log.d(TAG, "Improv scan request ignored because app doesn't have permission")
+            return false
+        } else {
+            Log.d(TAG, "Improv scan starting")
+        }
         improvJobStarted = System.currentTimeMillis()
         improvJob = mainScope.launch {
             withContext(Dispatchers.IO) {
@@ -517,6 +522,7 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun stopScanningForImprov(force: Boolean) {
         if (improvJob?.isActive == true && (force || System.currentTimeMillis() - improvJobStarted > 1000)) {
+            Log.d(TAG, "Improv scan stopping")
             improvRepository.stopScanning()
             improvJob?.cancel()
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Adds a log statement with the app's decision to an Improv scan request to help with #4936, where nothing appears to happen.

Why: I expected the app requirements to be simple enough to verify and the library simply throws exceptions if things don't work, but right now it's unclear why nothing is happening. The line `D WebviewActivity: External bus {"type":"improv/scan","id":4}` should be followed by [`I ImprovManager: Find Devices`](https://github.com/improv-wifi/sdk-android/blob/2b7e2d892862a541f576f05ed0867f35f3072e90/library/src/main/java/com/wifi/improv/ImprovManager.kt#L240), if not something between the external bus and library seems to decide not to work and these lines should tell if that is the app.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->