### PR TITLE
Merge SARIF reports

### DIFF
--- a/.github/actions/upload-sarif-results/action.yml
+++ b/.github/actions/upload-sarif-results/action.yml
@@ -1,0 +1,27 @@
+name: "Upload SARIF results"
+description: "Merge and adjust the SARIF files to be compatible with GitHub Security Code Scanning and upload it to the GitHub Security tab."
+inputs:
+  category:
+    description: "Categy used to group the SARIF results."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Merge ${{ inputs.category }} report into one
+      shell: bash
+      if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }} 
+      run: python3 ./.github/scripts/merge_sarif.py
+
+    - name: Upload SARIF results
+      if: ${{ !cancelled() && hashFiles('merged_results.sarif') != '' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.category }}_sarif_results
+        path: merged_results.sarif
+
+    - name: Upload ${{ inputs.category }} reports (SARIF)
+      if: ${{ !cancelled() && hashFiles('merged_results.sarif') != '' }}
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: "./merged_results.sarif"
+        category: ${{ inputs.category }}

--- a/.github/scripts/merge_sarif.py
+++ b/.github/scripts/merge_sarif.py
@@ -1,0 +1,57 @@
+import json
+import glob
+import os
+
+# Directory containing SARIF files
+sarif_directory = "."
+output_file = os.path.join(sarif_directory, "merged_results.sarif")
+
+print(f"Looking for SARIF files in: {sarif_directory}")
+
+# Initialize the merged SARIF structure
+merged_sarif = None
+merged_results = []
+
+
+# Function to clean the 'uri' field inside 'artifactLocation' blocks from CI paths so that Github
+# can interpret them correctly and create the annotation.
+def clean_artifact_location_uris(results):
+    for result in results:
+        locations = result.get("locations", [])
+        for location in locations:
+            physical_location = location.get("physicalLocation", {})
+            artifact_location = physical_location.get("artifactLocation", {})
+            if "uri" in artifact_location and isinstance(artifact_location["uri"], str):
+                # Remove 'work/android/android/' from the URI
+                artifact_location["uri"] = artifact_location["uri"].replace(
+                    "work/android/android/", ""
+                )
+
+
+# Iterate over all SARIF files in the directory
+for sarif_file in glob.glob(
+    os.path.join(sarif_directory, "**/*.sarif"), recursive=True
+):
+    print(f"Processing SARIF file: {sarif_file}")
+    with open(sarif_file, "r") as file:
+        sarif_data = json.load(file)
+        if merged_sarif is None:
+            # Use the first file's structure as the base
+            merged_sarif = sarif_data
+        # Merge the `results` array
+        merged_results.extend(sarif_data.get("runs", [])[0].get("results", []))
+
+# Clean up 'uri' fields in the 'artifactLocation' blocks
+clean_artifact_location_uris(merged_results)
+
+# Update the merged SARIF structure with the combined results
+if merged_sarif:
+    merged_sarif["runs"][0]["results"] = merged_results
+
+    # Write the merged SARIF to a new file
+    with open(output_file, "w") as file:
+        json.dump(merged_sarif, file, indent=4)
+
+    print(f"Merged SARIF file created at: {output_file}")
+else:
+    print("No SARIF files found or invalid SARIF structure.")

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,11 +37,9 @@ jobs:
       - name: Validate ktlint
         run: ./gradlew ktlintCheck :build-logic:convention:ktlintCheck --continue
 
-      - name: Upload lint reports (SARIF)
-        if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+      - uses: ./.github/actions/upload-sarif-results
+        if: always()
         with:
-          sarif_file: "./"
           category: "KTlint"
 
   unit_tests:
@@ -86,11 +84,9 @@ jobs:
           name: lint-reports
           path: "**/build/reports/lint-results-*.html"
 
-      - name: Upload lint reports (SARIF)
-        if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }}
-        uses: github/codeql-action/upload-sarif@v3
+      - uses: ./.github/actions/upload-sarif-results
+        if: always()
         with:
-          sarif_file: "./"
           category: "Android Lint"
 
   pr_build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Since `build-logic` is added with `includeBuild` we have to call ktlint explicitly on `:convention`.
       - name: Validate ktlint
-        run: ./gradlew ktlintCheck :build-logic:convention:ktlintCheck
+        run: ./gradlew ktlintCheck :build-logic:convention:ktlintCheck --continue
 
       - name: Upload lint reports (SARIF)
         if: ${{ !cancelled() && hashFiles('**/*.sarif') != '' }}
@@ -77,7 +77,7 @@ jobs:
           mock-google-services: "true"
 
       - name: Validate Lint
-        run: ./gradlew lint
+        run: ./gradlew lint --continue
 
       - name: Upload lint reports (HTML)
         if: ${{ !cancelled() }}

--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,6 @@ playStorePublishServiceCredentialsFile.json
 .idea/emulatorDisplays.xml
 .idea/runConfigurations.xml
 .idea/studiobot.xml
+
+## Temp results from the CI
+merged_results.sarif

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -22,6 +22,7 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
+import android.util.Log
 import android.util.Rational
 import android.view.HapticFeedbackConstants
 import android.view.KeyEvent
@@ -122,7 +123,7 @@ import timber.log.Timber
 
 @OptIn(androidx.media3.common.util.UnstableApi::class)
 @AndroidEntryPoint
-class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webview.WebView {
+class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webview.WebView{
 
     companion object {
         const val EXTRA_PATH = "path"
@@ -134,6 +135,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         private const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
 
         fun newInstance(context: Context, path: String? = null, serverId: Int? = null): Intent {
+            Log.e("WebViewActivity", "newInstance")
             return Intent(context, WebViewActivity::class.java).apply {
                 putExtra(EXTRA_PATH, path)
                 putExtra(EXTRA_SERVER, serverId)

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationResponseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationResponseTest.kt
@@ -6,7 +6,7 @@ import io.homeassistant.companion.android.common.util.jacksonObjectMapperForHACo
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
-class ConversationResponseTest {
+class ConversationResponseTest{
 
     private val objectMapper: ObjectMapper = jacksonObjectMapperForHACore()
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/complications/AssistDataSourceService.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/complications/AssistDataSourceService.kt
@@ -15,7 +15,7 @@ import com.mikepenz.iconics.typeface.library.community.material.CommunityMateria
 import com.mikepenz.iconics.utils.colorInt
 import io.homeassistant.companion.android.common.R
 
-class AssistDataSourceService : ComplicationDataSourceService() {
+class AssistDataSourceService : ComplicationDataSourceService(){
 
     override fun onComplicationRequest(request: ComplicationRequest, listener: ComplicationRequestListener) {
         if (request.complicationType != ComplicationType.MONOCHROMATIC_IMAGE) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
While working on the introduction of screenshot testing we found out that we were generating too many SARIF files and we ran on the limitation of the numbers of file that we can give to codeql. On top of that I ignored the warning from the codeql plugin saying 
> Uploading multiple SARIF runs with the same category is deprecated and will be removed on June 4, 2025. Please update your workflow to upload a single run per category. For more information, see https://github.blog/changelog/2024-05-06-code-scanning-will-stop-combining-runs-from-a-single-upload

I also found out that the KTLint errors were not reported within the pull request as comment since the physical path was containing the path on the Github Action worker.

This PR solves all this issues at once. To do that a python script has been created to merge all the SARIF file into one by merging the JSON `results` array, the python script strip the worker path from the `uri`.

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->
While testing the PR I found out that the linter were stopping at the first error to avoid this I added the `--continue` flag so that gradle executes all the tasks before failing.