### PR TITLE
Add `wear_keep.xml` to prevent ProGuard from removing necessary resou…

### DIFF
--- a/app/src/full/res/raw/wear_keep.xml
+++ b/app/src/full/res/raw/wear_keep.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@array/android_wear_capabilities"/>

--- a/wear/src/main/res/raw/wear_keep.xml
+++ b/wear/src/main/res/raw/wear_keep.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:keep="@array/android_wear_capabilities"/>


### PR DESCRIPTION
## Summary

Add wear_keep in the correct location to ensure proguard (if applied) doesn't strip Wear capabilities.

See https://github.com/google/horologist/issues/2281#issuecomment-2763461479 and https://issuetracker.google.com/issues/348688201 for discussion.

## Any other notes

- [ ] Testing with a release build including shrinkResources