### PR TITLE
Convert floats to longs for `when` in notification data

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1020,9 +1020,9 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>
     ) {
         try { // Without this, a non-numeric when value will crash the app
-            var notificationWhen = data[WHEN]?.toLongOrNull()?.times(1000) ?: 0
-            val isRelative = data[WHEN_RELATIVE]?.toBoolean() ?: false
-            val usesChronometer = data[CHRONOMETER]?.toBoolean() ?: false
+            var notificationWhen = data[WHEN]?.toLongOrNull()?.times(1000) ?: data[WHEN]?.toFloatOrNull()?.times(1000)?.toLong() ?: 0
+            val isRelative = data[WHEN_RELATIVE]?.toBoolean() == true
+            val usesChronometer = data[CHRONOMETER]?.toBoolean() == true
 
             if (notificationWhen != 0L) {
                 if (isRelative) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fix #5024 by converting floats to longs if it isn't a long, so the user doesn't have to think too much about it.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->