### PR TITLE
Add missing content write permission for update screenshot workflow

### DIFF
--- a/.github/workflows/updateScreenshot.yml
+++ b/.github/workflows/updateScreenshot.yml
@@ -10,12 +10,11 @@ name: Update Screenshots
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   update_screenshots:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # To push to the current branch
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The screenshot update workflow needs to be able to write to a branch so it needs `content: write` permission.