### PR TITLE
Fix/anr settings

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -491,16 +491,18 @@ class SettingsFragment(private val presenter: SettingsPresenter, private val lan
             serverPreference.setOnPreferenceClickListener {
                 serverAuth = server.id
                 val settingsActivity = requireActivity() as SettingsActivity
-                val needsAuth = settingsActivity.isAppLocked(server.id)
-                if (!needsAuth) {
-                    onServerLockResult(Authenticator.SUCCESS)
-                } else {
-                    val canAuth = settingsActivity.requestAuthentication(
-                        getString(commonR.string.biometric_set_title),
-                        ::onServerLockResult,
-                    )
-                    if (!canAuth) {
+                lifecycleScope.launch {
+                    val needsAuth = settingsActivity.isAppLocked(server.id)
+                    if (!needsAuth) {
                         onServerLockResult(Authenticator.SUCCESS)
+                    } else {
+                        val canAuth = settingsActivity.requestAuthentication(
+                            getString(commonR.string.biometric_set_title),
+                            ::onServerLockResult,
+                        )
+                        if (!canAuth) {
+                            onServerLockResult(Authenticator.SUCCESS)
+                        }
                     }
                 }
                 return@setOnPreferenceClickListener true

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenter.kt
@@ -12,7 +12,6 @@ interface ServerSettingsPresenter {
     fun updateServerName()
     fun updateUrlStatus()
     fun hasWifi(): Boolean
-    fun isSsidUsed(): Boolean
     fun clearSsids()
 
     fun setAppActive(active: Boolean)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -165,10 +165,6 @@ class ServerSettingsPresenterImpl @Inject constructor(
 
     override fun hasWifi(): Boolean = wifiHelper.hasWifi()
 
-    override fun isSsidUsed(): Boolean = runBlocking {
-        serverManager.getServer(serverId)?.connection?.internalSsids?.isNotEmpty() == true
-    }
-
     override fun clearSsids() {
         mainScope.launch {
             serverManager.getServer(serverId)?.let {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -84,8 +84,8 @@ private class LocalStorageWithMigration(
                     }
 
                     localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
-                    migrationChecked.set(true)
                 }
+                migrationChecked.set(true)
             }
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Potential fix of https://github.com/home-assistant/android/issues/5665. I was able to reproduce an ANR by making an artificial delay within the bounds of the `runBlocking` of the `isActive` method. By making sure that it doesn't block the UI thread the ANR is gone with this artificial delay. 

It might be only one part of the issue so we need people impacted by this issue to test the fix to see if it is enough. On a longer term we need to get rid of almost of `runBlocking` since we do have other ANRs.

I suspect the issue to only appear on old devices with a small amount of available threads in the IO thread pool (since it's based on the number of thread available on the CPU).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.


## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Credits to @loganrosen from https://github.com/home-assistant/android/pull/5651 for the fix on the migration.