### PR TITLE
Always request Bluetooth permission for Improv if 1/2 is granted

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -157,6 +157,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 downloadFile(downloadFileUrl, downloadFileContentDisposition, downloadFileMimetype)
             }
         }
+    private val requestImprovPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                presenter.startScanningForImprov()
+            }
+        }
     private val writeNfcTag = registerForActivityResult(WriteNfcTag()) { messageId ->
         sendExternalBusMessage(
             ExternalBusMessage(
@@ -1696,7 +1702,12 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 val dialog = ImprovPermissionDialog()
                 dialog.show(supportFragmentManager, ImprovPermissionDialog.TAG)
             } else {
-                presenter.startScanningForImprov()
+                val safePermissionToRequest = presenter.shouldRequestImprovPermission()
+                if (safePermissionToRequest != null) {
+                    requestImprovPermission.launch(safePermissionToRequest)
+                } else {
+                    presenter.startScanningForImprov()
+                }
             }
         }
     }

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -69,6 +69,13 @@ interface WebViewPresenter {
     /** @return `true` if the app should prompt the user for Improv permissions before scanning */
     suspend fun shouldShowImprovPermissions(): Boolean
 
+    /**
+     * @return Improv permission the app should request directly, without showing a prompt.
+     * This may occur when one of two Bluetooth related permissions is granted and the other one
+     * is not. The system should automatically grant this when requested.
+     * */
+    fun shouldRequestImprovPermission(): String?
+
     /** @return `true` if the app tried starting scanning or `false` if it was missing permissions */
     fun startScanningForImprov(): Boolean
     fun stopScanningForImprov(force: Boolean)

--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -1,12 +1,15 @@
 package io.homeassistant.companion.android.webview
 
+import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.IntentSender
+import android.content.pm.PackageManager
 import android.graphics.Color
 import android.net.Uri
 import android.util.Log
 import androidx.activity.result.ActivityResult
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ActivityContext
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.authentication.SessionState
@@ -486,6 +489,23 @@ class WebViewPresenterImpl @Inject constructor(
             false
         } else {
             prefsRepository.getImprovPermissionDisplayedCount() < 2
+        }
+    }
+
+    override fun shouldRequestImprovPermission(): String? {
+        var returnPermissions = try {
+            improvRepository.getRequiredPermissions().filter {
+                ContextCompat.checkSelfPermission(view as Context, it) != PackageManager.PERMISSION_GRANTED
+            }
+        } catch (_: Exception) {
+            // Unable to check, ignore
+            emptyList<String>()
+        }
+        return if (returnPermissions.size == 1 && returnPermissions[0] != Manifest.permission.ACCESS_FINE_LOCATION) {
+            Log.d(TAG, "Should request Improv permission: $returnPermissions")
+            returnPermissions[0]
+        } else {
+            null
         }
     }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #4936. The issue is caused by the following combination:
1. from the Nearby devices permission group _a_ Bluetooth permission is granted, so the system settings show the permission as on, but not _all_ permissions are granted
2. the in-app permission prompt was shown at least twice so it is not shown again

It results in the user thinking everything is good, while the app doesn't continue and doesn't request additional permissions -> confusion why nothing is discovered.

This PR tries to fix it by checking when 1) not all permissions are granted and 2) the prompt was shown at least twice, if we need just _one_ Bluetooth permission, and if so always requesting that permission. Because Improv needs _two_ Bluetooth permissions that means something from the Nearby devices group was granted so when requesting it Android automatically grants it without asking the user.

For testing this you probably want to use some adb commands:
- `adb shell dumpsys package io.homeassistant.companion.android.debug | grep permission` to verify what exactly is granted
- `adb shell pm revoke io.homeassistant.companion.android.debug android.permission.BLUETOOTH_CONNECT` to revoke one but not the other Bluetooth permission (or the `grant` equivalent)
![adb output with Improv related permissions highlighted](https://github.com/user-attachments/assets/0a755a9d-00ef-4670-9fbb-3c686d195a4c)

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->