### PR TITLE
Add battery cycle count sensor

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -57,6 +57,7 @@
     <string name="basic_sensor_name_app_rx_gb">App Rx GB</string>
     <string name="basic_sensor_name_app_standby">App standby bucket</string>
     <string name="basic_sensor_name_app_tx_gb">App Tx GB</string>
+    <string name="basic_sensor_name_battery_cycles">Battery cycle count</string>
     <string name="basic_sensor_name_battery_health">Battery health</string>
     <string name="basic_sensor_name_battery_level">Battery level</string>
     <string name="basic_sensor_name_battery_state">Battery state</string>
@@ -592,6 +593,7 @@
     <string name="sensor_description_app_tx_gb">App Tx GB since last device reboot</string>
     <string name="sensor_description_audio_mode">The state of the device\'s audio mode</string>
     <string name="sensor_description_audio_sensor">The state of the device\'s ringer mode</string>
+    <string name="sensor_description_battery_cycles">The number of charge cycles completed by the battery.\n\nNote: not all devices will report or update the cycle count.</string>
     <string name="sensor_description_battery_health">The health of the battery</string>
     <string name="sensor_description_battery_level">The current battery level of the device</string>
     <string name="sensor_description_battery_state">The current charging state of the battery</string>


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR adds a new sensor for the [battery cycle count](https://developer.android.com/reference/android/os/BatteryManager#EXTRA_CYCLE_COUNT).

The intent extra is available on Android 14+, but also requires devices to support it. Looking at this open source app that was one of the first to expose the info that support is far from guaranteed, so I've added a note in the description about it: https://gitlab.com/narektor/batt/-/blob/main/app/src/main/java/com/porg/batt/CompatChecker.kt?ref_type=heads

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
|Light|Dark|
|----|----|
|![In-app sensor screen for a sensor named 'Battery cycle count', state 375, light mode.](https://github.com/user-attachments/assets/ed8ce031-18c8-4592-9f5e-7a5fac0f8f3e)|![In-app sensor screen for a sensor named 'Battery cycle count', state 375, dark mode.](https://github.com/user-attachments/assets/59f574b6-141b-4b07-a2e2-b5d60179644b)|

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#1165

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Screenshots from a Pixel 7a. I don't have access to system settings showing this value but assume it is the same.