### PR TITLE
Use a new string for unknown error in ConnectionViewModel

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -187,7 +187,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                     )
 
                     else -> ConnectionError.UnknownError(
-                        message = commonR.string.error_http_generic,
+                        message = R.string.connection_error_unknown_error,
                         errorDetails = errorDetails,
                         rawErrorType = WebResourceError::class.toString(),
                     )
@@ -226,7 +226,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                     )
 
                     else -> ConnectionError.UnknownError(
-                        message = commonR.string.error_http_generic,
+                        message = R.string.connection_error_unknown_error,
                         errorDetails = errorDetails,
                         rawErrorType = WebResourceResponse::class.toString(),
                     )

--- a/onboarding/src/main/res/values/strings.xml
+++ b/onboarding/src/main/res/values/strings.xml
@@ -48,5 +48,6 @@
     <string name="connection_error_documentation_content_description">Home Assistant Documentation</string>
     <string name="connection_error_forum_content_description">Home Assistant Forum</string>
     <string name="connection_error_github_content_description">Home Assistant GitHub"</string>
+    <string name="connection_error_unknown_error">There was an error loading Home Assistant. Please review the connection settings and try again.</string>
     <string name="back">Back</string>
 </resources>

--- a/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -317,7 +317,7 @@ class ConnectionViewModelTest {
                     every { reasonPhrase } returns "I'm a teapot"
                 },
             )
-            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(commonR.string.error_http_generic, errorDetails(418, "I'm a teapot"), WebResourceResponse::class)
+            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(R.string.connection_error_unknown_error, errorDetails(418, "I'm a teapot"), WebResourceResponse::class)
 
             // Generic error without reason
             webViewClient.isTLSClientAuthNeeded = false
@@ -330,7 +330,7 @@ class ConnectionViewModelTest {
                     every { reasonPhrase } returns ""
                 },
             )
-            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(commonR.string.error_http_generic, errorDetails(418, "No description"), WebResourceResponse::class)
+            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(R.string.connection_error_unknown_error, errorDetails(418, "No description"), WebResourceResponse::class)
             navigationEventsFlow.expectNoEvents()
         }
     }
@@ -398,7 +398,7 @@ class ConnectionViewModelTest {
                     every { this@mockk.description } returns "description"
                 },
             )
-            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(commonR.string.error_http_generic, errorDetails(-1, "description"), WebResourceError::class)
+            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(R.string.connection_error_unknown_error, errorDetails(-1, "description"), WebResourceError::class)
 
             // Generic error without description
             viewModel.webViewClient.onReceivedError(
@@ -409,7 +409,7 @@ class ConnectionViewModelTest {
                     every { this@mockk.description } returns ""
                 },
             )
-            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(commonR.string.error_http_generic, errorDetails(-1, "No description"), WebResourceError::class)
+            errorFlow.awaitConnectionError<ConnectionError.UnknownError>(R.string.connection_error_unknown_error, errorDetails(-1, "No description"), WebResourceError::class)
             navigationEventsFlow.expectNoEvents()
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The previous string for unknown error was made for the authentication fragment where the string was containing also the error code through positional arguments. The new error screen doesn't inject the error in the string anymore. This PR add a new version of the string without arguments.