### PR TITLE
Remove gradle tasks dependency to ktlint for typesafe plugin in builld-logic

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -17,6 +17,12 @@ allprojects {
             reporter(ReporterType.SARIF)
             reporter(ReporterType.PLAIN)
         }
+
+        // Fix for an implicit_dependency after bumping typesafe-conventions to 0.5.1
+        // https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin/issues/34
+        filter {
+            exclude { it.file.path.contains("build/generated-sources") }
+        }
     }
 }
 
@@ -42,17 +48,6 @@ tasks {
         enableStricterValidation = true
         failOnWarning = true
     }
-
-    // Fix for an implicit_dependency after bumping typesafe-conventions to 0.5.1
-    // issue can be tracked here: https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin/issues/34
-    getByName("runKtlintCheckOverMainSourceSet").mustRunAfter(
-        "generateEntrypointForLibs",
-        "generateEntrypointForLibsInPluginsBlock"
-    )
-    getByName("runKtlintFormatOverMainSourceSet").mustRunAfter(
-        "generateEntrypointForLibs",
-        "generateEntrypointForLibsInPluginsBlock"
-    )
 }
 
 gradlePlugin {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The initial fix after updating typesafe plugin was not great it added an explicit lint between this plugin and ktlint tasks. The author of the plugin proposed another solution cleaner. https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin/issues/34 