### PR TITLE
Ensure -android is part of the version capturing group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,7 +40,7 @@
             "packagePatterns": [
                 "^com.google.guava:"
             ],
-            "versionCompatibility": "^(?<version>.*)-android$",
+            "versionCompatibility": "^(?<version>.*-android)$",
             "versioning": "semver"
         },
         {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
The PR https://github.com/home-assistant/android/pull/5183 was an attempt to fix the auto update of `guava` but I've made a mistake in the regex that led to the strip of `-android` when renovate is looking for new version. It led to this logs 

```
DEBUG: GET https://repo1.maven.org/maven2/com/google/guava/guava/33.4.6/guava-33.4.6.pom = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 retryCount=0, duration=4)
DEBUG: Rejected release
{
  "datasource": "maven"
  "packageName": "com.google.guava:guava"
  "registryUrl": "https://repo1.maven.org/maven2/"
  "version": "33.4.6"
}
```

I'm not 100% sure this PR is going to fix the issue but I need this on main to validate my theory.