### PR TITLE
Fix links within documentation of HAButtons

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HAButtons.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HAButtons.kt
@@ -57,7 +57,7 @@ enum class ButtonVariant {
  * Displays an accent button, typically used for the most prominent call to action on a screen.
  * The button's appearance is determined by the [variant] and the current theme.
  *
- * @see https://design.home-assistant.io/#components/ha-button
+ * [Design Website](https://design.home-assistant.io/#components/ha-button)
  *
  * @param text The text label displayed on the button.
  * @param onClick The lambda function to be executed when the button is clicked.
@@ -94,7 +94,7 @@ fun HAAccentButton(
  * Displays a filled button, which is a standard button.
  * The button's appearance is determined by the [variant] and the current theme.
  *
- * @see https://design.home-assistant.io/#components/ha-button
+ * [Design Website](https://design.home-assistant.io/#components/ha-button)
  *
  * @param text The text label displayed on the button.
  * @param onClick The lambda function to be executed when the button is clicked.
@@ -131,7 +131,7 @@ fun HAFilledButton(
  * Displays a plain button, which is typically a text-only button with no background fill.
  * The button's appearance is determined by the [variant] and the current theme.
  *
- * @see https://design.home-assistant.io/#components/ha-button
+ * [Design Website](https://design.home-assistant.io/#components/ha-button)
  *
  * @param text The text label displayed on the button.
  * @param onClick The lambda function to be executed when the button is clicked.


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The links within the KDocs of the `HAButtons` was not correctly being displayed since it was not using markdown.