### PR TITLE
Add appVersion and downloadFileSupported to external bus config response

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -84,6 +84,7 @@ import io.homeassistant.companion.android.common.data.keychain.KeyChainRepositor
 import io.homeassistant.companion.android.common.data.keychain.NamedKeyChain
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.GestureDirection
@@ -110,6 +111,7 @@ import io.homeassistant.companion.android.util.isStarted
 import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.webview.WebView.ErrorType
 import io.homeassistant.companion.android.webview.externalbus.ExternalBusMessage
+import io.homeassistant.companion.android.webview.externalbus.ExternalConfigResponse
 import io.homeassistant.companion.android.webview.externalbus.NavigateTo
 import io.homeassistant.companion.android.webview.externalbus.ShowSidebar
 import javax.inject.Inject
@@ -207,6 +209,9 @@ class WebViewActivity :
     @Inject
     @NamedKeyChain
     lateinit var keyChainRepository: KeyChainRepository
+
+    @Inject
+    lateinit var appVersionProvider: AppVersionProvider
 
     private lateinit var webView: WebView
     private lateinit var loadedUrl: String
@@ -761,25 +766,13 @@ class WebViewActivity :
                                             0
                                         }
                                     sendExternalBusMessage(
-                                        ExternalBusMessage(
+                                        ExternalConfigResponse(
                                             id = JSONObject(message).get("id"),
-                                            type = "result",
-                                            success = true,
-                                            result = JSONObject(
-                                                mapOf(
-                                                    "hasSettingsScreen" to true,
-                                                    "canWriteTag" to hasNfc,
-                                                    "hasExoPlayer" to true,
-                                                    "canCommissionMatter" to canCommissionMatter,
-                                                    "canImportThreadCredentials" to canExportThread,
-                                                    "hasAssist" to true,
-                                                    "hasBarCodeScanner" to hasBarCodeScanner,
-                                                    "canSetupImprov" to true,
-                                                ),
-                                            ),
-                                            callback = {
-                                                Timber.d("Callback $it")
-                                            },
+                                            hasNfc = hasNfc,
+                                            canCommissionMatter = canCommissionMatter,
+                                            canExportThread = canExportThread,
+                                            hasBarCodeScanner = hasBarCodeScanner,
+                                            appVersion = appVersionProvider(),
                                         ),
                                     )
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
@@ -1,7 +1,15 @@
 package io.homeassistant.companion.android.webview.externalbus
 
 import android.webkit.ValueCallback
+import io.homeassistant.companion.android.common.util.AppVersion
+import org.json.JSONObject
+import timber.log.Timber
 
+/**
+ * [External bus documentation](https://developers.home-assistant.io/docs/frontend/external-bus)
+ *
+ * [External bus frontend implementation](https://github.com/home-assistant/frontend/blob/dev/src/external_app/external_messaging.ts)
+ */
 open class ExternalBusMessage(
     val id: Any?,
     val type: String,
@@ -29,4 +37,34 @@ object ShowSidebar : ExternalBusMessage(
     id = -1,
     type = "command",
     command = "sidebar/show",
+)
+
+class ExternalConfigResponse(
+    id: Any,
+    hasNfc: Boolean,
+    canCommissionMatter: Boolean,
+    canExportThread: Boolean,
+    hasBarCodeScanner: Int,
+    appVersion: AppVersion,
+) : ExternalBusMessage(
+    id = id,
+    type = "result",
+    success = true,
+    result = JSONObject(
+        mapOf(
+            "hasSettingsScreen" to true,
+            "canWriteTag" to hasNfc,
+            "hasExoPlayer" to true,
+            "canCommissionMatter" to canCommissionMatter,
+            "canImportThreadCredentials" to canExportThread,
+            "hasAssist" to true,
+            "hasBarCodeScanner" to hasBarCodeScanner,
+            "canSetupImprov" to true,
+            "downloadFileSupported" to true,
+            "appVersion" to appVersion.value,
+        ),
+    ),
+    callback = {
+        Timber.d("Callback from external config (id=$id): $it")
+    },
 )


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to display the version of the application within the frontend we need to send the version through the external bus.

The frontend PR https://github.com/home-assistant/frontend/pull/27064
This PR also contains a new field added in https://github.com/home-assistant/frontend/pull/22675  about `downloadFileSupported`. For now it doesn't have a significant impact on our side, but for future evolution it is important to set the property since we support this feature.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="108" height="240" alt="image" src="https://github.com/user-attachments/assets/a2171638-3795-40f5-bddd-77c6e4c65c15" />
