### PR TITLE
Make sure setDefaultNightMode is invoke on Main

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/themes/NightModeManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/themes/NightModeManager.kt
@@ -5,9 +5,12 @@ import androidx.appcompat.app.AppCompatDelegate
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme.ANDROID
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme.DARK
+import io.homeassistant.companion.android.common.data.prefs.NightModeTheme.LIGHT
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme.SYSTEM
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import javax.inject.Inject
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -24,9 +27,9 @@ class NightModeManager @Inject constructor(private val prefsRepository: PrefsRep
         val nightMode = prefsRepository.getCurrentNightModeTheme()
         return if (nightMode == null) {
             val nightModeThemeToSet = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                NightModeTheme.SYSTEM
+                SYSTEM
             } else {
-                NightModeTheme.LIGHT
+                LIGHT
             }
             prefsRepository.saveNightModeTheme(nightModeThemeToSet)
             nightModeThemeToSet
@@ -53,16 +56,18 @@ class NightModeManager @Inject constructor(private val prefsRepository: PrefsRep
     }
 }
 
-private fun NightModeTheme.setAsDefaultNightMode() {
-    when (this) {
-        DARK -> {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
-        }
-        ANDROID, SYSTEM -> {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
-        }
-        else -> {
-            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+private suspend fun NightModeTheme.setAsDefaultNightMode() {
+    withContext(Dispatchers.Main) {
+        when (this@setAsDefaultNightMode) {
+            DARK -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+            }
+            ANDROID, SYSTEM -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
+            }
+            else -> {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After pushing this https://github.com/home-assistant/android/pull/5609 we started to see some crashes on the beta 2025.8.3 about `Must be called from main thread` for `setAsDefaultNightMode`.
<img width="820" height="84" alt="image" src="https://github.com/user-attachments/assets/2d858c23-aa13-4240-9690-69f16ebff1d2" />

The documentation isn't mentioning any restriction on the thread to use
<img width="649" height="280" alt="image" src="https://github.com/user-attachments/assets/01e951d4-3853-4ea6-a020-ae42a615ae4b" />

I did the implementation and test only on emulators and Pixels phone that seems to work fine with this call being made from `IO`. It seems that other vendors are not accepting this and cause a crash like Fairphone and Samsung.

To avoid any issue this PR makes sure that this code is executed from the Main thread.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.