### PR TITLE
Upgrade fastlane and remove explicit abbrev dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source "https://rubygems.org"
 
-gem "abbrev" # https://github.com/fastlane/fastlane/issues/29183#issuecomment-3165960899
 gem "fastlane"
 gem "fastlane-plugin-amazon_app_submission"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,6 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  abbrev
   fastlane
   fastlane-plugin-amazon_app_submission
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

This is a follow-up to https://github.com/home-assistant/android/pull/5940:

> Bump to ruby 3.4.7 #5907 did break fastlane since `abbrev` needs to be added manually according to [fastlane/fastlane#29183](https://github.com/fastlane/fastlane/issues/29183).
> 
> I tested locally and I was able to reproduce the issue we have on main https://github.com/home-assistant/android/actions/runs/18520711132/job/52779842472 and after the add of `abbrev` the issue is gone. We need to merge this PR to fully test the deployment.

A couple days ago, fastlane published a new released which supports ruby 3.4.0 without us having to manually
declare a dependency on the abbrev gem:
https://github.com/fastlane/fastlane/releases/tag/2.229.0
so this PR upgrades fastlane to that version, and removes the workaround of declaring `abbrev` in our own `Gemfile`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction). _N/A_
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.