### PR TITLE
Make Widget DAOs suspensible

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidget.kt
@@ -158,7 +158,7 @@ class ButtonWidget : AppWidgetProvider() {
         context.startActivity(intent)
     }
 
-    private fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
+    private suspend fun getWidgetRemoteViews(context: Context, appWidgetId: Int): RemoteViews {
         // Every time AppWidgetManager.updateAppWidget(...) is called, the button listener
         // and label need to be re-assigned, or the next time the layout updates
         // (e.g home screen rotation) the widget will fall back on its default layout
@@ -278,9 +278,8 @@ class ButtonWidget : AppWidgetProvider() {
         loadingViews.setViewVisibility(R.id.widgetImageButtonLayout, View.GONE)
         appWidgetManager.partiallyUpdateAppWidget(appWidgetId, loadingViews)
 
-        val widget = buttonWidgetDao.get(appWidgetId)
-
         mainScope.launch {
+            val widget = buttonWidgetDao.get(appWidgetId)
             // Set default feedback as negative
             var feedbackColor = R.drawable.widget_button_background_red
             var feedbackIcon = R.drawable.ic_clear_black

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -50,14 +50,15 @@ import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetDynamicFieldAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetUtils
 import javax.inject.Inject
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
 class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity() {
     companion object {
-        @Suppress("ktlint:standard:max-line-length")
-        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
+        private const val PIN_WIDGET_CALLBACK =
+            "io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     @Inject
@@ -123,80 +124,88 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity() {
 
     private val actionTextWatcher: TextWatcher = (
         object : TextWatcher {
+            private var ongoingJob: Job? = null
+
             @SuppressLint("NotifyDataSetChanged")
             override fun afterTextChanged(p0: Editable?) {
                 val actionText: String = p0.toString()
+                // To make sure only one job at the time is updating the data we keep a reference to the job and cancel
+                // it if it gets call again.
+                ongoingJob?.cancel()
+                ongoingJob = lifecycleScope.launch {
+                    if (actions[selectedServerId].orEmpty().keys.contains(actionText)) {
+                        Timber.d("Valid domain and action--processing dynamic fields")
 
-                if (actions[selectedServerId].orEmpty().keys.contains(actionText)) {
-                    Timber.d("Valid domain and action--processing dynamic fields")
-
-                    // Make sure there are not already any dynamic fields created
-                    // This can happen if selecting the drop-down twice or pasting
-                    dynamicFields.clear()
-
-                    // We only call this if servicesAvailable was fetched and is not null,
-                    // so we can safely assume that it is not null here
-                    val actionData = actions[selectedServerId]!![actionText]!!.actionData
-                    val target = actionData.target
-                    val fields = actionData.fields
-
-                    val fieldKeys = fields.keys
-                    Timber.d("Fields applicable to this action: $fields")
-
-                    val existingActionData = mutableMapOf<String, Any?>()
-                    val addedFields = mutableListOf<String>()
-                    buttonWidgetDao.get(appWidgetId)?.let { buttonWidget ->
-                        if (
-                            buttonWidget.serverId != selectedServerId ||
-                            "${buttonWidget.domain}.${buttonWidget.service}" != actionText
-                        ) {
-                            return@let
-                        }
-
-                        val dbMap: Map<String, Any?> = kotlinJsonMapper.decodeFromString(
-                            MapAnySerializer,
-                            buttonWidget.serviceData,
-                        )
-                        for (item in dbMap) {
-                            val value =
-                                item.value.toString().replace("[", "").replace("]", "") +
-                                    if (item.key == "entity_id") ", " else ""
-                            existingActionData[item.key] = value.ifEmpty { null }
-                            addedFields.add(item.key)
-                        }
-                    }
-
-                    if (target != false) {
-                        dynamicFields.add(
-                            0,
-                            ActionFieldBinder(actionText, "entity_id", existingActionData["entity_id"]),
-                        )
-                    }
-
-                    fieldKeys.sorted().forEach { fieldKey ->
-                        Timber.d("Creating a text input box for $fieldKey")
-
-                        // Insert a dynamic layout
-                        // IDs get priority and go at the top, since the other fields
-                        // are usually optional but the ID is required
-                        if (fieldKey.contains("_id")) {
-                            dynamicFields.add(0, ActionFieldBinder(actionText, fieldKey, existingActionData[fieldKey]))
-                        } else {
-                            dynamicFields.add(ActionFieldBinder(actionText, fieldKey, existingActionData[fieldKey]))
-                        }
-                    }
-                    addedFields.minus("entity_id").minus(fieldKeys).forEach { extraFieldKey ->
-                        Timber.d("Creating a text input box for extra $extraFieldKey")
-                        dynamicFields.add(
-                            ActionFieldBinder(actionText, extraFieldKey, existingActionData[extraFieldKey]),
-                        )
-                    }
-
-                    dynamicFieldAdapter.notifyDataSetChanged()
-                } else {
-                    if (dynamicFields.size > 0) {
+                        // Make sure there are not already any dynamic fields created
+                        // This can happen if selecting the drop-down twice or pasting
                         dynamicFields.clear()
+
+                        // We only call this if servicesAvailable was fetched and is not null,
+                        // so we can safely assume that it is not null here
+                        val actionData = actions[selectedServerId]!![actionText]!!.actionData
+                        val target = actionData.target
+                        val fields = actionData.fields
+
+                        val fieldKeys = fields.keys
+                        Timber.d("Fields applicable to this action: $fields")
+
+                        val existingActionData = mutableMapOf<String, Any?>()
+                        val addedFields = mutableListOf<String>()
+                        buttonWidgetDao.get(appWidgetId)?.let { buttonWidget ->
+                            if (
+                                buttonWidget.serverId != selectedServerId ||
+                                "${buttonWidget.domain}.${buttonWidget.service}" != actionText
+                            ) {
+                                return@let
+                            }
+
+                            val dbMap: Map<String, Any?> = kotlinJsonMapper.decodeFromString(
+                                MapAnySerializer,
+                                buttonWidget.serviceData,
+                            )
+                            for (item in dbMap) {
+                                val value =
+                                    item.value.toString().replace("[", "").replace("]", "") +
+                                        if (item.key == "entity_id") ", " else ""
+                                existingActionData[item.key] = value.ifEmpty { null }
+                                addedFields.add(item.key)
+                            }
+                        }
+
+                        if (target != false) {
+                            dynamicFields.add(
+                                0,
+                                ActionFieldBinder(actionText, "entity_id", existingActionData["entity_id"]),
+                            )
+                        }
+
+                        fieldKeys.sorted().forEach { fieldKey ->
+                            Timber.d("Creating a text input box for $fieldKey")
+
+                            // Insert a dynamic layout
+                            // IDs get priority and go at the top, since the other fields
+                            // are usually optional but the ID is required
+                            if (fieldKey.contains("_id")) {
+                                dynamicFields.add(
+                                    0,
+                                    ActionFieldBinder(actionText, fieldKey, existingActionData[fieldKey]),
+                                )
+                            } else {
+                                dynamicFields.add(ActionFieldBinder(actionText, fieldKey, existingActionData[fieldKey]))
+                            }
+                        }
+                        addedFields.minus("entity_id").minus(fieldKeys).forEach { extraFieldKey ->
+                            Timber.d("Creating a text input box for extra $extraFieldKey")
+                            dynamicFields.add(
+                                ActionFieldBinder(actionText, extraFieldKey, existingActionData[extraFieldKey]),
+                            )
+                        }
                         dynamicFieldAdapter.notifyDataSetChanged()
+                    } else {
+                        if (dynamicFields.isNotEmpty()) {
+                            dynamicFields.clear()
+                            dynamicFieldAdapter.notifyDataSetChanged()
+                        }
                     }
                 }
             }
@@ -241,41 +250,71 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity() {
             return
         }
 
-        val buttonWidget = buttonWidgetDao.get(appWidgetId)
         val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
         binding.backgroundType.adapter =
             ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
 
-        if (buttonWidget != null) {
-            val actionText = "${buttonWidget.domain}.${buttonWidget.service}"
-            binding.widgetTextConfigService.setText(actionText)
-            binding.label.setText(buttonWidget.label)
-            binding.backgroundType.setSelection(
-                WidgetUtils.getSelectedBackgroundOption(
-                    this,
-                    buttonWidget.backgroundType,
-                    backgroundTypeValues,
-                ),
-            )
-            binding.textColor.isVisible = buttonWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
-            binding.textColorWhite.isChecked =
-                buttonWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, android.R.color.white) }
-                    ?: true
-            binding.textColorBlack.isChecked =
-                buttonWidget.textColor?.let {
-                    it.toColorInt() ==
-                        ContextCompat.getColor(this, commonR.color.colorWidgetButtonLabelBlack)
+        lifecycleScope.launch {
+            val buttonWidget = buttonWidgetDao.get(appWidgetId)
+            if (buttonWidget != null) {
+                val actionText = "${buttonWidget.domain}.${buttonWidget.service}"
+                binding.widgetTextConfigService.setText(actionText)
+                binding.label.setText(buttonWidget.label)
+                binding.backgroundType.setSelection(
+                    WidgetUtils.getSelectedBackgroundOption(
+                        this@ButtonWidgetConfigureActivity,
+                        buttonWidget.backgroundType,
+                        backgroundTypeValues,
+                    ),
+                )
+                binding.textColor.isVisible = buttonWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
+                binding.textColorWhite.isChecked =
+                    buttonWidget.textColor?.let {
+                        it.toColorInt() == ContextCompat.getColor(
+                            this@ButtonWidgetConfigureActivity,
+                            android.R.color.white,
+                        )
+                    }
+                        ?: true
+                binding.textColorBlack.isChecked =
+                    buttonWidget.textColor?.let {
+                        it.toColorInt() ==
+                            ContextCompat.getColor(
+                                this@ButtonWidgetConfigureActivity,
+                                commonR.color.colorWidgetButtonLabelBlack,
+                            )
+                    }
+                        ?: false
+
+                binding.addButton.setText(commonR.string.update_widget)
+
+                binding.widgetCheckboxRequireAuthentication.isChecked = buttonWidget.requireAuthentication
+            } else {
+                binding.backgroundType.setSelection(0)
+            }
+
+            setupServerSelect(buttonWidget?.serverId)
+
+            // Do this off the main thread, takes a second or two...
+            runOnUiThread {
+                // Create an icon pack and load all drawables.
+                val iconName = buttonWidget?.iconName ?: "mdi:flash"
+                val icon = CommunityMaterial.getIconByMdiName(iconName) ?: CommunityMaterial.Icon2.cmd_flash
+                onIconDialogIconsSelected(icon)
+                binding.widgetConfigIconSelector.setOnClickListener {
+                    var alertDialog: DialogFragment? = null
+
+                    alertDialog = IconDialogFragment(
+                        callback = {
+                            onIconDialogIconsSelected(it)
+                            alertDialog?.dismiss()
+                        },
+                    )
+
+                    alertDialog.show(supportFragmentManager, IconDialogFragment.TAG)
                 }
-                    ?: false
-
-            binding.addButton.setText(commonR.string.update_widget)
-
-            binding.widgetCheckboxRequireAuthentication.isChecked = buttonWidget.requireAuthentication
-        } else {
-            binding.backgroundType.setSelection(0)
+            }
         }
-
-        setupServerSelect(buttonWidget?.serverId)
 
         actionAdapter = SingleItemArrayAdapter(this) {
             if (it != null) getActionString(it) else ""
@@ -360,26 +399,6 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity() {
         dynamicFieldAdapter = WidgetDynamicFieldAdapter(HashMap(), HashMap(), dynamicFields)
         binding.widgetConfigFieldsLayout.adapter = dynamicFieldAdapter
         binding.widgetConfigFieldsLayout.layoutManager = LinearLayoutManager(this)
-
-        // Do this off the main thread, takes a second or two...
-        runOnUiThread {
-            // Create an icon pack and load all drawables.
-            val iconName = buttonWidget?.iconName ?: "mdi:flash"
-            val icon = CommunityMaterial.getIconByMdiName(iconName) ?: CommunityMaterial.Icon2.cmd_flash
-            onIconDialogIconsSelected(icon)
-            binding.widgetConfigIconSelector.setOnClickListener {
-                var alertDialog: DialogFragment? = null
-
-                alertDialog = IconDialogFragment(
-                    callback = {
-                        onIconDialogIconsSelected(it)
-                        alertDialog?.dismiss()
-                    },
-                )
-
-                alertDialog.show(supportFragmentManager, IconDialogFragment.TAG)
-            }
-        }
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidgetConfigureActivity.kt
@@ -28,15 +28,14 @@ import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 @AndroidEntryPoint
 class CameraWidgetConfigureActivity : BaseWidgetConfigureActivity() {
 
     companion object {
-        @Suppress("ktlint:standard:max-line-length")
-        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.camera.CameraWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
+        private const val PIN_WIDGET_CALLBACK =
+            "io.homeassistant.companion.android.widgets.camera.CameraWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     private lateinit var binding: WidgetCameraConfigureBinding
@@ -114,13 +113,13 @@ class CameraWidgetConfigureActivity : BaseWidgetConfigureActivity() {
         }
         initTapActionsSpinner()
 
-        val cameraWidget = cameraWidgetDao.get(appWidgetId)
-        if (cameraWidget != null) {
-            setCurrentTapAction(tapAction = cameraWidget.tapAction)
-            binding.widgetTextConfigEntityId.setText(cameraWidget.entityId)
-            binding.addButton.setText(commonR.string.update_widget)
-            val entity = runBlocking {
-                try {
+        lifecycleScope.launch {
+            val cameraWidget = cameraWidgetDao.get(appWidgetId)
+            if (cameraWidget != null) {
+                setCurrentTapAction(tapAction = cameraWidget.tapAction)
+                binding.widgetTextConfigEntityId.setText(cameraWidget.entityId)
+                binding.addButton.setText(commonR.string.update_widget)
+                val entity = try {
                     serverManager.integrationRepository(cameraWidget.serverId).getEntity(cameraWidget.entityId)
                 } catch (e: Exception) {
                     Timber.e(e, "Unable to get entity information")
@@ -128,13 +127,14 @@ class CameraWidgetConfigureActivity : BaseWidgetConfigureActivity() {
                         .show()
                     null
                 }
-            }
-            if (entity != null) {
-                selectedEntity = entity as Entity?
-            }
-        }
 
-        setupServerSelect(cameraWidget?.serverId)
+                if (entity != null) {
+                    selectedEntity = entity as Entity?
+                }
+            }
+
+            setupServerSelect(cameraWidget?.serverId)
+        }
 
         entityAdapter = SingleItemArrayAdapter(this) { it?.entityId ?: "" }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/template/TemplateWidgetConfigureActivity.kt
@@ -37,8 +37,8 @@ import timber.log.Timber
 @AndroidEntryPoint
 class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
     companion object {
-        @Suppress("ktlint:standard:max-line-length")
-        private const val PIN_WIDGET_CALLBACK = "io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
+        private const val PIN_WIDGET_CALLBACK =
+            "io.homeassistant.companion.android.widgets.template.TemplateWidgetConfigureActivity.PIN_WIDGET_CALLBACK"
     }
 
     @Inject
@@ -86,43 +86,57 @@ class TemplateWidgetConfigureActivity : BaseWidgetConfigureActivity() {
             return
         }
 
-        val templateWidget = templateWidgetDao.get(appWidgetId)
-
         val backgroundTypeValues = WidgetUtils.getBackgroundOptionList(this)
         binding.backgroundType.adapter =
-            ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, backgroundTypeValues)
-
-        setupServerSelect(templateWidget?.serverId)
-
-        if (templateWidget != null) {
-            binding.templateText.setText(templateWidget.template)
-            binding.textSize.setText(templateWidget.textSize.toInt().toString())
-            binding.addButton.setText(commonR.string.update_widget)
-            if (templateWidget.template.isNotEmpty()) {
-                renderTemplateText(templateWidget.template)
-            } else {
-                binding.renderedTemplate.text = getString(commonR.string.empty_template)
-                binding.addButton.isEnabled = false
-            }
-            binding.backgroundType.setSelection(
-                WidgetUtils.getSelectedBackgroundOption(
-                    this,
-                    templateWidget.backgroundType,
-                    backgroundTypeValues,
-                ),
+            ArrayAdapter(
+                this,
+                android.R.layout.simple_spinner_dropdown_item,
+                backgroundTypeValues,
             )
-            binding.textColor.isVisible = templateWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
-            binding.textColorWhite.isChecked =
-                templateWidget.textColor?.let { it.toColorInt() == ContextCompat.getColor(this, android.R.color.white) }
-                    ?: true
-            binding.textColorBlack.isChecked =
-                templateWidget.textColor?.let {
-                    it.toColorInt() ==
-                        ContextCompat.getColor(this, commonR.color.colorWidgetButtonLabelBlack)
+
+        lifecycleScope.launch {
+            val templateWidget = templateWidgetDao.get(appWidgetId)
+
+            setupServerSelect(templateWidget?.serverId)
+
+            if (templateWidget != null) {
+                binding.templateText.setText(templateWidget.template)
+                binding.textSize.setText(templateWidget.textSize.toInt().toString())
+                binding.addButton.setText(commonR.string.update_widget)
+                if (templateWidget.template.isNotEmpty()) {
+                    renderTemplateText(templateWidget.template)
+                } else {
+                    binding.renderedTemplate.text = getString(commonR.string.empty_template)
+                    binding.addButton.isEnabled = false
                 }
-                    ?: false
-        } else {
-            binding.backgroundType.setSelection(0)
+                binding.backgroundType.setSelection(
+                    WidgetUtils.getSelectedBackgroundOption(
+                        this@TemplateWidgetConfigureActivity,
+                        templateWidget.backgroundType,
+                        backgroundTypeValues,
+                    ),
+                )
+                binding.textColor.isVisible = templateWidget.backgroundType == WidgetBackgroundType.TRANSPARENT
+                binding.textColorWhite.isChecked =
+                    templateWidget.textColor?.let {
+                        it.toColorInt() == ContextCompat.getColor(
+                            this@TemplateWidgetConfigureActivity,
+                            android.R.color.white,
+                        )
+                    }
+                        ?: true
+                binding.textColorBlack.isChecked =
+                    templateWidget.textColor?.let {
+                        it.toColorInt() ==
+                            ContextCompat.getColor(
+                                this@TemplateWidgetConfigureActivity,
+                                commonR.color.colorWidgetButtonLabelBlack,
+                            )
+                    }
+                        ?: false
+            } else {
+                binding.backgroundType.setSelection(0)
+            }
         }
 
         binding.templateText.doAfterTextChanged { renderTemplateText() }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/ButtonWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/ButtonWidgetDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface ButtonWidgetDao : WidgetDao {
 
     @Query("SELECT * FROM button_widgets WHERE id = :id")
-    fun get(id: Int): ButtonWidgetEntity?
+    suspend fun get(id: Int): ButtonWidgetEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun add(buttonWidgetEntity: ButtonWidgetEntity)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface CameraWidgetDao : WidgetDao {
 
     @Query("SELECT * FROM camera_widgets WHERE id = :id")
-    fun get(id: Int): CameraWidgetEntity?
+    suspend fun get(id: Int): CameraWidgetEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun add(cameraWidgetEntity: CameraWidgetEntity)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface MediaPlayerControlsWidgetDao : WidgetDao {
 
     @Query("SELECT * FROM media_player_controls_widgets WHERE id = :id")
-    fun get(id: Int): MediaPlayerControlsWidgetEntity?
+    suspend fun get(id: Int): MediaPlayerControlsWidgetEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun add(mediaPlayCtrlWidgetEntity: MediaPlayerControlsWidgetEntity)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface StaticWidgetDao : WidgetDao {
 
     @Query("SELECT * FROM static_widget WHERE id = :id")
-    fun get(id: Int): StaticWidgetEntity?
+    suspend fun get(id: Int): StaticWidgetEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun add(staticWidgetEntity: StaticWidgetEntity)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.Flow
 interface TemplateWidgetDao : WidgetDao {
 
     @Query("SELECT * FROM template_widgets WHERE id = :id")
-    fun get(id: Int): TemplateWidgetEntity?
+    suspend fun get(id: Int): TemplateWidgetEntity?
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun add(templateWidgetEntity: TemplateWidgetEntity)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After enabling `StrictMode` in #5483 I found out that we are doing many db calls on the main thread where we shouldn't. It most probably causes some ANR. This PR is related to the Widget DAOs all the DAO methods should be marked as `suspend`. 

Part of https://github.com/home-assistant/android/issues/5520

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
In `ButtonWidgetConfigure` I introduce a regression when moving the `get` into the coroutine because it gets called multiple times and because of that it cause a concurrent modification of the item of the list of field and most of the time it result into a duplicate fields. To avoid this I've kept a reference to the currently running job and cancel any previous job before starting a new one.