### PR TITLE
Move includeBuild outside of pluginManagement

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,8 +3,9 @@ include(":common", ":app", ":wear", ":automotive", ":testing-unit", ":lint")
 
 rootProject.name = "home-assistant-android"
 
+includeBuild("build-logic")
+
 pluginManagement {
-    includeBuild("build-logic")
     repositories {
         google {
             content {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Our current configuration was causing this warning
> WARNING: This build (:build-logic) is being evaluated before the parent build. If you import any external version catalogs or use VersionCatalogBuilder API, those catalogs won't be available in this build. Consider moving includeBuild(...) outside the pluginManagement { ... } block in settings.gradle.kts of the parent build. To suppress this warning, set typesafeConventions.suppressPluginManagementIncludedBuildWarning = true. Read more at: https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin?tab=readme-ov-file#known-limitations

This PR apply the suggestion and everything works as it should.