### PR TITLE
Update status/navigation bar colors on page change for insets

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -462,13 +462,12 @@ class WebViewPresenterImpl @Inject constructor(
     override suspend fun parseWebViewColor(webViewColor: String): Int = withContext(Dispatchers.IO) {
         var color = 0
 
-        Timber.d("Try getting color from webview color \"$webViewColor\".")
         if (webViewColor.isNotEmpty() && webViewColor != "null") {
             try {
                 color = parseColorWithRgb(webViewColor)
                 Timber.i("Found color $color.")
             } catch (e: Exception) {
-                Timber.w(e, "Could not get color from webview.")
+                Timber.w(e, "Could not get color from webview color \"$webViewColor\".")
             }
         } else {
             Timber.w("Could not get color from webview. Color \"$webViewColor\" is not a valid color.")


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR adds a new Javascript event listener for navigation events, and updates the status/navigation bar colors on page changes for servers with insets. With older servers or devices without a recent WebView, this will simply do nothing.

This fixes the issue where any settings page would result in invisible notifications, time, etc. with the default HA light theme.

 - Fixes #6270
 - Does not yet fix issue with the navigation drawer (I don't think we can fix this without a frontend change - can't have different colors for left/right)
 - Does not yet fix more info dialogs (the new listener is fired for this because it is navigation, just need to find a reliable way to determine the color with JS).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
Note how the status bar changes between white/black in test, but not in a release build (~2026.1.4):

https://github.com/user-attachments/assets/a61be834-86b1-497c-b785-38a320e0d64a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
 - I've also removed comments about deprecation because this is now relevant and the frontend still [appears to send the event ](https://github.com/home-assistant/frontend/blob/e4d6f3c9d72c58b3a1ad47af39291d3dcd994533/src/panels/profile/ha-pick-theme-row.ts#L232) that was mentioned as deprecated.
 - Logging was minimized to avoid cluttering the logs too much