### PR TITLE
Duplicate isStarted extension in onboarding to avoid crash in debug

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/util/ActivityExtensions.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/util/ActivityExtensions.kt
@@ -4,6 +4,14 @@ import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewGroupCompat
+import androidx.lifecycle.Lifecycle
+
+/**
+ * Check if the state of the activity is at least started,
+ * meaning onStart has been called but the state has not reached onSavedInstanceState (yet).
+ */
+val ComponentActivity.isStarted: Boolean
+    get() = lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
 
 /**
  * Enables edge-to-edge display with enhanced WindowInsets compatibility.


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I've duplicated the `ActivityExtension` file in a previous PR but I didn't copy the `isStarted` one, which lead to crash while playing with the app in debug. 
This PR is just to add the missing `isStarted`, even if the code is going to be removed once we remove the old onboarding.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.