### PR TITLE
Use painter instead of ImageVector to avoid crashes in old version

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt
@@ -27,9 +27,8 @@ import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -213,7 +212,8 @@ fun MatterCommissioningViewHeader(modifier: Modifier = Modifier) {
     Column(modifier = modifier.fillMaxWidth()) {
         Spacer(modifier = Modifier.height(32.dp))
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_matter),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.ic_matter),
             contentDescription = null,
             modifier = Modifier
                 .size(48.dp)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
@@ -13,8 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
@@ -109,7 +108,8 @@ fun LinkActivityScreen(modifier: Modifier = Modifier) {
     HomeAssistantAppTheme {
         Box(modifier = modifier.fillMaxSize()) {
             Image(
-                imageVector = ImageVector.vectorResource(R.drawable.app_icon_launch),
+                // Use painterResource instead of vector resource for API < 24
+                painter = painterResource(R.drawable.app_icon_launch),
                 contentDescription = null,
                 modifier = Modifier
                     .size(112.dp)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/loading/LoadingScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/loading/LoadingScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.contentDescription
@@ -29,7 +30,8 @@ fun LoadingScreen(modifier: Modifier = Modifier) {
         modifier = modifier.fillMaxSize(),
     ) {
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_home_assistant_branding),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.ic_home_assistant_branding),
             contentDescription = null,
             modifier = Modifier.size(ICON_SIZE),
         )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionErrorScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionErrorScreen.kt
@@ -30,10 +30,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -107,7 +107,8 @@ internal fun ConnectionErrorScreen(
 
         ConnectionErrorScreen(
             onOpenExternalLink = onOpenExternalLink,
-            icon = ImageVector.vectorResource(icon),
+            // Use painterResource instead of vector resource for API < 24
+            icon = painterResource(icon),
             title = stringResource(error.title),
             subtitle = stringResource(error.message),
             url = url,
@@ -126,7 +127,7 @@ internal fun ConnectionErrorScreen(
 @Composable
 internal fun ConnectionErrorScreen(
     onOpenExternalLink: suspend (Uri) -> Unit,
-    icon: ImageVector,
+    icon: Painter,
     title: String,
     subtitle: String,
     url: String?,
@@ -169,7 +170,7 @@ private fun ConnectionErrorContent(
     url: String?,
     connectivityCheckState: ConnectivityCheckState,
     onRetryConnectivityCheck: () -> Unit,
-    icon: ImageVector,
+    icon: Painter,
     errorDetailsExpanded: Boolean,
     actions: @Composable () -> Unit,
     modifier: Modifier = Modifier,
@@ -206,7 +207,7 @@ private fun ConnectionErrorContent(
 }
 
 @Composable
-private fun ColumnScope.Header(icon: ImageVector, title: String, subtitle: String) {
+private fun ColumnScope.Header(icon: Painter, title: String, subtitle: String) {
     Image(
         modifier = Modifier
             // This padding and size are adjusted to have image
@@ -214,7 +215,7 @@ private fun ColumnScope.Header(icon: ImageVector, title: String, subtitle: Strin
             .padding(top = HADimens.SPACE6)
             .padding(all = 20.dp)
             .size(120.dp),
-        imageVector = icon,
+        painter = icon,
         contentDescription = null,
     )
 
@@ -343,7 +344,8 @@ private fun ColumnScope.GetMoreHelp(onOpenExternalLink: suspend (Uri) -> Unit) {
             },
         )
         HAIconButton(
-            icon = ImageVector.vectorResource(R.drawable.github),
+            // Use painterResource instead of vector resource for API < 24
+            icon = painterResource(R.drawable.github),
             contentDescription = stringResource(commonR.string.connection_error_github_content_description),
             onClick = {
                 coroutineScope.launch {
@@ -352,7 +354,8 @@ private fun ColumnScope.GetMoreHelp(onOpenExternalLink: suspend (Uri) -> Unit) {
             },
         )
         HAIconButton(
-            icon = ImageVector.vectorResource(R.drawable.discord),
+            // Use painterResource instead of vector resource for API < 24
+            icon = painterResource(R.drawable.discord),
             contentDescription = stringResource(commonR.string.connection_error_discord_content_description),
             onClick = {
                 coroutineScope.launch {
@@ -387,7 +390,8 @@ private fun ConnectionErrorScreenPreview() {
             url = "http://ha.org",
             connectivityCheckState = ConnectivityCheckState(),
             onRetryConnectivityCheck = {},
-            icon = ImageVector.vectorResource(R.drawable.ic_casita_no_connection),
+            // Use painterResource instead of vector resource for API < 24
+            icon = painterResource(R.drawable.ic_casita_no_connection),
             errorDetailsExpanded = true,
             actions = {
                 CloseAction { }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.R
@@ -108,7 +109,8 @@ private fun ErrorPlaceholder() {
         contentAlignment = Alignment.Center,
     ) {
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_home_assistant_branding),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.ic_home_assistant_branding),
             contentDescription = null,
             modifier = Modifier.size(ICON_SIZE),
         )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
@@ -57,10 +57,9 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.scale
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
@@ -291,7 +290,8 @@ private fun ServerItemContent(server: ServerDiscovered, onConnectClick: (URL) ->
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_home_assistant_branding),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.ic_home_assistant_branding),
             contentDescription = null,
             modifier = Modifier
                 .size(ICON_SIZE)
@@ -371,7 +371,8 @@ private fun AnimatedIcon() {
             label = "icon_pulse_value",
         )
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.dots),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.dots),
             contentDescription = null,
             modifier = Modifier
                 .size(220.dp)
@@ -386,7 +387,8 @@ private fun AnimatedIcon() {
                 .background(HABrandColors.Blue, CircleShape),
         ) {
             Icon(
-                imageVector = ImageVector.vectorResource(commonR.drawable.ic_stat_ic_notification_blue),
+                // Use painterResource instead of vector resource for API < 24
+                painter = painterResource(commonR.drawable.ic_stat_ic_notification_blue),
                 contentDescription = null,
                 modifier = Modifier
                     .align(Alignment.Center)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/welcome/WelcomeScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/welcome/WelcomeScreen.kt
@@ -20,9 +20,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
@@ -58,7 +57,8 @@ internal fun WelcomeScreen(
         Spacer(modifier = Modifier.weight(positionPercentage))
 
         Image(
-            imageVector = ImageVector.vectorResource(R.drawable.ic_home_assistant_branding),
+            // Use painterResource instead of vector resource for API < 24
+            painter = painterResource(R.drawable.ic_home_assistant_branding),
             contentDescription = stringResource(commonR.string.home_assistant_branding_icon_content_description),
             modifier = Modifier.size(ICON_SIZE),
         )

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HAButtons.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/compose/composable/HAButtons.kt
@@ -24,7 +24,10 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
+import androidx.compose.ui.modifier.modifierLocalConsumer
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -235,6 +238,36 @@ fun HAIconButton(
     variant: ButtonVariant = ButtonVariant.PRIMARY,
     enabled: Boolean = true,
 ) {
+    HAIconButton(
+        icon = rememberVectorPainter(icon),
+        onClick = onClick,
+        contentDescription = contentDescription,
+        modifier = modifier,
+        variant = variant,
+        enabled = enabled
+    )
+}
+
+/**
+ * A Home Assistant styled icon button using a [Painter].
+ * Use painterResource instead of vector resource for API < 24 compatibility.
+ *
+ * @param icon The [Painter] to display.
+ * @param onClick The callback to be invoked when the button is clicked.
+ * @param contentDescription The content description of the button.
+ * @param modifier Optional [androidx.compose.ui.Modifier] to be applied to the button.
+ * @param variant The [ButtonVariant] that determines the button's color scheme. Defaults to [ButtonVariant.PRIMARY].
+ * @param enabled Controls the enabled state of the button. When `false`, the button will not be clickable.
+ */
+@Composable
+fun HAIconButton(
+    icon: Painter,
+    onClick: () -> Unit,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    variant: ButtonVariant = ButtonVariant.PRIMARY,
+    enabled: Boolean = true,
+) {
     val colors = LocalHAColorScheme.current.iconButtonColorsFromVariant(variant)
 
     RippleConfigurationLocalProvider(colors.rippleColor) {
@@ -246,7 +279,7 @@ fun HAIconButton(
             colors = colors.buttonColors,
         ) {
             Icon(
-                imageVector = icon,
+                painter = icon,
                 contentDescription = contentDescription,
                 // We only support one size for now
                 modifier = Modifier.size(24.dp),


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We already replaced this for complex icon using gradient but it seems that is also crashes for simple icon on some device. So one crash in Sentry on the Welcome screen about missing a pathData. I decided to migrate everything to a painterResource instead of the VectorImage.