### PR TITLE
Handle missing field exception in CompressedEntityState

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
@@ -62,9 +62,9 @@ data class CompressedEntityState(
     fun toEntity(entityId: String): Entity {
         return Entity(
             entityId = entityId,
-            state = state!!,
+            state = checkNotNull(state) { "State must not be null" },
             attributes = attributes,
-            lastChanged = LocalDateTime.ofEpochSecond(round(lastChanged!!).toLong(), 0, ZoneOffset.UTC),
+            lastChanged = LocalDateTime.ofEpochSecond(round(checkNotNull(lastChanged) { "lastChanged must not be null" }).toLong(), 0, ZoneOffset.UTC),
             lastUpdated = LocalDateTime.ofEpochSecond(
                 if (lastUpdated != null) {
                     round(lastUpdated * 1000).toLong()

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
@@ -49,7 +49,7 @@ data class CompressedEntityState(
     val state: String? = null,
     @Serializable(with = MapAnySerializer::class)
     @JsonNames("a")
-    val attributes: Map<String, @Polymorphic Any?>,
+    val attributes: Map<String, @Polymorphic Any?> = emptyMap(),
     @JsonNames("lc")
     val lastChanged: Double? = null,
     @JsonNames("lu")

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
@@ -18,7 +18,7 @@ class CompressedEntityTest {
         val state = Random.nextInt().toString()
         val lastChanged = 42.0
         val lastUpdated = 41.1
-        val rawData = """{"s":"$state","lc":$lastChanged,"lu":$lastUpdated,}"""
+        val rawData = """{"s":"$state","lc":$lastChanged,"lu":$lastUpdated}"""
         assertEquals(CompressedEntityState(state = state, lastChanged = lastChanged, lastUpdated = lastUpdated), kotlinJsonMapper.decodeFromString<CompressedEntityState>(rawData))
     }
 

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.common.data.websocket.impl.entities
 
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import kotlin.random.Random
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -8,7 +9,30 @@ class CompressedEntityTest {
 
     @Test
     fun `CompressedEntityState decoding with empty data`() {
-        val rawData = "{}"
+        val rawData = """{}"""
         assertEquals(CompressedEntityState(), kotlinJsonMapper.decodeFromString<CompressedEntityState>(rawData))
+    }
+
+    @Test
+    fun `CompressedEntityState decoding with empty attributes`() {
+        val state = Random.nextInt().toString()
+        val lastChanged = 42.0
+        val lastUpdated = 41.1
+        val rawData = """{"s":"$state","lc":$lastChanged,"lu":$lastUpdated,}"""
+        assertEquals(CompressedEntityState(state = state, lastChanged = lastChanged, lastUpdated = lastUpdated), kotlinJsonMapper.decodeFromString<CompressedEntityState>(rawData))
+    }
+
+    @Test
+    fun `CompressedEntityState decoding with random data`() {
+        val state = Random.nextInt().toString()
+        val lastChanged = 42.0
+        val lastUpdated = 41.1
+        val attributes = mapOf(
+            "friendly_name" to Random.nextInt().toString(),
+            "icon" to Random.nextInt().toString(),
+        )
+        val rawData = """{"s":"$state","lc":$lastChanged,"lu":$lastUpdated,"a":{"friendly_name":"${attributes["friendly_name"]}","icon":"${attributes["icon"]}"}}"""
+        val expected = CompressedEntityState(state, attributes, lastChanged, lastUpdated)
+        assertEquals(expected, kotlinJsonMapper.decodeFromString<CompressedEntityState>(rawData))
     }
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntityTest.kt
@@ -1,0 +1,14 @@
+package io.homeassistant.companion.android.common.data.websocket.impl.entities
+
+import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CompressedEntityTest {
+
+    @Test
+    fun `CompressedEntityState decoding with empty data`() {
+        val rawData = "{}"
+        assertEquals(CompressedEntityState(), kotlinJsonMapper.decodeFromString<CompressedEntityState>(rawData))
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After migrating to Kotlinx serialization the initialization of the classes are more strict than before. So a field that doesn't have a default value needs to be present in the JSON while decoding. In this case it is possible that the field `attributes` is empty or null (for reference see iOS impl https://github.com/home-assistant/HAKit/pull/49/files#diff-becad62c1e040b15f3ebfefa6bb6d7bc25de151dcc3eddc1599d27d76bb11f69).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I saw a `!!` while converting to an `Entity` and I changed it to `checkNotNull` for more readability if it ever happens.
I'm wondering if we actually should support `null` for the `state` I'm going to follow up with core on this.