### PR TITLE
Fix fire and forget resync to avoid blocking UI at startup

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchPresenterBase.kt
@@ -30,8 +30,7 @@ abstract class LaunchPresenterBase(
      *
      * **Note:** Using a dedicated scope like this means that the underlying Activity might not be
      * destroyed immediately if these background tasks are still running. This is a trade-off
-     * for improved UI responsiveness in scenarios with potential network delays. If we
-     * introduce a new server state like disable we could maybe bring this back in the flow.
+     * for improved UI responsiveness in scenarios with potential network delays.
      *
      * We use a [SupervisorJob] on purpose because it ensures that if one task fails, it won't
      * impact the others.


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In https://github.com/home-assistant/android/pull/5581 we've introduce a regression by making the `resyncRegistration` part of the flow. The regression is only visible when one server is not responding or any call during the registration. It was causing the start to be postpone until the server timeout (could be up to 30s).

 This PR does move the registration back into a dedicated coroutine scope. This fix the slow delay issue but it does mean that the activity could out live it's lifecycle, which is bad but it is limited to maximum the timeout of the server so 30s.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Fixes #5689 

We could consider adding a new state to a server to mark it as disabled and avoid calling a server if we know that it might not respond. It might be useful for ppl that are managing servers for other and where they are not able to reach out to this server but they still want the server in the app for when they are able to reach out.