### PR TITLE
Update ThreadDatasetResponse to handle nullable fields

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/ThreadDatasetResponse.kt
@@ -6,8 +6,8 @@ import kotlinx.serialization.Serializable
 data class ThreadDatasetResponse(
     val datasetId: String,
     val extendedPanId: String,
-    val networkName: String,
-    val panId: String,
+    val networkName: String?,
+    val panId: String?,
     val preferred: Boolean,
     // only on core >= 2023.9, may still be null
     val preferredBorderAgentId: String? = null,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR updates the type of the attributes in `ThreadDatasetResponse` based on the core API defined in https://github.com/home-assistant/core/blob/6a07b468a3b42f8ef9ffb5dc2f4bbb11b1710292/homeassistant/components/thread/dataset_store.py#L38

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Fixes #6009 