### PR TITLE
Do not send recording/voice input to Assist if input is intentionally interrupted

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -187,7 +187,7 @@ class AssistViewModel @Inject constructor(
     fun changePipeline(serverId: Int, id: String) = viewModelScope.launch {
         if (serverId == selectedServerId && id == selectedPipeline?.id) return@launch
 
-        stopRecording()
+        stopRecording(sendRecorded = false)
         stopPlayback()
 
         selectedServerId = serverId
@@ -247,7 +247,7 @@ class AssistViewModel @Inject constructor(
                 inputMode = AssistInputMode.TEXT
             }
             AssistInputMode.VOICE_ACTIVE -> {
-                stopRecording()
+                stopRecording(sendRecorded = false)
                 inputMode = AssistInputMode.TEXT
             }
         }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -197,17 +197,19 @@ abstract class AssistViewModelBase(
         } ?: false
     }
 
-    protected fun stopRecording() {
+    protected fun stopRecording(sendRecorded: Boolean = true) {
         audioRecorder.stopRecording()
         recorderJob?.cancel()
         recorderJob = null
         if (binaryHandlerId != null) {
             viewModelScope.launch {
-                recorderQueue?.forEach {
-                    sendVoiceData(it)
+                if (sendRecorded) {
+                    recorderQueue?.forEach {
+                        sendVoiceData(it)
+                    }
+                    sendVoiceData(byteArrayOf()) // Empty message to indicate end of recording
                 }
                 recorderQueue = null
-                sendVoiceData(byteArrayOf()) // Empty message to indicate end of recording
                 binaryHandlerId = null
             }
         } else {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/conversation/ConversationViewModel.kt
@@ -170,7 +170,7 @@ class ConversationViewModel @Inject constructor(
     fun changePipeline(id: String) = viewModelScope.launch {
         if (id == currentPipeline?.id) return@launch
 
-        stopRecording()
+        stopRecording(sendRecorded = false)
         stopPlayback()
 
         setPipeline(id)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #5817 

If recording/voice input for Assist is intentionally interrupted, which happens when switching input or pipelines while voice is active, do not send the voice data to the server and disregard it instead. All other scenarios (done/pressed stop/pause/...) will still send data like before.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction). - _It is part of an AndroidViewModel which has no tests, adding one here would make the PR about setting up testing instead of the fix._
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->