### PR TITLE
Update renovate config to avoid 429

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,21 @@
     ],
     "lockFileMaintenance": {"enabled": true},
     "minimumReleaseAge": "3 days",
+    "hostRules": [
+		{
+			"matchHost": "repo.maven.apache.org",
+			"concurrentRequestLimit": 1,
+			"maxRequestsPerSecond": 8
+		}
+    ],
     "packageRules": [
+        {
+            "matchDatasources": ["maven"],
+            "registryUrls": ["https://jitpack.io"],
+            "matchPackageNames": [
+                "com.github.AppDevNext"
+            ]
+        },
         {
             "groupName": "org.jetbrains.kotlin:*",
             "matchPackageNames": [

--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
     "packageRules": [
         {
             "matchDatasources": ["maven"],
+            "registryUrls": ["https://repo1.maven.org/maven2/", "https://plugins.gradle.org/m2/", "https://dl.google.com/android/maven2/"]
+        },
+        {
+            "matchDatasources": ["maven"],
             "registryUrls": ["https://jitpack.io"],
             "matchPackageNames": [
                 "com.github.AppDevNext"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Renovate is failing to properly verify all our dependencies because it is doing too many request at once on the public maven repo. 
The value picked should avoid this issue and keep the check reasonable in time.
While looking at the logs of renovate it seems that it was not searching within the gradle plugin repo nor jitpack so I've added the missing registry URLs. 