### PR TITLE
Use new frontend entity more info deeplink

### DIFF
--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,7 @@
     tools:ignore="MissingDefaultResource">
     <release version="2025.6.3 - Main" versioncode="3">
         <change>The app now uses all available space on the screen (edge-to-edge support)</change>
+        <change>Viewing more info for entities from device controls, notifications, shortcuts and tiles is now more responsive</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2025.6.3 - Wear" versioncode="2">


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The latest frontend release randomly added an official option to open the more info dialog programmatically, [using a query paramater](https://github.com/home-assistant/frontend/pull/25733), after we have been unable to get such a frontend change for the app's deeplinks for years. Better late than never, I guess.

This PR switches from the workaround to the new query parameter to open more info, if the server version is recent enough.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

Using two examples, but this obviously applies to all. Also confirmed it works correctly if you changed the default dashboard/url. Really nice how responsive this now feels!

 - From a push notification

https://github.com/user-attachments/assets/0604d1be-2bf6-409c-8f27-2edc04f3c0fc

 - From device controls

https://github.com/user-attachments/assets/5fa702c5-f17b-4f7a-8721-3a83ded1f042

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->