### PR TITLE
Stronger URL validation in manual server

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerViewModel.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.onboarding.manualserver
 import android.webkit.URLUtil
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.net.URL
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,7 +24,7 @@ internal class ManualServerViewModel @Inject constructor() : ViewModel() {
 
     private fun validateServerUrl(url: String) {
         isServerUrlValidMutableFlow.update {
-            URLUtil.isValidUrl(url)
+            URLUtil.isValidUrl(url) && runCatching { URL(url) }.isSuccess
         }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
`URLUtil.isValidUrl` seems to not properly validate a URL and causing crashing for instance for `http://homeassistant.local::8123`. This PR verify that we can properly transform the string into a URL using the URL constructor.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.