### PR TITLE
Fix already resumed exception in AudioUrlPlayer

### DIFF
--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/AudioUrlPlayerTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/AudioUrlPlayerTest.kt
@@ -220,4 +220,21 @@ class AudioUrlPlayerTest {
             assertEquals(AudioAttributes.CONTENT_TYPE_MUSIC, contentType)
         }
     }
+
+    @Test
+    fun `Given anything that happens when invoking playAudio then it does not throw IllegalStateException Already resumed`() = runTest {
+        every { audioManager.getStreamVolume(any()) } returns 1
+
+        val onCompletionListener = slot<MediaPlayer.OnCompletionListener>()
+        val onErrorListener = slot<MediaPlayer.OnErrorListener>()
+        every { mediaPlayer.setOnCompletionListener(capture(onCompletionListener)) } answers {
+            onCompletionListener.captured.onCompletion(mediaPlayer)
+        }
+        every { mediaPlayer.setOnErrorListener(capture(onErrorListener)) } answers {
+            onErrorListener.captured.onError(mediaPlayer, 1, 42)
+        }
+        every { mediaPlayer.prepareAsync() } throws IllegalStateException("dummy")
+
+        player.playAudio("test_url", false)
+    }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In some cases we were calling `resume` multiple times in `AudioUrlPlayer` which led to some crashes.
<img width="837" height="72" alt="image" src="https://github.com/user-attachments/assets/174b0576-34f1-4ecb-8620-fbd689e2feb0" />

This PR make sure that we won't resume by checking if the continuation is still active.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
