### PR TITLE
Remove all runBlocking from WebViewPresenter

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1011,11 +1011,9 @@ class WebViewActivity :
     override fun onResume() {
         super.onResume()
         lifecycleScope.launch {
-            currentAutoplay?.let {
-                // if it is null it means that the settings were not called yet so we should not recreate
-                if (currentAutoplay != presenter.isAutoPlayVideoEnabled()) {
-                    recreate()
-                }
+            // if null it means that the settings were not yet read so we should not recreate
+            if (currentAutoplay != null && currentAutoplay != presenter.isAutoPlayVideoEnabled()) {
+                recreate()
             }
 
             appLocked.value = presenter.isAppLocked()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -351,7 +351,10 @@ class WebViewActivity :
                 },
             )
 
-            settings.mediaPlaybackRequiresUserGesture = !presenter.isAutoPlayVideoEnabled()
+            lifecycleScope.launch {
+                settings.mediaPlaybackRequiresUserGesture = !presenter.isAutoPlayVideoEnabled()
+            }
+
             webViewClient = object : TLSWebViewClient(keyChainRepository) {
                 @Deprecated("Deprecated in Java for SDK >= 23")
                 override fun onReceivedError(
@@ -588,8 +591,10 @@ class WebViewActivity :
 
                 override fun onHideCustomView() {
                     customViewFromWebView.value = null
-                    if (!presenter.isFullScreen()) {
-                        showSystemUI()
+                    lifecycleScope.launch {
+                        if (!presenter.isFullScreen()) {
+                            showSystemUI()
+                        }
                     }
                     isVideoFullScreen = false
                     super.onHideCustomView()
@@ -605,17 +610,13 @@ class WebViewActivity :
 
         window.decorView.setOnSystemUiVisibilityChangeListener { visibility ->
             if (visibility and View.SYSTEM_UI_FLAG_FULLSCREEN == 0) {
-                if (presenter.isFullScreen()) {
-                    hideSystemUI()
+                lifecycleScope.launch {
+                    if (presenter.isFullScreen()) {
+                        hideSystemUI()
+                    }
                 }
             }
         }
-
-        if (presenter.isKeepScreenOnEnabled()) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-
-        currentAutoplay = presenter.isAutoPlayVideoEnabled()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val webviewPackage = WebViewCompat.getCurrentWebViewPackage(this)
@@ -625,6 +626,12 @@ class WebViewActivity :
         }
 
         lifecycleScope.launch {
+            if (presenter.isKeepScreenOnEnabled()) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+
+            currentAutoplay = presenter.isAutoPlayVideoEnabled()
+
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 presenter.getMatterThreadStepFlow().collect {
                     Timber.d("Matter/Thread step changed to $it")
@@ -1003,40 +1010,42 @@ class WebViewActivity :
 
     override fun onResume() {
         super.onResume()
-        if (currentAutoplay != presenter.isAutoPlayVideoEnabled()) {
-            recreate()
-        }
-
         lifecycleScope.launch {
+            if (currentAutoplay != presenter.isAutoPlayVideoEnabled()) {
+                recreate()
+            }
+
             appLocked.value = presenter.isAppLocked()
             presenter.updateActiveServer()
         }
 
         setWebViewZoom()
 
-        WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
-
-        requestedOrientation = when (presenter.getScreenOrientation()) {
-            getString(
-                R.string.screen_orientation_option_array_value_portrait,
-            ),
-            -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-            getString(
-                R.string.screen_orientation_option_array_value_landscape,
-            ),
-            -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
-            else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
-        }
-
-        if (presenter.isKeepScreenOnEnabled()) {
-            window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        } else {
-            window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        }
-
         SensorWorker.start(this)
         WebsocketManager.start(this)
         lifecycleScope.launch {
+            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
+
+            requestedOrientation = when (presenter.getScreenOrientation()) {
+                getString(
+                    R.string.screen_orientation_option_array_value_portrait,
+                ),
+                -> ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+
+                getString(
+                    R.string.screen_orientation_option_array_value_landscape,
+                ),
+                -> ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
+
+                else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+            }
+
+            if (presenter.isKeepScreenOnEnabled()) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+
             checkAndWarnForDisabledLocation()
         }
         changeLog.showChangeLog(this, false)
@@ -1048,12 +1057,16 @@ class WebViewActivity :
 
     override fun onStop() {
         super.onStop()
-        openFirstViewOnDashboardIfNeeded()
+        lifecycleScope.launch {
+            openFirstViewOnDashboardIfNeeded()
+        }
     }
 
     override fun onPause() {
         super.onPause()
-        presenter.setAppActive(false)
+        lifecycleScope.launch {
+            presenter.setAppActive(false)
+        }
         if (!isFinishing && !isRelaunching) SensorReceiver.updateAllSensors(this)
     }
 
@@ -1231,7 +1244,9 @@ class WebViewActivity :
             Authenticator.SUCCESS -> {
                 Timber.d("Authentication successful, unlocking app")
                 appLocked.value = false
-                presenter.setAppActive(true)
+                lifecycleScope.launch {
+                    presenter.setAppActive(true)
+                }
             }
 
             Authenticator.CANCELED -> {
@@ -1297,7 +1312,9 @@ class WebViewActivity :
 
     override fun onUserLeaveHint() {
         super.onUserLeaveHint()
-        presenter.setAppActive(false)
+        lifecycleScope.launch {
+            presenter.setAppActive(false)
+        }
         videoHeight = decor.height
         val bounds = Rect(0, 0, 1920, 1080)
         if (isVideoFullScreen or isExoFullScreen) {
@@ -1754,7 +1771,7 @@ class WebViewActivity :
         return super.dispatchKeyEvent(event)
     }
 
-    private fun setWebViewZoom() {
+    private fun setWebViewZoom() = lifecycleScope.launch {
         // Set base zoom level (percentage must be scaled to device density/percentage)
         webView.setInitialScale((resources.displayMetrics.density * presenter.getPageZoomLevel()).toInt())
 
@@ -1786,7 +1803,7 @@ class WebViewActivity :
         ) {}
     }
 
-    private fun openFirstViewOnDashboardIfNeeded() {
+    private suspend fun openFirstViewOnDashboardIfNeeded() {
         if (presenter.isAlwaysShowFirstViewOnAppStartEnabled() &&
             LifecycleHandler.isAppInBackground()
         ) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -26,24 +26,21 @@ interface WebViewPresenter {
 
     fun onRevokeExternalAuth(callback: String)
 
-    fun isFullScreen(): Boolean
+    suspend fun isFullScreen(): Boolean
 
-    fun getScreenOrientation(): String?
+    suspend fun getScreenOrientation(): String?
 
-    fun isKeepScreenOnEnabled(): Boolean
+    suspend fun isKeepScreenOnEnabled(): Boolean
 
-    fun getPageZoomLevel(): Int
-    fun isPinchToZoomEnabled(): Boolean
-    fun isWebViewDebugEnabled(): Boolean
+    suspend fun getPageZoomLevel(): Int
+    suspend fun isPinchToZoomEnabled(): Boolean
+    suspend fun isWebViewDebugEnabled(): Boolean
 
     suspend fun isAppLocked(): Boolean
-    fun setAppActive(active: Boolean)
+    suspend fun setAppActive(active: Boolean)
 
-    fun isLockEnabled(): Boolean
-    fun isAutoPlayVideoEnabled(): Boolean
-    fun isAlwaysShowFirstViewOnAppStartEnabled(): Boolean
-
-    fun sessionTimeOut(): Int
+    suspend fun isAutoPlayVideoEnabled(): Boolean
+    suspend fun isAlwaysShowFirstViewOnAppStartEnabled(): Boolean
 
     fun onExternalBusMessage(message: JSONObject)
 
@@ -55,7 +52,7 @@ interface WebViewPresenter {
 
     suspend fun isSsidUsed(): Boolean
 
-    fun getAuthorizationHeader(): String
+    suspend fun getAuthorizationHeader(): String
 
     suspend fun parseWebViewColor(webViewColor: String): Int
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Part of the effort describe in https://github.com/home-assistant/android/issues/5688 we should remove all the `runBlocking`. The one in the WebViewPresenter are causing a lot (the most) of ANRs within the app. The changes are quite straightforward I tested the changes on Android 16 and 9. I didn't see any regression there.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.