### PR TITLE
Use snapshot version scheme locally to allow for better caching

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,8 +24,16 @@ plugins {
 }
 
 reckon {
+    val isCiBuild = providers.environmentVariable("CI").isPresent
+
     setDefaultInferredScope("patch")
-    stages("beta", "final")
+    if (!isCiBuild) {
+        // Use a snapshot version scheme with Reckon when not running in CI, which allows caching to
+        // improve performance. Background: https://github.com/home-assistant/android/issues/5220.
+        snapshots()
+    } else {
+        stages("beta", "final")
+    }
     setScopeCalc { java.util.Optional.of(org.ajoberstar.reckon.core.Scope.PATCH) }
     setStageCalc(calcStageFromProp())
     setTagWriter { it.toString() }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Closes #5220 by only configuring Reckon to use the stage-based versions when running in CI, and using snapshot versions when running locally.

This is a choice that removes some information, but I feel after this many years with Reckon the value of the timestamps in versions locally is too limited to be worth the performance loss, especially considering more frequent builds for previews etc. For builds on GitHub Actions, where this information can be useful, it is unchanged and continues to use stages.

Using the `CI` environment variable to detect running in CI [seems](https://github.com/detekt/detekt/blob/f2ef08bb8d3b4f49d0dc2402109044fefdd2002a/build-logic/build.gradle.kts#L30) [to be](https://github.com/pinterest/ktlint/blob/96ce4a13838ffae670ddfa9e462a12aa38592456/settings.gradle.kts#L27) [quite](https://github.com/ktorio/ktor/blob/8c878b20d6eee760cfd84dac2e47dfce3c6af56c/build-logic/src/main/kotlin/ktorbuild/KtorBuildExtension.kt#L32) [common](https://github.com/search?q=providers.environmentVariable%28%22CI%22%29&type=code). I tested it locally by setting and then removing the environment variable:

![Terminal output showing added CI environment variable and a version with a timestamp, followed by removing CI environment variable and version with snapshot](https://github.com/user-attachments/assets/8c0a3e8a-eaa7-4f45-8fd7-ba8eff5d0f4f)


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

I tried being fancy with a settings plugin but couldn't get it to work reliably and also remembered that it is two unrelated changes so I wouldn't accept that if I were reviewing my own PR. [Commit here](https://github.com/jpelgrom/home-assistant-android/commit/976864c2deace2abb08afbe539688aef54ff34c4).