### PR TITLE
Robolectric tests needs to override the application to avoid strictMode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -305,6 +305,13 @@ Use the `Clock` available from `Hilt`.
 - **Framework**: JUnit Jupiter for unit tests (or 4 when necessary to use Robolectric)
 - **Mocking**: MockK (Use real objects when you can or fakes)
 - **Android APIs**: Robolectric (requires JUnit 4 compatibility)
+- **Robolectric tests**: All Robolectric test classes must use both annotations:
+  ```kotlin
+  @RunWith(RobolectricTestRunner::class)
+  @Config(application = HiltTestApplication::class)
+  class MyTest {
+  ```
+  Without the `@Config` override, Robolectric defaults to the manifest's `HomeAssistantApplication`, which enables StrictMode and FailFast, leaking process-wide state that can crash the test JVM.
 - **Test Location**: Tests should mirror source structure in `src/test/kotlin/` directory
 - **Test Naming**: Use GIVEN-WHEN-THEN structure with descriptive sentences:
   ```kotlin

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.launch.link
 
+import dagger.hilt.android.testing.HiltTestApplication
 import androidx.core.net.toUri
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
@@ -13,9 +14,11 @@ import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.fail
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 // We need Robolectric because of the usage of URI from `android.net.URI`
 @RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
 class LinkHandlerTest {
 
     private val serverManager: ServerManager = mockk()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoGlanceAppWidgetTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoGlanceAppWidgetTest.kt
@@ -10,14 +10,17 @@ import androidx.glance.testing.unit.assertHasNoClickAction
 import androidx.glance.testing.unit.hasContentDescriptionEqualTo
 import androidx.glance.testing.unit.hasTestTag
 import androidx.glance.testing.unit.hasTextEqualTo
+import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
 class TodoGlanceAppWidgetTest {
     private val context = RuntimeEnvironment.getApplication()
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6428                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
The issue was quite tricky to spot and only surfaced with #6342. Some Robolectric tests didn't have the `@Config` annotation that sets the Application class to something else than `HomeAssistantApplication`. Because of that, any test that runs without this override is going to instantiate `HomeAssistantApplication` and turn on `StrictMode.`                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                   
It was not an issue so far because the classes without the annotation were `io.homeassistant.companion.android.launch.link.LinkHandlerTest` and `io.homeassistant.companion.android.widgets.todo.TodoGlanceAppWidgetTest`. Luckily we didn't have any compose screen test after these two tests following the alphabetical order. But the moment we introduced a test without the annotation but before compose screen tests like `io.homeassistant.companion.android.assist.service.AssistVoiceInteractionServiceTest`, it started to fail on the first test with a `StrictMode` violation (that we want to ignore in tests) and crash the process because of `FailFast`.

To make it even harder:
- The violation doesn't happen while running within Android Studio, only on CLI.
- We were not storing the reports on CI so it was hard to see (fixed in #6430).

This PR simply adds the missing annotation and updates the AI instructions file so that anyone using AI will be warned. Also useful for AI review.