### PR TITLE
Upload test reports and test result in an unify manner in pr workflow

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -1,0 +1,25 @@
+name: "Upload test results"
+description: "Upload test result (always) and test reports (on failure) as artifacts."
+inputs:
+  test-name:
+    description: "Name of the test used as prefix for the artifact names."
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Upload test results
+      if: always()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: ${{ inputs.test-name }} results
+        path: |
+          **/build/test-results/**/TEST-*.xml
+          **/build/outputs/*/connected/*
+
+    - name: Upload test reports
+      if: failure()
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+      with:
+        name: ${{ inputs.test-name }} reports
+        path: |
+          **/build/reports/**

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -118,21 +118,10 @@ jobs:
       - name: Validate Screenshot Previews
         run: ./gradlew validateDebugScreenshotTest validateFullDebugScreenshotTest
 
-      - name: Upload test results
+      - uses: ./.github/actions/upload-test-results
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: Screenshot test results
-          path: |
-            **/build/test-results/**/TEST-*.xml
-
-      - name: Upload test results
-        if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: Screenshot test failure HTML report
-          path: |
-            **/build/reports/screenshotTest/**
+          test-name: Screenshot test
 
   pr_build:
     needs: [lockfiles, ktlint]
@@ -227,13 +216,10 @@ jobs:
         # Run testFullDebugUnitTest at the app level since :automotive shares the same sourceSet than app. Minimal and Full are the same in unit tests for now
         run: ./gradlew testDebugUnitTest :app:testFullDebugUnitTest :lint:test
 
-      - name: Upload test results
+      - uses: ./.github/actions/upload-test-results
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: Unit test results
-          path: |
-            **/build/test-results/**/TEST-*.xml
+          test-name: Unit test
 
   instrumentation_test:
     name: "Instrumentation Tests"
@@ -313,14 +299,10 @@ jobs:
           system-image-api-level: ${{ matrix.configuration.system-image-api-level }}
           script: ./gradlew ${{ matrix.configuration.gradle_target }}
 
-      - name: Upload test results
+      - uses: ./.github/actions/upload-test-results
         if: always()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: Instrumentation test results (API${{ matrix.configuration.api-level }}) ${{ matrix.configuration.target }}
-          path: |
-            **/build/reports/*
-            **/build/outputs/*/connected/*
+          test-name: Instrumentation test (API${{ matrix.configuration.api-level }}) ${{ matrix.configuration.target }}
 
   publish_test_results:
     name: "Publish Tests Results"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
It turns out that we are not storing the test reports on CI, which make hard to debug when something goes wrong like FailFast triggering in Unit Test. We are also uploading test result in different manner depending on the job we are on. This PR address this two issue.