### PR TITLE
Handle JsonLiteral in MapAnySerializer

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -777,7 +777,7 @@ class WebViewActivity :
                                         }
                                     sendExternalBusMessage(
                                         ExternalConfigResponse(
-                                            id = json.getIntOrElse("id", 0),
+                                            id = json["id"],
                                             hasNfc = hasNfc,
                                             canCommissionMatter = canCommissionMatter,
                                             canExportThread = canExportThread,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/externalbus/ExternalBusMessage.kt
@@ -40,7 +40,7 @@ object ShowSidebar : ExternalBusMessage(
 )
 
 class ExternalConfigResponse(
-    id: Any,
+    id: Any?,
     hasNfc: Boolean,
     canCommissionMatter: Boolean,
     canExportThread: Boolean,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/JsonUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/JsonUtil.kt
@@ -271,6 +271,11 @@ private fun toJsonElement(encoder: JsonEncoder, value: Any?): JsonElement {
 
             is List<*> -> JsonArray(value.map { toJsonElement(encoder, it) })
             is Array<*> -> JsonArray(value.map { toJsonElement(encoder, it) })
+            // Handles internal JsonElement types from kotlinx.serialization, such as JsonLiteral
+            // (returned when accessing elements from parsed JSON using [] operator). JsonLiteral is an internal
+            // implementation detail that extends JsonPrimitive but doesn't have a public serializer.
+            // This case allows passing through any JsonElement directly without re-encoding.
+            is JsonElement -> value
             else -> {
                 throw IllegalArgumentException("Unsupported type: ${value::class}")
             }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/JsonUtilTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/JsonUtilTest.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.util
 import java.time.LocalDateTime
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
@@ -108,12 +109,14 @@ class JsonUtilTest {
             "key9" to 1.0f,
             "key10" to arrayOf(4, 5, 6),
             "key11" to DummyValueObject(DummyObject("hello", 1)),
+            // Tests JsonLiteral handling (internal JsonElement type returned by [] operator)
+            "key12" to (Json.parseToJsonElement("""{"value": 1,"test": "hello"}""") as JsonObject)["value"],
         )
 
         val json = kotlinJsonMapper.encodeToString(MapAnySerializer, map)
 
         assertEquals(
-            """{"key1":"value1","key2":true,"key3":1,"key4":9223372036854775807,"key5":1.0,"key6":null,"key7":[1,2,3],"key8":{"subkey1":"value1","subkey2":1,"subkey3":true},"key9":1.0,"key10":[4,5,6],"key11":{"str_value":"hello","int_value":1}}""".trimIndent(),
+            """{"key1":"value1","key2":true,"key3":1,"key4":9223372036854775807,"key5":1.0,"key6":null,"key7":[1,2,3],"key8":{"subkey1":"value1","subkey2":1,"subkey3":true},"key9":1.0,"key10":[4,5,6],"key11":{"str_value":"hello","int_value":1},"key12":1}""".trimIndent(),
             json,
         )
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
When migrating to Kotlinx serialization https://github.com/home-assistant/android/pull/5976/files#r2493910149 a conversion for the ID in external message hide an issue in the MapAnySerializer. When parsing a json to a JsonElement the framework use a JsonLiteral object that is not serializable and the [] operator returns this type. If this type is given to the MapAnySerializer it crashes because it's not serializable, but it does implement JsonPrimitive that is. This PR simply make sure that if a class implement JsonElement then it should be serializable.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.