### PR TITLE
Fix: use cloudhook URL instead of cloud URL for integration requests

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProviderImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProviderImpl.kt
@@ -109,8 +109,8 @@ class ServerConnectionStateProviderImpl @AssistedInject constructor(
                 connection.internalHttpUrl?.buildWebhookUrl(webhookId)?.let(::add)
             }
 
-            // Cloud URL: always add if available
-            connection.cloudHttpUrl?.let(::add)
+            // Cloudhook URL: always add if available
+            connection.cloudhookHttpUrl?.let(::add)
 
             // External URL: use when on home network, or when connection is secure/allowed
             val externalUrlIsSecure = connection.externalUrl.startsWith("https://")

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProviderImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProviderImplTest.kt
@@ -534,27 +534,29 @@ class ServerConnectionStateProviderImplTest {
         }
 
         @Test
-        fun `Given not on home network and has cloudUrl when calling getApiUrls then cloudUrl is first`() = runTest {
+        fun `Given not on home network and has cloudhookUrl when calling getApiUrls then cloudhookUrl is first`() = runTest {
             val provider = createServerConnectionStateProvider(
                 externalUrl = "https://external.example.com",
                 internalUrl = "http://192.168.1.1:8123",
-                cloudUrl = "https://cloud.nabu.casa/abc123",
+                cloudUrl = "https://abc123.ui.nabu.casa",
+                cloudhookUrl = "https://hooks.nabu.casa/cloudhook123",
                 webhookId = "webhook123",
             )
 
             val result = provider.getApiUrls()
 
             assertEquals(2, result.size)
-            assertEquals("https://cloud.nabu.casa/abc123", result[0].toString())
+            assertEquals("https://hooks.nabu.casa/cloudhook123", result[0].toString())
             assertEquals("https://external.example.com/api/webhook/webhook123", result[1].toString())
         }
 
         @Test
-        fun `Given on home network with cloudUrl when calling getApiUrls then internal is first followed by cloudUrl`() = runTest {
+        fun `Given on home network with cloudhookUrl when calling getApiUrls then internal is first followed by cloudhookUrl`() = runTest {
             val provider = createServerConnectionStateProvider(
                 externalUrl = "https://external.example.com",
                 internalUrl = "http://192.168.1.1:8123",
-                cloudUrl = "https://cloud.nabu.casa/abc123",
+                cloudUrl = "https://abc123.ui.nabu.casa",
+                cloudhookUrl = "https://hooks.nabu.casa/cloudhook123",
                 webhookId = "webhook123",
                 internalEthernet = true,
             )
@@ -564,7 +566,7 @@ class ServerConnectionStateProviderImplTest {
 
             assertEquals(3, result.size)
             assertEquals("http://192.168.1.1:8123/api/webhook/webhook123", result[0].toString())
-            assertEquals("https://cloud.nabu.casa/abc123", result[1].toString())
+            assertEquals("https://hooks.nabu.casa/cloudhook123", result[1].toString())
             assertEquals("https://external.example.com/api/webhook/webhook123", result[2].toString())
         }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6194 

When getting logs with a debug build, the issue is obvious: it is trying to use the UI cloud URL instead of the cloudhook URL for integration (webhook) requests. This PR adjusts the `getApiUrls` function, which is only used for integration requests, to return the cloudhook URL instead of cloud URL.

Tests have been adjusted to a server which still has a cloud URL so this mistake is caught if reverted in the future. Realistically a server with cloud will also have a cloudhook.

```
2025-12-25 09:09:02.839 15966-16045 OkHttp                  io....stant.companion.android.debug  I  --> POST https://secretletters.ui.nabu.casa/
2025-12-25 09:09:02.839 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Content-Type: application/json; charset=UTF-8
2025-12-25 09:09:02.839 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Content-Length: 216
2025-12-25 09:09:02.839 15966-16045 OkHttp                  io....stant.companion.android.debug  I  
2025-12-25 09:09:02.840 15966-16045 OkHttp                  io....stant.companion.android.debug  I  {"type":"update_registration","data":{"app_version":"2025.12.4-SNAPSHOT-full (1)","device_name":"Pixel 7a dev","manufacturer":"Google","model":"Pixel 7a","os_version":"36","app_data":{"push_websocket_channel":true}}}
2025-12-25 09:09:02.840 15966-16045 OkHttp                  io....stant.companion.android.debug  I  --> END POST (216-byte body)
(...)
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  <-- 405 Method Not Allowed https://secretletters.ui.nabu.casa/ (241ms)
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Content-Type: text/plain; charset=utf-8
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Allow: GET
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Referrer-Policy: no-referrer
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  X-Content-Type-Options: nosniff
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Server: 
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  X-Frame-Options: SAMEORIGIN
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Content-Length: 23
2025-12-25 09:09:03.081 15966-16045 OkHttp                  io....stant.companion.android.debug  I  Date: Thu, 25 Dec 2025 08:09:02 GMT
2025-12-25 09:09:03.082 15966-16045 OkHttp                  io....stant.companion.android.debug  I  
2025-12-25 09:09:03.082 15966-16045 OkHttp                  io....stant.companion.android.debug  I  405: Method Not Allowed
2025-12-25 09:09:03.082 15966-16045 OkHttp                  io....stant.companion.android.debug  I  <-- END HTTP (241ms, 23-byte body)
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->