### PR TITLE
Make FavoriteCachesDao methods suspensible

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/FavoriteCachesDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/FavoriteCachesDao.kt
@@ -9,17 +9,17 @@ import androidx.room.Query
 interface FavoriteCachesDao {
 
     @Query("SELECT * FROM favorite_cache where id = :id")
-    fun get(id: String): FavoriteCaches?
+    suspend fun get(id: String): FavoriteCaches?
 
     @Query("SELECT * FROM favorite_cache ORDER BY id ASC")
-    fun getAll(): List<FavoriteCaches>
+    suspend fun getAll(): List<FavoriteCaches>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    fun add(cache: FavoriteCaches)
+    suspend fun add(cache: FavoriteCaches)
 
     @Query("DELETE FROM favorite_cache where id = :id")
-    fun delete(id: String)
+    suspend fun delete(id: String)
 
     @Query("DELETE FROM favorite_cache")
-    fun deleteAll()
+    suspend fun deleteAll()
 }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -72,6 +72,12 @@ class MainViewModel @Inject constructor(
     private var deviceRegistry: List<DeviceRegistryResponse>? = null
     private var entityRegistry: List<EntityRegistryResponse>? = null
 
+    init {
+        viewModelScope.launch {
+            favoriteCaches.addAll(favoriteCachesDao.getAll())
+        }
+    }
+
     // TODO: This is bad, do this instead: https://stackoverflow.com/questions/46283981/android-viewmodel-additional-arguments
     fun init(homePresenter: HomePresenter) {
         this.homePresenter = homePresenter
@@ -90,7 +96,8 @@ class MainViewModel @Inject constructor(
      * IDs of favorites in the Favorites database.
      */
     val favoriteEntityIds = favoritesDao.getAllFlow().collectAsState()
-    private val favoriteCaches = favoriteCachesDao.getAll()
+    var favoriteCaches = mutableStateListOf<FavoriteCaches>()
+        private set
 
     val shortcutEntitiesMap = mutableStateMapOf<Int?, SnapshotStateList<SimplifiedEntity>>()
 
@@ -547,8 +554,6 @@ class MainViewModel @Inject constructor(
             }
         }
     }
-
-    fun getCachedEntity(entityId: String): FavoriteCaches? = favoriteCaches.find { it.id == entityId }
 
     private fun addCachedFavorite(entityId: String) {
         viewModelScope.launch {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/MainView.kt
@@ -81,7 +81,7 @@ fun MainView(
                         val favoriteEntityID = favoriteEntityIds[index].split(",")[0]
                         if (mainViewModel.entities.isEmpty()) {
                             // when we don't have the state of the entity, create a Chip from cache as we don't have the state yet
-                            val cached = mainViewModel.getCachedEntity(favoriteEntityID)
+                            val cached = mainViewModel.favoriteCaches.find { it.id == favoriteEntityID }
                             Button(
                                 modifier = Modifier
                                     .fillMaxWidth(),


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After enabling `StrictMode` in #5483 I found out that we are doing many network, db calls on the main thread where we shouldn't. It most probably causes some ANR. This PR is related to the `FavoriteCachesDao` all the DAO methods should be marked as `suspend`. 

Part of https://github.com/home-assistant/android/issues/5520

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.