### PR TITLE
Sync Thread network preference on Matter commissioning from frontend, if necessary

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -23,6 +23,9 @@ interface ThreadManager {
         object NoneHaveCredentials : SyncResult()
     }
 
+    /** Exception related to Thread Network operations */
+    class ThreadNetworkException(message: String?) : Exception()
+
     /**
      * Indicates if the app on this device supports Thread credential management.
      */
@@ -53,6 +56,13 @@ interface ThreadManager {
     ): SyncResult
 
     /**
+     * Check if there was ever a Thread dataset synchronization to or from the specified server.
+     * @see syncPreferredDataset for syncing details.
+     * @return `true` if the server has ever synced, `false` if the server has never synced.
+     */
+    suspend fun hasSyncedPreferredDataset(serverId: Int): Boolean
+
+    /**
      * Get the preferred Thread dataset from the server.
      */
     suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse?
@@ -78,6 +88,14 @@ interface ThreadManager {
      * @throws Exception if it is not possible to get the preferred dataset
      */
     suspend fun getPreferredDatasetFromDevice(context: Context): IntentSender?
+
+    /**
+     * Compares the supplied dataset to what is preferred by the device.
+     * @return `true` if preferred by the device, `false` otherwise
+     * @throws IllegalArgumentException if the tlv is malformed
+     * @throws ThreadNetworkException if it is not possible to get the preferred dataset
+     */
+    suspend fun isPreferredDatasetByDevice(context: Context, tlv: String): Boolean
 
     /**
      * Process the result from [syncPreferredDataset] or [getPreferredDatasetFromDevice]'s intent

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -938,7 +938,7 @@ class WebViewActivity :
                                         ),
                                     )
 
-                                "matter/commission" -> presenter.startCommissioningMatterDevice(this@WebViewActivity)
+                                "matter/commission" -> startMatterCommissioning(json)
                                 "thread/import_credentials" -> {
                                     presenter.exportThreadCredentials(this@WebViewActivity)
 
@@ -1007,6 +1007,13 @@ class WebViewActivity :
                 javascriptInterface,
             )
         }
+    }
+
+    private fun startMatterCommissioning(json: JsonObject) {
+        val payload = json["payload"]?.jsonObjectOrNull()
+        val tlv = payload?.getStringOrNull("active_operational_dataset")
+        val borderAgentId = payload?.getStringOrNull("border_agent_id")
+        presenter.startCommissioningMatterDevice(this@WebViewActivity, tlv, borderAgentId)
     }
 
     private fun addEntityTo(json: JsonObject) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -73,7 +73,7 @@ interface WebViewPresenter {
     suspend fun parseWebViewColor(webViewColor: String): Int
 
     fun appCanCommissionMatterDevice(): Boolean
-    fun startCommissioningMatterDevice(context: Context)
+    fun startCommissioningMatterDevice(context: Context, tlv: String?, borderAgentId: String?)
 
     /** @return `true` if the app can send this device's preferred Thread credential to the server */
     fun appCanExportThreadCredentials(): Boolean

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -516,7 +516,7 @@ class WebViewPresenterImpl @Inject constructor(
             mainScope.launch {
                 if (tlv != null && borderAgentId != null) {
                     Timber.d("Matter commissioning payload has preferred Thread dataset, comparing")
-                    compareThreadCredentialsForCommissioning(context, tlv)
+                    compareThreadDatasetForCommissioning(context, tlv)
                 } else {
                     Timber.d("Matter commissioning payload doesn't have Thread, starting commissioning")
                     startMatterCommissioningFlow(context)
@@ -526,15 +526,15 @@ class WebViewPresenterImpl @Inject constructor(
     }
 
     /**
-     * Compare Thread credentials supplied for Matter commissioning, and take action depending on the device state:
-     * - Device prefers credentials: start (external) Matter commissioning flow
-     * - Device doesn't prefer credentials:
-     *    - Has never synced Thread for the server: do a full Thread credentials sync (this will usually result in the
-     *    credentials becoming preferred)
+     * Compare Thread dataset supplied for Matter commissioning, and take action depending on the device state:
+     * - Device prefers dataset: start (external) Matter commissioning flow
+     * - Device doesn't prefer dataset:
+     *    - Has never synced Thread for the server: do a full Thread dataset sync (this will usually result in the
+     *    dataset becoming preferred, if the device has no other Thread dataset)
      *    - Has previously synced Thread for the server: start (external) Matter commissioning flow (the app is
      *    expected to be unable to change the preferred state by syncing)
      */
-    private suspend fun compareThreadCredentialsForCommissioning(context: Context, tlv: String) {
+    private suspend fun compareThreadDatasetForCommissioning(context: Context, tlv: String) {
         val isPreferred = threadUseCase.isPreferredDatasetByDevice(context, tlv)
 
         if (isPreferred) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -509,15 +509,54 @@ class WebViewPresenterImpl @Inject constructor(
 
     override fun appCanCommissionMatterDevice(): Boolean = matterUseCase.appSupportsCommissioning()
 
-    override fun startCommissioningMatterDevice(context: Context) {
+    override fun startCommissioningMatterDevice(context: Context, tlv: String?, borderAgentId: String?) {
         if (mutableMatterThreadStep.value != MatterThreadStep.REQUESTED) {
             mutableMatterThreadStep.tryEmit(MatterThreadStep.REQUESTED)
 
-            // The app used to sync Thread credentials here until commit 26a472a, but it was
-            // (temporarily?) removed due to slowing down the Matter commissioning flow for the user
-            // and limited usefulness of the result (because of API limitations)
+            mainScope.launch {
+                if (tlv != null && borderAgentId != null) {
+                    Timber.d("Matter commissioning payload has preferred Thread dataset, comparing")
+                    val isPreferred = threadUseCase.isPreferredDatasetByDevice(context, tlv)
 
-            startMatterCommissioningFlow(context)
+                    if (isPreferred) {
+                        Timber.d("Device prefers core preferred dataset, starting commissioning")
+                        startMatterCommissioningFlow(context)
+                    } else if (!threadUseCase.hasSyncedPreferredDataset(serverId)) {
+                        // We only sync if the server has never synced, as a full sync can be slow
+                        Timber.d("Device doesn't prefer core preferred dataset, starting first sync")
+                        val deviceThreadIntent = try {
+                            val result = threadUseCase.syncPreferredDataset(
+                                context = context,
+                                serverId = serverId,
+                                exportOnly = false,
+                                scope = CoroutineScope(mainScope.coroutineContext + SupervisorJob()),
+                            )
+                            when (result) {
+                                is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
+                                is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
+                                else -> null
+                            }
+                        } catch (e: Exception) {
+                            Timber.w(e, "Unable to sync preferred Thread dataset, continuing")
+                            null
+                        }
+                        if (deviceThreadIntent != null) {
+                            matterThreadIntentSender = deviceThreadIntent
+                            mutableMatterThreadStep.tryEmit(MatterThreadStep.THREAD_EXPORT_TO_SERVER_MATTER)
+                        } else {
+                            startMatterCommissioningFlow(context)
+                        }
+                    } else {
+                        Timber.d(
+                            "Device doesn't prefer core preferred dataset but has previously synced, starting commissioning",
+                        )
+                        startMatterCommissioningFlow(context)
+                    }
+                } else {
+                    Timber.d("Matter commissioning payload doesn't have Thread, starting commissioning")
+                    startMatterCommissioningFlow(context)
+                }
+            }
         } // else already waiting for a result, don't send another request
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -516,42 +516,7 @@ class WebViewPresenterImpl @Inject constructor(
             mainScope.launch {
                 if (tlv != null && borderAgentId != null) {
                     Timber.d("Matter commissioning payload has preferred Thread dataset, comparing")
-                    val isPreferred = threadUseCase.isPreferredDatasetByDevice(context, tlv)
-
-                    if (isPreferred) {
-                        Timber.d("Device prefers core preferred dataset, starting commissioning")
-                        startMatterCommissioningFlow(context)
-                    } else if (!threadUseCase.hasSyncedPreferredDataset(serverId)) {
-                        // We only sync if the server has never synced, as a full sync can be slow
-                        Timber.d("Device doesn't prefer core preferred dataset, starting first sync")
-                        val deviceThreadIntent = try {
-                            val result = threadUseCase.syncPreferredDataset(
-                                context = context,
-                                serverId = serverId,
-                                exportOnly = false,
-                                scope = CoroutineScope(mainScope.coroutineContext + SupervisorJob()),
-                            )
-                            when (result) {
-                                is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
-                                is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
-                                else -> null
-                            }
-                        } catch (e: Exception) {
-                            Timber.w(e, "Unable to sync preferred Thread dataset, continuing")
-                            null
-                        }
-                        if (deviceThreadIntent != null) {
-                            matterThreadIntentSender = deviceThreadIntent
-                            mutableMatterThreadStep.tryEmit(MatterThreadStep.THREAD_EXPORT_TO_SERVER_MATTER)
-                        } else {
-                            startMatterCommissioningFlow(context)
-                        }
-                    } else {
-                        Timber.d(
-                            "Device doesn't prefer core preferred dataset but has previously synced, starting commissioning",
-                        )
-                        startMatterCommissioningFlow(context)
-                    }
+                    compareThreadCredentialsForCommissioning(context, tlv)
                 } else {
                     Timber.d("Matter commissioning payload doesn't have Thread, starting commissioning")
                     startMatterCommissioningFlow(context)
@@ -560,6 +525,67 @@ class WebViewPresenterImpl @Inject constructor(
         } // else already waiting for a result, don't send another request
     }
 
+    /**
+     * Compare Thread credentials supplied for Matter commissioning, and take action depending on the device state:
+     * - Device prefers credentials: start (external) Matter commissioning flow
+     * - Device doesn't prefer credentials:
+     *    - Has never synced Thread for the server: do a full Thread credentials sync (this will usually result in the
+     *    credentials becoming preferred)
+     *    - Has previously synced Thread for the server: start (external) Matter commissioning flow (the app is
+     *    expected to be unable to change the preferred state by syncing)
+     */
+    private suspend fun compareThreadCredentialsForCommissioning(context: Context, tlv: String) {
+        val isPreferred = threadUseCase.isPreferredDatasetByDevice(context, tlv)
+
+        if (isPreferred) {
+            Timber.d("Device prefers core preferred dataset, starting commissioning")
+            startMatterCommissioningFlow(context)
+        } else if (!threadUseCase.hasSyncedPreferredDataset(serverId)) {
+            // We only sync if the server has never synced, as a full sync can be slow
+            Timber.d("Device doesn't prefer core preferred dataset, starting first sync")
+            val syncExportIntent = syncThreadDataset(context)
+
+            if (syncExportIntent != null) {
+                matterThreadIntentSender = syncExportIntent
+                mutableMatterThreadStep.tryEmit(MatterThreadStep.THREAD_EXPORT_TO_SERVER_MATTER)
+            } else {
+                startMatterCommissioningFlow(context)
+            }
+        } else {
+            Timber.d(
+                "Device doesn't prefer core preferred dataset, has previously synced, starting commissioning",
+            )
+            startMatterCommissioningFlow(context)
+        }
+    }
+
+    /**
+     * Try to sync the preferred Thread dataset between the server and the device.
+     * @return [IntentSender] if syncing requires starting an intent to complete (export to server), otherwise `null`
+     */
+    private suspend fun syncThreadDataset(context: Context): IntentSender? {
+        return try {
+            val result = threadUseCase.syncPreferredDataset(
+                context = context,
+                serverId = serverId,
+                exportOnly = false,
+                scope = CoroutineScope(mainScope.coroutineContext + SupervisorJob()),
+            )
+            when (result) {
+                is ThreadManager.SyncResult.OnlyOnDevice -> result.exportIntent
+                is ThreadManager.SyncResult.AllHaveCredentials -> result.exportIntent
+                else -> null
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Unable to sync preferred Thread dataset, continuing")
+            null
+        }
+    }
+
+    /**
+     * Start the (external) Matter commissioning flow. Depending on the result, this will emit a new step with the
+     * intent to open the activity, or a new step for an error.
+     * */
     private fun startMatterCommissioningFlow(context: Context) {
         matterUseCase.startNewCommissioningFlow(
             context,

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -23,6 +23,8 @@ class ThreadManagerImpl @Inject constructor() : ThreadManager {
         scope: CoroutineScope,
     ): ThreadManager.SyncResult = ThreadManager.SyncResult.AppUnsupported
 
+    override suspend fun hasSyncedPreferredDataset(serverId: Int): Boolean = false
+
     override suspend fun getPreferredDatasetFromServer(serverId: Int): ThreadDatasetResponse? = null
 
     override suspend fun importDatasetFromServer(
@@ -33,7 +35,11 @@ class ThreadManagerImpl @Inject constructor() : ThreadManager {
     ) { }
 
     override suspend fun getPreferredDatasetFromDevice(context: Context): IntentSender? {
-        throw IllegalStateException("Thread is not supported with the minimal flavor")
+        throw ThreadManager.ThreadNetworkException("Thread is not supported with the minimal flavor")
+    }
+
+    override suspend fun isPreferredDatasetByDevice(context: Context, tlv: String): Boolean {
+        throw ThreadManager.ThreadNetworkException("Thread is not supported with the minimal flavor")
     }
 
     override suspend fun sendThreadDatasetExportResult(result: ActivityResult, serverId: Int): String? = null

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/IntegrationRepository.kt
@@ -69,6 +69,12 @@ interface IntegrationRepository {
 
     suspend fun setLastUsedPipeline(pipelineId: String, supportsStt: Boolean)
 
+    /** @return Whether Thread credentials have ever been synced to or from this server */
+    suspend fun getThreadCredentialsSynced(): Boolean
+
+    /** Set whether Thread credentials have ever been synced to or from this server */
+    suspend fun setThreadCredentialsSynced(synced: Boolean)
+
     /** @return List of border agent IDs added to this device from the server */
     suspend fun getThreadBorderAgentIds(): List<String>
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -99,6 +99,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         private const val PREF_SEC_WARNING_NEXT = "sec_warning_last"
         private const val PREF_LAST_USED_PIPELINE_ID = "last_used_pipeline"
         private const val PREF_LAST_USED_PIPELINE_STT = "last_used_pipeline_stt"
+        private const val PREF_THREAD_CREDENTIALS_SYNCED = "thread_credentials_synced"
         private const val PREF_THREAD_BORDER_AGENT_IDS = "thread_border_agent_ids"
 
         @VisibleForTesting internal const val PREF_ASK_NOTIFICATION_PERMISSION = "ask_notification_permission"
@@ -439,6 +440,13 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
     override suspend fun setLastUsedPipeline(pipelineId: String, supportsStt: Boolean) {
         localStorage.putString("${serverId}_$PREF_LAST_USED_PIPELINE_ID", pipelineId)
         localStorage.putBoolean("${serverId}_$PREF_LAST_USED_PIPELINE_STT", supportsStt)
+    }
+
+    override suspend fun getThreadCredentialsSynced(): Boolean =
+        localStorage.getBoolean("${serverId}_$PREF_THREAD_CREDENTIALS_SYNCED")
+
+    override suspend fun setThreadCredentialsSynced(synced: Boolean) {
+        localStorage.putBoolean("${serverId}_$PREF_THREAD_CREDENTIALS_SYNCED", synced)
     }
 
     override suspend fun getThreadBorderAgentIds(): List<String> =


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR tries to improve the user experience for commissioning of Matter over Thread devices, by actively syncing a dataset if necessary.

### Background

In #4150, the full Thread credential sync was removed from the start of Matter commissioning because of the slow GMS API. However, for users with a Thread network only known to HA (like those who added a ZBT-2, or Apple network synced from an iOS device!), this means Matter over Thread device commissioning would fail unless a full sync was manually triggered from companion app settings.

After the removal, the frontend [started sending information](https://github.com/home-assistant/frontend/pull/22022) about the preferred Thread network, if any, in the commissioning payload. Instead of doing a full sync every time, this allows us to sync the device only if necessary by checking if the device knows these credentials.

_Note that the GMS API unfortunately hasn't seen any improvement and we still cannot specify which Thread network to use, so the check/sync remains best effort, instead of being sure this Thread network is used for commissioning like the frontend's intention._

### Code in this PR

If the frontend commissioning payload includes Thread credentials, the app checks if the device prefers the network for these credentials (we can do this without asking for permissions or showing additional UI).
 - If there are no credentials in the payload, or the device prefers these credentials: the Matter commissioning flow starts.
 - If there are credentials: if the app has never synced we do a full sync once, once synced the Matter commissioning flow starts.

In a flowchart this looks like:

```mermaid
flowchart LR
    A(Frontend starts Matter commissioning) --> B{Payload with Thread credentials?}
    B -- No --> C(Start Matter commissioning flow)
    B -- Yes --> D{Thread network from credentials preferred by device?}
    D -- Yes --> C
    D -- No --> E{Thread synced at least once?}
    E -- No --> F[Perform full sync]
    F --> C
    E -- Yes --> C
```

While testing, asking the GMS API whether the dataset is preferred still takes almost exactly 10 seconds most of the time, but not always - I suspect it is waiting for a timeout somewhere. That means this change still slows down starting commissioning, but only if core knows about Thread and less than a full sync.

<img width="1340" height="138" alt="Logcat showing 10 seconds between messages for frontend commissioning start and Thread network preferred check complete" src="https://github.com/user-attachments/assets/409f901e-249d-46bf-a3ac-6568b93d789c" />

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

[Discussion](https://discord.com/channels/330944238910963714/1346948551892009101/1444757127322271917) on Discord that started this PR.

This PR is still draft while I want to
 - test a bit more with removing credentials and when to set/unset the has synced boolean
 - polish exception handling without changing all the code