### PR TITLE
Fix always show first view when opening the app

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1663,20 +1663,17 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         if (presenter.isAlwaysShowFirstViewOnAppStartEnabled() &&
             LifecycleHandler.isAppInBackground()
         ) {
-            /**
-             * Pattern matches urls which are NOT allowed to show the first view after app is started
-             * This is
-             * /config/ as these are the settings of HA but NOT /config/dashboard. This is just the overview of the HA settings
-             * /hassio/ as these are the addons section of HA settings.
-             */
+            // Clearing history and replace the current page with the default page from the frontend.
+            // This way the user have a clear history stack.
+            webView.clearHistory()
+
+            // Pattern matches urls which are NOT allowed to show the first view after app is started
+            // This is
+            // /config/* as these are the settings of HA but NOT /config/dashboard. This is just the overview of the HA settings
+            // /hassio/* as these are the addons section of HA settings.
             if (webView.url?.matches(".*://.*/(config/(?!\\bdashboard\\b)|hassio)/*.*".toRegex()) == false) {
                 Timber.d("Show first view of default dashboard.")
                 if (serverManager.getServer(presenter.getActiveServer())?.version?.isAtLeast(2025, 6, 0) == true) {
-                    /**
-                     * Clearing history and replace the current page with the default page from the frontend.
-                     * This way the user have a clear history stack.
-                     */
-                    webView.clearHistory()
                     sendExternalBusMessage(
                         NavigateTo("/", true),
                     )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1664,6 +1664,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
             LifecycleHandler.isAppInBackground()
         ) {
             if (serverManager.getServer(presenter.getActiveServer())?.version?.isAtLeast(2025, 6, 0) == true) {
+                /**
+                 * Clearing history and replace the current page with the default page from the frontend.
+                 * This way the user have a clear history stack.
+                 */
+                webView.clearHistory()
                 sendExternalBusMessage(
                     NavigateTo("/", true)
                 )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1665,7 +1665,7 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         ) {
             if (serverManager.getServer(presenter.getActiveServer())?.version?.isAtLeast(2025, 6, 0) == true) {
                 sendExternalBusMessage(
-                    NavigateTo("/config", true)
+                    NavigateTo("/", true)
                 )
             } else {
                 // Pattern matches urls which are NOT allowed to show the first view after app is started

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1663,22 +1663,24 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
         if (presenter.isAlwaysShowFirstViewOnAppStartEnabled() &&
             LifecycleHandler.isAppInBackground()
         ) {
-            if (serverManager.getServer(presenter.getActiveServer())?.version?.isAtLeast(2025, 6, 0) == true) {
-                /**
-                 * Clearing history and replace the current page with the default page from the frontend.
-                 * This way the user have a clear history stack.
-                 */
-                webView.clearHistory()
-                sendExternalBusMessage(
-                    NavigateTo("/", true)
-                )
-            } else {
-                // Pattern matches urls which are NOT allowed to show the first view after app is started
-                // This is
-                // /config/* as these are the settings of HA but NOT /config/dashboard. This is just the overview of the HA settings
-                // /hassio/* as these are the addons section of HA settings.
-                if (webView.url?.matches(".*://.*/(config/(?!\\bdashboard\\b)|hassio)/*.*".toRegex()) == false) {
-                    Timber.d("Show first view of default dashboard.")
+            /**
+             * Pattern matches urls which are NOT allowed to show the first view after app is started
+             * This is
+             * /config/ as these are the settings of HA but NOT /config/dashboard. This is just the overview of the HA settings
+             * /hassio/ as these are the addons section of HA settings.
+             */
+            if (webView.url?.matches(".*://.*/(config/(?!\\bdashboard\\b)|hassio)/*.*".toRegex()) == false) {
+                Timber.d("Show first view of default dashboard.")
+                if (serverManager.getServer(presenter.getActiveServer())?.version?.isAtLeast(2025, 6, 0) == true) {
+                    /**
+                     * Clearing history and replace the current page with the default page from the frontend.
+                     * This way the user have a clear history stack.
+                     */
+                    webView.clearHistory()
+                    sendExternalBusMessage(
+                        NavigateTo("/", true),
+                    )
+                } else {
                     webView.evaluateJavascript(
                         """
                     var anchor = 'a:nth-child(1)';
@@ -1689,11 +1691,11 @@ class WebViewActivity : BaseActivity(), io.homeassistant.companion.android.webvi
                                                                    .shadowRoot.querySelector('paper-listbox > ' + anchor).click();
                     window.scrollTo(0, 0);
                     """,
-                        null
+                        null,
                     )
-                } else {
-                    Timber.d("User is in the Home Assistant config. Will not show first view of the default dashboard.")
                 }
+            } else {
+                Timber.d("User is in the Home Assistant config. Will not show first view of the default dashboard.")
             }
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
@@ -1,8 +1,9 @@
 package io.homeassistant.companion.android.webview.externalbus
 
 import android.webkit.ValueCallback
+import kotlinx.serialization.Serializable
 
-data class ExternalBusMessage(
+open class ExternalBusMessage(
     val id: Any,
     val type: String,
     val command: String? = null,
@@ -10,5 +11,18 @@ data class ExternalBusMessage(
     val result: Any? = null,
     val error: Any? = null,
     val payload: Any? = null,
-    val callback: ValueCallback<String>? = null
+    val callback: ValueCallback<String>? = null,
+)
+
+@Serializable
+class NavigateTo(path: String, replace: Boolean = false) : ExternalBusMessage(
+    id = -1,
+    type = "command",
+    command = "navigate",
+    payload = mapOf(
+        "path" to path,
+        "options" to mapOf(
+            "replace" to replace,
+        ),
+    ),
 )


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #5297, by using the new `navigate` external message introduced in https://github.com/home-assistant/frontend/pull/25516

I kept the old implementation but it only works with old version of the frontend. It means that this feature won't work if you have a version of core that is between the two implementation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
To test it you need a frontend dev environement or wait for the next release of core.
Ideally the message sent to the external bus should be strongly typed so I decided to create a dedicated class for this new message.
The current implementation doesn't erase the backstack, but only replace the head of the backstack. It leads to a weird behavior in the navigation depending on where you were before putting the app in background. To avoid this we could have a command to the frontend to clear the backstack.