### PR TITLE
Add more logs to see current network state in launcher

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
@@ -8,6 +8,7 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 abstract class LaunchPresenterBase(
     private val view: LaunchView,
@@ -45,23 +46,26 @@ abstract class LaunchPresenterBase(
         }
     }
 
-    private suspend fun handleNetworkState(state: NetworkState): Boolean = when (state) {
-        NetworkState.READY_LOCAL, NetworkState.READY_REMOTE -> {
-            view.dismissDialog()
-            resyncRegistration()
-            view.displayWebView()
-            true
-        }
+    private suspend fun handleNetworkState(state: NetworkState): Boolean {
+        Timber.i("Current network state $state")
+        return when (state) {
+            NetworkState.READY_LOCAL, NetworkState.READY_REMOTE -> {
+                view.dismissDialog()
+                resyncRegistration()
+                view.displayWebView()
+                true
+            }
 
-        // the activity has a CircularProgressIndicator running
-        NetworkState.CONNECTING -> {
-            view.dismissDialog()
-            false
-        }
+            // the activity has a CircularProgressIndicator running
+            NetworkState.CONNECTING -> {
+                view.dismissDialog()
+                false
+            }
 
-        NetworkState.UNAVAILABLE -> {
-            view.displayAlertMessageDialog(R.string.error_connection_failed_no_network)
-            false
+            NetworkState.UNAVAILABLE -> {
+                view.displayAlertMessageDialog(R.string.error_connection_failed_no_network)
+                false
+            }
         }
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We've recently introduced a checker when the app starts in https://github.com/home-assistant/android/pull/5581. It seems some users are noticing a slow down in the start of the app https://github.com/home-assistant/android/issues/5689. In order to debug I've added a small log that would help us to see if there are an issue with the network checker.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.