### PR TITLE
Add back missing ruby deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,9 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.8)
+      base64
+      nkf
+      rexml
     abbrev (0.1.2)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
@@ -169,6 +172,7 @@ GEM
     mutex_m (0.3.0)
     nanaimo (0.4.0)
     naturally (2.3.0)
+    nkf (0.2.0)
     optparse (0.8.0)
     os (1.1.4)
     plist (3.7.2)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After merging https://github.com/home-assistant/android/pull/6057 `fastlane` started to fail
https://github.com/home-assistant/android/actions/runs/19426545153/job/55578827605
<img width="1775" height="549" alt="image" src="https://github.com/user-attachments/assets/70d46974-c120-42dc-89d4-3c9808e22cb2" />

This PR brings back the missing deps in the lock file