### PR TITLE
Use FirebaseAppDistributionDefault

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.google.firebase.appdistribution.gradle.firebaseAppDistribution
-
 plugins {
     alias(libs.plugins.homeassistant.android.application)
     alias(libs.plugins.homeassistant.android.flavor)
@@ -30,7 +28,7 @@ android {
     }
 }
 
-firebaseAppDistribution {
+firebaseAppDistributionDefault {
     serviceCredentialsFile = "firebaseAppDistributionServiceCredentialsFile.json"
     releaseNotesFile = "./app/build/outputs/changelogBeta"
     groups = "continuous-deployment"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
`firebaseAppDistribution` has been deprecated in favor of `firebaseAppDistributionDefault`.
The warning was displayed while syncing the project
```
Detected use of deprecated firebaseAppDistribution { } block. If you used this block in your root project, switch to firebaseAppDistributionDefault { } instead. If you used this block in a productFlavors or buildTypes, import `com.google.firebase.appdistribution.gradle.firebaseAppDistribution` to fix this issue.
```