### PR TITLE
Make app windget available to Samsung Z Flip flex window

### DIFF
--- a/app/src/main/res/xml/button_widget_info.xml
+++ b/app/src/main/res/xml/button_widget_info.xml
@@ -13,6 +13,6 @@
     android:updatePeriodMillis="86400000"
     android:widgetFeatures="reconfigurable"
     android:description="@string/button_widget_desc"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_example_button"
     android:previewLayout="@layout/widget_button_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/camera_widget_info.xml
+++ b/app/src/main/res/xml/camera_widget_info.xml
@@ -9,7 +9,7 @@
     android:targetCellWidth="2"
     android:resizeMode="vertical|horizontal"
     android:updatePeriodMillis="3600000"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:widgetFeatures="reconfigurable"
     android:description="@string/camera_widget_desc"
     android:previewImage="@drawable/widget_example_camera" />

--- a/app/src/main/res/xml/entity_widget_info.xml
+++ b/app/src/main/res/xml/entity_widget_info.xml
@@ -13,6 +13,6 @@
     android:updatePeriodMillis="1800000"
     android:widgetFeatures="reconfigurable"
     android:description="@string/entity_widget_desc"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_example_entity"
     android:previewLayout="@layout/widget_static_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/media_player_control_widget_info.xml
+++ b/app/src/main/res/xml/media_player_control_widget_info.xml
@@ -11,6 +11,6 @@
     android:resizeMode="horizontal|vertical"
     android:widgetFeatures="reconfigurable"
     android:description="@string/media_player_widget_desc"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_example_media_player_controls"
     android:previewLayout="@layout/widget_media_controls_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/template_widget_info.xml
+++ b/app/src/main/res/xml/template_widget_info.xml
@@ -13,6 +13,6 @@
     android:widgetFeatures="reconfigurable"
     android:description="@string/template_widget_desc"
     android:updatePeriodMillis="1800000"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_example_template"
     android:previewLayout="@layout/widget_template_wrapper_dynamiccolor" />

--- a/app/src/main/res/xml/todo_widget_info.xml
+++ b/app/src/main/res/xml/todo_widget_info.xml
@@ -13,6 +13,6 @@
     android:updatePeriodMillis="1800000"
     android:widgetFeatures="reconfigurable"
     android:description="@string/todo_widget_desc"
-    android:widgetCategory="home_screen"
+    android:widgetCategory="home_screen|keyguard"
     android:previewImage="@drawable/widget_example_todo"
     tools:ignore="UnusedAttribute,UnusedResources" />


### PR DESCRIPTION
see samsung references : https://developer.samsung.com/codelab/galaxy-z/widget-flex-window.html

<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Add keyguard widget category to all widget, doing so allow homeassistant widgets to be listed in cover screen option on z flip line of products (I own a broken z flip 5 and z flip 7)
## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.


    Note: Remove this section if there are no screenshots.
-->
![Screenshot_20250907_073901_One UI Cover Home](https://github.com/user-attachments/assets/4011c67d-b29f-454e-844c-ca5ad0ec88b4)
![Screenshot_20250907_073619_One UI Cover Home](https://github.com/user-attachments/assets/5e238f68-2da9-478c-ad84-a6981babcefd)
![Screenshot_20250907_073507_One UI Cover Home](https://github.com/user-attachments/assets/f53e6ea5-cc4f-4a04-a8f7-8ee9ad9f76b5)
https://github.com/user-attachments/assets/c2c574a7-68fd-42ed-b1c2-b51cb482009d


## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->