### PR TITLE
Guard against null menu item in notification history

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/notification/NotificationHistoryFragment.kt
@@ -55,8 +55,8 @@ class NotificationHistoryFragment : PreferenceFragmentCompat() {
                             menu.removeItem(R.id.action_delete)
                         } else {
                             val searchViewItem = menu.findItem(R.id.search_notifications)
-                            val searchView: SearchView = searchViewItem.actionView as SearchView
-                            searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+                            val searchView = searchViewItem?.actionView as? SearchView
+                            searchView?.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                                 override fun onQueryTextSubmit(query: String?): Boolean {
                                     searchView.clearFocus()
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6079 by using `?.` for calls on this specific menu item, which is already consistently done for other menu items in the settings fragments.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->