### PR TITLE
Check session state in registered check to avoid using transferred servers more

### DIFF
--- a/common/src/main/java/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
+++ b/common/src/main/java/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.data.servers
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepository
 import io.homeassistant.companion.android.common.data.authentication.AuthenticationRepositoryFactory
+import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepositoryFactory
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
@@ -85,7 +86,11 @@ class ServerManagerImpl @Inject constructor(
     }
 
     override fun isRegistered(): Boolean =
-        mutableServers.values.any { it.type == ServerType.DEFAULT && it.connection.isRegistered() }
+        mutableServers.values.any {
+            it.type == ServerType.DEFAULT &&
+                it.connection.isRegistered() &&
+                authenticationRepository(it.id).getSessionState() == SessionState.CONNECTED
+        }
 
     override suspend fun addServer(server: Server): Int {
         val newServer = server.copy(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
#4650, #4975

This PR updates `serverManager::isRegistered()` which is used in many places as a general "does the app have a server" check, to also check that the server _session_ is good to use (which internally checks the webhook/install ID existing and being valid).

The install ID is random and [excluded](https://github.com/home-assistant/android/blob/cb99f4c4dad4a8a2112c4b28cd9ce51c52faf229/app/src/main/res/xml/backup_rules.xml#L5) from backups and transfers to avoid using the same registration/tokens on another device, which can resolve the issues if used at the correct time. However, it was only checked when [launching the app](https://github.com/home-assistant/android/blob/cb99f4c4dad4a8a2112c4b28cd9ce51c52faf229/app/src/main/java/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt#L25-L28), and any other entrypoints simply continued as if you had a server configured. With this change, many more features including sensor updates will return instead of re-using a (duplicate) registration.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->