### PR TITLE
Handle null speech in Assist intent-end event

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -98,7 +98,7 @@ abstract class AssistViewModelBase(
                 )
             } else {
                 serverManager.integrationRepository(selectedServerId).getAssistResponse(
-                    text = text!!,
+                    text = text,
                     pipelineId = pipeline?.id,
                     conversationId = conversationId
                 )
@@ -137,7 +137,7 @@ abstract class AssistViewModelBase(
                         val data = (it.data as? AssistPipelineIntentEnd)?.intentOutput ?: return@collect
                         conversationId = data.conversationId
                         continueConversation.set(data.continueConversation)
-                        data.response.speech.plain["speech"]?.let { speech ->
+                        data.response.speech?.plain?.get("speech")?.let { speech ->
                             onEvent(AssistEvent.Message.Output(speech))
                         }
                     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationSpeechPlainResponse.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationSpeechPlainResponse.kt
@@ -4,5 +4,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ConversationSpeechPlainResponse(
-    val plain: Map<String, String?>
+    val plain: Map<String, String?>?
 )

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationSpeechResponse.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ConversationSpeechResponse.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class ConversationSpeechResponse(
-    val speech: ConversationSpeechPlainResponse,
+    val speech: ConversationSpeechPlainResponse?,
     val card: Any?,
     val language: String?,
     val responseType: String?,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #5167 by allowing more nullability in the Assist `intent-end` events [matching the frontend](https://github.com/home-assistant/frontend/blob/ab415188babbe04ae0f2ae04ff2847e6e6327364/src/components/ha-assist-chat.ts#L375-L378):
 - `response.speech` can be null (JS `?`)
 - `response.speech.plain` can be null (JS `if` checks for null, and the cause of the crash)

If there is no text, the dialog will keep showing "..." as the response to the request, which should match frontend behavior.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

Also includes a one line fix for an unnecessary `!!` that I noticed scrolling down in the file.