### PR TITLE
Support ?server=name in homeassistant navigate deeplink 

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -94,8 +94,14 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
             var serverParameter: Int? = null
             if (intent.data?.queryParameterNames.orEmpty().contains("server")) {
                 val serverName = intent.data?.getQueryParameter("server").takeIf { !it.isNullOrBlank() }
-                serverManager.defaultServers.firstOrNull { it.friendlyName == serverName }?.let {
-                    serverParameter = it.id
+                if (serverName == "default" || serverName == null) {
+                    serverParameter = serverManager.getServer()?.id
+                } else {
+                    serverManager.defaultServers
+                        .firstOrNull { it.friendlyName.equals(serverName, ignoreCase = true) }
+                        ?.let {
+                            serverParameter = it.id
+                        }
                 }
             }
 

--- a/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -91,19 +91,31 @@ class LaunchActivity : AppCompatActivity(), LaunchView {
             ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(carIntent)
         } else if (presenter.hasMultipleServers() && intent.data?.path?.isNotBlank() == true) {
-            supportFragmentManager.setFragmentResultListener(ServerChooserFragment.RESULT_KEY, this) { _, bundle ->
-                val serverId = if (bundle.containsKey(ServerChooserFragment.RESULT_SERVER)) {
-                    bundle.getInt(ServerChooserFragment.RESULT_SERVER)
-                } else {
-                    null
+            var serverParameter: Int? = null
+            if (intent.data?.queryParameterNames.orEmpty().contains("server")) {
+                val serverName = intent.data?.getQueryParameter("server").takeIf { !it.isNullOrBlank() }
+                serverManager.defaultServers.firstOrNull { it.friendlyName == serverName }?.let {
+                    serverParameter = it.id
                 }
-                supportFragmentManager.clearFragmentResultListener(ServerChooserFragment.RESULT_KEY)
-                startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverId))
-                finish()
-                overridePendingTransition(0, 0) // Disable activity start/stop animation
             }
-            ServerChooserFragment().show(supportFragmentManager, ServerChooserFragment.TAG)
-            return
+
+            if (serverParameter != null) {
+                startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverParameter))
+            } else { // Show server chooser
+                supportFragmentManager.setFragmentResultListener(ServerChooserFragment.RESULT_KEY, this) { _, bundle ->
+                    val serverId = if (bundle.containsKey(ServerChooserFragment.RESULT_SERVER)) {
+                        bundle.getInt(ServerChooserFragment.RESULT_SERVER)
+                    } else {
+                        null
+                    }
+                    supportFragmentManager.clearFragmentResultListener(ServerChooserFragment.RESULT_KEY)
+                    startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverId))
+                    finish()
+                    overridePendingTransition(0, 0) // Disable activity start/stop animation
+                }
+                ServerChooserFragment().show(supportFragmentManager, ServerChooserFragment.TAG)
+                return
+            }
         } else {
             startActivity(WebViewActivity.newInstance(this, intent.data?.path))
         }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds support for specifying the server to navigate to when using `homeassistant://navigate` deeplinks, creating feature parity with iOS. See [docs](https://companion.home-assistant.io/docs/integrations/url-handler#specify-server-to-navigate-to) and [iOS source](https://github.com/home-assistant/iOS/blob/e880f9784c01525c5dcefdabaf4f9df16d154eb1/Sources/App/WebView/WebViewWindowController.swift#L216-L244).

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a, chooser is skipped

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1161

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->