### PR TITLE
Add jitpack to global list of repositories

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,19 +24,17 @@
 			"matchHost": "dl.google.com",
 			"concurrentRequestLimit": 1,
 			"maxRequestsPerSecond": 8
+		},
+		{
+			"matchHost": "jitpack.io",
+			"concurrentRequestLimit": 1,
+			"maxRequestsPerSecond": 8
 		}
     ],
     "packageRules": [
         {
             "matchDatasources": ["maven"],
-            "registryUrls": ["https://repo1.maven.org/maven2/", "https://plugins.gradle.org/m2/", "https://dl.google.com/android/maven2/"]
-        },
-        {
-            "matchDatasources": ["maven"],
-            "registryUrls": ["https://jitpack.io"],
-            "matchPackageNames": [
-                "com.github.AppDevNext"
-            ]
+            "registryUrls": ["https://repo1.maven.org/maven2/", "https://plugins.gradle.org/m2/", "https://dl.google.com/android/maven2/", "https://jitpack.io"]
         },
         {
             "groupName": "org.jetbrains.kotlin:*",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
It seems that the package rules for jitpack was not working properly. So I've moved jitpack into the global list of repositories.