### PR TITLE
Remove runBlocking from ServerManager.activeServerId

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.1)" variant="all" version="8.12.1">
+<issues format="6" by="lint 8.12.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.2)" variant="all" version="8.12.2">
 
     <issue
         id="MissingPermission"
@@ -886,17 +886,6 @@
     <issue
         id="UseKtx"
         message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                                Uri.parse(&quot;geo:$lat,$lon&quot;),"
-        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt"
-            line="186"
-            column="49"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
         errorLine1="            Intent(Intent.ACTION_VIEW, Uri.parse(resources.getString(commonR.string.privacy_url))).also {"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -914,17 +903,6 @@
             file="src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt"
             line="248"
             column="45"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                Uri.parse(&quot;geo:${pair.second[0]},${pair.second[1]}&quot;),"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt"
-            line="134"
-            column="33"/>
     </issue>
 
     <issue

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/DomainListScreen.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.lifecycleScope
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.integration.domain
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
@@ -28,7 +27,6 @@ import kotlinx.coroutines.launch
 class DomainListScreen(
     carContext: CarContext,
     val serverManager: ServerManager,
-    val integrationRepository: IntegrationRepository,
     private val serverId: StateFlow<Int>,
     private val allEntities: Flow<Map<String, Entity>>,
     private val prefsRepository: PrefsRepository,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.vehicle
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
@@ -14,6 +13,7 @@ import androidx.car.app.model.GridItem
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.ItemList
 import androidx.car.app.model.Template
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -54,7 +54,7 @@ class EntityGridVehicleScreen(
     val serverManager: ServerManager,
     val serverId: StateFlow<Int>,
     val prefsRepository: PrefsRepository,
-    val integrationRepository: IntegrationRepository,
+    val integrationRepositoryProvider: suspend () -> IntegrationRepository,
     val title: String,
     private val entityRegistry: List<EntityRegistryResponse>?,
     private val domains: MutableSet<String>,
@@ -102,7 +102,7 @@ class EntityGridVehicleScreen(
                 getNavigationGridItem(
                     carContext,
                     screenManager,
-                    integrationRepository,
+                    integrationRepositoryProvider,
                     allEntities,
                     entityRegistry,
                 ).build(),
@@ -113,7 +113,6 @@ class EntityGridVehicleScreen(
                         carContext,
                         screenManager,
                         serverManager,
-                        integrationRepository,
                         serverId,
                         allEntities,
                         prefsRepository,
@@ -183,7 +182,7 @@ class EntityGridVehicleScreen(
                                         if (lat != null && lon != null) {
                                             val intent = Intent(
                                                 CarContext.ACTION_NAVIGATE,
-                                                Uri.parse("geo:$lat,$lon"),
+                                                "geo:$lat,$lon".toUri(),
                                             )
                                             carContext.startCarApp(intent)
                                         }
@@ -192,7 +191,7 @@ class EntityGridVehicleScreen(
 
                                 in SUPPORTED_DOMAINS -> {
                                     lifecycleScope.launch {
-                                        entity.onPressed(integrationRepository)
+                                        entity.onPressed(integrationRepositoryProvider())
                                     }
                                 }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -136,7 +136,7 @@ class MainVehicleScreen(
                 serverManager,
                 serverId,
                 prefsRepository,
-                serverManager.integrationRepository(serverId.value),
+                { serverManager.integrationRepository(serverId.value) },
                 carContext.getString(commonR.string.favorites),
                 entityRegistry,
                 domains,
@@ -163,7 +163,7 @@ class MainVehicleScreen(
                 getNavigationGridItem(
                     carContext,
                     screenManager,
-                    serverManager.integrationRepository(serverId.value),
+                    { serverManager.integrationRepository(serverId.value) },
                     allEntities,
                     entityRegistry,
                 ).build(),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.vehicle
 
 import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
@@ -14,6 +13,7 @@ import androidx.car.app.model.GridItem
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.ItemList
 import androidx.car.app.model.Template
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -37,7 +37,7 @@ import timber.log.Timber
 @RequiresApi(Build.VERSION_CODES.O)
 class MapVehicleScreen(
     carContext: CarContext,
-    val integrationRepository: IntegrationRepository,
+    val integrationRepositoryProvider: suspend () -> IntegrationRepository,
     private val entitiesFlow: Flow<List<Entity>>,
 ) : Screen(carContext) {
 
@@ -119,7 +119,7 @@ class MapVehicleScreen(
                             Timber.i("${pair.first.entityId} clicked")
                             lifecycleScope.launch {
                                 try {
-                                    integrationRepository.fireEvent(
+                                    integrationRepositoryProvider().fireEvent(
                                         "android.navigation_started",
                                         mapOf(
                                             "entity_id" to pair.first.entityId,
@@ -131,7 +131,7 @@ class MapVehicleScreen(
                             }
                             val intent = Intent(
                                 CarContext.ACTION_NAVIGATE,
-                                Uri.parse("geo:${pair.second[0]},${pair.second[1]}"),
+                                "geo:${pair.second[0]},${pair.second[1]}".toUri(),
                             )
                             carContext.startCarApp(intent)
                         }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/BaseGlanceEntityWidgetReceiverTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/BaseGlanceEntityWidgetReceiverTest.kt
@@ -115,7 +115,7 @@ class BaseGlanceEntityWidgetReceiverTest {
         coEvery { glanceManager.getGlanceIds(mockedWidget.javaClass) } returns glanceIds
         every { glanceManager.getAppWidgetId(any()) } answers { firstArg<FakeGlanceId>().id }
         coEvery { mockedServerManager.getServer(any<Int>()) } returns mockk()
-        every { mockedServerManager.integrationRepository(any()) } returns integrationRepository
+        coEvery { mockedServerManager.integrationRepository(any()) } returns integrationRepository
         coEvery { integrationRepository.getEntityUpdates(listOf("entity1")) } returns channelFlow {
             close()
         }
@@ -153,7 +153,7 @@ class BaseGlanceEntityWidgetReceiverTest {
         every { glanceManager.getGlanceIdBy(any<Int>()) } answers { FakeGlanceId(firstArg()) }
         coJustRun { mockedWidget.update(context, any()) }
         coEvery { mockedServerManager.getServer(any<Int>()) } returns mockk()
-        every { mockedServerManager.integrationRepository(any()) } returns integrationRepository
+        coEvery { mockedServerManager.integrationRepository(any()) } returns integrationRepository
         coEvery { integrationRepository.getEntityUpdates(listOf("entity1")) } returns channelFlow {
             widget1EntityProducer = this
             awaitClose()
@@ -226,7 +226,7 @@ class BaseGlanceEntityWidgetReceiverTest {
         coEvery { glanceManager.getGlanceIds(mockedWidget.javaClass) } returns glanceIds
         every { glanceManager.getAppWidgetId(any()) } answers { firstArg<FakeGlanceId>().id }
         coEvery { mockedServerManager.getServer(any<Int>()) } returns mockk()
-        every { mockedServerManager.integrationRepository(any()) } returns integrationRepository
+        coEvery { mockedServerManager.integrationRepository(any()) } returns integrationRepository
         coEvery { integrationRepository.getEntityUpdates(listOf("entity1")) } returns channelFlow {
             producer = this
             awaitClose()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdaterTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdaterTest.kt
@@ -13,7 +13,6 @@ import io.mockk.coEvery
 import io.mockk.coJustAwait
 import io.mockk.coJustRun
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
@@ -30,8 +29,8 @@ class TodoWidgetStateUpdaterTest {
     private val integrationRepository = mockk<IntegrationRepository>()
     private val webSocketRepository = mockk<WebSocketRepository>()
     private val serverManager = mockk<ServerManager>().apply {
-        every { integrationRepository(any()) } returns integrationRepository
-        every { webSocketRepository(any()) } returns webSocketRepository
+        coEvery { integrationRepository(any()) } returns integrationRepository
+        coEvery { webSocketRepository(any()) } returns webSocketRepository
     }
     private val updater = TodoWidgetStateUpdater(dao, serverManager)
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetToggleActionsTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetToggleActionsTest.kt
@@ -27,7 +27,7 @@ class TodoWidgetToggleActionsTest {
         val dao = mockk<TodoWidgetDao>()
         val webSocketRepository = mockk<WebSocketRepository>()
         val serverManager = mockk<ServerManager>().apply {
-            every { webSocketRepository(any()) } returns webSocketRepository
+            coEvery { webSocketRepository(any()) } returns webSocketRepository
         }
 
         override fun serverManager(): ServerManager = serverManager

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.12.1" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.1)" variant="all" version="8.12.1">
+<issues format="6" by="lint 8.12.2" type="baseline" client="gradle" dependencies="false" name="AGP (8.12.2)" variant="all" version="8.12.2">
 
     <issue
         id="MissingPermission"
@@ -613,7 +613,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/vehicle/DomainListScreen.kt"
-            line="27"
+            line="26"
             column="1"/>
     </issue>
 
@@ -701,7 +701,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/util/vehicle/GridItems.kt"
-            line="202"
+            line="205"
             column="1"/>
     </issue>
 
@@ -2868,17 +2868,6 @@
     <issue
         id="UseKtx"
         message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                                Uri.parse(&quot;geo:$lat,$lon&quot;),"
-        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/vehicle/EntityGridVehicleScreen.kt"
-            line="186"
-            column="49"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
         errorLine1="            Intent(Intent.ACTION_VIEW, Uri.parse(resources.getString(commonR.string.privacy_url))).also {"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -2896,17 +2885,6 @@
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt"
             line="248"
             column="45"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                Uri.parse(&quot;geo:${pair.second[0]},${pair.second[1]}&quot;),"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/vehicle/MapVehicleScreen.kt"
-            line="134"
-            column="33"/>
     </issue>
 
     <issue

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManager.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManager.kt
@@ -75,17 +75,17 @@ interface ServerManager {
      * @return [AuthenticationRepository] for the server with the provided ID
      * @throws [IllegalArgumentException] if there is no server with the provided ID
      */
-    fun authenticationRepository(serverId: Int = SERVER_ID_ACTIVE): AuthenticationRepository
+    suspend fun authenticationRepository(serverId: Int = SERVER_ID_ACTIVE): AuthenticationRepository
 
     /**
      * @return [IntegrationRepository] for the server with the provided ID
      * @throws [IllegalArgumentException] if there is no server with the provided ID
      */
-    fun integrationRepository(serverId: Int = SERVER_ID_ACTIVE): IntegrationRepository
+    suspend fun integrationRepository(serverId: Int = SERVER_ID_ACTIVE): IntegrationRepository
 
     /**
      * @return [WebSocketRepository] for the server with the provided ID
      * @throws [IllegalArgumentException] if there is no server with the provided ID
      */
-    fun webSocketRepository(serverId: Int = SERVER_ID_ACTIVE): WebSocketRepository
+    suspend fun webSocketRepository(serverId: Int = SERVER_ID_ACTIVE): WebSocketRepository
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
@@ -125,10 +125,10 @@ class ServerManagerImpl @Inject constructor(
         }
     }
 
-    private fun activeServerId(): Int? = runBlocking {
+    private suspend fun activeServerId(): Int? {
         val pref = localStorage.getInt(PREF_ACTIVE_SERVER)
 
-        if (pref != null && mutableServers[pref] != null) {
+        return if (pref != null && mutableServers[pref] != null) {
             pref
         } else {
             mutableServers.keys.maxOfOrNull { it }
@@ -203,30 +203,33 @@ class ServerManagerImpl @Inject constructor(
         mutableServers.remove(id)
     }
 
-    override fun authenticationRepository(serverId: Int): AuthenticationRepository {
+    override suspend fun authenticationRepository(serverId: Int): AuthenticationRepository {
         val id = if (serverId == SERVER_ID_ACTIVE) activeServerId() else serverId
         return authenticationRepos[id] ?: run {
             if (id == null || mutableServers[id] == null) throw IllegalArgumentException("No server for ID")
-            authenticationRepos[id] = authenticationRepositoryFactory.create(id)
-            authenticationRepos[id]!!
+            val repository = authenticationRepositoryFactory.create(id)
+            authenticationRepos[id] = repository
+            checkNotNull(authenticationRepos[id]) { "Should not be null since we've just called create ($repository)" }
         }
     }
 
-    override fun integrationRepository(serverId: Int): IntegrationRepository {
+    override suspend fun integrationRepository(serverId: Int): IntegrationRepository {
         val id = if (serverId == SERVER_ID_ACTIVE) activeServerId() else serverId
         return integrationRepos[id] ?: run {
             if (id == null || mutableServers[id] == null) throw IllegalArgumentException("No server for ID")
-            integrationRepos[id] = integrationRepositoryFactory.create(id)
-            integrationRepos[id]!!
+            val repository = integrationRepositoryFactory.create(id)
+            integrationRepos[id] = repository
+            checkNotNull(integrationRepos[id]) { "Should not be null since we've just called create ($repository)" }
         }
     }
 
-    override fun webSocketRepository(serverId: Int): WebSocketRepository {
+    override suspend fun webSocketRepository(serverId: Int): WebSocketRepository {
         val id = if (serverId == SERVER_ID_ACTIVE) activeServerId() else serverId
         return webSocketRepos[id] ?: run {
             if (id == null || mutableServers[id] == null) throw IllegalArgumentException("No server for ID")
-            webSocketRepos[id] = webSocketRepositoryFactory.create(id)
-            webSocketRepos[id]!!
+            val repository = webSocketRepositoryFactory.create(id)
+            webSocketRepos[id] = repository
+            checkNotNull(webSocketRepos[id]) { "Should not be null since we've just caled create ($repository)" }
         }
     }
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImplTest.kt
@@ -86,7 +86,7 @@ class WebSocketCoreImplTest {
 
         mockConnection = mockk(relaxed = true)
         coEvery { mockServerManager.getServer(any<Int>()) } returns testServer
-        every { mockServerManager.authenticationRepository(testServerId) } returns mockAuthenticationRepository
+        coEvery { mockServerManager.authenticationRepository(testServerId) } returns mockAuthenticationRepository
         coEvery { mockAuthenticationRepository.retrieveAccessToken() } returns "mock_access_token"
         // The implementation use a background scope to properly handle async messages, to not block the test
         // we are injecting a background scope to properly control it within the tests, the scope will close itself at the end of the test

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomePresenter.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomePresenter.kt
@@ -27,7 +27,7 @@ interface HomePresenter {
 
     suspend fun isConnected(): Boolean
     suspend fun getServerId(): Int?
-    fun getWebSocketState(): WebSocketState?
+    suspend fun getWebSocketState(): WebSocketState?
 
     suspend fun getEntities(): List<Entity>?
     suspend fun getEntityUpdates(entityIds: List<String>): Flow<Entity>?

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomePresenterImpl.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomePresenterImpl.kt
@@ -202,7 +202,7 @@ class HomePresenterImpl @Inject constructor(
 
     override suspend fun getServerId(): Int? = serverManager.getServer()?.id
 
-    override fun getWebSocketState(): WebSocketState? {
+    override suspend fun getWebSocketState(): WebSocketState? {
         return serverManager.webSocketRepository().getConnectionState()
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Part of the effort describe in https://github.com/home-assistant/android/issues/5688 we should remove all the `runBlocking`. There was one in `ServerManager` to get the active server.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.