### PR TITLE
Fix `AutoboxingStateCreation` lint warnings in `app` module

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -541,50 +541,6 @@
     </issue>
 
     <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var serverId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)"
-        errorLine2="                    ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/widgets/assist/AssistShortcutViewModel.kt"
-            line="19"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var selectedServerId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)"
-        errorLine2="                            ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt"
-            line="148"
-            column="29"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var submitButtonLabel by mutableStateOf(commonR.string.tile_save)"
-        errorLine2="                             ~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt"
-            line="155"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var serverId by mutableStateOf(0)"
-        errorLine2="                    ~~~~~~~~~~~~~~">
-        <location
-            file="src/full/kotlin/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt"
-            line="40"
-            column="21"/>
-    </issue>
-
-    <issue
         id="DisableBaselineAlignment"
         message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
         errorLine1="    &lt;LinearLayout"

--- a/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
@@ -37,7 +38,7 @@ class MatterCommissioningViewModel @Inject constructor(
     var step by mutableStateOf<CommissioningFlowStep>(CommissioningFlowStep.NotStarted)
         private set
 
-    var serverId by mutableStateOf(0)
+    var serverId by mutableIntStateOf(0)
         private set
 
     fun checkSetup(isNewDevice: Boolean) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -7,6 +7,7 @@ import android.content.ComponentName
 import android.graphics.drawable.Icon
 import android.os.Build
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.core.content.getSystemService
@@ -145,14 +146,14 @@ class ManageTilesViewModel @Inject constructor(
         private set
     var sortedEntities by mutableStateOf<List<Entity>>(emptyList())
         private set
-    var selectedServerId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)
+    var selectedServerId by mutableIntStateOf(ServerManager.SERVER_ID_ACTIVE)
         private set
     var selectedIconId by mutableStateOf<String?>(null)
         private set
     var selectedEntityId by mutableStateOf("")
     var tileLabel by mutableStateOf("")
     var tileSubtitle by mutableStateOf<String?>(null)
-    var submitButtonLabel by mutableStateOf(commonR.string.tile_save)
+    var submitButtonLabel by mutableIntStateOf(commonR.string.tile_save)
         private set
     var selectedShouldVibrate by mutableStateOf(false)
     var tileAuthRequired by mutableStateOf(false)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/assist/AssistShortcutViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/assist/AssistShortcutViewModel.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.widgets.assist
 
 import android.app.Application
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
@@ -16,7 +17,7 @@ import kotlinx.coroutines.launch
 class AssistShortcutViewModel @Inject constructor(val serverManager: ServerManager, application: Application) :
     AndroidViewModel(application) {
 
-    var serverId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)
+    var serverId by mutableIntStateOf(ServerManager.SERVER_ID_ACTIVE)
         private set
 
     var servers by mutableStateOf(serverManager.defaultServers)

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -2490,50 +2490,6 @@
     </issue>
 
     <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var serverId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)"
-        errorLine2="                    ~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/widgets/assist/AssistShortcutViewModel.kt"
-            line="19"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var selectedServerId by mutableStateOf(ServerManager.SERVER_ID_ACTIVE)"
-        errorLine2="                            ~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt"
-            line="148"
-            column="29"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var submitButtonLabel by mutableStateOf(commonR.string.tile_save)"
-        errorLine2="                             ~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt"
-            line="155"
-            column="30"/>
-    </issue>
-
-    <issue
-        id="AutoboxingStateCreation"
-        message="Prefer `mutableIntStateOf` instead of `mutableStateOf`"
-        errorLine1="    var serverId by mutableStateOf(0)"
-        errorLine2="                    ~~~~~~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/matter/MatterCommissioningViewModel.kt"
-            line="40"
-            column="21"/>
-    </issue>
-
-    <issue
         id="DisableBaselineAlignment"
         message="Set `android:baselineAligned=&quot;false&quot;` on this element for better performance"
         errorLine1="    &lt;LinearLayout"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
Fixing all of the `AutoboxingStateCreation` lint warnings in the `app` module and updating the lint baseline accordingly, as part of #5221.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.