### PR TITLE
Add .kotlin to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,6 +337,9 @@ google-services.json
 *.keystore
 version.txt
 
+## Kotlin daemon
+.kotlin
+
 ## Make sure our translation downloads don't make our repo dirty when building.
 strings.zip
 common/src/main/res/*/strings.xml


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Recently we started to see logs and session files appearing in `.kotlin` from the Kotlin compiler that should not be pushed. For now we ignore the whole folder.