### PR TITLE
Fix potential NPE while using CarUxRestrictionsManager

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/BaseActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/BaseActivity.kt
@@ -59,7 +59,7 @@ open class BaseActivity : AppCompatActivity() {
         if (isAutomotive()) {
             car = Car.createCar(this)
             carRestrictionManager =
-                car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+                car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as? CarUxRestrictionsManager
             val listener =
                 CarUxRestrictionsManager.OnUxRestrictionsChangedListener { restrictions ->
                     if (restrictions.isRequiresDistractionOptimization) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/BaseVehicleScreen.kt
@@ -14,11 +14,10 @@ abstract class BaseVehicleScreen(carContext: CarContext) : Screen(carContext) {
     private var carRestrictionManager: CarUxRestrictionsManager? = null
     protected val isDrivingOptimized
         get() = try {
-            car?.let {
-                (
-                    it.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
-                    ).currentCarUxRestrictions.isRequiresDistractionOptimization
-            } ?: false
+            (car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as? CarUxRestrictionsManager)
+                ?.currentCarUxRestrictions
+                ?.isRequiresDistractionOptimization
+                ?: false
         } catch (e: Exception) {
             Timber.e(e, "Error getting UX Restrictions")
             false
@@ -46,7 +45,7 @@ abstract class BaseVehicleScreen(carContext: CarContext) : Screen(carContext) {
             Timber.i("Register for Automotive Restrictions")
             car = Car.createCar(carContext)
             carRestrictionManager =
-                car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as CarUxRestrictionsManager
+                car?.getCarManager(Car.CAR_UX_RESTRICTION_SERVICE) as? CarUxRestrictionsManager
             val listener =
                 CarUxRestrictionsManager.OnUxRestrictionsChangedListener { restrictions ->
                     onDrivingOptimizedChanged(restrictions.isRequiresDistractionOptimization)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We received a crash report on automotive about a NPE

```
12-12 10:47:12.729 30724 30724 E AndroidRuntime: FATAL EXCEPTION: main
12-12 10:47:12.729 30724 30724 E AndroidRuntime: Process: io.homeassistant.companion.android.minimal, PID: 30724
12-12 10:47:12.729 30724 30724 E AndroidRuntime: java.lang.RuntimeException: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.car.drivingstate.CarUxRestrictions.isRequiresDistractionOptimization()' on a null object reference
12-12 10:47:12.729 30724 30724 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.car.drivingstate.CarUxRestrictions.isRequiresDistractionOptimization()' on a null object reference
12-12 10:47:12.729 30724 30724 E AndroidRuntime: at io.homeassistant.companion.android.vehicle.BaseVehicleScreen.isDrivingOptimized(BaseVehicleScreen.kt:25)
```

This PR is a quick fix to avoid crashing the app, but I suspect a more deeper issue about some race condition that the manager is not yet ready. I don't have the device to reproduce and investigate the issue so I'm going to wait to get more details.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->