### PR TITLE
Use WindowsInsets.safeDrawing for all the onboarding screen

### DIFF
--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionErrorScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionErrorScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
@@ -126,6 +128,7 @@ internal fun ConnectionErrorScreen(
 ) {
     Scaffold(
         modifier = modifier,
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         ConnectionErrorContent(
             onOpenExternalLink = onOpenExternalLink,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/localfirst/LocalFirstScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/localfirst/LocalFirstScreen.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -31,7 +33,7 @@ private val MaxContentWidth = MaxButtonWidth
 
 @Composable
 internal fun LocalFirstScreen(onNextClick: () -> Unit, modifier: Modifier = Modifier) {
-    Scaffold(modifier = modifier) { contentPadding ->
+    Scaffold(modifier = modifier, contentWindowInsets = WindowInsets.safeDrawing) { contentPadding ->
         LocalFirstContent(
             onNextClick = onNextClick,
             modifier = Modifier.padding(contentPadding),

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreen.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
@@ -92,6 +94,7 @@ internal fun LocationForSecureConnectionScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onBackClick = onBackClick, onHelpClick = onHelpClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         LocationForSecureConnectionContent(
             isStandaloneScreen = isStandaloneScreen,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/LocationSharingScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/LocationSharingScreen.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -57,6 +59,7 @@ internal fun LocationSharingScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onHelpClick = onHelpClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         LocationSharingContent(
             onGoToNextScreen = onGoToNextScreen,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerScreen.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -85,6 +87,7 @@ internal fun ManualServerScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onHelpClick = onHelpClick, onBackClick = onBackClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         ManualServerContent(
             onConnectClick = onConnectClick,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceScreen.kt
@@ -5,9 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -78,6 +80,7 @@ internal fun NameYourDeviceScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onHelpClick = onHelpClick, onBackClick = onBackClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         NameYourDeviceContent(
             deviceName = deviceName,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
@@ -125,9 +125,8 @@ internal fun ServerDiscoveryScreen(
 ) {
     Scaffold(
         modifier = modifier,
-        topBar = {
-            HATopBar(onBackClick = onBackClick, onHelpClick = onHelpClick)
-        },
+        topBar = { HATopBar(onBackClick = onBackClick, onHelpClick = onHelpClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         ScreenContent(
             contentPadding = contentPadding,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/sethomenetwork/SetHomeNetworkScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/sethomenetwork/SetHomeNetworkScreen.kt
@@ -7,9 +7,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
@@ -98,6 +100,7 @@ internal fun SetHomeNetworkScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onHelpClick = onHelpClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) { contentPadding ->
         SetHomeNetworkContent(
             currentWifiNetwork = currentWifiNetwork,

--- a/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/wearmtls/WearMTLSScreen.kt
+++ b/onboarding/src/main/kotlin/io/homeassistant/companion/android/onboarding/wearmtls/WearMTLSScreen.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -94,6 +96,7 @@ internal fun WearMTLSScreen(
     Scaffold(
         modifier = modifier,
         topBar = { HATopBar(onHelpClick = onHelpClick, onBackClick = onBackClick) },
+        contentWindowInsets = WindowInsets.safeDrawing,
     ) {
         WearMTLSContent(
             modifier = Modifier.padding(it),


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I was wrong when answering to this comment https://github.com/home-assistant/android/pull/6039#issuecomment-3529404438 and we do need safeDrawing in order to adjust the screen size when the keyboard is displayed which the default value of the Scaffold doesn't handle.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I didn't know if I wanted to wrap the Scaffold into a custom Composable so for now I kept it like this.