### PR TITLE
Avoid change of WebView composable after adding/removing insets

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewContentScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewContentScreen.kt
@@ -153,6 +153,10 @@ internal fun WebViewContentScreen(
  * If the Home Assistant frontend does not handle edge-to-edge insets
  * (core <2025.12), it also wraps the WebView with colored overlays matching
  * the safe area insets.
+ *
+ * This wrapper ensures the [HAWebView] is not removed from composition when
+ * the app lock, theme or server inset support changes, to avoid losing loading
+ * progress or frontend state when it isn't necessary.
  */
 @OptIn(ExperimentalHazeMaterialsApi::class)
 @Composable


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Following [discussion on Discord](https://discord.com/channels/330944238910963714/1346948551892009101/1461063873887994111)

It appears that we missed that #5346 results in a timeout on cold starts of the app with servers on 2025.12+. This appears to be because the default value for inset support is `false`, but loading changes it to `true`, causing the WebView composable to change and stop loading at the same time as/shortly after loading the initial page.

<img width="2751" height="373" alt="logcat output showing loading immediately followed by webview released stopping loading" src="https://github.com/user-attachments/assets/6245a764-92bc-4ed3-af2f-07388bd90d3a" />

Timeouts are not tied to the composable, so still fire and show a dialog that Home Assistant could not be loaded. If you press reload in this dialog, it avoids the issue because the value for inset support doesn't change this time.

To avoid the composable changing, this PR makes sure the same composable is used for the WebView regardless of inset support.
For 2025.12+, this resolves the issue in my testing. For <2025.12, this change shouldn't make any difference. (It's based on the function for <2025.12 but has added `if` statements to remove insets around the WebView for 2025.12+).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->