### PR TITLE
Disable strict mode for PR artifacts to ease sharing

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Build Debug APK
         run: |
-          ./gradlew :common:assemble :app:assembleDebug :wear:assembleDebug :automotive:assembleDebug
+          ./gradlew :common:assemble :app:assembleDebug :wear:assembleDebug :automotive:assembleDebug -PnoStrictMode
 
       - name: Check for missing/modified DB schemas after build
         run: |
@@ -175,6 +175,7 @@ jobs:
       - name: Archive Debug Build
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
+          name: APKs
           path: ./**/*.apk
 
   pr_build_release:


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
StrictMode is enable in debug and it's nice to catch issues while working locally on a new feature, but sometimes we ask some users to test a branch/PR and we use the CI to distribute a trusted APK. 
Unfortunately StrictMode also captures issue on devices side, we do ignore some of them but far from all. Because of that most of the time the application just crashes and we need to disable StrictMode manually by modifying the workflow.

I don't see the gain of using StrictMode in this scenario, so I've decided to disable in while building the debug APK on CI.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I've also renamed the artifact so that it's easier to spot when looking for the APK on a PR.