### PR TITLE
Fix clearing history when switching between servers

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1509,12 +1509,12 @@ class WebViewActivity :
             }
             supportFragmentManager.clearFragmentResultListener(BlockInsecureFragment.RESULT_KEY)
 
-            clearHistory = !keepHistory
             val oldUrl = loadedUrl
             // It means that if we loaded an URL with a path previously and we try to load the same URL without
             // a path we don't do anything.
             val shouldLoadUrl = !url.hasSameOrigin(oldUrl) || url.hasNonRootPath()
             if (shouldLoadUrl) {
+                clearHistory = !keepHistory
                 loadedUrl = url
                 webView.loadUrl(url.toString())
                 waitForConnection()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -16,6 +16,7 @@ interface WebViewPresenter {
         lifecycle: Lifecycle,
         path: String? = null,
         isInternalOverride: ((ServerConnectionInfo) -> Boolean)? = null,
+        isNewServer: Boolean? = null,
     )
 
     fun getActiveServer(): Int

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -107,10 +107,11 @@ class WebViewPresenterImpl @Inject constructor(
         lifecycle: Lifecycle,
         path: String?,
         isInternalOverride: ((ServerConnectionInfo) -> Boolean)?,
+        isNewServer: Boolean?,
     ) {
         urlFlowJob?.cancel()
 
-        val isNewServer = ensureServerIsAvailable()
+        val isNewServer = isNewServer ?: ensureServerIsAvailable()
         if (!isSessionConnected()) return
 
         urlFlowJob = lifecycle.cancelOnLifecycle(Lifecycle.State.STARTED) {
@@ -260,11 +261,12 @@ class WebViewPresenterImpl @Inject constructor(
     }
 
     override suspend fun switchActiveServer(lifecycle: Lifecycle, id: Int) {
+        val isNewServer = serverId != id
         if (serverId != id && serverId != ServerManager.SERVER_ID_ACTIVE) {
             setAppActive(false) // 'Lock' old server
         }
         setActiveServer(id)
-        load(lifecycle = lifecycle)
+        load(lifecycle, isNewServer = isNewServer)
         view.unlockAppIfNeeded()
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6356 

The changes to server changes and the URL detection made it so that the history was only cleared if the server changed externally to the WebViewActivity because it was removed. This PR passes the information that it was actually changed by the activity to the load function, so that server changes using the bottom sheet or gesture properly clear the history.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->