### PR TITLE
Enable Gradle Configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4096m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -24,6 +24,8 @@ homeAssistantAndroidRateLimitUrl=https://mobile-apps.home-assistant.io/api/check
 org.gradle.caching=true
 org.gradle.parallel=true
 org.gradle.vfs.watch=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 
 plugins {
     // So we can't reach the libs.plugins.* aliases from here so we need to declare them the old way...
-    id("org.ajoberstar.reckon.settings").version("0.19.1")
+    id("org.ajoberstar.reckon.settings").version("0.19.2")
 }
 
 reckon {


### PR DESCRIPTION
## Summary
This PR does the following
* bumps the Reckon plugin to add support for the configuration cache. https://github.com/ajoberstar/reckon/issues/202 (full changes https://github.com/ajoberstar/reckon/compare/0.19.1...0.19.2)
* enables configuration cache
* Add metaspace heap arguments to avoid bug in Gradle: https://github.com/gradle/gradle/issues/19750

