### PR TITLE
Adjust edge to edge in BarecodeActivity for API 36 and landscape

### DIFF
--- a/app/src/debug/kotlin/io/homeassistant/companion/android/developer/DevPlaygroundActivity.kt
+++ b/app/src/debug/kotlin/io/homeassistant/companion/android/developer/DevPlaygroundActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.homeassistant.companion.android.barcode.BarcodeScannerActivity
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 
@@ -68,6 +69,11 @@ private fun DevPlayGroundScreen(context: Context? = null) {
             context?.run { startActivity(SettingsActivity.newInstance(context)) }
         }) {
             Text("Start Settings")
+        }
+        Button(modifier = Modifier.padding(top = 16.dp), onClick = {
+            context?.run { startActivity(BarcodeScannerActivity.newInstance(this, 0, "Title", "Subtitle", null)) }
+        }) {
+            Text("Start barcode")
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
@@ -6,7 +6,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
-import androidx.activity.SystemBarStyle
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -16,7 +15,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -24,7 +22,6 @@ import com.google.zxing.BarcodeFormat
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.barcode.view.BarcodeScannerView
-import io.homeassistant.companion.android.barcode.view.barcodeScannerOverlayColor
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import java.util.Locale
@@ -65,8 +62,7 @@ class BarcodeScannerActivity : BaseActivity() {
     private var requestSilently by mutableStateOf(true)
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val overlaySystemBarStyle = SystemBarStyle.dark(barcodeScannerOverlayColor.toArgb())
-        enableEdgeToEdge(overlaySystemBarStyle, overlaySystemBarStyle)
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         val messageId = intent.getIntExtra(EXTRA_MESSAGE_ID, -1)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/view/BarcodeScannerOverlay.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/view/BarcodeScannerOverlay.kt
@@ -63,4 +63,4 @@ fun BarcodeScannerOverlay(
     }
 }
 
-val barcodeScannerOverlayColor = Color(0xAA000000)
+private val barcodeScannerOverlayColor = Color(0xAA000000)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/view/BarcodeScannerView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/view/BarcodeScannerView.kt
@@ -1,17 +1,19 @@
 package io.homeassistant.companion.android.barcode.view
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Icon
@@ -56,6 +58,7 @@ import io.homeassistant.companion.android.util.compose.safeScreenHeight
 import io.homeassistant.companion.android.util.compose.screenWidth
 import io.homeassistant.companion.android.util.getActivity
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun BarcodeScannerView(
     title: String,
@@ -112,7 +115,6 @@ fun BarcodeScannerView(
 
         BoxWithConstraints(
             modifier = Modifier
-                .safeDrawingPadding()
                 .fillMaxSize()
         ) {
             val screenHeight = safeScreenHeight()
@@ -151,6 +153,7 @@ fun BarcodeScannerView(
                             }
                         },
                         backgroundColor = Color.Transparent,
+                        windowInsets = WindowInsets.statusBars,
                         elevation = 0.dp
                     )
                 },


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
BarecodeActivity inset is not working properly if we target API 36
![Screenshot_20250523_160046](https://github.com/user-attachments/assets/e772734f-380f-4a29-9353-c8787f914ed1)

It is also not working properly without changing the target in landscape
![Screenshot_20250523_155720](https://github.com/user-attachments/assets/146979bf-8616-4ed3-8c26-7d01a871ea65)

This PR propose a change so that the overlay is properly displayed.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
![image](https://github.com/user-attachments/assets/bc910149-7d9f-4744-aa30-d7f43b2d0e13)
![image](https://github.com/user-attachments/assets/3b129742-50e7-4665-8730-f210a9fc2794)

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Part of #5328