### PR TITLE
Fix database-related lint/ksp warnings

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
@@ -47,7 +47,7 @@ class NotificationHistoryFragment : PreferenceFragmentCompat() {
                     val prefCategory = findPreference<PreferenceCategory>("list_notifications")
                     val allNotifications = notificationDao.getAll()
 
-                    if (allNotifications.isNullOrEmpty()) {
+                    if (allNotifications.isEmpty()) {
                         menu.removeItem(R.id.search_notifications)
                         menu.removeItem(R.id.notification_filter)
                         menu.removeItem(R.id.action_delete)
@@ -117,7 +117,7 @@ class NotificationHistoryFragment : PreferenceFragmentCompat() {
         val notificationList = notificationDao.getLastItems(25)
 
         val prefCategory = findPreference<PreferenceCategory>("list_notifications")
-        if (!notificationList.isNullOrEmpty()) {
+        if (notificationList.isNotEmpty()) {
             prefCategory?.isVisible = true
             reloadNotifications(notificationList, prefCategory)
         } else {
@@ -156,30 +156,28 @@ class NotificationHistoryFragment : PreferenceFragmentCompat() {
         alert?.show()
     }
 
-    private fun reloadNotifications(notificationList: Array<NotificationItem>?, prefCategory: PreferenceCategory?) {
+    private fun reloadNotifications(notificationList: Array<NotificationItem>, prefCategory: PreferenceCategory?) {
         prefCategory?.removeAll()
-        if (notificationList != null) {
-            for (item in notificationList) {
-                val pref = Preference(preferenceScreen.context)
-                val cal: Calendar = GregorianCalendar()
-                cal.timeInMillis = item.received
-                pref.key = item.id.toString()
-                pref.title = "${cal.time} - ${item.source}"
-                pref.summary = HtmlCompat.fromHtml(item.message, HtmlCompat.FROM_HTML_MODE_LEGACY)
-                pref.isIconSpaceReserved = false
+        for (item in notificationList) {
+            val pref = Preference(preferenceScreen.context)
+            val cal: Calendar = GregorianCalendar()
+            cal.timeInMillis = item.received
+            pref.key = item.id.toString()
+            pref.title = "${cal.time} - ${item.source}"
+            pref.summary = HtmlCompat.fromHtml(item.message, HtmlCompat.FROM_HTML_MODE_LEGACY)
+            pref.isIconSpaceReserved = false
 
-                pref.setOnPreferenceClickListener {
-                    val args = Bundle()
-                    args.putSerializable(NotificationDetailFragment.ARG_NOTIF, item)
-                    parentFragmentManager.commit {
-                        replace(R.id.content, NotificationDetailFragment::class.java, args)
-                        addToBackStack("Notification Detail")
-                    }
-                    return@setOnPreferenceClickListener true
+            pref.setOnPreferenceClickListener {
+                val args = Bundle()
+                args.putSerializable(NotificationDetailFragment.ARG_NOTIF, item)
+                parentFragmentManager.commit {
+                    replace(R.id.content, NotificationDetailFragment::class.java, args)
+                    addToBackStack("Notification Detail")
                 }
-
-                prefCategory?.addPreference(pref)
+                return@setOnPreferenceClickListener true
             }
+
+            prefCategory?.addPreference(pref)
         }
     }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -208,7 +208,6 @@ abstract class AppDatabase : RoomDatabase() {
                     MIGRATION_23_24,
                     Migration40to41(context.assets)
                 )
-                .fallbackToDestructiveMigration()
                 .build()
         }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/notification/NotificationDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/notification/NotificationDao.kt
@@ -15,10 +15,10 @@ interface NotificationDao {
     fun get(id: Int): NotificationItem?
 
     @Query("SELECT * FROM notification_history ORDER BY received DESC")
-    fun getAll(): Array<NotificationItem>?
+    fun getAll(): Array<NotificationItem>
 
     @Query("SELECT * FROM notification_history ORDER BY received DESC LIMIT (:amount)")
-    fun getLastItems(amount: Int): Array<NotificationItem>?
+    fun getLastItems(amount: Int): Array<NotificationItem>
 
     @Query("DELETE FROM notification_history WHERE id = :id")
     suspend fun delete(id: Int)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

Fixes two sets of lint/ksp warnings related to the database

> w: [ksp] The nullable `Array` (kotlin.Array<io.homeassistant.`companion`.android.database.notification.NotificationItem>?) return type in a DAO function is meaningless because Room will instead return an empty `Array` if no rows are returned from the query.

These can be non-null.

> w: file:///home/runner/work/android/android/common/src/main/kotlin/io/homeassistant/companion/android/database/AppDatabase.kt:211:18 'fun fallbackToDestructiveMigration(): RoomDatabase.Builder<AppDatabase>' is deprecated. Replace by overloaded version with parameter to indicate if all tables should be dropped or not.

Losing data is not acceptable, and we have migrations for all current versions + require new migrations using GitHub Actions, so remove instead of replace.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Related to #5221