### PR TITLE
Collect more information on crash (thread dump and view hierarchy)

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/CrashHandling.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/CrashHandling.kt
@@ -27,6 +27,8 @@ fun initCrashReporting(context: Context, enabled: Boolean) {
 
     SentryAndroid.init(context) { options ->
         options.isEnableAutoSessionTracking = true
+        options.isAttachAnrThreadDump = true
+        options.isAttachViewHierarchy = true
 
         // We are using Sentry Android core library that doesn't come with the support for NDK.
         options.isEnableNdk = false
@@ -69,9 +71,9 @@ fun initCrashReporting(context: Context, enabled: Boolean) {
  * anrEnabled: true
  * anrReportInDebug: false
  * anrTimeoutIntervalMillis: 5000
- * attachAnrThreadDump: false
+ * attachAnrThreadDump: true
  * attachScreenshot: false
- * attachViewHierarchy: false
+ * attachViewHierarchy: true
  * beforeScreenshotCaptureCallback: null
  * beforeViewHierarchyCaptureCallback: null
  * collectAdditionalContext: true


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We have few ANRs with stack that is not very useful in Sentry. This PR adds two new flags about collecting [threadDump](https://docs.sentry.io/platforms/android/configuration/app-not-respond/#attaching-thread-dump) and [view hierarchy](https://docs.sentry.io/platforms/android/configuration/options/#attachViewHierarchy) to help debug.


