### PR TITLE
Allow trailing comma but do not enforce it to follow Kotlin coding conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,4 +12,9 @@ ij_kotlin_name_count_to_use_star_import = 9999
 ij_kotlin_name_count_to_use_star_import_for_members = 9999
 # ktlint overrides
 ktlint_function_naming_ignore_when_annotated_with=Composable
+# Allow trailing commas but do not enforce it
+ktlint_standard_trailing-comma-on-call-site = disabled
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ktlint_standard_trailing-comma-on-declaration-site = disabled
+ij_kotlin_allow_trailing_comma = true
 max_line_length = off


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
Kotlin coding [conventions](https://kotlinlang.org/docs/reference/coding-conventions.html#trailing-commas) leaves the choice of the developer to choose or not to have trailing comma. I think that we should do the same. In some cases it makes the review clearer to have a training comma since next modification are not going to modify a line just to add a comma.

This question arise from this PR https://github.com/home-assistant/android/pull/5169 after this PR KTlint won't complain anymore about the trailing comma and won't add any automatically.