### PR TITLE
Use ViewModelFactory for LocationForSecureConnectionViewModel

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionViewModel.kt
@@ -1,28 +1,23 @@
 package io.homeassistant.companion.android.onboarding.locationforsecureconnection
 
-import androidx.annotation.VisibleForTesting
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.navigation.toRoute
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.onboarding.locationforsecureconnection.navigation.LocationForSecureConnectionRoute
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import timber.log.Timber
 
-@HiltViewModel
-class LocationForSecureConnectionViewModel @VisibleForTesting constructor(
-    private val serverId: Int,
+/**
+ * ViewModel for the security level configuration screen.
+ */
+@HiltViewModel(assistedFactory = LocationForSecureConnectionViewModelFactory::class)
+class LocationForSecureConnectionViewModel @AssistedInject constructor(
+    @Assisted private val serverId: Int,
     private val serverManager: ServerManager,
 ) : ViewModel() {
-    @Inject
-    constructor(
-        savedStateHandle: SavedStateHandle,
-        serverManager: ServerManager,
-    ) : this(savedStateHandle.toRoute<LocationForSecureConnectionRoute>().serverId, serverManager)
-
     val allowInsecureConnection: Flow<Boolean?> = flow {
         try {
             val value = serverManager.getServer(serverId)?.connection?.allowInsecureConnection
@@ -51,4 +46,9 @@ class LocationForSecureConnectionViewModel @VisibleForTesting constructor(
             )
         }
     }
+}
+
+@AssistedFactory
+interface LocationForSecureConnectionViewModelFactory {
+    fun create(serverId: Int): LocationForSecureConnectionViewModel
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/navigation/LocationForSecureConnectionNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/navigation/LocationForSecureConnectionNavigation.kt
@@ -7,6 +7,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionScreen
+import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModel
+import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModelFactory
 import kotlinx.serialization.Serializable
 
 internal const val URL_SECURITY_LEVEL_DOCUMENTATION =
@@ -25,11 +27,18 @@ internal fun NavGraphBuilder.locationForSecureConnectionScreen(
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
 ) {
     composable<LocationForSecureConnectionRoute> {
+        val route = it.toRoute<LocationForSecureConnectionRoute>()
+        val viewModel = hiltViewModel<
+            LocationForSecureConnectionViewModel,
+            LocationForSecureConnectionViewModelFactory,
+            >(
+            creationCallback = { factory -> factory.create(route.serverId) },
+        )
         LocationForSecureConnectionScreen(
-            viewModel = hiltViewModel(),
+            viewModel = viewModel,
             onHelpClick = onHelpClick,
             onGoToNextScreen = { allowInsecureConnection ->
-                onGotoNextScreen(allowInsecureConnection, it.toRoute<LocationForSecureConnectionRoute>().serverId)
+                onGotoNextScreen(allowInsecureConnection, route.serverId)
             },
             onShowSnackbar = onShowSnackbar,
         )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/ConnectionSecurityLevelFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/ConnectionSecurityLevelFragment.kt
@@ -23,14 +23,15 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.createViewModelLazy
 import androidx.fragment.app.setFragmentResult
-import androidx.lifecycle.DEFAULT_ARGS_KEY
-import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
+import dagger.hilt.android.lifecycle.withCreationCallback
 import io.homeassistant.companion.android.common.compose.theme.HATheme
+import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionScreen
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModel
+import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModelFactory
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.navigation.URL_SECURITY_LEVEL_DOCUMENTATION
 
 /**
@@ -77,16 +78,12 @@ class ConnectionSecurityLevelFragment : Fragment() {
         }
     }
 
-    private val viewModel: LocationForSecureConnectionViewModel by createViewModelLazy(
-        viewModelClass = LocationForSecureConnectionViewModel::class,
-        storeProducer = { viewModelStore },
+    private val viewModel: LocationForSecureConnectionViewModel by viewModels(
         extrasProducer = {
-            // Extract serverId from Fragment arguments and inject into SavedStateHandle
-            // to satisfy LocationForSecureConnectionRoute requirements
-            val serverId = arguments?.getInt(EXTRA_SERVER, -1) ?: -1
-            MutableCreationExtras(defaultViewModelCreationExtras).apply {
-                // Key need to match the name of the attribute in the route
-                set(DEFAULT_ARGS_KEY, bundleOf("serverId" to serverId))
+            val serverId =
+                arguments?.getInt(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE) ?: ServerManager.SERVER_ID_ACTIVE
+            defaultViewModelCreationExtras.withCreationCallback<LocationForSecureConnectionViewModelFactory> { factory ->
+                factory.create(serverId)
             }
         },
     )

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/HAAppTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/HAAppTest.kt
@@ -25,9 +25,12 @@ import dagger.hilt.android.testing.BindValue
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
+import dagger.hilt.android.testing.UninstallModules
 import io.homeassistant.companion.android.HiltComponentActivity
 import io.homeassistant.companion.android.automotive.navigation.AutomotiveRoute
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.di.ServerManagerModule
 import io.homeassistant.companion.android.frontend.navigation.FrontendActivityRoute
 import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
 import io.homeassistant.companion.android.launch.HAStartDestinationRoute
@@ -35,7 +38,6 @@ import io.homeassistant.companion.android.onboarding.OnboardingRoute
 import io.homeassistant.companion.android.onboarding.WearOnboardApp
 import io.homeassistant.companion.android.onboarding.WearOnboardingRoute
 import io.homeassistant.companion.android.onboarding.connection.navigation.ConnectionRoute
-import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModel
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.navigation.navigateToLocationForSecureConnection
 import io.homeassistant.companion.android.onboarding.nameyourweardevice.navigation.navigateToNameYourWearDevice
 import io.homeassistant.companion.android.onboarding.serverdiscovery.navigation.ServerDiscoveryRoute
@@ -43,7 +45,7 @@ import io.homeassistant.companion.android.onboarding.welcome.navigation.WelcomeR
 import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
 import io.homeassistant.companion.android.testing.unit.stringResource
 import io.homeassistant.companion.android.util.compose.webview.HA_WEBVIEW_TAG
-import io.mockk.coJustRun
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -61,6 +63,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = HiltTestApplication::class)
+@UninstallModules(ServerManagerModule::class)
 @HiltAndroidTest
 class HAAppTest {
 
@@ -73,7 +76,7 @@ class HAAppTest {
     @get:Rule(order = 2)
     val composeTestRule = createAndroidComposeRule<HiltComponentActivity>()
 
-    // Mock the ViewModel to prevent the real allowInsecureConnection() from executing.
+    // Mock the ServerManager to prevent the real allowInsecureConnection() from executing.
     // Without this, the suspend function switches to Dispatchers.IO and the coroutine resumes
     // on a non-main thread, causing navigation to fail with "Method setCurrentState must be
     // called on the main thread" because LifecycleRegistry requires main thread access.
@@ -81,8 +84,8 @@ class HAAppTest {
     // where dispatcher context is not properly preserved across suspend function boundaries.
     @BindValue
     @JvmField
-    val locationForSecureConnectionViewModel = spyk(LocationForSecureConnectionViewModel(0, mockk())).apply {
-        coJustRun { this@apply.allowInsecureConnection(any()) }
+    val serverManager: ServerManager = mockk(relaxed = true) {
+        coEvery { getServer(any<Int>()) } returns null
     }
 
     private lateinit var navController: TestNavHostController

--- a/common/src/main/kotlin/io/homeassistant/companion/android/di/DataModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/di/DataModule.kt
@@ -27,8 +27,6 @@ import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryImpl
-import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.data.servers.ServerManagerImpl
 import io.homeassistant.companion.android.common.util.DeferredCreationDataSource
 import io.homeassistant.companion.android.common.util.createDataSourceFactory
 import io.homeassistant.companion.android.common.util.di.SuspendProvider
@@ -168,10 +166,6 @@ internal abstract class DataModule {
     @Singleton
     @NamedKeyStore
     internal abstract fun bindKeyStore(keyStore: KeyStoreRepositoryImpl): KeyChainRepository
-
-    @Binds
-    @Singleton
-    internal abstract fun bindServerManager(serverManager: ServerManagerImpl): ServerManager
 
     @Multibinds
     abstract fun bindOkHttpClientConfigurator(): Set<@JvmSuppressWildcards OkHttpConfigurator>

--- a/common/src/main/kotlin/io/homeassistant/companion/android/di/ServerManagerModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/di/ServerManagerModule.kt
@@ -1,0 +1,23 @@
+package io.homeassistant.companion.android.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.servers.ServerManagerImpl
+import javax.inject.Singleton
+
+/**
+ * Module providing the [ServerManager] binding.
+ *
+ * Extracted to a separate module to allow tests to uninstall it and provide a mock.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ServerManagerModule {
+
+    @Binds
+    @Singleton
+    internal abstract fun bindServerManager(serverManager: ServerManagerImpl): ServerManager
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to be able to use the LocationForSecureConnectionViewModel in the FrontendScreen we need to inject the serverID instead of using the savedState directly. 

It is a bit annoying for the test since AssistFactory cannot be replaced in test so I had to modify the ServerManager injection.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.