### PR TITLE
Trigger prepareNextRelease using Github Action API to bypass limitation

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -19,3 +19,14 @@ jobs:
         uses: rickstaa/action-create-tag@v1.7.2
         with:
           tag: ${{ steps.current-time.outputs.year }}.${{ steps.current-time.outputs.month }}.0
+
+      - name: Trigger Prepare Next Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'prepareNextRelease.yml',
+              ref: 'main',
+            })

--- a/.github/workflows/prepareNextRelease.yml
+++ b/.github/workflows/prepareNextRelease.yml
@@ -1,16 +1,13 @@
 name: Prepare next release
 #  This workflow prepares the next release by updating the changelog and creating a pull request.
-#  It is triggered manually or when a tag that matches the version format is pushed.
+#  It is triggered using the GitHub Actions API (in monthly and weekly workflows) or manually.
 
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  # Trigger on new release (made by weekly.yml workflow)
-  release:
-    types: [prereleased]
-  # Trigger on new tag push (made by monthly.yml workflow)
-  push:
-    tags:
-      - '20[2-9][0-9].[0-9]+.[0-9]+' # Simple matching for CalVer, even if it's not perfect it is enough for detecting that it is a version tag.
+
+concurrency:
+  group: prepare-next-release
+  cancel-in-progress: true
 
 jobs:
   tag:

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -35,3 +35,14 @@ jobs:
                 "beta": "true",
               },
             })
+
+      - name: Trigger Prepare Next Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'prepareNextRelease.yml',
+              ref: 'main',
+            })


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The prepareNextRelease workflow is not triggered since Github added a security that prevent recursive workflows when we use the token `GITHUB_TOKEN` available in the action. 

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs. 

https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow

In order to by-pass this limitation I've manually trigger the workflow from the other workflow (weekly and monthly).

I've also set a concurrency limit to avoid running the workflow in //.