### PR TITLE
Remove horizontal safe insets for ModalBottomSheet

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/ModalBottomSheet.kt
@@ -9,13 +9,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.rememberNestedScrollInteropConnection
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.text.style.TextAlign
@@ -33,9 +37,12 @@ fun ModalBottomSheet(title: String?, showHandle: Boolean = true, content: @Compo
     val sheetCornerRadius = dimensionResource(R.dimen.bottom_sheet_corner_radius)
     Surface(
         shape = RoundedCornerShape(topStart = sheetCornerRadius, topEnd = sheetCornerRadius),
+        modifier = Modifier.nestedScroll(rememberNestedScrollInteropConnection()),
     ) {
         Column(
-            modifier = Modifier.windowInsetsPadding(safeBottomWindowInsets(false)),
+            modifier = Modifier
+                .verticalScroll(rememberScrollState())
+                .windowInsetsPadding(safeBottomWindowInsets(false)),
         ) {
             if (showHandle) {
                 Row(


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
As pointed out in https://github.com/home-assistant/frontend/issues/26818#issuecomment-3451160171 the horizontal insets were wrongly applied. This PR simply removes the horizontal insets.