### PR TITLE
Make sure Deeplink URL parameters is not stripped

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -121,7 +121,7 @@ class LaunchActivity :
             }
 
             if (serverParameter != null) {
-                startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverParameter))
+                startActivity(WebViewActivity.newInstance(this, intent.data?.toString(), serverParameter))
             } else { // Show server chooser
                 supportFragmentManager.setFragmentResultListener(ServerChooserFragment.RESULT_KEY, this) { _, bundle ->
                     val serverId = if (bundle.containsKey(ServerChooserFragment.RESULT_SERVER)) {
@@ -130,7 +130,7 @@ class LaunchActivity :
                         null
                     }
                     supportFragmentManager.clearFragmentResultListener(ServerChooserFragment.RESULT_KEY)
-                    startActivity(WebViewActivity.newInstance(this, intent.data?.path, serverId))
+                    startActivity(WebViewActivity.newInstance(this, intent.data?.toString(), serverId))
                     finish()
                     overridePendingTransition(0, 0) // Disable activity start/stop animation
                 }
@@ -138,7 +138,7 @@ class LaunchActivity :
                 return
             }
         } else {
-            startActivity(WebViewActivity.newInstance(this, intent.data?.path))
+            startActivity(WebViewActivity.newInstance(this, intent.data?.toString()))
         }
         finish()
         overridePendingTransition(0, 0) // Disable activity start/stop animation


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Deep link like `homeassistant://navigate/history?start_date=2025-08-08T11%3A00%3A00.001Z&end_date=2025-08-08T14%3A00%3A00.001Z` are not fully working since the parameters are not given when opening the webview activity we only give the `path`. This PR fix this by passing the whole URL instead.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.