### PR TITLE
Fix UnsafeIntentLaunchViolation when selecting autofill option on login screen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/IgnoreViolationRules.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/IgnoreViolationRules.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import android.os.strictmode.DiskReadViolation
 import android.os.strictmode.DiskWriteViolation
 import android.os.strictmode.IncorrectContextUseViolation
+import android.os.strictmode.UnsafeIntentLaunchViolation
 import android.os.strictmode.Violation
 import androidx.annotation.RequiresApi
 import io.homeassistant.companion.android.common.util.IgnoreViolationRule
@@ -11,6 +12,7 @@ import io.homeassistant.companion.android.common.util.IgnoreViolationRule
 val vmPolicyIgnoredViolationRules = listOf(
     IgnoreChromiumTrichomeWrongContextUsage,
     IgnoreBarcodeScannerRotationListenerWrongContextUsage,
+    IgnoreAutofillUnsafeIntentLaunch,
 )
 
 val threadPolicyIgnoredViolationRules = listOf(
@@ -23,6 +25,21 @@ val threadPolicyIgnoredViolationRules = listOf(
     IgnoreAndroidAutoServiceConnectionDiskRead,
     IgnoreAndroidAutoRendererServiceDiskRead,
 )
+
+/**
+ * Ignore an [UnsafeIntentLaunchViolation] that can occur
+ * when selecting an autofill option on the login screen.
+ */
+private data object IgnoreAutofillUnsafeIntentLaunch : IgnoreViolationRule {
+    @RequiresApi(Build.VERSION_CODES.S)
+    override fun shouldIgnore(violation: Violation): Boolean {
+        if (violation !is UnsafeIntentLaunchViolation) return false
+
+        return violation.stackTrace.any {
+            it.className == "android.view.autofill.AutofillManager"
+        }
+    }
+}
 
 /**
  * Ignore an [IncorrectContextUseViolation] that can occur


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6109[ Crash when selecting autofill option on onboarding login screen](https://github.com/home-assistant/android/issues/6109). Please read the description of the issue for context.

I introduced a new `IgnoreViolationRule` which checks if any of the stack trace lines' class is `android.view.autofill.AutofillManager`. I didn't find a more elegant solution than this. I checked the `Intent` from `UnsafeIntentLaunchViolation::getIntent`, but it didn't contain anything meaningful tha I could use:

<img width="1359" height="924" alt="image" src="https://github.com/user-attachments/assets/fc090a05-edc0-4aa1-9f4e-4a2db8daaf8b" />

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

I didn't write unit tests because the added logic is very simple, and other `IgnoreViolationRules` are also not unit tested.