### PR TITLE
Disable ha_launcher by default and hide it in automotive

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -557,11 +557,10 @@ class SettingsFragment(
     }
 
     private fun setupLauncherPrefs() {
-        val launcherCategory = findPreference<PreferenceCategory>("launcher_category")
         val launcherSwitchPref = findPreference<SwitchPreference>("enable_ha_launcher")
         val launcherPref = findPreference<Preference>("set_launcher_app")
 
-        launcherCategory?.isVisible = true
+        findPreference<PreferenceCategory>("launcher_category")?.isVisible = true
 
         launcherSwitchPref?.setOnPreferenceClickListener {
             launcherPref?.isVisible = launcherSwitchPref.isChecked

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -360,7 +360,9 @@ class SettingsFragment(
             }
         }
 
-        setupLauncherPrefs()
+        if (!isAutomotive) {
+            setupLauncherPrefs()
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -555,8 +557,11 @@ class SettingsFragment(
     }
 
     private fun setupLauncherPrefs() {
+        val launcherCategory = findPreference<PreferenceCategory>("launcher_category")
         val launcherSwitchPref = findPreference<SwitchPreference>("enable_ha_launcher")
         val launcherPref = findPreference<Preference>("set_launcher_app")
+
+        launcherCategory?.isVisible = true
 
         launcherSwitchPref?.setOnPreferenceClickListener {
             launcherPref?.isVisible = launcherSwitchPref.isChecked

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -311,7 +311,7 @@ class SettingsPresenterImpl @Inject constructor(
         view.getPackageManager()?.setComponentEnabledSetting(
             launcherAliasComponent,
             if (enable) PackageManager.COMPONENT_ENABLED_STATE_ENABLED else PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-            if (enable) PackageManager.DONT_KILL_APP else 0,
+            PackageManager.DONT_KILL_APP,
         )
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -85,7 +85,8 @@ class SettingsPresenterImpl @Inject constructor(
             }
             "enable_ha_launcher" -> {
                 val componentSetting = view.getPackageManager()?.getComponentEnabledSetting(launcherAliasComponent)
-                componentSetting != null && componentSetting != PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+                // By default it should be disabled and only shown when the user enabled it
+                componentSetting != null && componentSetting == PackageManager.COMPONENT_ENABLED_STATE_ENABLED
             }
             else -> throw IllegalArgumentException("No boolean found by this key: $key")
         }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -186,7 +186,9 @@
             android:summary="@string/manage_widgets_summary" />
     </PreferenceCategory>
     <PreferenceCategory
-        android:title="@string/launcher">
+        android:key="launcher_category"
+        android:title="@string/launcher"
+        app:isPreferenceVisible="false">
         <SwitchPreference
             android:key="enable_ha_launcher"
             android:icon="@drawable/ic_android_debug_bridge"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The new feature about being able to use HA as a launcher was not properly setup in the SettingsFragment. It was enabled by default where it should have been disabled by default.

We also don't want to expose this feature in the automotive variant of the app.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.


CC @fpetrovski 