### PR TITLE
Remove value strings of preference arrays from Lokalise

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -900,8 +900,8 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
 
         requestedOrientation = when (presenter.getScreenOrientation()) {
-            getString(commonR.string.screen_orientation_option_value_portrait) -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            getString(commonR.string.screen_orientation_option_value_landscape) -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+            getString(R.string.screen_orientation_option_array_value_portrait) -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            getString(R.string.screen_orientation_option_array_value_landscape) -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
             else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -5,15 +5,25 @@
         <item>@string/themes_option_label_light</item>
         <item>@string/themes_option_label_dark</item>
     </string-array>
+    <!--
+    The strings used as array value should not be translated to avoid this kind of issue
+    https://github.com/home-assistant/android/issues/5292
+    -->
+    <string name="themes_option_array_value_dark">dark</string>
+    <string name="themes_option_array_value_light">light</string>
+    <string name="themes_option_array_value_system">system</string>
     <string-array name="pref_theme_option_values">
-        <item>@string/themes_option_value_system</item>
-        <item>@string/themes_option_value_light</item>
-        <item>@string/themes_option_value_dark</item>
+        <item>@string/themes_option_array_value_system</item>
+        <item>@string/themes_option_array_value_light</item>
+        <item>@string/themes_option_array_value_dark</item>
     </string-array>
+    <string name="screen_orientation_option_array_value_system">system</string>
+    <string name="screen_orientation_option_array_value_portrait">portrait</string>
+    <string name="screen_orientation_option_array_value_landscape">landscape</string>
     <string-array name="pref_screen_orientation_option_values">
-        <item>@string/screen_orientation_option_value_system</item>
-        <item>@string/screen_orientation_option_value_landscape</item>
-        <item>@string/screen_orientation_option_value_portrait</item>
+        <item>@string/screen_orientation_option_array_value_system</item>
+        <item>@string/screen_orientation_option_array_value_landscape</item>
+        <item>@string/screen_orientation_option_array_value_portrait</item>
     </string-array>
     <string-array name="pref_screen_orientation_option_labels">
         <item>@string/screen_orientation_option_label_system</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,7 +44,7 @@
             android:summary="@string/fullscreen_def"/>
         <ListPreference
             android:key="screen_orientation"
-            android:defaultValue="@string/screen_orientation_option_value_system"
+            android:defaultValue="@string/screen_orientation_option_array_value_system"
             android:entries="@array/pref_screen_orientation_option_labels"
             android:entryValues="@array/pref_screen_orientation_option_values"
             android:icon="@drawable/ic_screen_orientation"
@@ -88,7 +88,7 @@
             android:summary="@string/lang_summary_settings" />
         <ListPreference
             android:key="themes"
-            android:defaultValue="@string/themes_option_value_light"
+            android:defaultValue="@string/themes_option_array_value_light"
             android:entries="@array/pref_theme_option_labels"
             android:entryValues="@array/pref_theme_option_values"
             android:icon="@drawable/ic_color_lens_24dp"

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -293,9 +293,6 @@
     <string name="screen_orientation_option_label_system">Follow system settings</string>
     <string name="screen_orientation_option_label_portrait">Portrait</string>
     <string name="screen_orientation_option_label_landscape">Landscape</string>
-    <string name="screen_orientation_option_value_system">system</string>
-    <string name="screen_orientation_option_value_portrait">portrait</string>
-    <string name="screen_orientation_option_value_landscape">landscape</string>
     <string name="get_help">Get help</string>
     <string name="grant_permission">Grant permission</string>
     <string name="help">Help</string>
@@ -909,10 +906,6 @@
     <string name="themes_option_label_dark">Dark</string>
     <string name="themes_option_label_light">Light</string>
     <string name="themes_option_label_system">Follow system settings</string>
-    <string name="themes_option_value_android">android</string>
-    <string name="themes_option_value_dark">dark</string>
-    <string name="themes_option_value_light">light</string>
-    <string name="themes_option_value_system">system</string>
     <string name="themes_title_settings">Theme</string>
     <string name="tile_1">Tile 1</string>
     <string name="tile_10">Tile 10</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The switch for the theme was not working because it was using values from `strings.xml` in one side (from the xml arrays) and harcoded values in ThemeManager. Because of that when the translation of the values where different than the hardcoded value it was always defaulting to `AppCompatDelegate.MODE_NIGHT_NO`.

I decided to rename the strings of the values used in the arrays to avoid any issues, when we are going to download the translation for the next release.

⚠️ I need to check that after this PR is merged we are not pushing the new keys into Localize again otherwise the issue will happen again later when someone will translate it again.

I decided to also apply this to the screen orientation that was built the same way. Even if the issue is not as obvious, the issue is only visible if you change the orientation and then you change your language.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Fixes #5292 
If you test the apk in this PR you cannot reproduce the issue since our repo only contains one language.
⚠️ People that previously had screen orientation set up in another language will get this settings reset if there was a translation.