### PR TITLE
Make sure to clear the back stack after NameYourDevice is done

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigation.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigation.kt
@@ -128,7 +128,7 @@ internal fun NavGraphBuilder.onboarding(
                     navOptions {
                         // We don't want to come back to name your device once the device
                         // is named since the auth_code has already been used.
-                        popUpTo<WelcomeRoute> {
+                        popUpTo(startDestination) {
                             inclusive = true
                         }
                     },

--- a/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigationTest.kt
+++ b/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigationTest.kt
@@ -370,10 +370,23 @@ internal class OnboardingNavigationTest {
     }
 
     @Test
+    fun `Given device named and skip welcome with url when pressing next then show LocalFirst then goes back stop the app`() {
+        localFirstTest(true, "http://ha.local")
+    }
+
+    @Test
+    fun `Given device named and skip welcome without url when pressing next then show LocalFirst then goes back stop the app`() {
+        localFirstTest(true, null)
+    }
+
+    @Test
     fun `Given device named when pressing next then show LocalFirst then goes back stop the app`() {
-        val instanceUrl = "http://ha.local"
-        testNavigation {
-            navController.navigateToNameYourDevice(instanceUrl, "code")
+        localFirstTest(false, null)
+    }
+
+    private fun localFirstTest(skipWelcome: Boolean, urlToOnboard: String?) {
+        testNavigation(skipWelcome = skipWelcome, urlToOnboard = urlToOnboard) {
+            navController.navigateToNameYourDevice("http://dummy.local", "code")
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<NameYourDeviceRoute>() == true)
 
             onNodeWithText(stringResource(R.string.name_your_device_save)).performScrollTo().assertIsDisplayed().assertIsEnabled().performClick()


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While testing the new onboading @klaasnicolaas found out that we can come back to name your device when adding a server from the settings. It put the apps in a weird state because the `auth_token` is already consumed so we cannot do anything on this screen and it leads to this error 

<img width="108" height="221" alt="image" src="https://github.com/user-attachments/assets/b3ad2803-60b5-4f7d-96e7-a851e30339b6" />

This is due to the recent changes that skip the welcome screen, we were poping up up to WelcomeScreen but since we've skipped it the framework is not able to clear the back stack properly. This PR ensure that we clear up to the startDestination instead.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

https://github.com/user-attachments/assets/b95a1d9f-4f24-4066-acd1-56cb5e6c9d94
