### PR TITLE
Bring back changelog of 2025.8.9

### DIFF
--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,12 +2,18 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2025.8.10 - Main" versioncode="3">
+        <change>Gesture settings for the main Home Assistant UI added, with new gestures and actions</change>
+        <change>Health Connect sensors now require permission to access health data in the background</change>
+        <change>Downloading snapshots from camera card is now working</change>
         <change>Bug fixes and dependency updates</change>
+        <change>&lt;b&gt;Note:&lt;/b&gt; This is the last app release supporting Android 5.0 and 5.1</change>
     </release>
     <release version="2025.8.10 - Wear" versioncode="2">
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2025.8.10 - Automotive" versioncode="1">
+        <change>Gesture settings for the native (dashboard) Home Assistant UI added, with new gestures and actions</change>
+        <change>Downloading snapshots from camera card is now working</change>
         <change>Bug fixes and dependency updates</change>
     </release>
 </changelog>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Since Google is taking a lot of time to approve the last beta with the quick fix, we might push 2025.8.10 before the actual release of the beta. To avoid a situation where we ship a version without a changelog I decided to bring back the previous one.