### PR TITLE
Revert "Update dependency ruby to v3.4.8 (#6176)"

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: ruby/setup-ruby@ac793fdd38cc468a4dd57246fa9d0e868aba9085 # v1.270.0
         with:
-          ruby-version: "3.4.8"
+          ruby-version: "3.4.7"
           bundler-cache: true
 
       - uses: ./.github/actions/create-release-number
@@ -141,7 +141,7 @@ jobs:
 
       - uses: ruby/setup-ruby@ac793fdd38cc468a4dd57246fa9d0e868aba9085 # v1.270.0
         with:
-          ruby-version: "3.4.8"
+          ruby-version: "3.4.7"
           bundler-cache: true
 
       - uses: ./.github/actions/create-release-number

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ruby/setup-ruby@ac793fdd38cc468a4dd57246fa9d0e868aba9085 # v1.270.0
         with:
-          ruby-version: "3.4.8"
+          ruby-version: "3.4.7"
           bundler-cache: true
 
       - uses: ./.github/actions/inflate-secrets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,4 +235,4 @@ DEPENDENCIES
   fastlane-plugin-amazon_app_submission
 
 BUNDLED WITH
-   2.6.9
+   2.4.10


### PR DESCRIPTION
This reverts commit 84e9ff4f1637af875867c9e200bc01cb861e69cc.

<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Revert Ruby bump to 3.4.8 since it is not yet available on Ubuntu https://github.com/home-assistant/android/actions/runs/20425722850