### PR TITLE
Move away from Main in Broadcast receiver and use goAsync

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/location/HighAccuracyLocationReceiver.kt
@@ -3,11 +3,11 @@ package io.homeassistant.companion.android.location
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import io.homeassistant.companion.android.common.util.launchAsync
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 
 class HighAccuracyLocationReceiver : BroadcastReceiver() {
     companion object {
@@ -18,16 +18,15 @@ class HighAccuracyLocationReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            HIGH_ACCURACY_LOCATION_DISABLE ->
-                {
-                    HighAccuracyLocationService.stopService(context)
-                    ioScope.launch {
-                        LocationSensorManager.setHighAccuracyModeSetting(context, false)
-                        val locationIntent = Intent(context, LocationSensorManager::class.java)
-                        locationIntent.action = LocationSensorManager.ACTION_REQUEST_LOCATION_UPDATES
-                        context.sendBroadcast(locationIntent)
-                    }
+            HIGH_ACCURACY_LOCATION_DISABLE -> {
+                HighAccuracyLocationService.stopService(context)
+                launchAsync(ioScope) {
+                    LocationSensorManager.setHighAccuracyModeSetting(context, false)
+                    val locationIntent = Intent(context, LocationSensorManager::class.java)
+                    locationIntent.action = LocationSensorManager.ACTION_REQUEST_LOCATION_UPDATES
+                    context.sendBroadcast(locationIntent)
                 }
+            }
         }
     }
 }

--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/ActivitySensorManager.kt
@@ -16,6 +16,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
+import io.homeassistant.companion.android.common.util.launchAsync
 import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.common.util.isAutomotive
 import java.util.concurrent.TimeUnit
@@ -74,8 +75,8 @@ class ActivitySensorManager :
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            ACTION_UPDATE_ACTIVITY -> ioScope.launch { handleActivityUpdate(intent, context) }
-            ACTION_SLEEP_ACTIVITY -> ioScope.launch { handleSleepUpdate(intent, context) }
+            ACTION_UPDATE_ACTIVITY -> launchAsync(ioScope) { handleActivityUpdate(intent, context) }
+            ACTION_SLEEP_ACTIVITY -> launchAsync(ioScope) { handleSleepUpdate(intent, context) }
             else -> Timber.w("Unknown intent action: ${intent.action}!")
         }
     }

--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -36,6 +36,7 @@ import io.homeassistant.companion.android.common.notifications.DeviceCommandData
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
+import io.homeassistant.companion.android.common.util.launchAsync
 import io.homeassistant.companion.android.database.DatabaseEntryPoint
 import io.homeassistant.companion.android.database.location.LocationHistoryDao
 import io.homeassistant.companion.android.database.location.LocationHistoryItem
@@ -225,7 +226,7 @@ class LocationSensorManager :
     override fun onReceive(context: Context, intent: Intent) {
         latestContext = context
 
-        sensorWorkerScope.launch {
+        launchAsync(sensorWorkerScope) {
             when (intent.action) {
                 Intent.ACTION_BOOT_COMPLETED,
                 ACTION_REQUEST_LOCATION_UPDATES,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/NotificationActionReceiver.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.cancel
+import io.homeassistant.companion.android.common.util.launchAsync
 import io.homeassistant.companion.android.database.notification.NotificationDao
 import io.homeassistant.companion.android.notifications.MessagingManager.Companion.KEY_TEXT_REPLY
 import javax.inject.Inject
@@ -99,8 +100,9 @@ class NotificationActionReceiver : BroadcastReceiver() {
 
         when (intent.action) {
             FIRE_EVENT -> {
-                ioScope.launch {
-                    val serverId = notificationDao.get(databaseId.toInt())?.serverId ?: ServerManager.SERVER_ID_ACTIVE
+                launchAsync(ioScope) {
+                    val serverId =
+                        notificationDao.get(databaseId.toInt())?.serverId ?: ServerManager.SERVER_ID_ACTIVE
                     fireEvent(notificationAction, serverId, onComplete, onFailure)
                 }
             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketBroadcastReceiver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketBroadcastReceiver.kt
@@ -3,16 +3,16 @@ package io.homeassistant.companion.android.websocket
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import io.homeassistant.companion.android.common.util.launchAsync
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 
 class WebsocketBroadcastReceiver : BroadcastReceiver() {
     private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + Job())
 
     override fun onReceive(context: Context, intent: Intent) {
-        ioScope.launch {
+        launchAsync(ioScope) {
             WebsocketManager.start(context)
         }
     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationDeleteReceiver.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationDeleteReceiver.kt
@@ -8,12 +8,12 @@ import androidx.core.app.NotificationManagerCompat
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
+import io.homeassistant.companion.android.common.util.launchAsync
 import io.homeassistant.companion.android.database.notification.NotificationDao
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -50,8 +50,7 @@ class NotificationDeleteReceiver : BroadcastReceiver() {
         // This maybe the case if timeoutAfter has deleted the notification
         // Then only the empty group is left and needs to be cancelled
         notificationManagerCompat.cancelGroupIfNeeded(group, groupId)
-
-        ioScope.launch {
+        launchAsync(ioScope) {
             try {
                 val databaseId = intent.getLongExtra(EXTRA_NOTIFICATION_DB, 0)
                 val serverId = notificationDao.get(databaseId.toInt())?.serverId ?: ServerManager.SERVER_ID_ACTIVE

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/BroadcastReceiverExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/BroadcastReceiverExt.kt
@@ -1,0 +1,28 @@
+package io.homeassistant.companion.android.common.util
+
+import android.content.BroadcastReceiver
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Launches a coroutine while keeping the [BroadcastReceiver] alive until completion.
+ *
+ * This function must be called from [BroadcastReceiver.onReceive] and only once per invocation.
+ * Calling it multiple times will result in multiple [BroadcastReceiver.goAsync] calls,
+ * which is not supported.
+ *
+ * It calls [BroadcastReceiver.goAsync] to prevent Android from killing the process
+ * while the coroutine executes, and automatically calls `finish()` when the coroutine completes
+ * (success, failure, or cancellation).
+ *
+ * Note: If `goAsync()` returns null (e.g., when called outside of an active `onReceive()`),
+ * the coroutine will still execute but without the lifecycle protection.
+ *
+ * @param coroutineScope The scope to launch the coroutine in (typically an IO-dispatched scope).
+ * @param block The suspend function to execute.
+ */
+fun BroadcastReceiver.launchAsync(coroutineScope: CoroutineScope, block: suspend CoroutineScope.() -> Unit) {
+    val pendingResult = goAsync()
+
+    coroutineScope.launch(block = block).invokeOnCompletion { pendingResult?.finish() }
+}

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/TileActionReceiver.kt
@@ -7,12 +7,19 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.data.integration.onEntityPressedWithoutState
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.launchAsync
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import timber.log.Timber
 
 @AndroidEntryPoint
 class TileActionReceiver : BroadcastReceiver() {
+
+    companion object {
+        private val receiverScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+    }
 
     @Inject
     lateinit var serverManager: ServerManager
@@ -24,7 +31,7 @@ class TileActionReceiver : BroadcastReceiver() {
         val entityId: String? = intent?.getStringExtra("entity_id")
 
         if (entityId != null) {
-            runBlocking {
+            launchAsync(receiverScope) {
                 if (wearPrefsRepository.getWearHapticFeedback() && context != null) hapticClick(context)
 
                 try {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
It's not addressing this https://github.com/home-assistant/android/issues/6000 but it is a first step to reduce the number of ANR we have on Sentry. The biggest issue we have today is due to background ANR and I suspect it is because we do everything on Main where we don't need in the broadcast receiver.
<img width="1168" height="125" alt="image" src="https://github.com/user-attachments/assets/7fe75284-6674-46e1-bdb2-698a134bbdb1" />

The receiver code doesn't need to be updated with Main, nor anything else we have. The only place where I fallback to Main was to display a Toast.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
This might introduce regressions, I decided to also make sure the scopes are isolated because `scopeWidget` from the base class companion object was used in classes that doesn't extend the base class ...