### PR TITLE
Fix device controls settings not selecting a server by default

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
@@ -84,7 +84,7 @@ fun ManageControlsView(
     onSetPanelSetting: (String, Int) -> Unit,
     onSetStructureEnabled: (Boolean) -> Unit,
 ) {
-    var selectedServer by remember { mutableIntStateOf(defaultServer) }
+    var selectedServer by remember(defaultServer) { mutableIntStateOf(defaultServer) }
     val initialPanelEnabled by rememberSaveable { mutableStateOf(panelEnabled) }
     var panelServer by remember(panelSetting?.second) { mutableIntStateOf(panelSetting?.second ?: defaultServer) }
     var panelPath by remember(panelSetting?.first) { mutableStateOf(panelSetting?.first ?: "") }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #5747: the device controls selected server was 0 (none) instead of the default. Previously the default server was loaded and set as selected when the view was loaded, but because the default server ID is now loaded async we need to reset the selected server when the default server ID changes (= is loaded).

(The default server ID doesn't change while using this screen, so this won't cause any changes for the user.)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->