### PR TITLE
Set Renovate versioning for Guava to use -android and ignore -jre

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,7 +40,7 @@
             "packagePatterns": [
                 "^com.google.guava:"
             ],
-            "versionScheme": "docker"
+            "versioning": "docker"
         },
         {
             "groupName": "org.jetbrains.kotlin:*",

--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,12 @@
             "registryUrls": ["https://repo1.maven.org/maven2/", "https://plugins.gradle.org/m2/", "https://dl.google.com/android/maven2/", "https://jitpack.io"]
         },
         {
+            "packagePatterns": [
+                "^com.google.guava:"
+            ],
+            "versionScheme": "docker"
+        },
+        {
             "groupName": "org.jetbrains.kotlin:*",
             "matchPackageNames": [
                 "org.jetbrains.kotlin:{/,}**",

--- a/renovate.json5
+++ b/renovate.json5
@@ -40,7 +40,7 @@
             "packagePatterns": [
                 "^com.google.guava:"
             ],
-            "versionCompatibility": "^(?<version>.*)-android$"
+            "versionCompatibility": "^(?<version>.*)-android$",
             "versioning": "semver"
         },
         {

--- a/renovate.json5
+++ b/renovate.json5
@@ -40,7 +40,8 @@
             "packagePatterns": [
                 "^com.google.guava:"
             ],
-            "versioning": "docker"
+            "versionCompatibility": "^(?<version>.*)-android$"
+            "versioning": "semver"
         },
         {
             "groupName": "org.jetbrains.kotlin:*",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR tries to 'fix' #5165, with Renovate trying to update our Guava dependency from `version-android` to `version-jre` because j > a. As we are building an Android app we should use the `-android` dependency so that change is unwanted.

Setting the `versionScheme` should prevent this based on [this comment](https://github.com/renovatebot/config-help/issues/232#issuecomment-491826549). Searching for code on GitHub shows the code submitted in this PR as more common than the one in the issue comment, so I picked the search results code.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
n/a

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
n/a

## Any other notes
<!-- If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here. -->