### PR TITLE
Catching wrong exception in ServerSettingsPresenter

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsPresenterImpl.kt
@@ -181,7 +181,7 @@ class ServerSettingsPresenterImpl @Inject constructor(
     override fun setAppActive(active: Boolean) = runBlocking {
         try {
             serverManager.integrationRepository(serverId).setAppActive(active)
-        } catch (e: IllegalArgumentException) {
+        } catch (e: IllegalStateException) {
             Timber.w(e, "Cannot set app active $active for server $serverId")
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
<img width="1380" height="993" alt="Screenshot 2026-01-19 at 08 29 00" src="https://github.com/user-attachments/assets/155f94b5-a817-4bb1-80c2-0e83d002bb1c" />

After the recent changes it turns out that we are catching the wrong exception while trying to setAppActive from the settings. This PR simply avoid the crash but doesn't fix the underlying issue that we should not try in the first place to setAppActive with an ID that doesn't exist. Which tells me that we should still proactively cleanup whatever that could lead to this scenario, probably with #6265.