### PR TITLE
Cleanup Active server if ID is not in database

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
@@ -168,8 +168,14 @@ internal class ServerManagerImpl @Inject constructor(
 
     private suspend fun getServerIdSanitize(serverId: Int): Int? {
         return if (serverId == SERVER_ID_ACTIVE) {
-            localStorage.getInt(PREF_ACTIVE_SERVER)
-                ?: serverDao.getLastServerId()
+            val storedActiveServerId = localStorage.getInt(PREF_ACTIVE_SERVER)
+            if (storedActiveServerId != null && serverDao.get(storedActiveServerId) == null) {
+                Timber.w("Active server ID $storedActiveServerId no longer exists, removing from storage")
+                localStorage.remove(PREF_ACTIVE_SERVER)
+                serverDao.getLastServerId()
+            } else {
+                storedActiveServerId ?: serverDao.getLastServerId()
+            }
         } else {
             serverId
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I'm trying to understand in which scenario we are giving an ID that doesn't exist anymore, while investigating this I had this idea that maybe we storing in the local storage the active server ID that doesn't exist anymore. I'm not sure if it possible but in case we could take this defensive approach to clear the local preference if the ID does not exist to unlock the situation on the next run.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I'm looking for other places, but the crashes that I see on sentry might also be because of old data that we didn't cleanup and that we are never cleaning.