### PR TITLE
GitHub: Add dependency uploading

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -118,6 +118,9 @@ jobs:
           AMAZON_APPSTORE_CLIENT_SECRET: ${{ secrets.AMAZON_APPSTORE_CLIENT_SECRET }}
           AMAZON_APPSTORE_APP_ID: ${{ secrets.AMAZON_APPSTORE_APP_ID }}
 
+      - name: Upload Github Dependencies
+        uses: gradle/actions/dependency-submission@v4
+
       - name: Print `git status`
         run: git status
 


### PR DESCRIPTION
## Summary

The gradle components don't automatically get detected upon build. Use the dependency-submission API to enable this dependency tracking.

Documentation explaining this:

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/dependency-graph-supported-package-ecosystems#package-ecosystems-supported-via-dependency-submission-actions

That article links to this action:

https://github.com/marketplace/actions/build-with-gradle#the-dependency-submission-action

## Screenshots

The GitHub front end will change :smile: It currently only displays GitHub and Ruby dependencies, not Gradle.

![image](https://github.com/user-attachments/assets/fcdaf869-1e80-4569-91aa-ff0ee3c26afe)

## Link to pull request in Documentation repository

N/A

## Any other notes

This is only for housekeeping / dependencies. I wasn't able to test the action easily due to app secrets, but it should work.