### PR TITLE
Release builds are missing DSN secret

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -62,6 +62,7 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS }}
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           ./gradlew :common:assemble :app:assembleRelease :wear:assembleRelease :automotive:assembleRelease
 
@@ -101,6 +102,7 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS }}
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.ORIGINAL_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: ./gradlew appDistributionUploadFullRelease
 
       - name: Prepare Amazon Listing
@@ -166,6 +168,7 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.UPLOAD_KEYSTORE_ALIAS }}
           KEYSTORE_ALIAS_PASSWORD: ${{ secrets.UPLOAD_KEYSTORE_ALIAS_PASSWORD }}
           VERSION_CODE: ${{ steps.rel_number.outputs.version-code }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: |
           ./gradlew :common:assemble :app:bundleFullRelease :wear:bundleRelease :automotive:bundleFullRelease
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request and helping to improve Home Assistant. Please complete the following sections to help the processing and review of your changes. Please do not delete anything from this template. -->

## Summary
<!-- Provide a brief summary of the changes you have made and most importantly what they aim to achieve -->
It seems that since 2022 we are not getting any crash from Sentry because on release pipeline is missing some on env variable. This PR fix this issue. I managed to debug this easily thanks to https://github.com/home-assistant/android/pull/5200 and I also tested the update of sentry to 8.7.0 so I can say it is working and we can proceed with the update (current PR from renovate needs to be updated since it targets 8.6.0).

This is the manifest of a beta build took from Github Action.
![image](https://github.com/user-attachments/assets/11f6fbcf-2135-4714-9f90-3f5a65a0522c)

And here a screenshot after the fix 
![image](https://github.com/user-attachments/assets/11a46489-05f5-4f32-9f4b-b20281641283)
