### PR TITLE
Use deprecated shouldOverrideUrlLoading in Connection and Webview

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -465,13 +465,17 @@ class WebViewActivity :
                     resourceURL = url!!
                 }
 
-                override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                    request?.url?.let {
+                // Override deprecated method for backward compatibility with API 23 and below.
+                // The non-deprecated shouldOverrideUrlLoading(WebView, WebResourceRequest) is not invoked
+                // on these older Android versions, so this method remains necessary.
+                @Suppress("DEPRECATION")
+                override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+                    url?.let {
                         try {
-                            if (it.toString().startsWith(APP_PREFIX)) {
+                            if (it.startsWith(APP_PREFIX)) {
                                 Timber.d("Launching the app")
                                 val intent = packageManager.getLaunchIntentForPackage(
-                                    it.toString().substringAfter(APP_PREFIX),
+                                    it.substringAfter(APP_PREFIX),
                                 )
                                 if (intent != null) {
                                     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
@@ -480,14 +484,14 @@ class WebViewActivity :
                                     Timber.w("No intent to launch app found, opening app store")
                                     val marketIntent = Intent(Intent.ACTION_VIEW)
                                     marketIntent.data =
-                                        (MARKET_PREFIX + it.toString().substringAfter(APP_PREFIX)).toUri()
+                                        (MARKET_PREFIX + it.substringAfter(APP_PREFIX)).toUri()
                                     startActivity(marketIntent)
                                 }
                                 return true
-                            } else if (it.toString().startsWith(INTENT_PREFIX)) {
+                            } else if (it.startsWith(INTENT_PREFIX)) {
                                 Timber.d("Launching the intent")
                                 val intent =
-                                    Intent.parseUri(it.toString(), Intent.URI_INTENT_SCHEME)
+                                    Intent.parseUri(it, Intent.URI_INTENT_SCHEME)
                                 val intentPackage = intent.`package`?.let { it1 ->
                                     packageManager.getLaunchIntentForPackage(
                                         it1,
@@ -503,9 +507,9 @@ class WebViewActivity :
                                     startActivity(intent)
                                 }
                                 return true
-                            } else if (!webView.url.toString().contains(it.toString())) {
+                            } else if (!webView.url.toString().contains(it)) {
                                 Timber.d("Launching browser")
-                                val browserIntent = Intent(Intent.ACTION_VIEW, it)
+                                val browserIntent = Intent(Intent.ACTION_VIEW, it.toUri())
                                 startActivity(browserIntent)
                                 return true
                             } else {

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -134,8 +134,12 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
             _isLoadingFlow.update { false }
         }
 
-        override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-            return request?.url?.let { interceptRedirectIfRequired(it) } ?: false
+        // Override deprecated method for backward compatibility with API 23 and below.
+        // The non-deprecated shouldOverrideUrlLoading(WebView, WebResourceRequest) is not invoked
+        // on these older Android versions, so this method remains necessary.
+        @Suppress("DEPRECATION")
+        override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+            return url?.toUri()?.let { interceptRedirectIfRequired(it) } ?: false
         }
 
         private fun errorDetails(context: Context?, code: Int?, description: String?): String {

--- a/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/onboarding/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -51,6 +51,8 @@ class ConnectionViewModelTest {
     fun setup() {
         Timber.plant(ConsoleLogTree)
         ConsoleLogTree.verbose = true
+
+        mockkStatic(Uri::class)
     }
 
     @ParameterizedTest
@@ -127,11 +129,7 @@ class ConnectionViewModelTest {
     @ValueSource(booleans = [true, false])
     fun `Given auth callback uri with code when shouldRedirect then emits Authenticated event with mTLS status and returns true`(requireMTLS: Boolean) = runTest {
         val authCode = "test_auth_code"
-        val callbackUri = mockk<Uri> {
-            every { scheme } returns "homeassistant"
-            every { host } returns "auth-callback"
-            every { getQueryParameter("code") } returns authCode
-        }
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
 
         val viewModel = ConnectionViewModel("http://homeassistant.local:8123", keyChainRepository)
 
@@ -145,9 +143,7 @@ class ConnectionViewModelTest {
 
             val result = viewModel.webViewClient.shouldOverrideUrlLoading(
                 null,
-                mockk<WebResourceRequest> {
-                    every { url } returns callbackUri
-                },
+                stringUri,
             )
 
             assertTrue(result)
@@ -162,13 +158,7 @@ class ConnectionViewModelTest {
 
     @Test
     fun `Given auth callback uri without code when shouldRedirect then no event and returns false`() = runTest {
-        val callbackUri = mockk<Uri> {
-            every { scheme } returns "homeassistant"
-            every { host } returns "auth-callback"
-            every { getQueryParameter("code") } returns null
-        }
-
-        mockUriParse()
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = null)
 
         val viewModel = ConnectionViewModel("http://homeassistant.local:8123", keyChainRepository)
 
@@ -180,9 +170,7 @@ class ConnectionViewModelTest {
 
             val result = viewModel.webViewClient.shouldOverrideUrlLoading(
                 null,
-                mockk<WebResourceRequest> {
-                    every { url } returns callbackUri
-                },
+                stringUri,
             )
 
             assertFalse(result)
@@ -193,15 +181,12 @@ class ConnectionViewModelTest {
 
     @Test
     fun `Given unmatching uri and webview not null when shouldRedirect is invoked then open in external browser and return true`() = runTest {
-        val callbackUri = mockk<Uri> {
-            every { scheme } returns "http"
-            every { host } returns "google"
-            every { getQueryParameter("code") } returns "not_related_code"
-        }
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", keyChainRepository)
 
+        // Used to parse the rawUrl given in the constructor of ConnectionViewModel
         mockUriParse()
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", keyChainRepository)
+        val stringUri = mockAuthCodeUri(scheme = "http", host = "google", authCode = "not_related_code")
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -211,15 +196,13 @@ class ConnectionViewModelTest {
 
             val result = viewModel.webViewClient.shouldOverrideUrlLoading(
                 null,
-                mockk<WebResourceRequest> {
-                    every { url } returns callbackUri
-                },
+                stringUri,
             )
 
             assertTrue(result)
             val event = navigationEventsFlow.awaitItem()
             assertTrue(event is ConnectionNavigationEvent.OpenExternalLink)
-            assertEquals(callbackUri, (event as ConnectionNavigationEvent.OpenExternalLink).url)
+            assertEquals(stringUri, (event as ConnectionNavigationEvent.OpenExternalLink).url.toString())
 
             navigationEventsFlow.expectNoEvents()
             errorFlow.expectNoEvents()
@@ -427,8 +410,21 @@ class ConnectionViewModelTest {
         assertEquals(errorClass.toString(), error.rawErrorType)
     }
 
+    private fun mockAuthCodeUri(scheme: String, host: String, authCode: String?): String {
+        val stringUri = "$scheme://$host${authCode?.let { "?code=$authCode" } ?: ""}"
+        every { Uri.parse(stringUri) } answers {
+            val uriString = firstArg<String>()
+            return@answers mockk<Uri> {
+                every { this@mockk.toString() } returns uriString
+                every { this@mockk.scheme } returns scheme
+                every { this@mockk.host } returns host
+                every { getQueryParameter("code") } returns authCode
+            }
+        }
+        return stringUri
+    }
+
     private fun mockUriParse() {
-        mockkStatic(Uri::class)
         every { Uri.parse(any()) } answers {
             val uriString = firstArg<String>()
             val javaURL = URL(uriString)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While testing https://github.com/home-assistant/android/issues/5539 we found out that the Connection screen in the new onboarding was not working on old API of Android (tested API 23). It is due to the fact that shouldOverride function is not invoked. It was already addressed in the AuthenticationFragment (old onboarding flow) but not in the WebViewActivity.

This PR make sure we use the right override.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.