### PR TITLE
Fix missing bundle install

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -110,6 +110,10 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: ./gradlew appDistributionUploadFullRelease
 
+      - name: Install Fastlane dependencies
+        if: github.event.inputs.beta == 'true'
+        run: bundle install
+
       - name: Prepare Amazon Listing
         if: github.event.inputs.beta == 'true'
         run: bundle exec fastlane prep_amazon
@@ -185,6 +189,9 @@ jobs:
         with:
           name: release-aabs
           path: ./**/*.aab
+
+      - name: Install Fastlane dependencies
+        run: bundle install
 
       - name: Deploy to Playstore Internal
         run: bundle exec fastlane deploy_internal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,5 +33,8 @@ jobs:
           firebase-creds: ${{ secrets.FIREBASECREDS }}
           playstore-creds: ${{ secrets.PLAYSTORECREDS }}
 
+      - name: Install Fastlane dependencies
+        run: bundle install
+
       - name: Promote Beta to Production Play Store
         run: bundle exec fastlane promote_to_production


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I didn't catch in https://github.com/home-assistant/android/pull/6446 that we now need to run `bundle install` manually. This PR is adding it where it is needed.