### PR TITLE
Replacing runBlocking with sensorWorkerScope in LocationSensorManager

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -54,7 +54,6 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -1274,7 +1273,7 @@ class LocationSensorManager :
                                     Timber.d(
                                         "Location accurate enough, all done with high accuracy.",
                                     )
-                                    runBlocking {
+                                    sensorWorkerScope.launch {
                                         locationResult.lastLocation?.let {
                                             getEnabledServers(
                                                 latestContext,
@@ -1296,7 +1295,7 @@ class LocationSensorManager :
                                         "No location was accurate enough, sending our last location anyway",
                                     )
                                     if (locationResult.lastLocation!!.accuracy <= minAccuracy * 2) {
-                                        runBlocking {
+                                        sensorWorkerScope.launch {
                                             getEnabledServers(
                                                 latestContext,
                                                 singleAccurateLocation,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Part of the effort describe in https://github.com/home-assistant/android/issues/5688 we should remove all the `runBlocking`. The one in the LocationSensorManager are causing significant of ANRs within the app. The changes are quite straightforward I tested the changes on Android 16. I didn't see any regression there.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.