### PR TITLE
Apply bottom inset to snackbar in SettingsFragment

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -13,10 +13,13 @@ import android.os.Bundle
 import android.os.PowerManager
 import android.provider.Settings
 import android.view.View
+import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -79,6 +82,8 @@ class SettingsFragment(
     private val serverMutex = Mutex()
 
     private var snackbar: Snackbar? = null
+
+    private var currentBottomInset: Int = 0
 
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         presenter.init(this)
@@ -368,6 +373,14 @@ class SettingsFragment(
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         applyBottomSafeDrawingInsets()
+
+        // Retrieve the bottom system inset. This is needed to manually adjust the position of the Snackbar,
+        // the Snackbar is rendered directly within a CoordinatorLayout that doesn't handle the inset on purpose.
+        ViewCompat.setOnApplyWindowInsetsListener(listView) { view, windowInsets ->
+            val insetsSystemBars = windowInsets.getInsets(systemBars())
+            currentBottomInset = insetsSystemBars.bottom
+            windowInsets
+        }
     }
 
     private fun removeSystemFromThemesIfNeeded() {
@@ -592,6 +605,10 @@ class SettingsFragment(
                         requireContext().startActivity(intent)
                     }
                 }
+                val snackbarView = this.view
+                val params = snackbarView.layoutParams as ViewGroup.MarginLayoutParams
+                params.bottomMargin += currentBottomInset
+                snackbarView.layoutParams = params
                 show()
             }
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I only noticed the issue because I was testing on API 21 another PR. The snackbar was display behind the navigation bar when adding a new server. 
![image](https://github.com/user-attachments/assets/738202af-f9b5-4c25-bd03-0a711dcb3e8a)
It happens because even if we apply the insets properly on the `listView` the snackbar is using the underlying `CoordinatorLayout` where we don't want to apply the insets. So to fix it I simply add a new listener to get the exact bottom inset value and apply it to the snackbar before displaying it.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
![image](https://github.com/user-attachments/assets/852205b1-a284-474a-87e4-6b2ea616e106)
