### PR TITLE
Ignore SSL errors for non‑critical in Ingress WebView

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -415,8 +415,14 @@ class WebViewActivity :
                     authenticationDialog(handler, host, resourceURL, realm, authError)
                 }
 
-                override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
-                    Timber.e("onReceivedSslError: $error")
+                override fun onReceivedSslError(view: WebView? ,handler: SslErrorHandler? ,error: SslError?) {
+                    val url = error?.url ?: ""
+                    Timber.e("onReceivedSslError: $url -> $error")
+                    if (url.contains("googletagmanager.com")) {
+                        Timber.w("Ignoring SSL error for non-critical resource: $url")
+                        handler?.proceed()
+                        return
+                    }
                     showError(
                         ErrorType.SSL,
                         error,


### PR DESCRIPTION
Ignore SSL errors for non‑critical external resources (e.g. Google Tag Manager) in Ingress WebView

## Summary
When using add‑ons via Ingress in the Android app, if a third‑party resource such as https://www.googletagmanager.com/gtm.js is blocked at the network/DNS level (e.g. via Pi‑hole, AdGuard), the WebView receives an onReceivedSslError for that resource. Currently, the app treats any SSL error as a fatal connection failure and shows the "The certificate authority for Home Assistant is not trusted" dialog, even though the main Home Assistant server certificate is valid.

This behavior is misleading and interrupts the user experience for a non‑critical resource.

This PR should resolve issues like [this](https://community.home-assistant.io/t/android-app-unable-to-connect-to-home-assistant-error/866366)

## Checklist
- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [X] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [X] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.


## Any other notes
This change is intentionally scoped to a specific known domain to minimize risk. If accepted, it could be extended in the future to ignore SSL errors for any non‑critical external host that is not the active Home Assistant server.