### PR TITLE
Open tile settings from newly created tile

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -63,7 +63,13 @@
             android:name="com.google.android.wearable.standalone"
             android:value="false" />
 
-        <activity android:name=".home.HomeActivity" />
+        <activity android:name=".home.HomeActivity"
+            android:exported="true">
+<!--                <intent-filter>-->
+<!--                    <action android:name="android.intent.action.VIEW" />-->
+<!--                    <category android:name="android.intent.category.DEFAULT" />-->
+<!--                </intent-filter>-->
+        </activity>
         <activity android:name=".splash.SplashActivity"
             android:theme="@style/Theme.HomeAssistant.SplashTheme"
             android:exported="true">
@@ -241,6 +247,16 @@
                 <action android:name="io.homeassistant.companion.android.TILE_ACTION" />
             </intent-filter>
         </receiver>
+<!--        <activity-->
+<!--            android:name="io.homeassistant.companion.android.home.HomeActivity"-->
+<!--            android:exported="true"-->
+<!--            android:taskAffinity="">-->
+<!--            <intent-filter>-->
+<!--                <action android:name="android.intent.action.VIEW" />-->
+<!--                <category android:name="android.intent.category.DEFAULT" />-->
+<!--                <data android:scheme="wear" android:host="settings" />-->
+<!--            </intent-filter>-->
+<!--        </activity>-->
         
         <!-- Complications -->
         <service android:name=".complications.EntityStateDataSourceService"

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.home
 
 import android.Manifest
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
@@ -18,13 +19,16 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.home.views.DEEPLINK_PREFIX_SET_CAMERA_TILE
 import io.homeassistant.companion.android.home.views.DEEPLINK_PREFIX_SET_SHORTCUT_TILE
 import io.homeassistant.companion.android.home.views.DEEPLINK_PREFIX_SET_TEMPLATE_TILE
+import io.homeassistant.companion.android.home.views.DEEPLINK_PREFIX_SET_THERMOSTAT_TILE
 import io.homeassistant.companion.android.home.views.LoadHomePage
 import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
+import io.homeassistant.companion.android.tiles.OpenTileSettingsActivity
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class HomeActivity :
@@ -58,6 +62,13 @@ class HomeActivity :
             HomeActivity::class.java,
         )
 
+        fun getThermostatTileSettingsIntent(context: Context, tileId: Int) = Intent(
+            Intent.ACTION_VIEW,
+            "$DEEPLINK_PREFIX_SET_THERMOSTAT_TILE/$tileId".toUri(),
+            context,
+            HomeActivity::class.java,
+        )
+
         fun getShortcutsTileSettingsIntent(context: Context, tileId: Int) = Intent(
             Intent.ACTION_VIEW,
             "$DEEPLINK_PREFIX_SET_SHORTCUT_TILE/$tileId".toUri(),
@@ -77,6 +88,31 @@ class HomeActivity :
         super.onCreate(savedInstanceState)
         // Get rid of me!
         presenter.init(this)
+
+        Timber.d("buttonclicktitle")
+        Timber.d(intent.getStringExtra("launch_mode"))
+        Timber.d(intent.getIntExtra("tile_id", 0).toString())
+
+        if (intent.getStringExtra("launch_mode") == "ConfigThermostatTile") {
+            Timber.d("Test")
+            try {
+                packageManager.getActivityInfo(
+                    ComponentName(packageName, OpenTileSettingsActivity::class.java.name),
+                    0
+                )
+            Timber.d("HomeActivity is resolvable in this APK")
+        } catch (e: Exception) {
+            Timber.e(e, "HomeActivity NOT found in wear APK")
+        }
+            startActivity(Intent(
+                this@HomeActivity,
+                OpenTileSettingsActivity::class.java)
+                .setAction("ConfigThermostatTile")
+                .putExtra("tile_id", intent.getIntExtra("tile_id", 0))
+            )
+            finish() // optional: don’t show this host activity
+            return
+        }
 
         presenter.onViewReady()
         setContent {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/OpenTileSettingsActivity.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/OpenTileSettingsActivity.kt
@@ -8,6 +8,7 @@ import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryI
 import io.homeassistant.companion.android.home.HomeActivity
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class OpenTileSettingsActivity : AppCompatActivity() {
@@ -17,7 +18,12 @@ class OpenTileSettingsActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val tileId = intent.extras?.getInt("com.google.android.clockwork.EXTRA_PROVIDER_CONFIG_TILE_ID")
+        Timber.d("TileSettingsActivity")
+        Timber.d(intent.action)
+        Timber.d(intent.getIntExtra("tile_id", 0).toString())
+//        val tileId = intent.extras?.getInt("com.google.android.clockwork.EXTRA_PROVIDER_CONFIG_TILE_ID")
+        val tileId = intent.extras?.getInt("tile_id")
+        Timber.d(tileId.toString())
         tileId?.takeIf { it != 0 }?.let {
             val settingsIntent = when (intent.action) {
                 "ConfigCameraTile" ->
@@ -43,11 +49,17 @@ class OpenTileSettingsActivity : AppCompatActivity() {
                         tileId = it,
                     )
                 }
+                "ConfigThermostatTile" ->
+                    HomeActivity.getThermostatTileSettingsIntent(
+                        context = this,
+                        tileId = it,
+                    )
                 else -> null
             }
-
+            Timber.d("selected")
             settingsIntent?.let { startActivity(settingsIntent) }
         }
+        Timber.d("Finish")
         finish()
     }
 }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
@@ -1,7 +1,11 @@
 package io.homeassistant.companion.android.tiles
 
+import android.content.ComponentName
+import android.util.Log
+import androidx.core.content.ContextCompat
 import androidx.wear.protolayout.ActionBuilders
 import androidx.wear.protolayout.ColorBuilders
+import androidx.wear.protolayout.ColorBuilders.argb
 import androidx.wear.protolayout.DimensionBuilders
 import androidx.wear.protolayout.LayoutElementBuilders
 import androidx.wear.protolayout.LayoutElementBuilders.LayoutElement
@@ -11,6 +15,10 @@ import androidx.wear.protolayout.ResourceBuilders.Resources
 import androidx.wear.protolayout.TimelineBuilders.Timeline
 import androidx.wear.protolayout.material.Button
 import androidx.wear.protolayout.material.ButtonColors
+import androidx.wear.protolayout.material.ChipColors
+import androidx.wear.protolayout.material.CompactChip
+import androidx.wear.protolayout.material.Colors
+import androidx.wear.protolayout.ActionBuilders.launchAction
 import androidx.wear.tiles.EventBuilders
 import androidx.wear.tiles.RequestBuilders
 import androidx.wear.tiles.RequestBuilders.ResourcesRequest
@@ -88,15 +96,68 @@ class ThermostatTile : TileService() {
                 ).build()
             } else {
                 if (tileConfig?.entityId.isNullOrBlank()) {
+
+                    val theme = Colors(
+                        ContextCompat.getColor(this@ThermostatTile, commonR.color.colorPrimary),
+                        ContextCompat.getColor(this@ThermostatTile, commonR.color.colorOnPrimary),
+                        // Surface
+                        ContextCompat.getColor(this@ThermostatTile, R.color.colorOverlay),
+                        // On surface
+                        ContextCompat.getColor(this@ThermostatTile, android.R.color.white),
+                    )
+                    val chipColors = ChipColors.primaryChipColors(theme)
+                    Timber.d(this@ThermostatTile.packageName)
+                    Timber.d(io.homeassistant.companion.android.home.HomeActivity::class.java.name)
+                    Timber.d(tileId.toString())
+                    val androidActivity = ActionBuilders.AndroidActivity.Builder()
+                        .setPackageName(this@ThermostatTile.packageName)
+                        .setClassName(io.homeassistant.companion.android.home.HomeActivity::class.java.name) // Full activity class name
+                        .addKeyToExtraMapping(
+                            "launch_mode",
+                            ActionBuilders.AndroidStringExtra.Builder().setValue("ConfigThermostatTile").build(),
+                        )
+                        .addKeyToExtraMapping(
+                            "tile_id",
+                            ActionBuilders.AndroidIntExtra.Builder().setValue(tileId).build()
+                        )
+                        .build()
+
+                    val launchAction = ActionBuilders.LaunchAction.Builder()
+                        .setAndroidActivity(androidActivity)
+                        .build()
+
+                    val clickable = Clickable.Builder()
+                        .setId("launch_settings")
+                        .setOnClick(launchAction)
+                        .build()
+
                     tile.setTileTimeline(
                         Timeline.fromLayoutElement(
-                            LayoutElementBuilders.Box.Builder()
+                            LayoutElementBuilders.Column.Builder()
                                 .addContent(
                                     LayoutElementBuilders.Text.Builder()
                                         .setText(getString(commonR.string.thermostat_tile_no_entity_yet))
-                                        .setMaxLines(10)
+                                        .setMaxLines(3)
                                         .build(),
-                                ).build(),
+                                )
+                                .addContent(
+                                    LayoutElementBuilders.Spacer.Builder()
+                                        .setHeight(DimensionBuilders.dp(10f)).build(),
+                                )
+                                .addContent(
+                                    LayoutElementBuilders.Row.Builder()
+                                        .addContent(
+                                            CompactChip.Builder(
+                                                this@ThermostatTile,
+                                                clickable,
+                                                requestParams.deviceConfiguration,
+                                            )
+                                                .setTextContent("Open settings")
+                                                .setChipColors(chipColors)
+                                                .build(),
+                                        ).build(),
+                                )
+                                .build(),
                         ),
                     ).build()
                 } else {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

This PR is intended to add buttons to newly created tiles that send the user directly to the settings page in the app where the user can configure the tile.

This enhancement is intended to resolve https://github.com/home-assistant/android/issues/4918.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
This PR is under development.