### PR TITLE
Don't show other webview errors if HTTP auth is pending

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1473,7 +1473,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
 
         if (!httpAuth?.host.isNullOrBlank()) {
             if (!authError) {
-                handler.proceed(httpAuth?.username, httpAuth?.password)
+                handler.proceed(httpAuth.username, httpAuth.password)
                 autoAuth = true
                 firstAuthTime = System.currentTimeMillis()
             }
@@ -1488,6 +1488,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             }
         }
         if (!autoAuth || authError) {
+            isShowingError = true
             AlertDialog.Builder(this, R.style.Authentication_Dialog)
                 .setTitle(commonR.string.auth_request)
                 .setMessage(message)
@@ -1527,6 +1528,10 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                 .setNeutralButton(android.R.string.cancel) { _, _ ->
                     Toast.makeText(applicationContext, commonR.string.auth_cancel, Toast.LENGTH_SHORT)
                         .show()
+                }
+                .setOnDismissListener {
+                    isShowingError = false
+                    waitForConnection()
                 }
                 .show()
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Trying to fix the following from #4894:

> it gives me the [[HTTP authentication username/password](https://github.com/home-assistant/android/blob/fe94d30070acb3611417c358c7e1f1692ff8f877/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt#L396)] window, but after a couple seconds, it pops a new window on top saying it couldn't connect

Similar to other WebView errors, treat this as an 'error dialog' so one does not overwrite the other. HTTP auth should be blocking other things from happening except timeout, and the timeout dialog is scheduled again when the dialog is dismissed.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->