### PR TITLE
Add feature to allow not displaying change log on update

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -341,6 +341,18 @@ class SettingsFragment(private val presenter: SettingsPresenter, private val lan
             true
         }
 
+        findPreference<SwitchPreference>("change_log_popup_enabled")?.let {
+            lifecycleScope.launch {
+                it.isChecked = presenter.isChangeLogPopupEnabled()
+            }
+            it.setOnPreferenceChangeListener { _, newValue ->
+                lifecycleScope.launch {
+                    presenter.setChangeLogPopupEnabled(newValue as Boolean)
+                }
+                true
+            }
+        }
+
         findPreference<Preference>("version")?.let {
             it.isCopyingEnabled = true
             it.summary = BuildConfig.VERSION_NAME

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -24,4 +24,6 @@ interface SettingsPresenter {
     fun getServerCount(): Int
     suspend fun getNotificationRateLimits(): RateLimitResponse?
     fun showChangeLog(context: Context)
+    suspend fun isChangeLogPopupEnabled(): Boolean
+    suspend fun setChangeLogPopupEnabled(enabled: Boolean)
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -81,6 +81,7 @@ class SettingsPresenterImpl @Inject constructor(
             "crash_reporting" -> prefsRepository.isCrashReporting()
             "autoplay_video" -> prefsRepository.isAutoPlayVideoEnabled()
             "always_show_first_view_on_app_start" -> prefsRepository.isAlwaysShowFirstViewOnAppStartEnabled()
+            "change_log_popup_enabled" -> prefsRepository.isChangeLogPopupEnabled()
             "assist_voice_command_intent" -> {
                 val componentSetting = view.getPackageManager()?.getComponentEnabledSetting(voiceCommandAppComponent)
                 componentSetting != null && componentSetting != PackageManager.COMPONENT_ENABLED_STATE_DISABLED
@@ -103,6 +104,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "crash_reporting" -> prefsRepository.setCrashReporting(value)
                 "autoplay_video" -> prefsRepository.setAutoPlayVideo(value)
                 "always_show_first_view_on_app_start" -> prefsRepository.setAlwaysShowFirstViewOnAppStart(value)
+                "change_log_popup_enabled" -> prefsRepository.setChangeLogPopupEnabled(value)
                 "assist_voice_command_intent" ->
                     view.getPackageManager()?.setComponentEnabledSetting(
                         voiceCommandAppComponent,
@@ -174,6 +176,14 @@ class SettingsPresenterImpl @Inject constructor(
 
     override fun showChangeLog(context: Context) {
         changeLog.showChangeLog(context, true)
+    }
+
+    override suspend fun isChangeLogPopupEnabled(): Boolean {
+        return prefsRepository.isChangeLogPopupEnabled()
+    }
+
+    override suspend fun setChangeLogPopupEnabled(enabled: Boolean) {
+        prefsRepository.setChangeLogPopupEnabled(enabled)
     }
 
     override suspend fun addServer(result: OnboardApp.Output?) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/ChangeLog.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/ChangeLog.kt
@@ -6,12 +6,24 @@ import android.view.ContextThemeWrapper
 import info.hannes.changelog.ChangeLog
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.themes.NightModeManager
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
 
-class ChangeLog @Inject constructor(val nightModeManager: NightModeManager) {
+class ChangeLog @Inject constructor(
+    val nightModeManager: NightModeManager,
+    private val prefsRepository: PrefsRepository
+) {
+    private fun createChangeLog(context: Context): ChangeLog {
+        return ChangeLog(context)
+    }
     fun showChangeLog(context: Context, forceShow: Boolean) {
+        // Check if user has enabled change log popup or this is a forced show
+        if (!forceShow && !runBlocking { prefsRepository.isChangeLogPopupEnabled() }) {
+            return
+        }
+
         val isDarkTheme = when (runBlocking { nightModeManager.getCurrentNightMode() }) {
             NightModeTheme.ANDROID, NightModeTheme.SYSTEM -> {
                 val nightModeFlags =
@@ -27,7 +39,7 @@ class ChangeLog @Inject constructor(val nightModeManager: NightModeManager) {
                 darkThemeChangeLog.fullLogDialog.show()
             }
         } else {
-            val changeLog = ChangeLog(context)
+            val changeLog = createChangeLog(context)
             if ((!changeLog.isFirstRunEver && changeLog.isFirstRun) || forceShow) {
                 changeLog.fullLogDialog.show()
             }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -224,6 +224,11 @@
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/app_version_info">
+        <SwitchPreference
+            android:key="change_log_popup_enabled"
+            android:icon="@drawable/ic_changelog"
+            android:title="@string/enable_change_log_popup"
+            android:summary="@string/enable_change_log_popup_summary" />
         <Preference
             android:key="changelog_prompt"
             android:icon="@drawable/ic_changelog"

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/ChangeLogTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/ChangeLogTest.kt
@@ -1,0 +1,56 @@
+package io.homeassistant.companion.android.util
+
+import android.app.AlertDialog
+import android.content.Context
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.themes.NightModeManager
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class ChangeLogTest {
+    private val context = mockk<Context>(relaxed = true)
+    private val prefsRepository = mockk<PrefsRepository>()
+    private val nightModeManager = mockk<NightModeManager>()
+    private val hannesChangeLog = mockk<info.hannes.changelog.ChangeLog>(relaxed = true)
+    private val dialog = mockk<AlertDialog>(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        coEvery { nightModeManager.getCurrentNightMode() } returns io.homeassistant.companion.android.common.data.prefs.NightModeTheme.LIGHT
+        every { hannesChangeLog.fullLogDialog } returns dialog
+        every { hannesChangeLog.isFirstRun } returns true
+        every { hannesChangeLog.isFirstRunEver } returns false
+    }
+
+    @Test
+    fun `Given change log popup is not enabled when showing change log then popup is not shown`() {
+        coEvery { prefsRepository.isChangeLogPopupEnabled() } returns false
+        val changeLog = spyk(ChangeLog(nightModeManager, prefsRepository), recordPrivateCalls = true)
+        every { changeLog["createChangeLog"](any<Context>()) } returns hannesChangeLog
+        changeLog.showChangeLog(context, forceShow = false)
+        verify(exactly = 0) { dialog.show() }
+    }
+
+    @Test
+    fun `Given change log popup is enabled when showing change log then popup is shown`() {
+        coEvery { prefsRepository.isChangeLogPopupEnabled() } returns true
+        val changeLog = spyk(ChangeLog(nightModeManager, prefsRepository), recordPrivateCalls = true)
+        every { changeLog["createChangeLog"](any<Context>()) } returns hannesChangeLog
+        changeLog.showChangeLog(context, forceShow = false)
+        verify(exactly = 1) { dialog.show() }
+    }
+
+    @Test
+    fun `Given forceShow is true when showing change log then popup is shown regardless of enabled setting`() {
+        coEvery { prefsRepository.isChangeLogPopupEnabled() } returns false
+        val changeLog = spyk(ChangeLog(nightModeManager, prefsRepository), recordPrivateCalls = true)
+        every { changeLog["createChangeLog"](any<Context>()) } returns hannesChangeLog
+        changeLog.showChangeLog(context, forceShow = true)
+        verify(exactly = 1) { dialog.show() }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -115,6 +115,10 @@ interface PrefsRepository {
 
     suspend fun setGestureAction(gesture: HAGesture, action: GestureAction)
 
+    suspend fun isChangeLogPopupEnabled(): Boolean
+
+    suspend fun setChangeLogPopupEnabled(enabled: Boolean)
+
     /** Clean up any app-level preferences that might reference servers */
     suspend fun removeServer(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -41,6 +41,7 @@ private const val PREF_AUTO_FAVORITES = "auto_favorites"
 private const val PREF_LOCATION_HISTORY_DISABLED = "location_history"
 private const val PREF_IMPROV_PERMISSION_DISPLAYED = "improv_permission_displayed"
 private const val PREF_GESTURE_ACTION_PREFIX = "gesture_action"
+private const val PREF_CHANGE_LOG_POPUP_ENABLED = "change_log_popup_enabled"
 
 /**
  * This class ensure that when we use the local storage in [PrefsRepositoryImpl] the migrations has been made
@@ -84,8 +85,8 @@ private class LocalStorageWithMigration(
                     }
 
                     localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
-                    migrationChecked.set(true)
                 }
+                migrationChecked.set(true)
             }
         }
     }
@@ -314,6 +315,15 @@ class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setGestureAction(gesture: HAGesture, action: GestureAction) {
         localStorage().putString("${PREF_GESTURE_ACTION_PREFIX}_${gesture.name}", action.name)
+    }
+
+    override suspend fun isChangeLogPopupEnabled(): Boolean {
+        // Default to true if not set
+        return localStorage().getBoolean(PREF_CHANGE_LOG_POPUP_ENABLED) ?: true
+    }
+
+    override suspend fun setChangeLogPopupEnabled(enabled: Boolean) {
+        localStorage().putBoolean(PREF_CHANGE_LOG_POPUP_ENABLED, enabled)
     }
 
     override suspend fun removeServer(serverId: Int) {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1131,6 +1131,8 @@
     <string name="info">Information</string>
     <string name="show_changelog">Show change log</string>
     <string name="show_changelog_summary">Show the change log dialog from when the app was updated</string>
+    <string name="enable_change_log_popup">Enable automatic change log popup</string>
+    <string name="enable_change_log_popup_summary">Allow the change log dialog to automatically appear when the app is updated</string>
     <string name="tile_icon">Tile icon</string>
     <string name="tile_icon_original">Use entity icon</string>
     <string name="tile_select">Select a tile to edit</string>

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -63,4 +63,35 @@ class PrefsRepositoryImplTest {
 
         assertEquals(GestureAction.NONE, result)
     }
+
+    @Test
+    fun `Given no preference set when checking change log popup enabled then default is true`() = runTest {
+        coEvery { localStorage.getBoolean("change_log_popup_enabled") } returns true
+
+        val result = repository.isChangeLogPopupEnabled()
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `Given user sets change log popup enabled to true when retrieving then value is true`() = runTest {
+        coEvery { localStorage.putBoolean("change_log_popup_enabled", true) } returns Unit
+        coEvery { localStorage.getBoolean("change_log_popup_enabled") } returns true
+        repository.setChangeLogPopupEnabled(true)
+
+        val result = repository.isChangeLogPopupEnabled()
+
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `Given user sets change log popup enabled to false when retrieving then value is false`() = runTest {
+        coEvery { localStorage.putBoolean("change_log_popup_enabled", false) } returns Unit
+        coEvery { localStorage.getBoolean("change_log_popup_enabled") } returns false
+        repository.setChangeLogPopupEnabled(false)
+
+        val result = repository.isChangeLogPopupEnabled()
+
+        assertEquals(false, result)
+    }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
As requested in #4018, adding a setting to allow not showing the change log popup on every update of the Home Assistant companion app. The default is to show it, but users can now opt out with this new toggle.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="336" height="748" alt="image" src="https://github.com/user-attachments/assets/d433b26d-33f8-47c2-ba5b-173f847e0b22" />
<img width="336" height="748" alt="image" src="https://github.com/user-attachments/assets/660562a9-301b-4aa5-8c7d-85871b302e06" />

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
As part of this change, in `PrefsRepositoryImpl`, I moved the line where `migrationChecked` is set to `true` outside of the conditional of `currentVersion == null || currentVersion < 1`, as I experienced a deadlock when trying to toggle the new setting without this change. This seems more logically correct anyway because the migration was checked at that point, regardless of whether the version condition matched – please let me know if this should be reverted/addressed differently.