### PR TITLE
Fix home network checks without internal URL

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -129,7 +129,7 @@ class WebsocketManager(
     private fun shouldRunForServer(serverId: Int): Boolean {
         val server = serverManager.getServer(serverId) ?: return false
         val setting = settingsDao.get(serverId)?.websocketSetting ?: DEFAULT_WEBSOCKET_SETTING
-        val isHome = server.connection.isInternal()
+        val isHome = server.connection.isInternal(requiresUrl = false)
 
         // Check for connectivity but not internet access, based on WorkManager's NetworkConnectedController API <26
         val powerManager = applicationContext.getSystemService<PowerManager>()!!

--- a/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -192,7 +192,7 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
         val raw = isLockEnabledRaw()
         val bypass = isLockHomeBypassEnabled()
         return if (raw && bypass) {
-            !server.connection.isInternal()
+            !server.connection.isInternal(requiresUrl = false)
         } else {
             raw
         }

--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BluetoothSensorManager.kt
@@ -250,7 +250,7 @@ class BluetoothSensorManager : SensorManager {
         )
     }
 
-    private fun isPermittedOnThisNetwork(context: Context) = serverManager(context).defaultServers.any { it.connection.isInternal() }
+    private fun isPermittedOnThisNetwork(context: Context) = serverManager(context).defaultServers.any { it.connection.isInternal(requiresUrl = false) }
 
     private suspend fun updateBLEDevice(context: Context) {
         val transmitActive = getToggleSetting(context, bleTransmitter, SETTING_BLE_TRANSMIT_ENABLED, default = true)

--- a/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
@@ -95,8 +95,14 @@ data class ServerConnectionInfo(
 
     fun canUseCloud(): Boolean = !this.cloudUrl.isNullOrBlank()
 
-    fun isInternal(): Boolean {
-        if (internalUrl.isNullOrBlank()) return false
+    /**
+     * Indicate if the device's current connection should be treated as internal for
+     * this server.
+     * @param requiresUrl Whether a valid internal url is required for internal or not.
+     *   Usually you want this `true` for url related actions and `false` for others.
+     */
+    fun isInternal(requiresUrl: Boolean = true): Boolean {
+        if (requiresUrl && internalUrl.isNullOrBlank()) return false
 
         if (internalEthernet == true) {
             val usesEthernet = wifiHelper.isUsingEthernet()


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes a regression in home network checks introduced by expanded home network indicators (ethernet, VPN) by making the internal URL check part optional. (Previously, they used `isHomeWifiSsid()` which does not consider the internal URL.)

Fixes #4934, confirmed [on the forums](https://community.home-assistant.io/t/companion-app-not-recognizing-home-wi-fi/816994/3?u=jpelgrom).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->