### PR TITLE
Remove WidgetEntity when server is removed

### DIFF
--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/WidgetsDaoTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/WidgetsDaoTest.kt
@@ -1,0 +1,105 @@
+package io.homeassistant.companion.android.widgets
+
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.database.widget.WidgetDao
+import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
+import java.util.jar.JarFile
+import javax.inject.Inject
+import junit.framework.TestCase.assertEquals
+import kotlin.reflect.KClass
+import kotlin.reflect.full.isSubclassOf
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+@HiltAndroidTest
+class WidgetsDaoTest {
+
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    var consoleLog = ConsoleLogRule()
+
+    @Inject
+    lateinit var widgetDaos: Set<@JvmSuppressWildcards WidgetDao<*>>
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun `Given injected widgetDaos then all WidgetDao interfaces are present`() {
+        val allWidgetDaoInterfaces = getAllWidgetDaoInterfaces()
+
+        // Extract the DAO interface from each injected _Impl class
+        val injectedDaoInterfaces = widgetDaos.map { dao ->
+            dao::class.supertypes
+                .mapNotNull { it.classifier as? KClass<*> }
+                .first { it.isSubclassOf(WidgetDao::class) && it != WidgetDao::class }
+        }.toSet()
+
+        assertEquals(allWidgetDaoInterfaces, injectedDaoInterfaces)
+    }
+
+    /**
+     * Uses reflection to find all interfaces in the widget package that extend [WidgetDao].
+     * This scans the classpath for classes in `io.homeassistant.companion.android`.
+     */
+    private fun getAllWidgetDaoInterfaces(): Set<KClass<*>> {
+        val widgetPackage = "io.homeassistant.companion.android"
+        val classLoader = Thread.currentThread().contextClassLoader
+            ?: return emptySet()
+
+        return findClassesInPackage(widgetPackage, classLoader)
+            .filter { clazz ->
+                clazz.isInterface &&
+                    clazz.kotlin.isSubclassOf(WidgetDao::class) &&
+                    clazz.kotlin != WidgetDao::class
+            }
+            .map { it.kotlin }
+            .toSet()
+    }
+
+    private fun findClassesInPackage(packageName: String, classLoader: ClassLoader): List<Class<*>> {
+        val path = packageName.replace('.', '/')
+        val resources = classLoader.getResources(path)
+        val classes = mutableListOf<Class<*>>()
+
+        while (resources.hasMoreElements()) {
+            val resource = resources.nextElement()
+            if (resource.protocol == "jar") {
+                val jarPath = resource.path.substringBefore("!").removePrefix("file:")
+                classes.addAll(findClassesInJar(jarPath, packageName, classLoader))
+            }
+        }
+        return classes
+    }
+
+    private fun findClassesInJar(
+        jarPath: String,
+        packageName: String,
+        classLoader: ClassLoader,
+    ): List<Class<*>> {
+        val path = packageName.replace('.', '/')
+        return JarFile(jarPath).use { jar ->
+            jar.entries().asSequence()
+                .filter { it.name.startsWith(path) && it.name.endsWith(".class") }
+                .mapNotNull { entry ->
+                    val className = entry.name
+                        .removeSuffix(".class")
+                        .replace('/', '.')
+                    runCatching { classLoader.loadClass(className) }.getOrNull()
+                }
+                .toList()
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImpl.kt
@@ -16,6 +16,7 @@ import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.server.ServerDao
 import io.homeassistant.companion.android.database.server.TemporaryServer
 import io.homeassistant.companion.android.database.settings.SettingsDao
+import io.homeassistant.companion.android.database.widget.WidgetDao
 import io.homeassistant.companion.android.di.qualifiers.NamedSessionStorage
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -75,6 +76,7 @@ internal class ServerManagerImpl @Inject constructor(
     private val serverDao: ServerDao,
     private val sensorDao: SensorDao,
     private val settingsDao: SettingsDao,
+    private val widgetDaos: Set<@JvmSuppressWildcards WidgetDao<*>>,
     @NamedSessionStorage private val localStorage: LocalStorage,
 ) : ServerManager {
 
@@ -143,6 +145,7 @@ internal class ServerManagerImpl @Inject constructor(
         if (localStorage.getInt(PREF_ACTIVE_SERVER) == id) localStorage.remove(PREF_ACTIVE_SERVER)
         settingsDao.delete(id)
         sensorDao.removeServer(id)
+        widgetDaos.forEach { it.deleteByServerId(id) }
         serverDao.delete(id)
     }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/DatabaseModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/DatabaseModule.kt
@@ -26,6 +26,7 @@ import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWid
 import io.homeassistant.companion.android.database.widget.StaticWidgetDao
 import io.homeassistant.companion.android.database.widget.TemplateWidgetDao
 import io.homeassistant.companion.android.database.widget.TodoWidgetDao
+import io.homeassistant.companion.android.database.widget.WidgetDao
 import javax.inject.Singleton
 
 private const val DATABASE_NAME = "HomeAssistantDB"
@@ -97,4 +98,21 @@ internal object DatabaseModule {
     @Provides
     fun provideEntityStateComplicationsDao(database: AppDatabase): EntityStateComplicationsDao =
         database.entityStateComplicationsDao()
+
+    @Provides
+    fun provideWidgetDaos(
+        buttonWidgetDao: ButtonWidgetDao,
+        cameraWidgetDao: CameraWidgetDao,
+        mediaPlayerControlsWidgetDao: MediaPlayerControlsWidgetDao,
+        staticWidgetDao: StaticWidgetDao,
+        templateWidgetDao: TemplateWidgetDao,
+        todoWidgetDao: TodoWidgetDao,
+    ): Set<WidgetDao<*>> = setOf(
+        buttonWidgetDao,
+        cameraWidgetDao,
+        mediaPlayerControlsWidgetDao,
+        staticWidgetDao,
+        templateWidgetDao,
+        todoWidgetDao,
+    )
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/ButtonWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/ButtonWidgetDao.kt
@@ -28,4 +28,7 @@ interface ButtonWidgetDao : WidgetDao<ButtonWidgetEntity> {
 
     @Query("SELECT COUNT(*) FROM button_widgets")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM button_widgets WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/CameraWidgetDao.kt
@@ -29,4 +29,7 @@ interface CameraWidgetDao : WidgetDao<CameraWidgetEntity> {
 
     @Query("SELECT COUNT(*) FROM camera_widgets")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM camera_widgets WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/MediaPlayerControlsWidgetDao.kt
@@ -28,4 +28,7 @@ interface MediaPlayerControlsWidgetDao : WidgetDao<MediaPlayerControlsWidgetEnti
 
     @Query("SELECT COUNT(*) FROM media_player_controls_widgets")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM media_player_controls_widgets WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/StaticWidgetDao.kt
@@ -32,4 +32,7 @@ interface StaticWidgetDao : WidgetDao<StaticWidgetEntity> {
 
     @Query("SELECT COUNT(*) FROM static_widget")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM static_widget WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TemplateWidgetDao.kt
@@ -32,4 +32,7 @@ interface TemplateWidgetDao : WidgetDao<TemplateWidgetEntity> {
 
     @Query("SELECT COUNT(*) FROM template_widgets")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM template_widgets WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TodoWidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/TodoWidgetDao.kt
@@ -38,4 +38,7 @@ interface TodoWidgetDao : WidgetDao<TodoWidgetEntity> {
 
     @Query("SELECT COUNT(*) FROM todo_widget")
     override fun getWidgetCountFlow(): Flow<Int>
+
+    @Query("DELETE FROM todo_widget WHERE server_id = :serverId")
+    override suspend fun deleteByServerId(serverId: Int)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/WidgetDao.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/widget/WidgetDao.kt
@@ -6,5 +6,6 @@ interface WidgetDao<T : WidgetEntity<T>> {
     suspend fun add(entity: T)
     suspend fun delete(id: Int)
     suspend fun deleteAll(ids: IntArray)
+    suspend fun deleteByServerId(serverId: Int)
     fun getWidgetCountFlow(): Flow<Int>
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/servers/ServerManagerImplTest.kt
@@ -18,6 +18,7 @@ import io.homeassistant.companion.android.database.server.ServerSessionInfo
 import io.homeassistant.companion.android.database.server.ServerUserInfo
 import io.homeassistant.companion.android.database.server.TemporaryServer
 import io.homeassistant.companion.android.database.settings.SettingsDao
+import io.homeassistant.companion.android.database.widget.WidgetDao
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -56,6 +57,8 @@ class ServerManagerImplTest {
     private val serverDao: ServerDao = mockk()
     private val sensorDao: SensorDao = mockk()
     private val settingsDao: SettingsDao = mockk()
+    private val widgetDao: WidgetDao<*> = mockk()
+    private val widgetDaos: Set<WidgetDao<*>> = setOf(widgetDao)
     private val localStorage: LocalStorage = mockk()
 
     private lateinit var serverManager: ServerManagerImpl
@@ -84,6 +87,7 @@ class ServerManagerImplTest {
             serverDao = serverDao,
             sensorDao = sensorDao,
             settingsDao = settingsDao,
+            widgetDaos = widgetDaos,
             localStorage = localStorage,
         )
     }
@@ -346,6 +350,7 @@ class ServerManagerImplTest {
             coEvery { localStorage.getInt("active_server") } returns null
             coEvery { settingsDao.delete(serverId) } just Runs
             coEvery { sensorDao.removeServer(serverId) } just Runs
+            coEvery { widgetDao.deleteByServerId(serverId) } just Runs
             coEvery { serverDao.delete(serverId) } just Runs
             coEvery { webSocketRepo.shutdown() } just Runs
 
@@ -360,6 +365,7 @@ class ServerManagerImplTest {
                 webSocketRepo.shutdown()
                 settingsDao.delete(serverId)
                 sensorDao.removeServer(serverId)
+                widgetDao.deleteByServerId(serverId)
                 serverDao.delete(serverId)
             }
         }
@@ -380,6 +386,7 @@ class ServerManagerImplTest {
             coEvery { localStorage.remove("active_server") } just Runs
             coEvery { settingsDao.delete(serverId) } just Runs
             coEvery { sensorDao.removeServer(serverId) } just Runs
+            coEvery { widgetDao.deleteByServerId(serverId) } just Runs
             coEvery { serverDao.delete(serverId) } just Runs
 
             serverManager.removeServer(serverId)
@@ -402,6 +409,7 @@ class ServerManagerImplTest {
             coEvery { localStorage.getInt("active_server") } returns 10
             coEvery { settingsDao.delete(serverId) } just Runs
             coEvery { sensorDao.removeServer(serverId) } just Runs
+            coEvery { widgetDao.deleteByServerId(serverId) } just Runs
             coEvery { serverDao.delete(serverId) } just Runs
 
             serverManager.removeServer(serverId)
@@ -426,6 +434,7 @@ class ServerManagerImplTest {
             coEvery { localStorage.getInt("active_server") } returns null
             coEvery { settingsDao.delete(serverId) } just Runs
             coEvery { sensorDao.removeServer(serverId) } just Runs
+            coEvery { widgetDao.deleteByServerId(serverId) } just Runs
             coEvery { serverDao.delete(serverId) } just Runs
             coEvery { webSocketRepo.shutdown() } just Runs
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
On Sentry we see some errors of server not found coming from the widget. Today we are not removing the widget entities when we remove a server. This PR does this, even if it doesn't remove the widget it is going to prevent a widget to try to use a serverID that doesn't exist anymore and would crash the app.

If a user tries to interact with a widget that has a deleted server now it won't do anything now except showing a toast or an error on the widget.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I tried to add a test that verify that we don't forget to add new WidgetDao inside the list of widgetDao. It uses the classloader to find all the sub-interfaces of WidgetDao.