### PR TITLE
Set end time for Health Connect aggregation request to end of day

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -1021,7 +1021,7 @@ class HealthConnectSensorManager : SensorManager {
             metrics = setOf(metric),
             timeRangeFilter = TimeRangeFilter.between(
                 LocalDateTime.of(LocalDate.now(), LocalTime.MIDNIGHT),
-                LocalDateTime.of(LocalDate.now(), LocalTime.now()),
+                LocalDateTime.of(LocalDate.now(), LocalTime.MAX),
             ),
         )
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #5286 

It seems that apps are writing daily totals records to Health Connects in two distinct ways:
 - a record for every minute of data (for example, Garmin Connect and Fitbit)
 - a record for the entire day which is updated throughout the day (for example, Samsung Health)

The app's aggregation request to get the "daily x" sensor worked fine with the first type, but not with the second type where the API would give x% of the value when x% of the day had passed instead of the actual value. By always asking for the aggregate of the full day, this issue is resolved.

Tested with apps writing both types of records, see screenshots below.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction). - _No, this is a 3rd party API implementation detail_
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
|     |One record per minute (example: Garmin Connect)|One record for the entire day (example: Samsung Health)|
|-----|-----|-----|
|Current code|✅ OK ![Screenshot showing 631 steps in HA and HC, with multiple entries for steps each for one minute from Garmin Connect](https://github.com/user-attachments/assets/984d1104-5f21-4196-ac79-eba3d271432e)|❌ Incorrect (11h/24h * 378 steps = 173 steps) ![Screenshot showing 173 steps in HA and 378 steps in HC, with one entry for steps for 00:00-23:59 from Samsung Health](https://github.com/user-attachments/assets/864b4d21-75e8-40f2-a27c-af0e2ceb8ef7)|
|With PR changes|✅ OK, still same value ![Screenshot showing 631 steps in HA and HC, with multiple entries for steps each for one minute from Garmin Connect](https://github.com/user-attachments/assets/a1285547-8a51-468a-a26c-aa1d93c12311)|✅ Now showing expected value ![Screenshot showing 378 steps in HA and HC, with one entry for steps for 00:00-23:59 from Samsung Health](https://github.com/user-attachments/assets/ccf8f5ec-8338-4cda-a919-554c187dcabd)

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->