### PR TITLE
Support intent-progress for Assist

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.assist.ui.AssistMessage
 import io.homeassistant.companion.android.assist.ui.AssistUiPipeline
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.assist.AssistEvent
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
@@ -290,24 +291,38 @@ class AssistViewModel @Inject constructor(
         runAssistPipelineInternal(
             text,
             selectedPipeline
-        ) { newMessage, isInput, isError, shouldContinueConversation ->
-            if (shouldContinueConversation) {
-                onMicrophoneInput()
-            } else {
-                _conversation.indexOf(message).takeIf { pos -> pos >= 0 }?.let { index ->
-                    _conversation[index] = message.copy(
-                        message = newMessage.trim(),
-                        isInput = isInput ?: message.isInput,
-                        isError = isError
-                    )
-                    if (isInput == true) {
-                        _conversation.add(haMessage)
-                        message = haMessage
-                    }
-                    if (isError && inputMode == AssistInputMode.VOICE_ACTIVE) {
-                        stopRecording()
+        ) { event ->
+            when (event) {
+                is AssistEvent.Message -> {
+                    _conversation.indexOf(message).takeIf { pos -> pos >= 0 }?.let { index ->
+                        val isInput = event is AssistEvent.Message.Input
+                        val isError = event is AssistEvent.Message.Error
+                        _conversation[index] = message.copy(
+                            message = event.message.trim(),
+                            isInput = isInput,
+                            isError = isError
+                        )
+                        if (isInput) {
+                            _conversation.add(haMessage)
+                            message = haMessage
+                        }
+                        if (isError && inputMode == AssistInputMode.VOICE_ACTIVE) {
+                            stopRecording()
+                        }
                     }
                 }
+                is AssistEvent.MessageChunk -> {
+                    val lastMessage = _conversation.last()
+                    if (lastMessage == haMessage) {
+                        // Remove '...' message and add the chunk received
+                        _conversation.removeAt(_conversation.lastIndex)
+                        _conversation.add(lastMessage.copy(message = event.chunk))
+                    } else {
+                        // Replace last message with the updated message with the new chunk append
+                        _conversation[_conversation.lastIndex] = lastMessage.copy(message = lastMessage.message + event.chunk)
+                    }
+                }
+                is AssistEvent.ContinueConversation -> onMicrophoneInput()
             }
         }
     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -9,6 +9,7 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineError
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineEventType
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentEnd
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentProgress
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineRunStart
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineSttEnd
@@ -19,6 +20,16 @@ import io.homeassistant.companion.android.util.UrlUtil
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+
+sealed interface AssistEvent {
+    sealed class Message(val message: String) : AssistEvent {
+        class Input(message: String) : Message(message)
+        class Output(message: String) : Message(message)
+        class Error(message: String) : Message(message)
+    }
+    class MessageChunk(val chunk: String) : AssistEvent
+    data object ContinueConversation : AssistEvent
+}
 
 abstract class AssistViewModelBase(
     private val serverManager: ServerManager,
@@ -68,14 +79,12 @@ abstract class AssistViewModelBase(
      * @param text input to run an intent pipeline with, or `null` to run a STT pipeline (check if
      * STT is supported _before_ calling this function)
      * @param pipeline information about the pipeline, or `null` to use the server's default
-     * @param onMessage callback for messages that should be posted for this pipeline run, with 4
-     * arguments: the message, whether the message is input/output/undetermined, whether the message
-     * is an error message, whether the conversation should continue
+     * @param onEvent callback for events that should be use to update the UI
      */
     protected fun runAssistPipelineInternal(
         text: String?,
         pipeline: AssistPipelineResponse?,
-        onMessage: (String, Boolean?, Boolean, Boolean) -> Unit
+        onEvent: (AssistEvent) -> Unit
     ) {
         val isVoice = text == null
         var job: Job? = null
@@ -116,15 +125,20 @@ abstract class AssistViewModelBase(
                     AssistPipelineEventType.STT_END -> {
                         stopRecording()
                         (it.data as? AssistPipelineSttEnd)?.sttOutput?.let { response ->
-                            onMessage(response["text"] as String, true, false, false)
+                            onEvent(AssistEvent.Message.Input(response["text"] as String))
+                        }
+                    }
+                    AssistPipelineEventType.INTENT_PROGRESS -> {
+                        (it.data as? AssistPipelineIntentProgress)?.chat_log_delta?.content?.let { delta ->
+                            onEvent(AssistEvent.MessageChunk(delta))
                         }
                     }
                     AssistPipelineEventType.INTENT_END -> {
                         val data = (it.data as? AssistPipelineIntentEnd)?.intentOutput ?: return@collect
                         conversationId = data.conversationId
                         continueConversation.set(data.continueConversation)
-                        data.response.speech.plain["speech"]?.let { response ->
-                            onMessage(response, false, false, false)
+                        data.response.speech.plain["speech"]?.let { speech ->
+                            onEvent(AssistEvent.Message.Output(speech))
                         }
                     }
                     AssistPipelineEventType.TTS_END -> {
@@ -134,7 +148,9 @@ abstract class AssistViewModelBase(
                             playAudio(audioPath) {
                                 // We send the continueConversation flag here after getting it from AssistPipelineEventType.INTENT_END so that
                                 // we let the mediaplayer finishing playing the audio before recording a new entry from the user.
-                                onMessage("", null, false, continueConversation.getAndSet(false))
+                                if (continueConversation.getAndSet(false)) {
+                                    onEvent(AssistEvent.ContinueConversation)
+                                }
                             }
                         }
                     }
@@ -144,14 +160,14 @@ abstract class AssistViewModelBase(
                     }
                     AssistPipelineEventType.ERROR -> {
                         val errorMessage = (it.data as? AssistPipelineError)?.message ?: return@collect
-                        onMessage(errorMessage, null, true, false)
+                        onEvent(AssistEvent.Message.Error(errorMessage))
                         stopRecording()
                         job?.cancel()
                     }
                     else -> { /* Do nothing */ }
                 }
             } ?: run {
-                onMessage(app.getString(R.string.assist_error), null, true, false)
+                onEvent(AssistEvent.Message.Output(app.getString(R.string.assist_error)))
             }
         }
     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -129,7 +129,7 @@ abstract class AssistViewModelBase(
                         }
                     }
                     AssistPipelineEventType.INTENT_PROGRESS -> {
-                        (it.data as? AssistPipelineIntentProgress)?.chat_log_delta?.content?.let { delta ->
+                        (it.data as? AssistPipelineIntentProgress)?.chatLogDelta?.content?.let { delta ->
                             onEvent(AssistEvent.MessageChunk(delta))
                         }
                     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -24,6 +24,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.As
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineEventType
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentEnd
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentProgress
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentStart
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineListResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
@@ -745,10 +746,14 @@ class WebSocketRepositoryImpl @AssistedInject constructor(
                             AssistPipelineEventType.RUN_START -> mapper.convertValue(eventDataMap, AssistPipelineRunStart::class.java)
                             AssistPipelineEventType.STT_END -> mapper.convertValue(eventDataMap, AssistPipelineSttEnd::class.java)
                             AssistPipelineEventType.INTENT_START -> mapper.convertValue(eventDataMap, AssistPipelineIntentStart::class.java)
+                            AssistPipelineEventType.INTENT_PROGRESS -> mapper.convertValue(eventDataMap, AssistPipelineIntentProgress::class.java)
                             AssistPipelineEventType.INTENT_END -> mapper.convertValue(eventDataMap, AssistPipelineIntentEnd::class.java)
                             AssistPipelineEventType.TTS_END -> mapper.convertValue(eventDataMap, AssistPipelineTtsEnd::class.java)
                             AssistPipelineEventType.ERROR -> mapper.convertValue(eventDataMap, AssistPipelineError::class.java)
-                            else -> null
+                            else -> {
+                                Log.d(TAG, "Unknown event type ignoring. received data = \n$response")
+                                null
+                            }
                         }
                         AssistPipelineEvent(eventType.textValue(), eventData)
                     } else {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/AssistPipelineEvent.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/AssistPipelineEvent.kt
@@ -13,6 +13,7 @@ object AssistPipelineEventType {
     const val STT_START = "stt-start"
     const val STT_END = "stt-end"
     const val INTENT_START = "intent-start"
+    const val INTENT_PROGRESS = "intent-progress"
     const val INTENT_END = "intent-end"
     const val TTS_START = "tts-start"
     const val TTS_END = "tts-end"
@@ -39,6 +40,14 @@ data class AssistPipelineIntentStart(
     val language: String,
     val intentInput: String
 ) : AssistPipelineEventData
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AssistPipelineIntentProgress(
+    val chat_log_delta: AssistChatLogDelta?
+) : AssistPipelineEventData
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class AssistChatLogDelta(val content: String?)
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AssistPipelineIntentEnd(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/AssistPipelineEvent.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/AssistPipelineEvent.kt
@@ -43,7 +43,7 @@ data class AssistPipelineIntentStart(
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class AssistPipelineIntentProgress(
-    val chat_log_delta: AssistChatLogDelta?
+    val chatLogDelta: AssistChatLogDelta?
 ) : AssistPipelineEventData
 
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
`intent-progress` allow streaming the answer of a LLM, right now it is not playing the sound before the text is fully written but that's a limitation of the API nothing we can do in the app.

This PR is inspired by iOS PR https://github.com/home-assistant/iOS/pull/3483 and the frontend PR https://github.com/home-assistant/frontend/pull/24143

The frontend is handling the `role` but it seems that in our case we don't need for now at least.

I took the liberty to replace the callback with unnamed arguments with a sealed class for better usability and evolution.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
[demo_stream.webm](https://github.com/user-attachments/assets/a1c84199-e97a-4777-bd6d-b1d9cd9ac8a5)

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
It only works with ChatGPT integration for now.