### PR TITLE
Enable edge to edge for modal bottom sheets

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -21,6 +22,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.util.safeBottomWindowInsets
 
 /**
  * A Material 3-style modal bottom sheet with an optional handle, for use with a
@@ -36,7 +38,9 @@ fun ModalBottomSheet(
     Surface(
         shape = RoundedCornerShape(topStart = sheetCornerRadius, topEnd = sheetCornerRadius)
     ) {
-        Column {
+        Column(
+            modifier = Modifier.windowInsetsPadding(safeBottomWindowInsets())
+        ) {
             if (showHandle) {
                 Row(
                     modifier = Modifier

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -16,7 +16,11 @@
     </style>
 
     <style name="ThemeOverlay.HomeAssistant.BottomSheetDialog" parent="ThemeOverlay.HomeAssistant.BottomSheetDialog.Base">
-        <item name="android:navigationBarColor">@color/colorSurface</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
         <item name="android:windowLightNavigationBar">@bool/isLightMode</item>
+        <item name="enableEdgeToEdge">true</item>
+        <item name="paddingBottomSystemWindowInsets">false</item>
+        <item name="paddingLeftSystemWindowInsets">false</item>
+        <item name="paddingRightSystemWindowInsets">false</item>
     </style>
 </resources>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Make the `BottomSheetDialogFragments` with `ModalBottomSheet` composables go edge to edge. Dialogs do not have `enableEdgeToEdge()` but do have similar built in support (with bad documentation) which requires you to manually set the navigation bar to transparent to enable it.

Special notes:
 - This works even if the underlying activity is not edge to edge. See the screenshots below: WebViewActivity is not yet edge to edge, SettingsActivity is edge to edge.
 - Because we need the system to be able to show a light navigation bar in light mode, this is limited to API 27+ (unchanged).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

|Edge to edge Improv dialog with gesture nav in WebView|![image](https://github.com/user-attachments/assets/42bec04d-810e-47ff-8158-d725662b18fb)|Edge to edge server chooser dialog with gesture nav in WebView|![image](https://github.com/user-attachments/assets/af814b5a-4e34-461b-a007-7193f16a4c74)|
|---|---|---|---|
|Edge to edge server chooser dialog with button nav in WebView|![image](https://github.com/user-attachments/assets/338be9b6-09b4-4720-ae36-fa4689ebaf7a)|Edge to edge server chooser dialog with gesture nav in settings|![image](https://github.com/user-attachments/assets/33562f4c-affc-49d9-a69e-76e4640460d2)|


## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Part of work for #5328