### PR TITLE
Change action for ManageAssistActivity

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -422,7 +422,7 @@ class SettingsFragment(private val presenter: SettingsPresenter, private val lan
     private fun updateAssistantApp() {
         // On Android Q+, this is a workaround as Android doesn't allow requesting the assistant role
         try {
-            val openIntent = Intent(Intent.ACTION_MAIN)
+            val openIntent = Intent("android.settings.VOICE_INPUT_SETTINGS")
             openIntent.component =
                 ComponentName("com.android.settings", "com.android.settings.Settings\$ManageAssistActivity")
             openIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We were using `Intent.ACTION_MAIN` for opening the settings but it was not the action that is defined in the manifest of the activity https://cs.android.com/android/platform/superproject/main/+/512046e84bcc51cc241bc6599f83ab345e93ab12:packages/apps/Settings/AndroidManifest.xml;l=1204

It was causing StrictMode to trigger. To be future proof this PR fix this.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.