### PR TITLE
Validate input for battery power sensor

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/sensors/BatterySensorManager.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.Build
+import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import io.homeassistant.companion.android.common.R as commonR
@@ -320,13 +321,19 @@ class BatterySensorManager : SensorManager {
         val voltage = getBatteryVolts(context, intent)
         val batteryManager = context.getSystemService(Context.BATTERY_SERVICE) as BatteryManager
         val current = getBatteryCurrent(context, batteryManager)
-        val wattage = voltage * current
-        val icon = if (wattage > 0) batteryPower.statelessIcon else "mdi:battery-minus"
+        var wattage: Float? = null
+        var icon = batteryPower.statelessIcon
+        if (voltage == null || current == null) {
+            Log.w(TAG, "Invalid voltage/current for battery power: $voltage/$current")
+        } else {
+            wattage = voltage * current
+            if (wattage <= 0) icon = "mdi:battery-minus"
+        }
 
         onSensorUpdated(
             context,
             batteryPower,
-            wattage.toBigDecimal().setScale(2, RoundingMode.HALF_UP),
+            wattage?.toBigDecimal()?.setScale(2, RoundingMode.HALF_UP) ?: STATE_UNAVAILABLE,
             icon,
             mapOf(
                 "current" to current,
@@ -398,23 +405,36 @@ class BatterySensorManager : SensorManager {
         return intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0) / 10f
     }
 
-    private fun getBatteryCurrent(context: Context, batteryManager: BatteryManager): Float {
-        val dividerSetting = getNumberSetting(
-            context,
-            batteryPower,
-            SETTING_BATTERY_CURRENT_DIVISOR,
-            DEFAULT_BATTERY_CURRENT_DIVISOR
-        )
-        return batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW) / dividerSetting.toFloat()
+    private fun getBatteryCurrent(context: Context, batteryManager: BatteryManager): Float? {
+        val current = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CURRENT_NOW)
+        return if (
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P && current != Int.MIN_VALUE) ||
+            current != 0
+        ) {
+            val dividerSetting = getNumberSetting(
+                context,
+                batteryPower,
+                SETTING_BATTERY_CURRENT_DIVISOR,
+                DEFAULT_BATTERY_CURRENT_DIVISOR
+            )
+            current / dividerSetting.toFloat()
+        } else {
+            null
+        }
     }
 
-    private fun getBatteryVolts(context: Context, intent: Intent): Float {
-        val dividerSetting = getNumberSetting(
-            context,
-            batteryPower,
-            SETTING_BATTERY_VOLTAGE_DIVISOR,
-            DEFAULT_BATTERY_VOLTAGE_DIVISOR
-        )
-        return intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0) / dividerSetting.toFloat()
+    private fun getBatteryVolts(context: Context, intent: Intent): Float? {
+        val voltage = intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0)
+        return if (voltage != 0) {
+            val dividerSetting = getNumberSetting(
+                context,
+                batteryPower,
+                SETTING_BATTERY_VOLTAGE_DIVISOR,
+                DEFAULT_BATTERY_VOLTAGE_DIVISOR
+            )
+            voltage / dividerSetting.toFloat()
+        } else {
+            null
+        }
     }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #4979 by only calculating battery power if the input values are valid; if not the state will be unavailable (individual attributes still added so you can find out which is faulty).

- For current: the docs mention "If the property is not supported or there is any other error, return (a) 0 if targetSdkVersion < VERSION_CODES.P or (b) Integer.MIN_VALUE if targetSdkVersion >= VERSION_CODES.P.".
- For voltage: treat the fallback value of 0 as an error, because a real battery should never have no voltage.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->