### PR TITLE
Add more disk space to emulator on CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -297,32 +297,6 @@ jobs:
           sudo udevadm trigger --name-match=kvm
           ls /dev/kvm
 
-      - name: AVD cache
-        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.configuration.target }}-${{ matrix.configuration.api-level }}
-
-      - name: Create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
-        with:
-          api-level: ${{ matrix.configuration.api-level }}
-          arch: ${{ matrix.configuration.arch }}
-          force-avd-creation: false
-          disable-animations: true
-          disk-size: 2G # We need to ensure that there is enough space for the emulator to run. If not we get 'Failed to commit install' errors.
-          heap-size: 1G
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          profile: ${{ matrix.configuration.profile }}
-          target: ${{ matrix.configuration.target }}
-          system-image-api-level: ${{ matrix.configuration.system-image-api-level }}
-          script: |
-            echo "Generated AVD snapshot for caching."
-
       - name: Build projects and run instrumentation tests
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
         with:
@@ -330,7 +304,7 @@ jobs:
           arch: ${{ matrix.configuration.arch }}
           force-avd-creation: false
           disable-animations: true
-          disk-size: 2G
+          disk-size: 2G # We need to ensure that there is enough space for the emulator to run. If not we get 'Failed to commit install' errors.
           heap-size: 1G
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           profile: ${{ matrix.configuration.profile }}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We have some failure on CI (not always) that we are running out of disk on the emulator to install a new APK, it only happens on old version (API23).

In order to mitigate the issue I've bump the disk size from 1G to 2G since it doesn't have an impact on the run on our side.

The issue is most probably because something is not cleaned up properly or not yet. My other guess is the partition for the system where the APKs are installed is too small on the API 23

Bumping to 2G is a quick fix, we might need to investigate more deeply if it doesn't fix the issue.

For more detail when it happens
https://github.com/home-assistant/android/actions/runs/20615098308/job/59207118248?pr=6188


While checking the cache size, I found out that the cache is scoped to the branch and base branch. Since we are not running the emulator on main we only hit the cache when we have multiple commit on a PR (and each commit need to be a success to save the cache).

I've also check the time it takes to run with and without cache and it's pretty much the same
- With cache https://github.com/home-assistant/android/actions/runs/20336471736/job/58428153276 --> 11mn to run
- Without cache https://github.com/home-assistant/android/actions/runs/20571806394/job/59082553352?pr=6163 --> 2mn (prep) + 9mn (run) so 11mn too

Since we are not saving time saving cache I'm removing the cache, we are going to save some resources by not storing cache and also speed up a bit the build by skipping the need to retrieve and save the cache.