### PR TITLE
Improve error handling when using Response from Retrofit

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/authentication/AuthorizationException.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/authentication/AuthorizationException.kt
@@ -1,3 +1,8 @@
 package io.homeassistant.companion.android.common.data.authentication
 
-class AuthorizationException : Exception()
+import okhttp3.ResponseBody
+
+class AuthorizationException : Exception {
+    constructor() : super()
+    constructor(message: String, httpCode: Int, errorBody: ResponseBody?) : super("$message, httpCode: $httpCode, errorBody: ${errorBody?.string()}")
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/authentication/impl/AuthenticationRepositoryImpl.kt
@@ -44,11 +44,11 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
             serverManager.updateServer(
                 server.copy(
                     session = ServerSessionInfo(
-                        it.accessToken,
-                        it.refreshToken!!,
-                        System.currentTimeMillis() / 1000 + it.expiresIn,
-                        it.tokenType,
-                        installId,
+                        accessToken = it.accessToken,
+                        refreshToken = it.refreshToken!!,
+                        tokenExpiration = System.currentTimeMillis() / 1000 + it.expiresIn,
+                        tokenType = it.tokenType,
+                        installId = installId,
                     ),
                 ),
             )
@@ -159,11 +159,11 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
                 serverManager.updateServer(
                     server.copy(
                         session = ServerSessionInfo(
-                            refreshedToken.accessToken,
-                            refreshToken,
-                            System.currentTimeMillis() / 1000 + refreshedToken.expiresIn,
-                            refreshedToken.tokenType,
-                            installId,
+                            accessToken = refreshedToken.accessToken,
+                            refreshToken = refreshToken,
+                            tokenExpiration = System.currentTimeMillis() / 1000 + refreshedToken.expiresIn,
+                            tokenType = refreshedToken.tokenType,
+                            installId = installId,
                         ),
                     ),
                 )
@@ -173,7 +173,7 @@ class AuthenticationRepositoryImpl @AssistedInject constructor(
             ) {
                 revokeSession()
             }
-            throw AuthorizationException()
+            throw AuthorizationException("Fail to refresh token", it.code(), it.errorBody())
         }
     }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/IntegrationException.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/IntegrationException.kt
@@ -1,7 +1,11 @@
 package io.homeassistant.companion.android.common.data.integration
 
+import okhttp3.ResponseBody
+
 class IntegrationException : Exception {
     constructor() : super()
     constructor(message: String) : super(message)
     constructor(cause: Throwable) : super(cause)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(message: String, httpCode: Int, errorBody: ResponseBody?) : super("$message, httpCode: $httpCode, errorBody: ${errorBody?.string()}")
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -19,6 +19,7 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.FireEventRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.GetConfigIntegrationRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.GetZonesIntegrationRequest
+import io.homeassistant.companion.android.common.data.integration.impl.entities.IntegrationRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitRequest
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RateLimitResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceIntegrationRequest
@@ -37,6 +38,8 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.As
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineEventType
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineIntentEnd
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
+import io.homeassistant.companion.android.common.util.FailFast
+import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import kotlinx.coroutines.flow.Flow
@@ -44,6 +47,8 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.ResponseBody
+import retrofit2.Response
 import timber.log.Timber
 
 class IntegrationRepositoryImpl @AssistedInject constructor(
@@ -127,44 +132,25 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
 
     override suspend fun updateRegistration(deviceRegistration: DeviceRegistration, allowReregistration: Boolean) {
         val request = RegisterDeviceIntegrationRequest(createUpdateRegistrationRequest(deviceRegistration))
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            try {
-                val response = integrationService.callWebhook(it.toHttpUrlOrNull()!!, request)
-                // The server should return a body with the registration, but might return:
-                // 200 with empty body for broken direct webhook
-                // 404 for broken cloudhook
-                // 410 for missing config entry
-                if (response.isSuccessful) {
-                    if (response.code() == 200 && (response.body()?.contentLength() ?: 0) == 0L) {
-                        throw IllegalStateException("update_registration returned empty body")
-                    } else {
-                        persistDeviceRegistration(deviceRegistration)
-                        return
+        server.connection.callWebhookOnUrls(request, onSuccess = { response ->
+            // The server should return a body with the registration, but might return:
+            // 200 with empty body for broken direct webhook
+            if (response.code() == 200 && response.body()?.contentLength() == 0L) {
+                Timber.w("update_registration returned empty body")
+                if (allowReregistration) {
+                    Timber.w("Device registration broken and reregistration allowed, reregistering")
+                    try {
+                        registerDevice(deviceRegistration)
+                    } catch (e: Exception) {
+                        throw IntegrationException("Device registration broken and reregistration failed", e)
                     }
-                } else if (response.code() == 404 || response.code() == 410) {
-                    throw IllegalStateException("update_registration returned code ${response.code()}")
-                }
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-        }
-
-        if (causeException != null) {
-            if (allowReregistration && (causeException is IllegalStateException)) {
-                Timber.w(causeException, "Device registration broken, reregistering")
-                try {
-                    registerDevice(deviceRegistration)
-                } catch (e: Exception) {
-                    throw IntegrationException(e)
+                } else {
+                    throw IntegrationException("Device registration broken and reregistration not allowed.")
                 }
             } else {
-                throw IntegrationException(causeException)
+                persistDeviceRegistration(deviceRegistration)
             }
-        } else {
-            throw IntegrationException("Error calling integration request update_registration")
-        }
+        })
     }
 
     override suspend fun getRegistration(): DeviceRegistration {
@@ -243,31 +229,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
 
     override suspend fun updateLocation(updateLocation: UpdateLocation) {
         val updateLocationRequest = createUpdateLocation(updateLocation)
-
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            var wasSuccess = false
-            try {
-                wasSuccess =
-                    integrationService.callWebhook(
-                        it.toHttpUrlOrNull()!!,
-                        updateLocationRequest,
-                    ).isSuccessful
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-            // if we had a successful call we can return
-            if (wasSuccess) {
-                return
-            }
-        }
-
-        if (causeException != null) {
-            throw IntegrationException(causeException)
-        } else {
-            throw IntegrationException("Error calling integration request update_location")
-        }
+        server.connection.callWebhookOnUrls(updateLocationRequest)
     }
 
     override suspend fun callAction(
@@ -275,105 +237,30 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         action: String,
         actionData: Map<String, Any?>,
     ) {
-        var wasSuccess = false
-
-        val actionRequest =
-            ActionRequest(
-                domain,
-                action,
-                actionData,
-            )
-
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            try {
-                wasSuccess =
-                    integrationService.callWebhook(
-                        it.toHttpUrlOrNull()!!,
-                        CallServiceIntegrationRequest(
-                            actionRequest,
-                        ),
-                    ).isSuccessful
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-            // if we had a successful call we can return
-            if (wasSuccess) {
-                return
-            }
-        }
-
-        if (causeException != null) {
-            throw IntegrationException(causeException)
-        } else {
-            throw IntegrationException("Error calling integration request call_service")
-        }
+        server.connection.callWebhookOnUrls(
+            CallServiceIntegrationRequest(
+                ActionRequest(
+                    domain,
+                    action,
+                    actionData,
+                ),
+            ),
+        )
     }
 
     override suspend fun scanTag(data: Map<String, String>) {
-        var wasSuccess = false
-
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            try {
-                wasSuccess =
-                    integrationService.callWebhook(
-                        it.toHttpUrlOrNull()!!,
-                        ScanTagIntegrationRequest(
-                            data,
-                        ),
-                    ).isSuccessful
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-            // if we had a successful call we can return
-            if (wasSuccess) {
-                return
-            }
-        }
-
-        if (causeException != null) {
-            throw IntegrationException(causeException)
-        } else {
-            throw IntegrationException("Error calling integration request scan_tag")
-        }
+        server.connection.callWebhookOnUrls(ScanTagIntegrationRequest(data))
     }
 
     override suspend fun fireEvent(eventType: String, eventData: Map<String, Any>) {
-        var wasSuccess = false
-
-        val fireEventRequest = FireEventRequest(
-            eventType,
-            eventData.plus(Pair("device_id", deviceId)),
+        server.connection.callWebhookOnUrls(
+            FireEventIntegrationRequest(
+                FireEventRequest(
+                    eventType,
+                    eventData.plus(Pair("device_id", deviceId)),
+                ),
+            ),
         )
-
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            try {
-                wasSuccess =
-                    integrationService.callWebhook(
-                        it.toHttpUrlOrNull()!!,
-                        FireEventIntegrationRequest(
-                            fireEventRequest,
-                        ),
-                    ).isSuccessful
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-            // if we had a successful call we can return
-            if (wasSuccess) {
-                return
-            }
-        }
-
-        if (causeException != null) {
-            throw IntegrationException(causeException)
-        } else {
-            throw IntegrationException("Error calling integration request fire_event")
-        }
     }
 
     override suspend fun getZones(): List<Entity> {
@@ -727,25 +614,9 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
 
         val integrationRequest = RegisterSensorIntegrationRequest(registrationData)
 
-        var causeException: Exception? = null
-        for (it in server.connection.getApiUrls()) {
-            try {
-                integrationService.callWebhook(it.toHttpUrlOrNull()!!, integrationRequest)
-                    .let {
-                        // If we created sensor or it already exists
-                        if (it.isSuccessful || it.code() == 409) {
-                            return
-                        }
-                    }
-            } catch (e: Exception) {
-                if (causeException == null) causeException = e
-                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
-            }
-        }
-        if (causeException != null) {
-            throw IntegrationException(causeException)
-        } else {
-            throw IntegrationException("Error calling integration request register_sensor")
+        server.connection.callWebhookOnUrls(integrationRequest) { response ->
+            // If we created sensor or it already exists
+            response.isSuccessful || response.code() == 409
         }
     }
 
@@ -795,6 +666,42 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         } else {
             false
         }
+    }
+
+    private suspend fun ServerConnectionInfo.callWebhookOnUrls(
+        request: IntegrationRequest,
+        onSuccess: suspend (response: Response<ResponseBody>) -> Unit = {},
+        isValidResponse: (response: Response<ResponseBody>) -> Boolean = { response -> response.isSuccessful },
+    ) {
+        var firstCauseException: Exception? = null
+        val httpURLs = getApiUrls().mapNotNull { it.toHttpUrlOrNull() }
+
+        if (httpURLs.isEmpty()) {
+            throw IntegrationException("No valid url can be found in server connection ${if (BuildConfig.DEBUG) getApiUrls() else ""}")
+        }
+
+        httpURLs.forEach { url ->
+            try {
+                val response = integrationService.callWebhook(url, request)
+                if (isValidResponse(response)) {
+                    onSuccess(response)
+                    // If the response is successful we return and ignore potential firstCauseException
+                    return
+                } else {
+                    throw IntegrationException(
+                        "Error calling webhook",
+                        response.code(),
+                        response.errorBody(),
+                    )
+                }
+            } catch (e: Exception) {
+                if (firstCauseException == null) firstCauseException = e
+                // Ignore failure until we are out of URLS to try, but use the first exception as cause exception
+            }
+        }
+
+        firstCauseException?.let { throw it }
+        FailFast.fail { "Error calling webhook without cause." }
     }
 
     private suspend fun createUpdateRegistrationRequest(deviceRegistration: DeviceRegistration): RegisterDeviceRequest {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorReceiverBase.kt
@@ -349,7 +349,7 @@ abstract class SensorReceiverBase : BroadcastReceiver() {
                 val exceptionOk = e is IntegrationException &&
                     (e.cause is IOException || e.cause is CancellationException)
                 if (exceptionOk) {
-                    Timber.w("Exception while updating sensors: ${e::class.java.simpleName}: ${e.cause?.let { it::class.java.name } }")
+                    Timber.w(e, "Exception while updating sensors")
                 } else {
                     Timber.e(e, "Exception while updating sensors.")
                 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While looking at #5486 I found out that we were simply not logging the potential error that we get from the API when calling the webhook endpoint.

To illustrate the issue I made sure that a server return a 404 when calling the webhook. As you can see bellow it only says that an `IntegrationException` was thrown and nothing else. We don't know what caused this failure.
![Screenshot 2025-07-04 at 11 07 46](https://github.com/user-attachments/assets/b8d4c320-ad7c-4fb7-9612-2dfa96e77640)

It makes the debugging of the issue almost impossible because we don't know why it failed. This is meanly due to the fact that we were using `Response<ResponseBody>`. When doing so Retrofit doesn't throw an error when it is an HTTP error (only when it is a network error like DNS), it sends back a Result with the code and the error in it that we were just ignoring.

This PR address this issue for every places where we uses `Response<>` from Retrofit to make sure we properly display the error.

After this PR is merged the error would becomes
![Screenshot 2025-07-04 at 11 13 00](https://github.com/user-attachments/assets/78fd1785-95cf-4b22-a159-2aee81c3b0e1)


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I took the liberty to also use named argument for `ServerSessionInfo`, because most of the parameters are strings and we might one day inverse the order of the parameters and it won't be catch at build time. I'm thinking about introducing a lint rule that would force the usage of named parameters when a type is used more than once in an invocation. It will make refactors safer.