### PR TITLE
Disable reckon plugin when used in Git worktree

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,25 +18,33 @@ pluginManagement {
     }
 }
 
+// Reckon plugin doesn't work in git worktrees (JGit doesn't handle worktree .git files).
+// Detect worktrees (.git is a file, not a directory) and skip reckon in that case.
+val isWorktree = settings.settingsDir.resolve(".git").isFile
+
 plugins {
     // So we can't reach the libs.plugins.* aliases from here so we need to declare them the old way...
-    id("org.ajoberstar.reckon.settings").version("1.0.1")
+    id("org.ajoberstar.reckon.settings").version("1.0.1").apply(false)
 }
 
-reckon {
-    val isCiBuild = providers.environmentVariable("CI").isPresent
+if (!isWorktree) {
+    apply(plugin = "org.ajoberstar.reckon.settings")
 
-    setDefaultInferredScope("patch")
-    if (!isCiBuild) {
-        // Use a snapshot version scheme with Reckon when not running in CI, which allows caching to
-        // improve performance. Background: https://github.com/home-assistant/android/issues/5220.
-        snapshots()
-    } else {
-        stages("beta", "final")
+    extensions.configure<org.ajoberstar.reckon.gradle.ReckonExtension>("reckon") {
+        val isCiBuild = providers.environmentVariable("CI").isPresent
+
+        setDefaultInferredScope("patch")
+        if (!isCiBuild) {
+            // Use a snapshot version scheme with Reckon when not running in CI, which allows caching to
+            // improve performance. Background: https://github.com/home-assistant/android/issues/5220.
+            snapshots()
+        } else {
+            stages("beta", "final")
+        }
+        setScopeCalc { java.util.Optional.of(org.ajoberstar.reckon.core.Scope.PATCH) }
+        setStageCalc(calcStageFromProp())
+        setTagWriter { it.toString() }
     }
-    setScopeCalc { java.util.Optional.of(org.ajoberstar.reckon.core.Scope.PATCH) }
-    setStageCalc(calcStageFromProp())
-    setTagWriter { it.toString() }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Multiple times I've commit a modification on the settings.gradle because I'm working on a worktree and reckon (JGit to be more precise) is not supporting it properly. This commit simply disable the plugin when within a worktree.

The side effect is that while working on a worktree the version is wrong but it only impact dev environment and I think it is fine.

The exact error was `Caused by: org.eclipse.jgit.errors.NoWorkTreeException: Bare Repository has neither a working tree, nor an index`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.