### PR TITLE
Add missing abbrev for fastlane on ruby 3.4.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
+gem "abbrev" # https://github.com/fastlane/fastlane/issues/29183#issuecomment-3165960899
 gem "fastlane"
 gem "fastlane-plugin-amazon_app_submission"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GEM
       base64
       nkf
       rexml
+    abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     artifactory (3.0.17)
@@ -221,10 +222,12 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-25
   x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
+  abbrev
   fastlane
   fastlane-plugin-amazon_app_submission
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Bump to ruby 3.4.7 https://github.com/home-assistant/android/pull/5907 did break fastlane since `abbrev` needs to be added manually according to https://github.com/fastlane/fastlane/issues/29183.

I tested locally and I was able to reproduce the issue we have on main https://github.com/home-assistant/android/actions/runs/18520711132/job/52779842472 and after the add of `abbrev` the issue is gone. We need to merge this PR to fully test the deployment.