### PR TITLE
Avoid Index out of bounds in ButtonWidgetConfigureActivitty

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/button/ButtonWidgetConfigureActivity.kt
@@ -389,8 +389,9 @@ class ButtonWidgetConfigureActivity : BaseWidgetConfigureActivity<ButtonWidgetEn
         val serverId = checkNotNull(selectedServerId) { "Selected server ID is null" }
         val actionText = binding.widgetTextConfigService.text.toString()
         val actions = actions[serverId].orEmpty()
-        val domain = actions[actionText]?.domain ?: actionText.split(".", limit = 2)[0]
-        val action = actions[actionText]?.action ?: actionText.split(".", limit = 2)[1]
+        val actionTextParts = actionText.split(".", limit = 2)
+        val domain = actions[actionText]?.domain ?: actionTextParts.getOrElse(0) { "" }
+        val action = actions[actionText]?.action ?: actionTextParts.getOrElse(1) { "" }
         val actionDataMap = HashMap<String, Any>()
 
         dynamicFields.forEach {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We have crashes on production about the ButtonWidgetConfigureActivitty when splitting the action text.

```
Exception java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
  at java.util.Collections$SingletonList.get (Collections.java:5260)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.getPendingDaoEntity (ButtonWidgetConfigureActivity.kt:393)
  at io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity.updateWidget (BaseWidgetConfigureActivity.kt:161)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.access$updateWidget (ButtonWidgetConfigureActivity.kt:53)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity$onCreate$5$2.invokeSuspend (ButtonWidgetConfigureActivity.kt:373)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith (DispatchedContinuation.kt:375)
  at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable (Cancellable.kt:26)
  at kotlinx.coroutines.CoroutineStart.invoke (CoroutineStart.kt:358)
  at kotlinx.coroutines.AbstractCoroutine.start (AbstractCoroutine.kt:134)
  at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch (Builders.common.kt:53)
  at kotlinx.coroutines.BuildersKt.launch (Unknown Source:1)
  at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default (Builders.common.kt:44)
  at kotlinx.coroutines.BuildersKt.launch$default (Unknown Source:1)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.onCreate$lambda$2 (ButtonWidgetConfigureActivity.kt:372)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity.$r8$lambda$XQggeGtIJJLheo7hNFAbCbfAm4Q (Unknown Source)
  at io.homeassistant.companion.android.widgets.button.ButtonWidgetConfigureActivity$$ExternalSyntheticLambda3.onClick (D8$$SyntheticClass)
  at android.view.View.performClick (View.java:8055)
  at android.widget.TextView.performClick (TextView.java:17819)
  at android.view.View.performClickInternal (View.java:8032)
  at android.view.View.-$$Nest$mperformClickInternal (Unknown Source)
  at android.view.View$PerformClick.run (View.java:31923)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:230)
  at android.os.Looper.loop (Looper.java:319)
  at android.app.ActivityThread.main (ActivityThread.java:9063)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:588)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1103)
```

This PR doesn't fix the issue about why it happens but it handle the case where we cannot split the action properly.