### PR TITLE
Disable lint tasks in release for automotive module

### DIFF
--- a/automotive/build.gradle.kts
+++ b/automotive/build.gradle.kts
@@ -26,6 +26,11 @@ android {
                 enableSplit = false
             }
         }
+        lint {
+            // We disable the lint tasks for release only for automotive because the baseline cannot be parsed in release builds due to the fact that we share sources between app and automotive.
+            // It is not an issue since we still check the :app module and the code is exactly the same.
+            checkReleaseBuilds = false
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
After merging https://github.com/home-assistant/android/pull/5139 master build started to fail. The issue was link to `lint` for release buildType of automotive
```
* What went wrong:
Execution failed for task ':automotive:lintVitalReportFullRelease'.
> A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintTask$AndroidLintLauncherWorkAction
   > There was a failure while executing work items
      > A failure occurred while executing com.android.build.gradle.internal.lint.AndroidLintWorkAction
         > Path variable $***:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5*** referenced in $***:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5***/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt not provided to serialization

```

While looking at the error we can see that it reference the first item in the `lint-baseline.xml` of the automotive module. The error indicates that it doesn't manage to parse the baseline. 
Since our configuration is not really standard and use the source of another module. I guess the lint baseline isn't supporting this behavior.

This PR fix this issue by simply disabling the lint tasks in release for automotive. We don't actually care to run the linter in release for automotive since we already do in app.