### PR TITLE
Introduce DevPlayground

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application tools:ignore="MissingApplicationIcon">
+
+        <activity android:name=".launch.LaunchActivity">
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
+        </activity>
+
+        <activity android:name=".developer.DevPlaygroundActivity"/>
+
+    </application>
+
+</manifest>

--- a/app/src/debug/kotlin/io/homeassistant/companion/android/developer/DevPlaygroundActivity.kt
+++ b/app/src/debug/kotlin/io/homeassistant/companion/android/developer/DevPlaygroundActivity.kt
@@ -1,0 +1,62 @@
+package io.homeassistant.companion.android.developer
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+
+/**
+ * This activity is meant to host a playground for development purposes.
+ *
+ * Like crashing the app on purpose, playing with the application theme.
+ *
+ * This activity is not meant to be used in production that's why it is only accessible through the debug build type.
+ * To avoid any mistakes this activity is only accessible from a shortcut
+ */
+class DevPlaygroundActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            HomeAssistantAppTheme {
+                DevPlayGroundScreen()
+            }
+        }
+    }
+}
+
+private class DummyException : Throwable()
+
+@Composable
+private fun DevPlayGroundScreen() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Button(modifier = Modifier.padding(top = 16.dp), onClick = {
+            throw DummyException()
+        }) {
+            Text("Crash the app")
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun DevPlayGroundScreenPreview() {
+    HomeAssistantAppTheme {
+        DevPlayGroundScreen()
+    }
+}

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="dev_playground_label">DevPlayground</string>
+</resources>

--- a/app/src/debug/res/xml/shortcuts.xml
+++ b/app/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,14 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:ignore="UnusedResources, UnusedAttribute">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_android_debug_bridge"
+        android:shortcutId="dev"
+        android:shortcutShortLabel="@string/dev_playground_label">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetClass="io.homeassistant.companion.android.developer.DevPlaygroundActivity"
+            android:targetPackage="io.homeassistant.companion.android.debug" />
+    </shortcut>
+</shortcuts>

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/CrashSaving.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/CrashSaving.kt
@@ -10,6 +10,10 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+/**
+ * Final location of a file on the device is /data/data/io.homeassistant.companion.android<.debug>/cache/fatalcrash/last_crash
+ */
+
 private const val FATAL_CRASH_FILE = "/fatalcrash/last_crash"
 
 fun initCrashSaving(context: Context) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
This PR introduce a new activity meant for developer while developing. This activity is only accessible in debug and through a static shortcut.

For now it only has one button that crash the app with a DummyException. It is meant to test the crash reporting. We could use this activity to actually validate that an update of Sentry is not breaking the upload of the crash.

## Screenshots
<!-- If this is a user-facing change not in the frontend, please include screenshots in light and dark mode. -->
![image](https://github.com/user-attachments/assets/ef08c37a-dc77-49db-9c70-29a1a5d26083)
![image](https://github.com/user-attachments/assets/855f2028-9069-442b-a420-cf883e09c863)

## Link to pull request in Documentation repository
<!-- Pull requests that add, change or remove functionality must have a corresponding pull request in the Companion App Documentation repository (https://github.com/home-assistant/companion.home-assistant). Please add the number of this pull request after the "#" -->
Documentation: home-assistant/developers.home-assistant#2642


