### PR TITLE
Exclude androidx wear package from compose and androidx groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,15 +40,15 @@
             "groupName": "androidx.compose.*",
             "matchPackageNames": [
                 "!androidx.compose.compiler{/,}**",
-                "androidx.compose.{/,}**",
-                "androidx.wear.compose.{/,}**"
+                "!androidx.wear.compose{/,}**",
+                "androidx.compose.{/,}**"
             ]
         },
         {
             "groupName": "androidx.*",
             "matchPackageNames": [
                 "!androidx.compose.{/,}**",
-                "!androidx.wear.compose.{/,}**",
+                "!androidx.wear.compose{/,}**",
                 "androidx.{/,}**"
             ]
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
In order to exclude wear from androidx and compose group. I've update the grouping in renovate config. We want to avoid this https://github.com/home-assistant/android/pull/5100

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
This is PR is going to be merge so that we can test if it works.