### PR TITLE
Add new android common gradle convention plugin and update common module

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -45,5 +45,9 @@ gradlePlugin {
             id = libs.plugins.homeassistant.android.flavor.get().pluginId
             implementationClass = "AndroidFullMinimalFlavorConventionPlugin"
         }
+        register("androidCommon") {
+            id = libs.plugins.homeassistant.android.common.get().pluginId
+            implementationClass = "AndroidCommonConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -4,9 +4,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.withType
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 private const val APPLICATION_ID = "io.homeassistant.companion.android"
 
@@ -15,6 +12,7 @@ private const val APPLICATION_ID = "io.homeassistant.companion.android"
  * This centralizes configuration, preventing duplication across multiple modules.
  *
  * This plugin applies several Gradle plugins that are commonly used in all application modules.
+ * More specifically it apply the [AndroidCommonConventionPlugin].
  *
  * After applying this plugin, the configured values can be overridden if necessary. However,
  * if extensive overrides are required, it may indicate that the configuration should be moved
@@ -37,14 +35,13 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
             apply(plugin = libs.plugins.ksp.getPluginId())
             apply(plugin = libs.plugins.hilt.getPluginId())
             apply(plugin = libs.plugins.compose.compiler.getPluginId())
+            AndroidCommonConventionPlugin().apply(target)
 
             extensions.configure<ApplicationExtension> {
                 namespace = APPLICATION_ID
-                compileSdk = libs.versions.androidSdk.compile.get().toInt()
 
                 defaultConfig {
                     applicationId = APPLICATION_ID
-                    minSdk = libs.versions.androidSdk.min.get().toInt()
                     targetSdk = libs.versions.androidSdk.target.get().toInt()
 
                     versionName = project.version.toString()
@@ -54,19 +51,10 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                 buildFeatures {
                     viewBinding = true
                     compose = true
-                    buildConfig = true
                 }
 
                 compileOptions {
                     isCoreLibraryDesugaringEnabled = true
-                    sourceCompatibility(libs.versions.javaVersion.get())
-                    targetCompatibility(libs.versions.javaVersion.get())
-                }
-
-                tasks.withType<KotlinCompile>().configureEach {
-                    compilerOptions {
-                        jvmTarget.set(JvmTarget.fromTarget(libs.versions.javaVersion.get()))
-                    }
                 }
 
                 signingConfigs {
@@ -89,15 +77,6 @@ class AndroidApplicationConventionPlugin : Plugin<Project> {
                         isJniDebuggable = false
                         signingConfig = signingConfigs.getByName("release")
                     }
-                }
-
-                testOptions {
-                    unitTests.isReturnDefaultValues = true
-                }
-
-                lint {
-                    abortOnError = false
-                    disable += "MissingTranslation"
                 }
             }
         }

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationConventionPlugin.kt
@@ -11,8 +11,8 @@ private const val APPLICATION_ID = "io.homeassistant.companion.android"
  * A convention plugin that applies common configurations to Android application modules.
  * This centralizes configuration, preventing duplication across multiple modules.
  *
- * This plugin applies several Gradle plugins that are commonly used in all application modules.
- * More specifically it apply the [AndroidCommonConventionPlugin].
+ * This plugin applies several Gradle plugins that are commonly used in all application modules,
+ * including the [AndroidCommonConventionPlugin].
  *
  * After applying this plugin, the configured values can be overridden if necessary. However,
  * if extensive overrides are required, it may indicate that the configuration should be moved

--- a/build-logic/convention/src/main/kotlin/AndroidCommonConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidCommonConventionPlugin.kt
@@ -1,0 +1,70 @@
+import com.android.build.api.dsl.ApplicationExtension
+import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.LibraryExtension
+import io.homeassistant.companion.android.getPluginId
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/**
+ * A convention plugin that applies common configurations to Android modules (Application and Library).
+ * This centralizes configuration, preventing duplication across multiple modules.
+ *
+ * This plugin applies several Gradle plugins that are commonly used in all android modules.
+ *
+ * After applying this plugin, the configured values can be overridden if necessary. However,
+ * if extensive overrides are required, it may indicate that the configuration should be moved
+ * out of this convention plugin.
+ *
+ */
+class AndroidCommonConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            apply(plugin = libs.plugins.kotlin.android.getPluginId())
+            apply(plugin = libs.plugins.ksp.getPluginId())
+            apply(plugin = libs.plugins.hilt.getPluginId())
+
+            fun CommonExtension<*, *, *, *, *, *>.configure() {
+                compileSdk = libs.versions.androidSdk.compile.get().toInt()
+
+                defaultConfig {
+                    minSdk = libs.versions.androidSdk.min.get().toInt()
+                }
+
+                buildFeatures {
+                    buildConfig = true
+                }
+
+                compileOptions {
+                    sourceCompatibility(libs.versions.javaVersion.get())
+                    targetCompatibility(libs.versions.javaVersion.get())
+                }
+
+                tasks.withType<KotlinCompile>().configureEach {
+                    compilerOptions {
+                        jvmTarget.set(JvmTarget.fromTarget(libs.versions.javaVersion.get()))
+                    }
+                }
+
+                testOptions {
+                    unitTests.isReturnDefaultValues = true
+                }
+
+                lint {
+                    abortOnError = false
+                    disable += "MissingTranslation"
+                    sarifReport = true
+                }
+            }
+
+            when (extensions.findByName("android")) {
+                is ApplicationExtension -> extensions.configure<ApplicationExtension> { configure() }
+                is LibraryExtension -> extensions.configure<LibraryExtension> { configure() }
+            }
+        }
+    }
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.hilt)
+    alias(libs.plugins.homeassistant.android.common)
 }
 
 val homeAssistantAndroidPushUrl: String by project
@@ -14,10 +12,7 @@ val versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
 android {
     namespace = "io.homeassistant.companion.android.common"
 
-    compileSdk = libs.versions.androidSdk.compile.get().toInt()
-
     defaultConfig {
-        minSdk = libs.versions.androidSdk.min.get().toInt()
         buildConfigField("String", "PUSH_URL", "\"$homeAssistantAndroidPushUrl\"")
         buildConfigField("String", "RATE_LIMIT_URL", "\"$homeAssistantAndroidRateLimitUrl\"")
         buildConfigField("String", "VERSION_NAME", "\"$versionName-$versionCode\"")
@@ -25,24 +20,6 @@ android {
         ksp {
             arg("room.schemaLocation", "$projectDir/schemas")
         }
-    }
-
-    buildFeatures {
-        buildConfig = true
-    }
-
-    kotlinOptions {
-        jvmTarget = libs.versions.javaVersion.get()
-    }
-
-    compileOptions {
-        sourceCompatibility(libs.versions.javaVersion.get())
-        targetCompatibility(libs.versions.javaVersion.get())
-    }
-
-    lint {
-        abortOnError = false
-        disable += "MissingTranslation"
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 
 # Plugins defined by this project in `:build-logic:convention` module.
 homeassistant-android-application = { id = "homeassistant.android.application" }
+homeassistant-android-common = { id = "homeassistant.android.common" }
 homeassistant-android-dependencies = { id = "homeassistant.android.dependencies" }
 homeassistant-android-flavor = { id = "homeassistant.android.flavor" }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This is a follow up of https://github.com/home-assistant/android/pull/5078 to avoid duplication in common gradle module.
The Application convention module does call this new module directly and `:common` call it too.