### PR TITLE
Stop observing network state after being READY

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
@@ -37,7 +37,7 @@ abstract class LaunchPresenterBase(
             ) {
                 networkStatusMonitor.observeNetworkStatus(activeServer.connection)
                     .takeWhile { state ->
-                        // Until the network is ready we continue to observer network status changes
+                        // Until the network is ready we continue to observe network status changes
                         !handleNetworkState(state)
                     }.collect()
             } else {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We potentially had a race condition with `collectLatest` and how we observe the network status. By simply making a synthetic implementation of my assumption

```kotlin
override fun observeNetworkStatus(serverConfig: ServerConnectionInfo): Flow<NetworkState> {
        return flow {
            emit(NetworkState.READY_LOCAL)
            emit(NetworkState.CONNECTING)
        }
}
```

I was stuck on the loading animation, I suspect that on some phone this situation might happen, but I have no idea how and why.

This PR is a proposal of how to avoid this situation by making sure that if that the flow is emitting `READY` at any point we proceed. I came to this conclusion based on the workaround exposed in https://github.com/home-assistant/android/issues/5689#issuecomment-3220109955 that says that to unlock this situation the user simply toggle WIFI on/off that actually will end up into observeNetworkStatus and unblock the situation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
@fpetrovski would you mind testing it with your initial use case since I've replace the `collectLatest` with a simple `collect` and a `takeWhile`.