### PR TITLE
Avoid adding server already in the list of discovered server

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
@@ -110,7 +110,15 @@ internal class ServerDiscoveryViewModel @Inject constructor(private val searcher
 
         _discoveryFlow.update {
             when (it) {
-                is ServersDiscovered -> it.copy(servers = it.servers + serverDiscovered)
+                is ServersDiscovered -> {
+                    // Avoid duplicates if the server was already found
+                    if (it.servers.contains(serverDiscovered)) {
+                        it
+                    } else {
+                        it.copy(servers = it.servers + serverDiscovered)
+                    }
+                }
+
                 is ServerDiscovered -> ServersDiscovered(
                     listOf(
                         it,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Since the server discovery screen is on the backstack we might open the screen multiples times and start the discovery multiple times. We don't keep history of the found servers in the searcher. To avoid displaying duplicates we simply make sure to not adds duplicates in the list of server within the `ServersDiscovered` state.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.