### PR TITLE
Use Gradle Build Action

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -70,10 +70,7 @@ jobs:
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
-          ./gradlew :common:assemble
-          ./gradlew :app:assembleRelease
-          ./gradlew :wear:assembleRelease
-          ./gradlew :automotive:assembleRelease
+          ./gradlew :common:assemble :app:assembleRelease :wear:assembleRelease :automotive:assembleRelease
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
@@ -181,10 +178,7 @@ jobs:
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
         run: |
-          ./gradlew :common:assemble
-          ./gradlew :app:bundleFullRelease
-          ./gradlew :wear:bundleRelease
-          ./gradlew :automotive:bundleFullRelease
+          ./gradlew :common:assemble :app:bundleFullRelease :wear:bundleRelease :automotive:bundleFullRelease
 
       - name: Archive Build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,23 +15,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Mock google-services.json
         run: |
           cp .github/mock-google-services.json app/google-services.json
           cp .github/mock-google-services.json wear/google-services.json
           cp .github/mock-google-services.json automotive/google-services.json
-
-      - uses: gradle/actions/wrapper-validation@v4
-        name: Validate Gradle Wrapper
 
       - name: Validate ktlint
         run: ./gradlew ktlintCheck
@@ -46,23 +37,14 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Mock google-services.json
         run: |
           cp .github/mock-google-services.json app/google-services.json
           cp .github/mock-google-services.json wear/google-services.json
           cp .github/mock-google-services.json automotive/google-services.json
-
-      - uses: gradle/actions/wrapper-validation@v4
-        name: Validate Gradle Wrapper
 
       - name: Validate Lint
         run: ./gradlew lint
@@ -102,10 +84,7 @@ jobs:
 
     - name: Build Debug APK
       run: |
-        ./gradlew :common:assemble
-        ./gradlew :app:assembleDebug
-        ./gradlew :wear:assembleDebug
-        ./gradlew :automotive:assembleDebug
+        ./gradlew :common:assemble :app:assembleDebug :wear:assembleDebug :automotive:assembleDebug
 
     - name: Check for missing/modified DB schemas after build
       run: |


### PR DESCRIPTION
## Summary
This adds the Gradle build action to all Gradle workflows to speed up
builds using caching.
This replaces the Github action cache as well as the Gradle Wrapper
Validation action since the Gradle Build action [performs the same
validation](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#gradle-wrapper-validation)

As an example: ktlint on this PR took just 56 seconds (compared to 2:30 on other PRs) due to partial caching since the Gradle Build Action is already enabled for some workflows.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
