### PR TITLE
Handle multiple returns types from renderTemplate

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -46,6 +46,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -201,12 +203,14 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         var causeException: Exception? = null
         for (it in server.connection.getApiUrls()) {
             try {
-                return integrationService.getTemplate(
+                val templateResult = integrationService.getTemplate(
                     it.toHttpUrlOrNull()!!,
                     RenderTemplateIntegrationRequest(
                         mapOf("template" to Template(template, variables)),
                     ),
                 )["template"]
+                // We check if the result is a JsonPrimitive instead of a simple global toString to avoid rendering " around the string
+                return if (templateResult is JsonPrimitive) templateResult.contentOrNull else templateResult.toString()
             } catch (e: Exception) {
                 if (causeException == null) causeException = e
                 // Ignore failure until we are out of URLS to try, but use the first exception as cause exception

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationService.kt
@@ -8,6 +8,7 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.integration.impl.entities.RegisterDeviceResponse
 import io.homeassistant.companion.android.common.data.integration.impl.entities.UpdateSensorResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
+import kotlinx.serialization.json.JsonObject
 import okhttp3.HttpUrl
 import okhttp3.ResponseBody
 import retrofit2.Response
@@ -42,7 +43,7 @@ interface IntegrationService {
     suspend fun getTemplate(
         @Url url: HttpUrl,
         @Body request: IntegrationRequest,
-    ): Map<String, String>
+    ): JsonObject
 
     @POST
     suspend fun getZones(

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImplTest.kt
@@ -1,0 +1,89 @@
+package io.homeassistant.companion.android.common.data.integration.impl
+
+import io.homeassistant.companion.android.common.data.LocalStorage
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.database.server.ServerConnectionInfo
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.net.URL
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class IntegrationRepositoryImplTest {
+
+    private val integrationService = mockk<IntegrationService>()
+    private val serverManager = mockk<ServerManager>()
+    private val serverID = 42
+    private val server = mockk<Server>()
+    private val serverConnection = mockk<ServerConnectionInfo>()
+    private val localStorage = mockk<LocalStorage>()
+
+    private lateinit var repository: IntegrationRepository
+
+    @BeforeEach
+    fun setUp() {
+        every { serverManager.getServer(serverID) } returns server
+        every { server.connection } returns serverConnection
+        every { serverConnection.getApiUrls() } returns listOf(URL("http://homeassistant:8123"))
+
+        repository = IntegrationRepositoryImpl(integrationService, serverManager, serverID, localStorage, "", "", "", "")
+    }
+
+    @Test
+    fun `Given an empty response when invoking renderTemplate then it returns an empty string`() = runTest {
+        val expectedResult = ""
+        coEvery { integrationService.getTemplate(any(), any()) } returns JsonObject(mapOf("template" to JsonPrimitive(expectedResult)))
+
+        val result = repository.renderTemplate("whatever", emptyMap())
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `Given a valid response with a number when invoking renderTemplate then it returns a valid string`() = runTest {
+        val expectedResult = 42
+        coEvery { integrationService.getTemplate(any(), any()) } returns JsonObject(mapOf("template" to JsonPrimitive(expectedResult)))
+
+        val result = repository.renderTemplate("whatever", emptyMap())
+
+        assertEquals(expectedResult.toString(), result)
+    }
+
+    @Test
+    fun `Given a valid response with a string when invoking renderTemplate then it returns a valid string`() = runTest {
+        val expectedResult = "hello world"
+        coEvery { integrationService.getTemplate(any(), any()) } returns JsonObject(mapOf("template" to JsonPrimitive(expectedResult)))
+
+        val result = repository.renderTemplate("whatever", emptyMap())
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `Given a valid response with a boolean when invoking renderTemplate then it returns a valid string`() = runTest {
+        val expectedResult = true
+        coEvery { integrationService.getTemplate(any(), any()) } returns JsonObject(mapOf("template" to JsonPrimitive(expectedResult)))
+
+        val result = repository.renderTemplate("whatever", emptyMap())
+
+        assertEquals(expectedResult.toString(), result)
+    }
+
+    @Test
+    fun `Given a valid response with a list when invoking renderTemplate then it returns a valid string`() = runTest {
+        val expectedResult = listOf(true, false)
+        coEvery { integrationService.getTemplate(any(), any()) } returns JsonObject(mapOf("template" to JsonArray(expectedResult.map { JsonPrimitive(it) })))
+
+        val result = repository.renderTemplate("whatever", emptyMap())
+
+        assertEquals("[true,false]", result)
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes https://github.com/home-assistant/android/issues/5502. The issue was introduced because Kotlin serialization is strict on the JSON is receiving and we were expecting the JSON strcuture to only contains strings by using a `Map<String,String>`. This PR is handling the case where the rendered template returns other value than a string and convert it to a valid string to be displayed.
Tests have been added to verified that the behavior is the one intended.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
![image](https://github.com/user-attachments/assets/f2403cd1-a864-4fed-93c8-67a2a0144d20)
The template is now properly render without adding an extra character to make the return type a string.