### PR TITLE
Automatically scroll to the end of LocationForSecureConnection on select

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreen.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.onboarding.locationforsecureconnection
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.SpringSpec
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -97,10 +99,11 @@ private fun LocationForSecureConnectionContent(
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
     modifier: Modifier = Modifier,
 ) {
+    val scrollState = rememberScrollState()
     Column(
         modifier = modifier
             .fillMaxSize()
-            .verticalScroll(rememberScrollState())
+            .verticalScroll(scrollState)
             .padding(horizontal = HADimens.SPACE4),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(HADimens.SPACE6),
@@ -139,6 +142,9 @@ private fun LocationForSecureConnectionContent(
             ),
             onSelect = {
                 selectedOption = it
+                coroutineScope.launch {
+                    scrollState.animateScrollTo(scrollState.maxValue, SpringSpec(stiffness = Spring.StiffnessMediumLow))
+                }
             },
             selectedOption = selectedOption,
         )

--- a/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreenTest.kt
+++ b/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -91,13 +92,12 @@ class LocationForSecureConnectionScreenTest {
         composeTestRule.apply {
             testScreen(false) {
                 val nextButton = onNodeWithText(stringResource(R.string.location_secure_connection_next))
-                    .performScrollTo()
-                    .assertIsDisplayed()
-                    .assertIsNotEnabled()
+                    .assertIsNotDisplayed()
 
                 onNodeWithText(stringResource(R.string.location_secure_connection_most_secure)).performScrollTo().performClick()
 
-                nextButton.assertIsEnabled().performClick()
+                // Should have scroll automatically to the end of the screen
+                nextButton.assertIsDisplayed().assertIsEnabled().performClick()
                 // The callback shouldn't be invoked since the permission is not granted
                 assertEquals(null, allowInsecureConnection)
                 assertEquals(stringResource(R.string.location_secure_connection_discard_permission), snackbarMessage)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
On small screen or in landscape it was not very obvious that you could have a button bellow the two options. This PR adds a simple animated scroll when an item is selected to the bottom of the screen.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

https://github.com/user-attachments/assets/42cee335-ced2-45b0-a209-f5700b4c46ae