### PR TITLE
Use positional arguments in string for description content

### DIFF
--- a/onboarding/src/main/res/values/strings.xml
+++ b/onboarding/src/main/res/values/strings.xml
@@ -41,7 +41,7 @@
     <string name="connection_error_url_info">The app is currently connecting to</string>
     <string name="connection_error_more_details">More details</string>
     <string name="connection_error_more_details_description">Description</string>
-    <string name="connection_error_more_details_description_content">Status Code: %s\nDetail: %s</string>
+    <string name="connection_error_more_details_description_content">Status Code: %1$s\nDetail: %2$s</string>
     <string name="connection_error_more_details_error">Error</string>
     <string name="connection_error_help">Get more help</string>
     <string name="connection_error_discord_content_description">Home Assistant Discord"</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I saw the warning while building the app again, that I forgot to use positional argument in the string.