### PR TITLE
Make a dumb modification so reckon trigger a version bump when on tag

### DIFF
--- a/.github/workflows/prepareNextRelease.yml
+++ b/.github/workflows/prepareNextRelease.yml
@@ -22,6 +22,10 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      # Without any change compare to the latest tag, reckon will not bump the version.
+      - name: Add dumb modification to trigger version bump
+        run: touch dumb_file_to_trigger_version_bump
+
       - name: Generate version.txt
         run: ./gradlew versionFile
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We are almost there to automate the update of the changelog. The last issue is that `reckon` is not bumping the version when the current commit is the latest tag. In order to say to `reckon` that it needs to bump the version, I simply add a empty file to the git repository and it will bump the version as it should (it will be `beta` but we don't care since the `sed` will ignore everything after the `-` in the version file).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.