### PR TITLE
Introduce sensitive utils function

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -239,15 +239,13 @@ Timber.e(exception, "Failed to load user dashboard for userId=$userId")
 // Bad - no context
 Timber.e(exception)
 
-// Good - conditional logging for expensive operations
-if (BuildConfig.DEBUG) {
-    Timber.d("Complex debug info: ${expensiveOperation()}")
-}
+// Good - use sensitive() to hide user data in release logs
+Timber.d("User logged in: userId=${sensitive(user.id)}")
 
 // Bad - leaks user data
 Timber.d("User logged in: ${user.email}")
 
-// Good - sanitized
+// Bad - manual BuildConfig.DEBUG check (use sensitive() instead)
 Timber.d("User logged in: userId=${if(BuildConfig.DEBUG) user.id else "redacted"}")
 ```
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.compose.composable.HAAccentButton
 import io.homeassistant.companion.android.common.compose.theme.HADimens
@@ -49,6 +48,7 @@ import io.homeassistant.companion.android.onboarding.locationforsecureconnection
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModelFactory
 import io.homeassistant.companion.android.util.compose.HAPreviews
 import io.homeassistant.companion.android.util.compose.webview.HAWebView
+import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.webview.insecure.BlockInsecureScreen
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
@@ -405,12 +405,12 @@ private fun Color.Overlay(modifier: Modifier = Modifier) {
 private fun WebViewEffects(webView: WebView?, url: String, scriptsToEvaluate: Flow<WebViewScript>) {
     if (webView != null) {
         LaunchedEffect(webView, url) {
-            Timber.v("Load url ${if (BuildConfig.DEBUG) url else ""}")
+            Timber.v("Load url ${sensitive(url)}")
             webView.loadUrl(url)
         }
         LaunchedEffect(webView) {
             scriptsToEvaluate.collect { webViewScript ->
-                Timber.d("Evaluating script: ${webViewScript.script}")
+                Timber.d("Evaluating script: ${sensitive(webViewScript.script)}")
                 webView.evaluateJavascript(webViewScript.script) { result ->
                     webViewScript.result.complete(result)
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.frontend.externalbus
 
-import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
 import io.homeassistant.companion.android.frontend.externalbus.incoming.IncomingExternalBusMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.OutgoingExternalBusMessage
@@ -11,6 +10,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.plus
+import io.homeassistant.companion.android.util.sensitive
 import timber.log.Timber
 
 private const val BUFFER_CAPACITY = 10
@@ -49,7 +49,7 @@ class FrontendExternalBusRepositoryImpl @Inject constructor() : FrontendExternal
     override suspend fun send(message: OutgoingExternalBusMessage) {
         val json = frontendExternalBusJson.encodeToString(message)
         val script = "externalBus($json);"
-        Timber.d("Queuing external bus message: ${if (BuildConfig.DEBUG) script else "HIDDEN"}")
+        Timber.d("Queuing external bus message: ${sensitive(script)}")
         scriptsFlow.emit(WebViewScript(script))
     }
 
@@ -78,7 +78,7 @@ class FrontendExternalBusRepositoryImpl @Inject constructor() : FrontendExternal
         }.onFailure { error ->
             Timber.w(
                 error,
-                "Failed to deserialize external bus message: ${if (BuildConfig.DEBUG) json else "HIDDEN"}",
+                "Failed to deserialize external bus message: ${sensitive(json)}",
             )
         }.getOrNull()
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -141,6 +141,7 @@ import io.homeassistant.companion.android.util.applyInsets
 import io.homeassistant.companion.android.util.hasNonRootPath
 import io.homeassistant.companion.android.util.hasSameOrigin
 import io.homeassistant.companion.android.util.isStarted
+import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.webview.WebView.ErrorType
 import io.homeassistant.companion.android.webview.addto.EntityAddToHandler
@@ -1500,7 +1501,7 @@ class WebViewActivity :
 
     override fun loadUrl(url: Uri, keepHistory: Boolean, openInApp: Boolean, serverHandleInsets: Boolean) {
         Timber.d(
-            "Loading ${if (BuildConfig.DEBUG) url else "HIDDEN"} (keepHistory $keepHistory, openInApp $openInApp, serverHandleInsets $serverHandleInsets)",
+            "Loading ${sensitive(url.toString())} (keepHistory $keepHistory, openInApp $openInApp, serverHandleInsets $serverHandleInsets)",
         )
         this.serverHandleInsets.value = serverHandleInsets
         if (openInApp) {
@@ -1878,7 +1879,7 @@ class WebViewActivity :
         if (supportFragmentManager.backStackEntryCount > 0) {
             Timber.i("Fragments ${supportFragmentManager.fragments} displayed, skipping connection wait")
         } else {
-            Timber.d("Waiting for loadedUrl ${if (BuildConfig.DEBUG) loadedUrl else "HIDDEN"}")
+            Timber.d("Waiting for loadedUrl ${sensitive(loadedUrl.toString())}")
             Handler(Looper.getMainLooper()).postDelayed(
                 {
                     val firstSegment = loadedUrl?.pathSegments?.firstOrNull().orEmpty()

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProvider.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/servers/ServerConnectionStateProvider.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.common.data.servers
 
 import dagger.assisted.AssistedFactory
-import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.integration.IntegrationException
 import io.homeassistant.companion.android.common.data.integration.NoUrlAvailableException
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
@@ -10,6 +9,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import okhttp3.HttpUrl
+import io.homeassistant.companion.android.util.sensitive
 import timber.log.Timber
 
 /**
@@ -55,7 +55,7 @@ suspend fun <T> tryOnUrls(urls: List<HttpUrl>, requestName: String, action: susp
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            Timber.w(e, "Failed $requestName ${if (BuildConfig.DEBUG) "on $url" else ""}")
+            Timber.w(e, "Failed $requestName on ${sensitive(url.toString())}")
             if (firstException == null) firstException = e
         }
     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImpl.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.common.data.websocket.impl
 
 import androidx.annotation.GuardedBy
 import androidx.annotation.VisibleForTesting
-import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.HomeAssistantApis.Companion.USER_AGENT
 import io.homeassistant.companion.android.common.data.HomeAssistantApis.Companion.USER_AGENT_STRING
 import io.homeassistant.companion.android.common.data.HomeAssistantVersion
@@ -13,6 +12,7 @@ import io.homeassistant.companion.android.common.data.websocket.HAWebSocketExcep
 import io.homeassistant.companion.android.common.data.websocket.WebSocketCore
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRequest
 import io.homeassistant.companion.android.common.data.websocket.WebSocketState
+import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketConstants.EVENT_AREA_REGISTRY_UPDATED
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketConstants.EVENT_DEVICE_REGISTRY_UPDATED
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketConstants.EVENT_ENTITY_REGISTRY_UPDATED
@@ -656,7 +656,7 @@ internal class WebSocketCoreImpl(
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onMessage(webSocket: WebSocket, text: String) {
-        Timber.d("Websocket: onMessage (${if (BuildConfig.DEBUG) "text: $text" else "text"})")
+        Timber.d("Websocket: onMessage (text: ${sensitive(text)})")
         if (isStaleConnection(webSocket)) {
             Timber.w("Ignoring onMessage from stale connection")
             return

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/JsonUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/JsonUtil.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.common.util
 
-import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.SocketResponse
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -15,6 +14,7 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.descriptors.mapSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
+import io.homeassistant.companion.android.util.sensitive
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonDecoder
@@ -348,7 +348,7 @@ fun String.toJsonObjectOrNull(): JsonObject? {
     return runCatching {
         Json.parseToJsonElement(this) as? JsonObject
     }.onFailure {
-        Timber.w("Failed to convert to a json object: ${if (BuildConfig.DEBUG) this else "HIDDEN"}")
+        Timber.w("Failed to convert to a json object: ${sensitive(this)}")
     }.getOrNull()
 }
 
@@ -381,7 +381,7 @@ fun JsonObject.getStringOrNull(key: String): String? {
         val value = this[key]
         if (value is JsonNull) null else value?.jsonPrimitive?.content
     }.onFailure {
-        Timber.w("Failed to get string value for $key in jsonObject: ${if (BuildConfig.DEBUG) this else "HIDDEN"}")
+        Timber.w("Failed to get string value for $key in jsonObject: ${sensitive(this.toString())}")
     }.getOrNull()
 }
 
@@ -436,7 +436,7 @@ fun JsonObject.getBooleanOrNull(key: String): Boolean? {
         val value = this[key]
         if (value is JsonNull) null else value?.jsonPrimitive?.booleanOrNull
     }.onFailure {
-        Timber.w("Failed to get boolean value for $key in jsonObject: ${if (BuildConfig.DEBUG) this else "HIDDEN"}")
+        Timber.w("Failed to get boolean value for $key in jsonObject: ${sensitive(this.toString())}")
     }.getOrNull()
 }
 
@@ -493,7 +493,7 @@ fun JsonObject.getIntOrNull(key: String): Int? {
         val value = this[key]
         if (value is JsonNull) null else value?.jsonPrimitive?.intOrNull
     }.onFailure {
-        Timber.w("Failed to get integer value for $key in jsonObject: ${if (BuildConfig.DEBUG) this else "HIDDEN"}")
+        Timber.w("Failed to get integer value for $key in jsonObject: ${sensitive(this.toString())}")
     }.getOrNull()
 }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/StringUtils.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/StringUtils.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.util
+
+import io.homeassistant.companion.android.common.BuildConfig
+
+/**
+ * Sanitizes sensitive data for logging by returning the actual value in a secure environment
+ * and "HIDDEN" otherwise, preventing user data from leaking into production logs.
+ *
+ * This should be used instead of manual `if (BuildConfig.DEBUG)` checks in Timber log messages
+ * whenever the log contains data that could identify the user or their Home Assistant setup
+ * (URLs, tokens, message payloads, etc.).
+ *
+ * ```kotlin
+ * Timber.d("Load url=${sensitive(url)}")
+ * // Debug:   "Load url=https://my-ha.example.com/api"
+ * // Release: "Load url=HIDDEN"
+ * ```
+ *
+ * @param sensitive the value to sanitize
+ * @return the original value when it is secure, "HIDDEN" otherwise
+ */
+fun sensitive(sensitive: String): String = sensitive.takeIf { BuildConfig.DEBUG } ?: "HIDDEN"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We have this pattern in logs where in logs we hide strings in release. I want to centralize the logic in one place if we ever want to enable this dynamically for any reason (the user might want to be able to see this sensitive information).