### PR TITLE
Disable test in WearDnsRequestListenerTest that breaks following tests

### DIFF
--- a/app/src/test/kotlin/io/homeassistant/companion/android/data/wear/WearDnsRequestListenerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/data/wear/WearDnsRequestListenerTest.kt
@@ -3,17 +3,15 @@ package io.homeassistant.companion.android.data.wear
 import io.homeassistant.companion.android.common.util.WearDataMessages.DnsLookup.PATH_DNS_LOOKUP
 import io.homeassistant.companion.android.common.util.WearDataMessages.DnsLookup.decodeDNSResult
 import io.homeassistant.companion.android.common.util.WearDataMessages.DnsLookup.encodeDNSRequest
-import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import java.net.InetAddress
 import kotlinx.coroutines.test.runTest
 import okhttp3.Dns
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
-import org.junit.jupiter.api.extension.ExtendWith
 
-@ExtendWith(MainDispatcherJUnit5Extension::class)
 class WearDnsRequestListenerTest {
     private val testHostname = "homeassistant.local"
 
@@ -41,6 +39,7 @@ class WearDnsRequestListenerTest {
     }
 
     @Test
+    @Disabled("This test is causing following tests to fail randomly without reason, we assume that it comes from the .asTask for coroutines-play-services library.")
     fun `Given a request with a DNS lookup path when a request is made then a task is returned`() {
         // Given
         val service = WearDnsRequestListener()


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While investigating why we have flaky tests on some very simple tests like the Changelog. I found out a pattern that it always happens when the tests are executed after the one in `WearDnsRequestListenerTest` while digging deeper I remember that `.asTask` was not testable easily since it's a layer on an obfuscated library from Google. After disabling the test that was invoking `.asTask` the tests started to behave normally again. Since the test is pretty dumb I decided to disable it but keep it to remember that it was causing an issue.