### PR TITLE
Fix `UseKtx` lint warnings in `app` module

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -481,7 +481,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="541"
+            line="542"
             column="17"/>
     </issue>
 
@@ -492,7 +492,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="541"
+            line="542"
             column="17"/>
     </issue>
 
@@ -859,138 +859,6 @@
             file="src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt"
             line="171"
             column="13"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse(&quot;package:$packageName&quot;)))"
-        errorLine2="                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt"
-            line="136"
-            column="80"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            Intent(Intent.ACTION_VIEW, Uri.parse(resources.getString(commonR.string.privacy_url))).also {"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/full/kotlin/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt"
-            line="18"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                            Uri.parse(&quot;geo:$latlng?q=$latlng(Home+Assistant)&quot;),"
-        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt"
-            line="248"
-            column="45"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(getString(commonR.string.privacy_url)))"
-        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt"
-            line="177"
-            column="49"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                Uri.parse(&quot;https://companion.home-assistant.io/docs/integrations/universal-links&quot;),"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt"
-            line="95"
-            column="33"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                    Uri.parse(&quot;package:${context.packageName}&quot;),"
-        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="126"
-            column="37"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="336"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="336"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(it.summary.toString()))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="373"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(it.summary.toString()))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="373"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            .setData(Uri.parse(PLAY_STORE_APP_URI))"
-        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/full/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt"
-            line="209"
-            column="22"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(docsLink))"
-        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt"
-            line="121"
-            column="61"/>
     </issue>
 
     <issue

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.settings.sensor
 
 import android.content.Intent
-import android.net.Uri
 import androidx.core.net.toUri
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.R as commonR

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.settings.sensor
 
 import android.content.Intent
 import android.net.Uri
+import androidx.core.net.toUri
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.common.R as commonR
 
@@ -15,7 +16,7 @@ class HealthConnectPermissionActivity : BaseActivity() {
                     intent.hasCategory("android.intent.category.HEALTH_PERMISSIONS")
                 )
         ) {
-            Intent(Intent.ACTION_VIEW, Uri.parse(resources.getString(commonR.string.privacy_url))).also {
+            Intent(Intent.ACTION_VIEW, resources.getString(commonR.string.privacy_url).toUri()).also {
                 startActivity(it)
             }
         }

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
@@ -206,7 +206,7 @@ class SettingsWearActivity :
         Timber.d("Number of nodes without app: " + nodesWithoutApp.size)
         val intent = Intent(Intent.ACTION_VIEW)
             .addCategory(Intent.CATEGORY_BROWSABLE)
-            .setData(Uri.parse(PLAY_STORE_APP_URI))
+            .setData(PLAY_STORE_APP_URI.toUri())
 
         // In parallel, start remote activity requests for all wear devices that don't have the app installed yet.
         nodesWithoutApp.forEach { node ->

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.settings.wear
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -117,10 +118,12 @@ fun SettingsWearTopAppBar(title: @Composable () -> Unit, onBackClicked: () -> Un
         },
         actions = {
             if (!docsLink.isNullOrBlank()) {
-                IconButton(onClick = {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(docsLink))
-                    context.startActivity(intent)
-                }) {
+                IconButton(
+                    onClick = {
+                        val intent = Intent(Intent.ACTION_VIEW, docsLink.toUri())
+                        context.startActivity(intent)
+                    },
+                ) {
                     Image(
                         asset = CommunityMaterial.Icon2.cmd_help_circle_outline,
                         contentDescription = stringResource(commonR.string.help),

--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.settings.wear.views
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.IconButton
 import androidx.compose.material.TopAppBar

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.barcode
 import android.Manifest
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.provider.Settings
 import androidx.activity.addCallback

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
@@ -14,6 +14,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -133,7 +134,7 @@ class BarcodeScannerActivity : BaseActivity() {
         if (inContext) {
             cameraPermission.launch(Manifest.permission.CAMERA)
         } else {
-            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse("package:$packageName")))
+            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, "package:$packageName".toUri()))
             requestSilently = true // Reset state to trigger new in context dialog/check when resumed
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
+import androidx.core.net.toUri
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -74,13 +75,15 @@ fun LoadNfcView(viewModel: NfcViewModel, startDestination: String, pressedUpAtRo
             TopAppBar(
                 title = { Text(stringResource(commonR.string.nfc_title_settings)) },
                 navigationIcon = {
-                    IconButton(onClick = {
-                        if (canNavigateUp.value) {
-                            navController.navigateUp()
-                        } else {
-                            pressedUpAtRoot()
-                        }
-                    }) {
+                    IconButton(
+                        onClick = {
+                            if (canNavigateUp.value) {
+                                navController.navigateUp()
+                            } else {
+                                pressedUpAtRoot()
+                            }
+                        },
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
                             contentDescription = stringResource(commonR.string.navigate_up),
@@ -88,14 +91,16 @@ fun LoadNfcView(viewModel: NfcViewModel, startDestination: String, pressedUpAtRo
                     }
                 },
                 actions = {
-                    IconButton(onClick = {
-                        val intent =
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse("https://companion.home-assistant.io/docs/integrations/universal-links"),
-                            )
-                        context.startActivity(intent)
-                    }) {
+                    IconButton(
+                        onClick = {
+                            val intent =
+                                Intent(
+                                    Intent.ACTION_VIEW,
+                                    "https://companion.home-assistant.io/docs/integrations/universal-links".toUri(),
+                                )
+                            context.startActivity(intent)
+                        },
+                    ) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Outlined.HelpOutline,
                             contentDescription = stringResource(commonR.string.get_help),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.nfc.views
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Icon

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt
@@ -14,6 +14,7 @@ import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
@@ -174,7 +175,7 @@ class MobileAppIntegrationFragment : Fragment() {
     }
 
     private fun openPrivacyPolicy() {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(getString(commonR.string.privacy_url)))
+        val intent = Intent(Intent.ACTION_VIEW, getString(commonR.string.privacy_url).toUri())
         startActivity(intent)
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -7,7 +7,6 @@ import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -16,6 +16,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.getSystemService
+import androidx.core.net.toUri
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -333,7 +334,7 @@ class SettingsFragment(private val presenter: SettingsPresenter, private val lan
                 ).replace("-minimal", "")}"
             }
             it.summary = link
-            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))
+            it.intent = Intent(Intent.ACTION_VIEW, link.toUri())
         }
 
         findPreference<Preference>("changelog_prompt")?.setOnPreferenceClickListener {
@@ -370,7 +371,7 @@ class SettingsFragment(private val presenter: SettingsPresenter, private val lan
 
         findPreference<Preference>("privacy")?.let {
             it.summary = "https://www.home-assistant.io/privacy/"
-            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(it.summary.toString()))
+            it.intent = Intent(Intent.ACTION_VIEW, it.summary.toString().toUri())
         }
 
         findPreference<Preference>("developer")?.setOnPreferenceClickListener {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.settings.developer.location.views
 
 import android.content.Intent
-import android.net.Uri
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.core.app.ShareCompat
+import androidx.core.net.toUri
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -240,15 +241,17 @@ fun LocationTrackingHistoryRow(item: LocationHistoryItem?, servers: List<Server>
                                 .padding(bottom = 8.dp),
                         ) {
                             if (item?.latitude != null && item.longitude != null) {
-                                IconButton(onClick = {
-                                    val latlng = "${item.latitude},${item.longitude}"
-                                    context.startActivity(
-                                        Intent(
-                                            Intent.ACTION_VIEW,
-                                            Uri.parse("geo:$latlng?q=$latlng(Home+Assistant)"),
-                                        ),
-                                    )
-                                }) {
+                                IconButton(
+                                    onClick = {
+                                        val latlng = "${item.latitude},${item.longitude}"
+                                        context.startActivity(
+                                            Intent(
+                                                Intent.ACTION_VIEW,
+                                                "geo:$latlng?q=$latlng(Home+Assistant)".toUri(),
+                                            ),
+                                        )
+                                    },
+                                ) {
                                     Image(
                                         asset = CommunityMaterial.Icon3.cmd_map,
                                         contentDescription = stringResource(commonR.string.show_on_map),
@@ -258,12 +261,14 @@ fun LocationTrackingHistoryRow(item: LocationHistoryItem?, servers: List<Server>
                                 }
                                 Spacer(Modifier.width(16.dp))
                             }
-                            IconButton(onClick = {
-                                ShareCompat.IntentBuilder(context)
-                                    .setText(item?.toSharingString(serverName) ?: "")
-                                    .setType("text/plain")
-                                    .startChooser()
-                            }) {
+                            IconButton(
+                                onClick = {
+                                    ShareCompat.IntentBuilder(context)
+                                        .setText(item?.toSharingString(serverName) ?: "")
+                                        .setType("text/plain")
+                                        .startChooser()
+                                },
+                            ) {
                                 Image(
                                     asset = CommunityMaterial.Icon3.cmd_share_variant,
                                     contentDescription = stringResource(commonR.string.share_logs),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -123,7 +124,7 @@ fun SensorDetailView(
                             context.startActivity(
                                 Intent(
                                     Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                                    Uri.parse("package:${context.packageName}"),
+                                    "package:${context.packageName}".toUri(),
                                 ),
                             )
                         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.settings.sensor.views
 
 import android.content.Intent
-import android.net.Uri
 import android.provider.Settings
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -1548,7 +1548,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="202"
+            line="203"
             column="17"/>
     </issue>
 
@@ -1559,7 +1559,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="215"
+            line="216"
             column="17"/>
     </issue>
 
@@ -1570,7 +1570,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="248"
+            line="249"
             column="13"/>
     </issue>
 
@@ -1581,7 +1581,7 @@
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="286"
+            line="287"
             column="29"/>
     </issue>
 
@@ -1592,7 +1592,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="386"
+            line="387"
             column="17"/>
     </issue>
 
@@ -1603,7 +1603,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="386"
+            line="387"
             column="17"/>
     </issue>
 
@@ -1614,7 +1614,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="419"
+            line="420"
             column="13"/>
     </issue>
 
@@ -1625,7 +1625,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="531"
+            line="532"
             column="13"/>
     </issue>
 
@@ -1636,7 +1636,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="541"
+            line="542"
             column="17"/>
     </issue>
 
@@ -1647,7 +1647,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="541"
+            line="542"
             column="17"/>
     </issue>
 
@@ -1658,7 +1658,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="569"
+            line="570"
             column="13"/>
     </issue>
 
@@ -2274,7 +2274,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="251"
+            line="256"
             column="13"/>
     </issue>
 
@@ -2285,7 +2285,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="507"
+            line="512"
             column="21"/>
     </issue>
 
@@ -2296,7 +2296,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="508"
+            line="513"
             column="21"/>
     </issue>
 
@@ -2307,7 +2307,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="538"
+            line="543"
             column="25"/>
     </issue>
 
@@ -2318,7 +2318,7 @@
         errorLine2="                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="538"
+            line="543"
             column="25"/>
     </issue>
 
@@ -2329,7 +2329,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="623"
+            line="628"
             column="13"/>
     </issue>
 
@@ -2340,7 +2340,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="1204"
+            line="1197"
             column="21"/>
     </issue>
 
@@ -2351,7 +2351,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="1323"
+            line="1316"
             column="17"/>
     </issue>
 
@@ -2808,138 +2808,6 @@
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/shortcuts/ManageShortcutsViewModel.kt"
             line="171"
             column="13"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, Uri.parse(&quot;package:$packageName&quot;)))"
-        errorLine2="                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt"
-            line="136"
-            column="80"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            Intent(Intent.ACTION_VIEW, Uri.parse(resources.getString(commonR.string.privacy_url))).also {"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/settings/sensor/HealthConnectPermissionActivity.kt"
-            line="18"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                            Uri.parse(&quot;geo:$latlng?q=$latlng(Home+Assistant)&quot;),"
-        errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/developer/location/views/LocationTrackingView.kt"
-            line="248"
-            column="45"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(getString(commonR.string.privacy_url)))"
-        errorLine2="                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationFragment.kt"
-            line="177"
-            column="49"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                Uri.parse(&quot;https://companion.home-assistant.io/docs/integrations/universal-links&quot;),"
-        errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/nfc/views/NfcNavigationView.kt"
-            line="95"
-            column="33"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                                    Uri.parse(&quot;package:${context.packageName}&quot;),"
-        errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="126"
-            column="37"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="336"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(link))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="336"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(it.summary.toString()))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="373"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            it.intent = Intent(Intent.ACTION_VIEW, Uri.parse(it.summary.toString()))"
-        errorLine2="                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="373"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="            .setData(Uri.parse(PLAY_STORE_APP_URI))"
-        errorLine2="                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/settings/wear/SettingsWearActivity.kt"
-            line="209"
-            column="22"/>
-    </issue>
-
-    <issue
-        id="UseKtx"
-        message="Use the KTX extension function `String.toUri` instead?"
-        errorLine1="                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(docsLink))"
-        errorLine2="                                                            ~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/settings/wear/views/SettingsWearHomeView.kt"
-            line="121"
-            column="61"/>
     </issue>
 
     <issue


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
Fixing all of the `UseKtx` lint warnings in the `app` module and updating the lint baseline accordingly, as part of #5221.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.