### PR TITLE
Do not require a wifi password to connect Improv.

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetView.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/improv/ui/ImprovSheetView.kt
@@ -222,7 +222,7 @@ fun ImprovWifiInput(
         )
         Button(
             modifier = Modifier.padding(vertical = 8.dp).align(Alignment.CenterHorizontally),
-            enabled = ssidInput.isNotBlank() && passwordInput.isNotBlank(),
+            enabled = ssidInput.isNotBlank(),
             onClick = { onSubmit(ssidInput, passwordInput) }
         ) {
             Text(stringResource(commonR.string.continue_connect))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Attempt to fix #5018 by not requiring a WiFi password to connect an Improv device.
## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/companion.home-assistant#

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->


I have not tested this at all; it's just a wild guess.