### PR TITLE
Fixup misleading nomenclature: s/frontend cache/client cache/g

### DIFF
--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="choose_server">Choose server</string>
     <string name="clear_favorites">Clear favorites</string>
     <string name="clear_search">Clear search</string>
-    <string name="clear_webview_cache">Reset frontend cache</string>
+    <string name="clear_webview_cache">Reset client cache</string>
     <string name="clear_webview_cache_active">Resetting…</string>
     <string name="clear_webview_cache_failed">Reset failed</string>
     <string name="clear_webview_cache_success">Reset completed</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)
-->

* What was the motivation behind this change?

This commit replaces every instance of a misleading reference to a "frontend cache" where there is no such thing with a correct, however generalized, reference to the "client cache."

In objective fact, a "frontend cache" is a term reserved for server-side caching reverse proxies centralized on and attributable to a frontend itself. No such resource exists in any Home Assistant deployment. This incorrect use of terms is confusing and misleading, and therefore is herein replaced. I will confess to having been thusly misled despite (and perhaps _because of_) being employed in the relevant technology industries for going on two decades.

The only relevant cache is attributable to the client, whether it is a browser or whether it is a dedicated platform client. This change categorically prevents the mistaken apprehension that any server-side cache attributable to the frontend requires resetting, and at the very least, is *less incorrect.* If the word "client" is objectionable, valid alternatives e.g. "browser" and "user," or simply eschewing the misleading qualifier entirely (not recommended), remain available.

* What is the impact of the changes on the application?

Functionally, none. For this repository, the change represents barely a single string.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ x ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
  (strictly irrelevant to this PR)
- [ x ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
  (no code has been changed; only a localization string)
- [ x ] The changes have been thoroughly tested, and edge cases have been considered.
  (there is no possibility of relevance here)
- [ x ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
  (no string matching the case-insensitive expression "frontend cache" appears in the documentation (indeed, this is the reason for the other corrections); therefore, no correction is required here)

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
cf. https://community.home-assistant.io/t/how-to-clear-the-frontend-cache/670491/91

This pull request is part of a set against the following repositories (crosslinks may be updated after the PR is opened):
  - home-assistant/android
  - home-assistant/iOS
  - hacs/integration