### PR TITLE
Improve SSL error handling in WebViewActivity for external resources

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -416,12 +416,23 @@ class WebViewActivity :
                 }
 
                 override fun onReceivedSslError(view: WebView?, handler: SslErrorHandler?, error: SslError?) {
+                    val failingUrl = error?.url ?: ""
+                    val activeHost = Uri.parse(
+                        serverManager.getServer(presenter.getActiveServer())?.connection?.getUrl(false)
+                    ).host ?: ""
+                
+                    if (Uri.parse(failingUrl).host != activeHost) {
+                        Timber.w("SSL error for external resource: $failingUrl")
+                        Toast.makeText(
+                            this,
+                            getString(R.string.webview_error_SSL_EXTERNAL_RESOURCE, Uri.parse(failingUrl).host),
+                            Toast.LENGTH_LONG
+                        ).show()
+                        handler?.proceed()
+                        return
+                    }
                     Timber.e("onReceivedSslError: $error")
-                    showError(
-                        ErrorType.SSL,
-                        error,
-                        null,
-                    )
+                    showError(ErrorType.SSL, error, null)
                 }
 
                 override fun onRenderProcessGone(view: WebView?, handler: RenderProcessGoneDetail?): Boolean {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1037,6 +1037,7 @@
     <string name="webview_error_SSL_INVALID">A generic SSL error occurred when loading Home Assistant, please review the Home Assistant certificate or the connection settings and try again.</string>
     <string name="webview_error_SSL_NOTYETVALID">The Home Assistant certificate is not yet valid, please review the Home Assistant certificate or the connection settings and try again.</string>
     <string name="webview_error_SSL_UNTRUSTED">The Home Assistant certificate authority is not trusted, please review the Home Assistant certificate or the connection settings and try again.</string>
+    <string name="webview_error_SSL_EXTERNAL_RESOURCE">SSL error while loading resource from %1$s.</string>
     <string name="webview_error">There was an error loading Home Assistant, please review the connection settings and try again. We will attempt to try another provided URL when you select Refresh.</string>
     <string name="welcome_hass_desc">This app connects to your Home Assistant server and allows integrating data about you and your phone.\n\nHome Assistant is free and open source home automation software with a focus on local control and privacy.</string>
     <string name="welcome_hass">Welcome to Home Assistant Companion!</string>


### PR DESCRIPTION
## Summary
Improve SSL error handling in WebViewActivity for external resources.

When an SSL error occurs for a resource whose host is different from the active
Home Assistant server (e.g. third-party scripts like Google Tag Manager),
the app will now:

- Log a warning with the failing URL.
- Show a non-blocking Toast message with the external domain name.
- Proceed with loading the rest of the Ingress content instead of stopping.

This prevents misleading "certificate authority not trusted" dialogs when the
main HA server certificate is valid, but a non-critical external resource fails
due to DNS blocking or certificate issues.

If the SSL error is for the active Home Assistant host, the existing error
handling remains unchanged.

Closes: #5725 

This PR should resolve issues like [this](https://community.home-assistant.io/t/android-app-unable-to-connect-to-home-assistant-error/866366)

## Checklist
- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [X] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [X] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
