### PR TITLE
Make safe interaction with fragment manager in the webview

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -102,6 +102,7 @@ import io.homeassistant.companion.android.common.util.getStringOrElse
 import io.homeassistant.companion.android.common.util.getStringOrNull
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.jsonObjectOrNull
+import io.homeassistant.companion.android.common.util.runFragmentTransactionIfStateSafe
 import io.homeassistant.companion.android.common.util.toJsonObject
 import io.homeassistant.companion.android.common.util.toJsonObjectOrNull
 import io.homeassistant.companion.android.database.authentication.Authentication
@@ -1433,20 +1434,6 @@ class WebViewActivity :
         isRelaunching = true
         startActivity(Intent(this, LaunchActivity::class.java))
         finish()
-    }
-
-    /**
-     * Executes fragment transactions only if the FragmentManager state hasn't been saved.
-     * This prevents IllegalStateException when called from the presenter that might call this after
-     * onSaveInstanceState (e.g., when the user backgrounds the app). Due to the fact that
-     * coroutines cancel are async.
-     */
-    private inline fun runFragmentTransactionIfStateSafe(block: () -> Unit) {
-        if (!supportFragmentManager.isStateSaved) {
-            block()
-        } else {
-            Timber.d("Skipping fragment transaction - state already saved")
-        }
     }
 
     override fun loadUrl(url: Uri, keepHistory: Boolean, openInApp: Boolean) {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/FragmentActivityExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/FragmentActivityExt.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.common.util
+
+import androidx.fragment.app.FragmentActivity
+import timber.log.Timber
+
+/**
+ * Executes fragment transactions only if the FragmentManager state hasn't been saved.
+ *
+ * This prevents [IllegalStateException] when attempting fragment transactions after
+ * [FragmentActivity.onSaveInstanceState] has been called (e.g., when the user backgrounds the app).
+ * This is particularly useful when transactions are triggered from coroutines or callbacks
+ * that may execute asynchronously after the activity's state has been saved.
+ *
+ * @param block The fragment transaction to execute if the state hasn't been saved.
+ */
+inline fun FragmentActivity.runFragmentTransactionIfStateSafe(block: () -> Unit) {
+    if (!supportFragmentManager.isStateSaved) {
+        block()
+    } else {
+        Timber.d("Skipping fragment transaction - state already saved")
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Even if the WebViewPresenter.load function is lifecycle aware we are using coroutines and the cancellation might happen at a bad time like after the onStop has been called on the WebViewActivity. This leads to crashes because the fragment manager is in a state that cannot take any new transaction at the moment.

```
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1862)
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1902)
  at androidx.fragment.app.FragmentManager.popBackStack (FragmentManager.java:1015)
  at io.homeassistant.companion.android.webview.WebViewActivity.loadUrl (WebViewActivity.kt:1442)
  at io.homeassistant.companion.android.webview.WebViewPresenterImpl$loadUrl$2$1.invokeSuspend (WebViewPresenterImpl.kt:225)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:34)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:100)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:280)
  at android.app.ActivityThread.main (ActivityThread.java:6706)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:858)
```

From the FragmentManager.isStateSaved docs:

```java
    /**
     * Returns {@code true} if the FragmentManager's state has already been saved
     * by its host. Any operations that would change saved state should not be performed
     * if this method returns true. For example, any popBackStack() method, such as
     * {@link #popBackStackImmediate()} or any FragmentTransaction using
     * {@link FragmentTransaction#commit()} instead of
     * {@link FragmentTransaction#commitAllowingStateLoss()} will change
     * the state and will result in an error.
     *
     * @return true if this FragmentManager's state has already been saved by its host
     */
    public boolean isStateSaved() {
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.