### PR TITLE
Revert "Update dependency ruby to v3.4.7"

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - uses: ./.github/actions/create-release-number
@@ -139,7 +139,7 @@ jobs:
 
       - uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - uses: ./.github/actions/create-release-number

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ruby/setup-ruby@0481980f17b760ef6bca5e8c55809102a0af1e5a # v1.263.0
         with:
-          ruby-version: "3.4.7"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - uses: ./.github/actions/inflate-secrets


### PR DESCRIPTION
Reverts home-assistant/android#5901

Current runner doesn't have ruby 3.4.7 available 

<img width="2182" height="758" alt="image" src="https://github.com/user-attachments/assets/12e2f302-b53b-4645-83e2-debcb8970994" />
