### PR TITLE
Skip some more notification data items if they are blank

### DIFF
--- a/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/java/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1215,8 +1215,9 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        data[SUBJECT]?.let {
-            builder.setContentText(prepareText(it))
+        val subject = data[SUBJECT]
+        if (!subject.isNullOrBlank()) {
+            builder.setContentText(prepareText(subject))
         }
     }
 
@@ -1237,8 +1238,9 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        data[ICON_URL]?.let {
-            val dataIcon = it.trim().replace(" ", "%20")
+        val iconUrl = data[ICON_URL]
+        if (!iconUrl.isNullOrBlank()) {
+            val dataIcon = iconUrl.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
             val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataIcon)
             val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(dataIcon))
@@ -1252,8 +1254,9 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        data[IMAGE_URL]?.let {
-            val dataImage = it.trim().replace(" ", "%20")
+        val imageUrl = data[IMAGE_URL]
+        if (!imageUrl.isNullOrBlank()) {
+            val dataImage = imageUrl.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
             val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataImage)
             val bitmap = getImageBitmap(serverId, url, !UrlUtil.isAbsoluteUrl(dataImage))
@@ -1342,8 +1345,9 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        data[VIDEO_URL]?.let {
-            val dataVideo = it.trim().replace(" ", "%20")
+        val videoUrl = data[VIDEO_URL]
+        if (!videoUrl.isNullOrBlank()) {
+            val dataVideo = videoUrl.trim().replace(" ", "%20")
             val serverId = data[THIS_SERVER_ID]!!.toInt()
             val url = UrlUtil.handle(serverManager.getServer(serverId)?.connection?.getUrl(), dataVideo)
             getVideoFrames(serverId, url, !UrlUtil.isAbsoluteUrl(dataVideo))?.let { frames ->
@@ -1459,9 +1463,10 @@ class MessagingManager @Inject constructor(
         builder: NotificationCompat.Builder,
         data: Map<String, String>
     ) {
-        data[VISIBILITY]?.let {
+        val visibility = data[VISIBILITY]
+        if (!visibility.isNullOrBlank()) {
             builder.setVisibility(
-                when (it) {
+                when (visibility) {
                     "public" -> NotificationCompat.VISIBILITY_PUBLIC
                     "secret" -> NotificationCompat.VISIBILITY_SECRET
                     else -> NotificationCompat.VISIBILITY_PRIVATE


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Fixes #5038 

Previously FCM would omit blank keys. This was changed and is now in line with websocket notifications, but in some places the behavior might be unexpected. This PR ignores a couple more keys if blank (like we already do for many) where it seems safe to do so.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
Testing note: if you try to send nothing from dev tools it will send a string `null`, so send a blank string `""` instead