### PR TITLE
Make sure fragments have public ctor for the FragmentFactory reflection

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/ConnectionSecurityLevelFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/ConnectionSecurityLevelFragment.kt
@@ -47,7 +47,7 @@ import io.homeassistant.companion.android.onboarding.locationforsecureconnection
  * This fragment is temporary and should be removed once the app fully migrates to Compose Navigation.
  */
 @AndroidEntryPoint
-class ConnectionSecurityLevelFragment private constructor() : Fragment() {
+class ConnectionSecurityLevelFragment : Fragment() {
 
     companion object {
         const val RESULT_KEY = "connection_security_level_result"

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/insecure/BlockInsecureFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/insecure/BlockInsecureFragment.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
  * Fragment explaining why the current connection is blocked.
  */
 @AndroidEntryPoint
-class BlockInsecureFragment private constructor() : Fragment() {
+class BlockInsecureFragment : Fragment() {
 
     companion object {
         const val RESULT_KEY = "block_insecure_result"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I learned the hard way that you should not make the default constructor of a class that extend https://developer.android.com/reference/androidx/fragment/app/Fragment.html private because the FragmentFactory does some reflection to find the default constructor at runtime when restoring the fragments.

This issue is causing some crashing each time a configuration changes happens. I found this issue on the beta lane of the Play console crash report.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
It would have been nice that Google made a lint rule instead of a hidden comment in the doc
> Constructor used by the default [FragmentFactory](https://developer.android.com/reference/androidx/fragment/app/FragmentFactory). You must [set a custom FragmentFactory](https://developer.android.com/reference/androidx/fragment/app/FragmentManager#setFragmentFactory(androidx.fragment.app.FragmentFactory)) if you want to use a non-default constructor to ensure that your constructor is called when the fragment is re-instantiated.