### PR TITLE
Run debug builds on master branch pushes

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,8 @@ name: Pull Request
 on:
   pull_request:
     branches: [ master ]
+  push:
+    branches: [ master ]
 
 jobs:
   ktlint:
@@ -49,7 +51,7 @@ jobs:
       - name: Validate Lint
         run: ./gradlew lint
 
-  pr_build:
+  build:
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
This runs debug builds on master branch pushes in order to populate the
github actions cache via the Gradle build action for faster PR builds. Future no-op builds should be significantly faster!
By default the Gradle build action writes to the caches on `master` branch builds. Other branches read from the `master` branch cache or their own branch cache. [Here is more information on branch caching](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#select-which-branches-should-write-to-the-cache).
I'm assuming that since this is an OSS project the github action runners
are free so there is no cost to this.

I also renamed `pr_build` to `build` to reflect this change but that means that the required status check has been renamed.