### PR TITLE
Show more info on QS tile long press

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -445,6 +445,15 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
+        <activity
+            android:name=".qs.TilePreferenceActivity"
+            android:exported="true"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".qs.Tile1Service"
             android:icon="@drawable/ic_stat_ic_notification"

--- a/app/src/main/java/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
@@ -1,0 +1,83 @@
+package io.homeassistant.companion.android.qs
+
+import android.content.ComponentName
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import androidx.core.os.BundleCompat
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.BaseActivity
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.qs.TileDao
+import io.homeassistant.companion.android.database.qs.isSetup
+import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.settings.SettingsActivity
+import io.homeassistant.companion.android.settings.qs.ManageTilesViewModel
+import io.homeassistant.companion.android.webview.WebViewActivity
+import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+@AndroidEntryPoint
+class TilePreferenceActivity : BaseActivity() {
+
+    companion object {
+        private const val TAG = "TilePrefActivity"
+    }
+
+    @Inject
+    lateinit var serverManager: ServerManager
+
+    @Inject
+    lateinit var tileDao: TileDao
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        var tileId = "-1"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            intent.extras?.let { extras ->
+                BundleCompat.getParcelable(extras, Intent.EXTRA_COMPONENT_NAME, ComponentName::class.java)?.let { component ->
+                    try {
+                        val tileClass = Class.forName(component.className)
+                        val tileMap = ManageTilesViewModel.idToTileService
+                        tileMap.filter { it.value == tileClass }.entries.firstOrNull()?.key?.let {
+                            Log.d(TAG, "Tile ID for long press action: $it")
+                            tileId = it
+                        }
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Couldn't get tile ID for component $component", e)
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            val tileData = tileDao.get(tileId)
+
+            val intent = if (!serverManager.isRegistered()) {
+                Intent(this@TilePreferenceActivity, LaunchActivity::class.java)
+            } else if (tileData?.isSetup == true) {
+                WebViewActivity.newInstance(
+                    this@TilePreferenceActivity,
+                    path = "entityId:${tileData.entityId}",
+                    serverId = tileData.serverId
+                )
+            } else {
+                SettingsActivity.newInstance(this@TilePreferenceActivity).apply {
+                    putExtra("fragment", "tiles/$tileId")
+                }
+            }
+
+            withContext(Dispatchers.Main) {
+                startActivity(intent)
+                finish()
+                @Suppress("DEPRECATION")
+                overridePendingTransition(0, 0) // Disable activity start/stop animation
+            }
+        }
+    }
+}

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -435,6 +435,15 @@
                 android:resource="@xml/provider_paths"/>
         </provider>
 
+        <activity
+            android:name=".qs.TilePreferenceActivity"
+            android:exported="true"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
+            </intent-filter>
+        </activity>
+
         <service
             android:name=".qs.Tile1Service"
             android:icon="@drawable/ic_stat_ic_notification"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Shows the more info dialog when long pressing on a quick settings tile (if setup; otherwise redirects to settings or onboarding). This implements #4955 partially - but this is the minimum to start, and personally I'm not sure we should allow more configuration here.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
Short clip showing long press opening frontend, more info (Android doesn't really have a smooth transition here):

https://github.com/user-attachments/assets/5133cdc6-4988-41b8-a392-7ddfebe6a037

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
I don't think this is necessary right now

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->