### PR TITLE
Disable weekly push

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,8 +2,8 @@ name: Tag Weekly Release
 
 on: # yamllint disable-line rule:truthy
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * 0"
+  # schedule:
+  #   - cron: "0 4 * * 0"
 jobs:
   tag:
     name: Tag Weekly Release


### PR DESCRIPTION
Google is currently testing a version, we don't want to cancel their test by pushing a new version tomorrow morning.