### PR TITLE
Use sealed class instead of an optional param for SettingsActivity links

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1655,7 +1655,7 @@ class MessagingManager @Inject constructor(
 
             uri.startsWith(SETTINGS_PREFIX) -> {
                 if (uri.substringAfter(SETTINGS_PREFIX) == NOTIFICATION_HISTORY) {
-                    SettingsActivity.newInstance(context, SettingsActivity.Deeplink.NOTIFICATION_HISTORY)
+                    SettingsActivity.newInstance(context, SettingsActivity.Deeplink.NotificationHistory)
                 } else {
                     WebViewActivity.newInstance(context, null, serverId)
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/qs/TileExtensions.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/qs/TileExtensions.kt
@@ -257,8 +257,7 @@ abstract class TileExtensions : TileService() {
             Timber.d("No tile data found for tile ID: $tileId")
             val tileSettingIntent = SettingsActivity.newInstance(
                 context,
-                SettingsActivity.Deeplink.QS_TILE,
-                tileId,
+                SettingsActivity.Deeplink.QSTile(tileId),
             ).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                 addFlags(Intent.FLAG_ACTIVITY_NEW_DOCUMENT)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
@@ -67,7 +67,7 @@ class TilePreferenceActivity : BaseActivity() {
                     serverId = tileData.serverId,
                 )
             } else {
-                SettingsActivity.newInstance(this@TilePreferenceActivity, SettingsActivity.Deeplink.QS_TILE, tileId)
+                SettingsActivity.newInstance(this@TilePreferenceActivity, SettingsActivity.Deeplink.QSTile(tileId))
             }
 
             withContext(Dispatchers.Main) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorReceiver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorReceiver.kt
@@ -138,7 +138,7 @@ class SensorReceiver : SensorReceiverBase() {
         sensorManagerId: String,
         notificationId: Int,
     ): PendingIntent? {
-        val intent = SettingsActivity.newInstance(context, SettingsActivity.Deeplink.SENSOR, sensorId).apply {
+        val intent = SettingsActivity.newInstance(context, SettingsActivity.Deeplink.Sensor(sensorId)).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -240,7 +240,7 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
             PendingIntent.FLAG_IMMUTABLE,
         )
 
-        val settingIntent = SettingsActivity.newInstance(applicationContext, SettingsActivity.Deeplink.WEBSOCKET)
+        val settingIntent = SettingsActivity.newInstance(applicationContext, SettingsActivity.Deeplink.Websocket)
         settingIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         settingIntent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
         settingIntent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -961,7 +961,7 @@ class WebViewActivity :
                 GestureAction.OPEN_APP_DEVELOPER -> startActivity(
                     SettingsActivity.newInstance(
                         context = this@WebViewActivity,
-                        screen = SettingsActivity.Deeplink.DEVELOPER,
+                        screen = SettingsActivity.Deeplink.Developer,
                     ),
                 )
             }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to ease the navigation within the settings I replace the optional parameter of `SettingsActivity.newInstance` with a sealed class. It is going to make easier the work in `Add to` shortcut and tile.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.