### PR TITLE
Fix HATextField with maxLines 1 scrolling vertically

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HATextField.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HATextField.kt
@@ -39,6 +39,10 @@ import io.homeassistant.companion.android.common.compose.theme.MaxButtonWidth
  * @param keyboardActions when the input service emits an IME action, the corresponding callback
  * is called. Note that this IME action may be different from what you specified in
  * [KeyboardOptions.imeAction]
+ * @param maxLines the maximum height in terms of maximum number of visible lines. If [singleLine]
+ * is set to `true`, this value will be ignored
+ * @param singleLine when `true`, this text field becomes a single horizontally scrolling text field
+ * instead of wrapping onto multiple lines. [maxLines] will be ignored and automatically set to 1
  */
 @Composable
 fun HATextField(
@@ -55,6 +59,7 @@ fun HATextField(
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     maxLines: Int = Int.MAX_VALUE,
+    singleLine: Boolean = maxLines == 1,
     visualTransformation: VisualTransformation = VisualTransformation.None,
 ) {
     // TODO probably replace the text composable by strings to control the applied style
@@ -67,6 +72,7 @@ fun HATextField(
         leadingIcon = leadingIcon,
         shape = RoundedCornerShape(size = HARadius.M),
         maxLines = maxLines,
+        singleLine = singleLine,
         // The color is controlled from the [colors] attribute
         textStyle = HATextStyle.UserInput.copy(color = Color.Unspecified),
         keyboardOptions = keyboardOptions,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
If HATextField has `maxLines` set to 1, and you have more text than fits in 1 line, it currently scrolls vertically. That is silly in some places like inputting URLs/passwords where the expected behavior would be scrolling horizontally. This PR fixes that by adding `singleLine`.

I don't see any reason where you would want a vertically scrolling text field of 1 line high. That's why the default is `true` if `maxLines` is set to 1, but I am making the option available just in case, similar to the underlying composable splitting maxLines from singleLine.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction). - _I don't know how to test for this, nor do I think it is useful_
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
Before:

https://github.com/user-attachments/assets/a6a285d1-9a45-431e-a821-9eca3a3a680b

After:

https://github.com/user-attachments/assets/4e3086ce-169d-4326-9712-9c4e36d5a46f

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->