### PR TITLE
Use on prereleased instead of tag to update changelog

### DIFF
--- a/.github/workflows/onPrereleased.yml
+++ b/.github/workflows/onPrereleased.yml
@@ -4,9 +4,8 @@ name: Prepare next release
 
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  push:
-    tags:
-      - '20[2-9][0-9].[0-9]+.[0-9]+' # Simple matching for CalVer, even if it's not perfect it is enough for detecting that it is a version tag.
+  release:
+    types: [prereleased]
 
 jobs:
   tag:


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
It seems that our `onTag` workflow was not triggered by the creation of a release. So this PR instead switch the trigger to `prereleased` which will do exactly the same has what we wanted with the tag. I didn't use `publish` or `release` since we always first create a `pre-release`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#