### PR TITLE
Detect missing lockfile update on CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,7 @@ jobs:
             echo -e "   ./gradlew alldependencies --write-locks"
             echo -e "   Then commit the updated lockfiles to your branch."
             error_message="Dependency changes detected, but lockfiles are not updated. Run \`./gradlew alldependencies --write-locks\` and commit the changes."
-            echo "::error title=⛔ Lockfile Update Required::${error_message}"
+            echo "::error file=gradle/libs.versions.toml,line=1,title=⛔ Lockfile Update Required::${error_message}"
 
             gh pr comment $PR_URL --body "## ⛔ Lockfile Update Required
             ${error_message}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,9 +35,6 @@ jobs:
         run: ./gradlew alldependencies --write-locks
 
       - name: Check for missing lockfiles update
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           if [[ $(git status --porcelain) ]]; then
             echo $(git status --porcelain)
@@ -47,10 +44,6 @@ jobs:
             echo -e "   Then commit the updated lockfiles to your branch."
             error_message="Dependency changes detected, but lockfiles are not updated. Run \`./gradlew alldependencies --write-locks\` and commit the changes."
             echo "::error file=gradle/libs.versions.toml,line=1,title=⛔ Lockfile Update Required::${error_message}"
-
-            gh pr comment $PR_URL --body "## ⛔ Lockfile Update Required
-            ${error_message}"
-
             exit 1;
           else
             echo -e "\n✔️ All dependency lockfiles are up to date. No uncommitted changes detected."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,32 @@ jobs:
       - name: Validate YAML
         run: yamllint --strict --format github .
 
+  lockfiles:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-build-env
+        with:
+          mock-google-services: "true"
+
+      - name: Update lockfiles
+        run: ./gradlew alldependencies --write-locks
+
+      - name: Check for missing lockfiles update
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+            echo $(git status --porcelain)
+            echo -e "\n❌ Uncommitted changes detected in the repository."
+            echo -e "🔍 It seems that the dependency lockfiles are outdated. Please update them by running:"
+            echo -e "   ./gradlew alldependencies --write-locks"
+            echo -e "   Then commit the updated lockfiles to your branch."
+            echo "::error title=⛔ Lockfile Update Required::Dependency changes detected, but lockfiles are not updated. Run './gradlew alldependencies --write-locks' and commit the changes."
+            exit 1;
+          else
+            echo -e "\n✔️ All dependency lockfiles are up to date. No uncommitted changes detected."
+          fi
+
   ktlint:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
           fi
 
   ktlint:
+    needs: [yamllint, lockfiles]
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -78,28 +79,8 @@ jobs:
           sarif_file: "./"
           category: "KTlint"
 
-  unit_tests:
-    name: "Unit Tests"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: ./.github/actions/setup-build-env
-        with:
-          mock-google-services: "true"
-
-      - name: Run test
-        run: ./gradlew :common:testDebugUnitTest # Should be adapted once we have more than one tests
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: Unit test results
-          path: |
-            **/build/test-results/**/TEST-*.xml
-
   lint:
+    needs: [yamllint, lockfiles]
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -128,6 +109,7 @@ jobs:
           category: "Android Lint"
 
   pr_build:
+    needs: [yamllint, lockfiles]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -168,8 +150,31 @@ jobs:
         with:
           path: ./**/*.apk
 
+  unit_tests:
+    name: "Unit Tests"
+    needs: [lint, lockfiles, ktlint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-build-env
+        with:
+          mock-google-services: "true"
+
+      - name: Run test
+        run: ./gradlew :common:testDebugUnitTest # Should be adapted once we have more than one tests
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Unit test results
+          path: |
+            **/build/test-results/**/TEST-*.xml
+
   instrumentation_test:
     name: "Instrumentation Tests"
+    needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
     strategy:
       # We want the result of each device to be reported, so we can't fail-fast

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,9 @@ jobs:
         run: ./gradlew alldependencies --write-locks
 
       - name: Check for missing lockfiles update
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.ref }}
         run: |
           if [[ $(git status --porcelain) ]]; then
             echo $(git status --porcelain)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,7 +42,9 @@ jobs:
             echo -e "🔍 It seems that the dependency lockfiles are outdated. Please update them by running:"
             echo -e "   ./gradlew alldependencies --write-locks"
             echo -e "   Then commit the updated lockfiles to your branch."
-            echo "::error title=⛔ Lockfile Update Required::Dependency changes detected, but lockfiles are not updated. Run './gradlew alldependencies --write-locks' and commit the changes."
+            error_message="Dependency changes detected, but lockfiles are not updated. Run './gradlew alldependencies --write-locks' and commit the changes."
+            echo "::error title=⛔ Lockfile Update Required::${error_message}"
+            gh pr comment $PR_URL --body "${error_message}"
             exit 1;
           else
             echo -e "\n✔️ All dependency lockfiles are up to date. No uncommitted changes detected."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check for missing lockfiles update
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           if [[ $(git status --porcelain) ]]; then
             echo $(git status --porcelain)
@@ -47,7 +47,7 @@ jobs:
             echo -e "   Then commit the updated lockfiles to your branch."
             error_message="Dependency changes detected, but lockfiles are not updated. Run './gradlew alldependencies --write-locks' and commit the changes."
             echo "::error title=⛔ Lockfile Update Required::${error_message}"
-            gh pr comment $PR_URL --body "${error_message}"
+            gh pr comment $PR_URL --body "# ⛔ Lockfile Update Required \n ${error_message}"
             exit 1;
           else
             echo -e "\n✔️ All dependency lockfiles are up to date. No uncommitted changes detected."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,9 +45,12 @@ jobs:
             echo -e "🔍 It seems that the dependency lockfiles are outdated. Please update them by running:"
             echo -e "   ./gradlew alldependencies --write-locks"
             echo -e "   Then commit the updated lockfiles to your branch."
-            error_message="Dependency changes detected, but lockfiles are not updated. Run './gradlew alldependencies --write-locks' and commit the changes."
+            error_message="Dependency changes detected, but lockfiles are not updated. Run `./gradlew alldependencies --write-locks` and commit the changes."
             echo "::error title=⛔ Lockfile Update Required::${error_message}"
-            gh pr comment $PR_URL --body "# ⛔ Lockfile Update Required \n ${error_message}"
+
+            gh pr comment $PR_URL --body "## ⛔ Lockfile Update Required
+            ${error_message}"
+
             exit 1;
           else
             echo -e "\n✔️ All dependency lockfiles are up to date. No uncommitted changes detected."

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
             echo -e "🔍 It seems that the dependency lockfiles are outdated. Please update them by running:"
             echo -e "   ./gradlew alldependencies --write-locks"
             echo -e "   Then commit the updated lockfiles to your branch."
-            error_message="Dependency changes detected, but lockfiles are not updated. Run `./gradlew alldependencies --write-locks` and commit the changes."
+            error_message="Dependency changes detected, but lockfiles are not updated. Run \`./gradlew alldependencies --write-locks\` and commit the changes."
             echo "::error title=⛔ Lockfile Update Required::${error_message}"
 
             gh pr comment $PR_URL --body "## ⛔ Lockfile Update Required

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 activity-compose = "1.10.1"
 androidBeaconLibrary = "2.20.7"
-androidGradlePlugin = "8.9.1"
+androidGradlePlugin = "8.9.0"
 androidSdk-compile = "35"
 androidSdk-min = "21"
 androidSdk-target = "34"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 [versions]
 activity-compose = "1.10.1"
 androidBeaconLibrary = "2.20.7"
-androidGradlePlugin = "8.9.0"
+androidGradlePlugin = "8.9.1"
 androidSdk-compile = "35"
 androidSdk-min = "21"
 androidSdk-target = "34"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Now that we are using lockfiles sometimes we forget to update them, which lead to issues that are not easy to associate with a missing update of the lockfile. In order to explicitly spot a missing update I've added a new job that checks if we forget to push the updated lockfiles.

If it is the case it will block the CI and send an error message in the PR code.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://github.com/user-attachments/assets/1ed7bdd9-08a7-40a2-bbaf-0e1c1283fb04)
This is the message you are getting when you forget to update the lockfile.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
To make more sense into our workflow I propose this new graph
![image](https://github.com/user-attachments/assets/f27164ec-5aa3-43a4-b715-4f9f33701ba2)
