### PR TITLE
Make new onboarding available in debug

### DIFF
--- a/app/src/debug/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
+++ b/app/src/debug/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
@@ -17,5 +17,9 @@ internal fun Context.startLauncherWithNavigateTo(path: String, serverId: Int) {
 }
 
 internal fun Context.intentLauncherWearOnboarding(wearName: String, serverUrl: String?): Intent {
-    return LauncherActivity.newInstance(this, LauncherActivity.DeepLink.WearOnboarding(wearName, serverUrl))
+    return LauncherActivity.newInstance(this, LauncherActivity.DeepLink.OpenWearOnboarding(wearName, serverUrl))
+}
+
+internal fun Context.intentLauncherOnboarding(url: String?): Intent {
+    return LauncherActivity.newInstance(this, LauncherActivity.DeepLink.OpenOnboarding(url))
 }

--- a/app/src/debug/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
+++ b/app/src/debug/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
@@ -8,8 +8,8 @@ import io.homeassistant.companion.android.launcher.LauncherActivity
  * This file is temporary and will be removed once the new launcher is available.
  */
 
-internal fun Context.startLauncherForInvite(serverToOnboard: String) {
-    startActivity(LauncherActivity.newInstance(this, LauncherActivity.DeepLink.Invite(serverToOnboard)))
+internal fun Context.startLauncherOnboarding(serverToOnboard: String) {
+    startActivity(LauncherActivity.newInstance(this, LauncherActivity.DeepLink.OpenOnboarding(serverToOnboard)))
 }
 
 internal fun Context.startLauncherWithNavigateTo(path: String, serverId: Int) {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -284,42 +284,6 @@
             </intent-filter>
         </receiver>
 
-        <activity android:name=".launch.LaunchActivity"
-            android:exported="true"
-            android:theme="@style/Theme.LaunchScreen">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-            </intent-filter>
-
-
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-
-                <data
-                    android:scheme="homeassistant"
-                    android:host="navigate" />
-            </intent-filter>
-        </activity>
-
-        <activity-alias
-            android:name=".launch.LauncherAlias"
-            android:targetActivity=".launch.LaunchActivity"
-            android:enabled="false"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.HOME" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-        </activity-alias>
-
         <activity android:name=".launch.link.LinkActivity"
             android:exported="true"
             android:launchMode="singleTask">
@@ -393,7 +357,7 @@
                     android:path="/request_home_assistant_instance" />
             </intent-filter>
         </service>
-        
+
         <activity
             android:name=".webview.WebViewActivity"
             android:supportsPictureInPicture="true"

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
@@ -25,7 +25,7 @@ import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.launch.LaunchActivity
-import io.homeassistant.companion.android.launch.startLauncherForInvite
+import io.homeassistant.companion.android.launch.startLauncherOnboarding
 import io.homeassistant.companion.android.launch.startLauncherWithNavigateTo
 import io.homeassistant.companion.android.settings.server.ServerChooserFragment
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
@@ -73,7 +73,7 @@ class LinkActivity : BaseActivity() {
                     LinkDestination.NoDestination -> finish()
                     is LinkDestination.Onboarding -> {
                         if (USE_NEW_LAUNCHER) {
-                            startLauncherForInvite(destination.serverUrl)
+                            startLauncherOnboarding(destination.serverUrl)
                         } else {
                             startActivity(LaunchActivity.newInstance(this@LinkActivity, destination.serverUrl))
                         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardApp.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardApp.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContract
 import io.homeassistant.companion.android.BuildConfig
+import io.homeassistant.companion.android.launch.intentLauncherOnboarding
 import io.homeassistant.companion.android.launch.intentLauncherWearOnboarding
 
 class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>() {
@@ -84,8 +85,14 @@ class OnboardApp : ActivityResultContract<OnboardApp.Input, OnboardApp.Output?>(
     }
 
     override fun createIntent(context: Context, input: Input): Intent {
-        return if (input.isWatch && BuildConfig.DEBUG) {
-            context.intentLauncherWearOnboarding(input.defaultDeviceName, input.url)
+        return if (BuildConfig.DEBUG) {
+            if (input.isWatch) {
+                context.intentLauncherWearOnboarding(input.defaultDeviceName, input.url)
+            } else {
+                context.intentLauncherOnboarding(input.url)
+                // TODO support discovery options HIDE_EXISTING
+                // TODO disable location tracking in minimal flavor
+            }
         } else {
             Intent(context, OnboardingActivity::class.java).apply {
                 putExtra(EXTRA_URL, input.url)

--- a/app/src/release/AndroidManifest.xml
+++ b/app/src/release/AndroidManifest.xml
@@ -1,0 +1,44 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application>
+        <activity
+            android:name="io.homeassistant.companion.android.launch.LaunchActivity"
+            android:exported="true"
+            android:theme="@style/Theme.LaunchScreen">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
+            </intent-filter>
+
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="navigate"
+                    android:scheme="homeassistant" />
+            </intent-filter>
+        </activity>
+
+        <activity-alias
+            android:name="io.homeassistant.companion.android.launch.LauncherAlias"
+            android:enabled="false"
+            android:exported="true"
+            android:targetActivity=".launch.LaunchActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity-alias>
+    </application>
+</manifest>

--- a/app/src/release/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
+++ b/app/src/release/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
@@ -20,3 +20,8 @@ internal fun Context.intentLauncherWearOnboarding(wearName: String, serverUrl: S
     FailFast.fail { "New Launcher is not available on release yet" }
     return Intent()
 }
+
+internal fun Context.intentLauncherOnboarding(url: String?): Intent {
+    FailFast.fail { "New Launcher is not available on release yet" }
+    return Intent()
+}

--- a/app/src/release/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
+++ b/app/src/release/kotlin/io/homeassistant/companion/android/launch/LauncherActivityExt.kt
@@ -8,7 +8,7 @@ import io.homeassistant.companion.android.common.util.FailFast
  * This file is temporary and will be removed once the new launcher is available.
  */
 
-internal fun Context.startLauncherForInvite(serverToOnboard: String) {
+internal fun Context.startLauncherOnboarding(serverToOnboard: String) {
     FailFast.fail { "New Launcher is not available on release yet" }
 }
 

--- a/onboarding/src/main/AndroidManifest.xml
+++ b/onboarding/src/main/AndroidManifest.xml
@@ -5,9 +5,7 @@
         <activity
             android:name="io.homeassistant.companion.android.launcher.LauncherActivity"
             android:exported="true"
-            android:label="Onboarding WIP"
-            android:windowSoftInputMode="adjustResize"
-            android:taskAffinity="io.homeassistant.companion.android.onboarding.wip">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -19,6 +17,18 @@
 <!--                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />-->
 <!--            </intent-filter>-->
         </activity>
-    </application>
 
+        <activity-alias
+            android:name="io.homeassistant.companion.android.launch.LauncherAlias"
+            android:enabled="false"
+            android:exported="true"
+            android:targetActivity="io.homeassistant.companion.android.launcher.LauncherActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.HOME" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity-alias>
+    </application>
 </manifest>

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/launcher/LauncherActivity.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/launcher/LauncherActivity.kt
@@ -35,10 +35,10 @@ private const val DEEP_LINK_KEY = "deep_link_key"
 class LauncherActivity : AppCompatActivity() {
     @Parcelize
     sealed interface DeepLink : Parcelable {
-        data class Invite(val url: String) : DeepLink
+        data class OpenOnboarding(val url: String?) : DeepLink
         data class NavigateTo(val path: String?, val serverId: Int) : DeepLink
 
-        data class WearOnboarding(val wearName: String, val url: String?) : DeepLink
+        data class OpenWearOnboarding(val wearName: String, val url: String?) : DeepLink
     }
 
     companion object {

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/launcher/LauncherViewModel.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/launcher/LauncherViewModel.kt
@@ -64,9 +64,9 @@ internal class LauncherViewModel @AssistedInject constructor(
 
     private suspend fun handleInitialState(initialDeepLink: LauncherActivity.DeepLink?) {
         when (initialDeepLink) {
-            is LauncherActivity.DeepLink.Invite -> navigateToOnboarding(initialDeepLink.url)
+            is LauncherActivity.DeepLink.OpenOnboarding -> navigateToOnboarding(initialDeepLink.url)
             is LauncherActivity.DeepLink.NavigateTo -> connectToServer(initialDeepLink.serverId, initialDeepLink.path)
-            is LauncherActivity.DeepLink.WearOnboarding -> navigateToWearOnboarding(
+            is LauncherActivity.DeepLink.OpenWearOnboarding -> navigateToWearOnboarding(
                 wearName = initialDeepLink.wearName,
                 url = initialDeepLink.url,
             )

--- a/onboarding/src/test/kotlin/io/homeassistant/companion/android/launcher/LauncherViewModelTest.kt
+++ b/onboarding/src/test/kotlin/io/homeassistant/companion/android/launcher/LauncherViewModelTest.kt
@@ -253,8 +253,8 @@ class LauncherViewModelTest {
     }
 
     @Test
-    fun `Given initial deep link is Invite when creating viewModel, then navigate to onboarding with the server url`() = runTest {
-        createViewModel(LauncherActivity.DeepLink.Invite("http://homeassistant.io"))
+    fun `Given initial deep link is OpenOnboarding when creating viewModel, then navigate to onboarding with the server url`() = runTest {
+        createViewModel(LauncherActivity.DeepLink.OpenOnboarding("http://homeassistant.io"))
         advanceUntilIdle()
         assertEquals(LauncherNavigationEvent.Onboarding("http://homeassistant.io"), viewModel.navigationEventsFlow.replayCache.first())
     }
@@ -277,8 +277,8 @@ class LauncherViewModelTest {
     }
 
     @Test
-    fun `Given initial deep link is WearOnboarding when creating viewModel, then navigate to wear onboarding with the server url and wear name`() = runTest {
-        createViewModel(LauncherActivity.DeepLink.WearOnboarding("ha_wear", "http://ha"))
+    fun `Given initial deep link is OpenWearOnboarding when creating viewModel, then navigate to wear onboarding with the server url and wear name`() = runTest {
+        createViewModel(LauncherActivity.DeepLink.OpenWearOnboarding("ha_wear", "http://ha"))
         advanceUntilIdle()
         assertEquals(LauncherNavigationEvent.WearOnboarding("ha_wear", "http://ha"), viewModel.navigationEventsFlow.replayCache.first())
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR makes the changes to replace the `LaunchActivity` with `LauncherActivity` to finally be able to distribute a test APK to some ppl to validate the new flow.

Known issues/limitations
- Deep link `homeassistant://navigate` is not supported
- background and notification permissions are not requested properly in the flow
- Missing error screen (today snackbars, but some errors are going to be moved as full screen actionable errors)
- URL protection `most secure` is not yet enforced
- Changelog dialog is missing
- After deleting the only server connected to going back lead to a loader (also the case in prod)
- Server discovery hide existing server while adding a new server from the settings is not working (we see the server we are connected to if visible)
- Minimal build (without google services) is still asking for location tracking even if there is no location tracking available
- Buttons are not using the right size LARGE instead of MEDIUM
- Documentation for the new flow is not ready (links in the screen are probably wrong, help us finding the right section if it exists already 🙏🏻)
- We have some known leaks while reaching the WebView
- TV onboarding is not yet tested and adjusted

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I renamed the deeplinks to have an action in their name and be more generic.