### PR TITLE
Fix duplicate notifications by removing leftover WorkManager with different unique work name

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -70,7 +70,7 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
 
             // Renaming the unique work name created two periodic workers and caused duplicate WebSocket notifications.
             // See: https://github.com/home-assistant/android/issues/6066#issuecomment-3608649429
-            // Could be remove .........
+            // Please don't remove before December 2026 to allow enough time for users to upgrade.
             workManager.cancelUniqueWork(OLD_UNIQUE_WORK_NAME)
 
             val workInfo = workManager.getWorkInfosForUniqueWork(UNIQUE_WORK_NAME).await().firstOrNull()


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary

Fixes #6066, where users were getting duplicate notifications over the persistent WebSocket connection. The bug was introduced in #5998, where the periodic WorkManager work request's unique name was renamed from `WebSockManager` to `WebSocketManager`. This change resulted in two periodic jobs, because the old one was still persisted, and scheduled to try to start every 15 minutes.

I used the `App Inspection` feature of Android Studio to see the list of WorkManager jobs, and I was able to capture this screenshot:

<img width="552" height="319" alt="image" src="https://github.com/user-attachments/assets/6f56cc9f-7e0b-4e97-8029-f1dc935d97d2" />

Here you can see two instances of `WebsocketManager` running at the bottom of the list. Unfortunately this tool cannot show the unique name of the jobs, but the fact that two of the same type are running should be enough proof.

<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->