### PR TITLE
Replace checkbox with switch in shortcuts tile name on/off

### DIFF
--- a/wear/src/main/java/io/homeassistant/companion/android/home/views/SelectShortcutsTileView.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/home/views/SelectShortcutsTileView.kt
@@ -9,15 +9,15 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.compose.foundation.lazy.itemsIndexed
 import androidx.wear.compose.material3.Button
-import androidx.wear.compose.material3.CheckboxButton
+import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.theme.WearAppTheme
-import io.homeassistant.companion.android.theme.getCheckboxButtonColors
 import io.homeassistant.companion.android.theme.getFilledTonalButtonColors
+import io.homeassistant.companion.android.theme.getSwitchButtonColors
 import io.homeassistant.companion.android.theme.wearColorScheme
 import io.homeassistant.companion.android.views.ListHeader
 import io.homeassistant.companion.android.views.ThemeLazyColumn
@@ -35,7 +35,7 @@ fun SelectShortcutsTileView(
                 ListHeader(id = commonR.string.shortcut_tiles)
             }
             item {
-                CheckboxButton(
+                SwitchButton(
                     modifier = Modifier.fillMaxWidth(),
                     checked = isShowShortcutTextEnabled,
                     onCheckedChange = { onShowShortcutTextEnabled(it) },
@@ -51,7 +51,7 @@ fun SelectShortcutsTileView(
                             colorFilter = ColorFilter.tint(wearColorScheme.onSurface)
                         )
                     },
-                    colors = getCheckboxButtonColors()
+                    colors = getSwitchButtonColors()
                 )
             }
             item {

--- a/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
@@ -51,14 +51,6 @@ internal val wearColorScheme: ColorScheme = ColorScheme(
 )
 
 @Composable
-fun getCheckboxButtonColors() = CheckboxButtonDefaults.checkboxButtonColors(
-    checkedBoxColor = wearColorScheme.onTertiary,
-    checkedCheckmarkColor = wearColorScheme.tertiary,
-    checkedContainerColor = wearColorScheme.surfaceContainerHigh,
-    uncheckedContentColor = wearColorScheme.surfaceContainerLow
-)
-
-@Composable
 fun getSwitchButtonColors() = SwitchButtonDefaults.switchButtonColors(
     checkedThumbColor = wearColorScheme.tertiary,
     checkedTrackColor = wearColorScheme.onTertiary,

--- a/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
+++ b/wear/src/main/java/io/homeassistant/companion/android/theme/Color.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.theme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.wear.compose.material3.ButtonDefaults
-import androidx.wear.compose.material3.CheckboxButtonDefaults
 import androidx.wear.compose.material3.ColorScheme
 import androidx.wear.compose.material3.SliderDefaults
 import androidx.wear.compose.material3.SwitchButtonDefaults


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In the settings screen for the shortcuts tile, replace the checkbox with a switch for the option to show names on the tile. A switch is the correct control here instead of a checkbox, because it is a standalone (and the only) option and not something to select in a list. See the Material guidelines: https://m3.material.io/components/switch/guidelines#6add393e-e4e8-41b6-862b-5ebffb894f72.

This PR also removes the checkbox button colors function because this was the last usage of it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://github.com/user-attachments/assets/406ad43a-b037-4528-9022-7edd9b1d32c6)
(the preview doesn't render the icon correctly, but that doesn't matter here)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->