### PR TITLE
Make Entity state parsing safer

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/entities/CompressedEntity.kt
@@ -10,6 +10,7 @@ import kotlin.math.round
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Polymorphic
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNames
 
 /**
@@ -46,7 +47,7 @@ data class CompressedStateDiff(
 @Serializable
 data class CompressedEntityState(
     @JsonNames("s")
-    val state: String? = null,
+    val state: JsonElement? = null,
     @Serializable(with = MapAnySerializer::class)
     @JsonNames("a")
     val attributes: Map<String, @Polymorphic Any?> = emptyMap(),

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/EntityTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/EntityTest.kt
@@ -1,18 +1,26 @@
 package io.homeassistant.companion.android.common.data.integration
 
+import android.content.Context
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedEntityRemoved
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedEntityState
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedStateDiff
+import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.mockk
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
+@ExtendWith(ConsoleLogExtension::class)
 class EntityTest {
 
     private val baseDateTime = LocalDateTime.of(2024, 1, 1, 12, 0, 0)
@@ -53,6 +61,72 @@ class EntityTest {
     }
 
     @Nested
+    inner class Deserialization {
+        private fun entityJson(stateValue: String) = """
+            {
+                "entity_id": "sensor.temperature",
+                "state": $stateValue,
+                "attributes": {"friendly_name": "Temperature"},
+                "last_changed": "2024-01-01T12:00:00",
+                "last_updated": "2024-01-01T12:00:00"
+            }
+        """.trimIndent()
+
+        @Test
+        fun `Given string state when deserializing then returns state value`() {
+            val entity = kotlinJsonMapper.decodeFromString<Entity>(entityJson("\"on\""))
+            assertEquals("on", entity.state)
+        }
+
+        @Test
+        fun `Given empty string state when deserializing then returns empty state`() {
+            val entity = kotlinJsonMapper.decodeFromString<Entity>(entityJson("\"\""))
+            assertEquals("", entity.state)
+        }
+
+        @Test
+        fun `Given numeric state when deserializing then returns empty state`() {
+            val entity = kotlinJsonMapper.decodeFromString<Entity>(entityJson("42"))
+            assertEquals("", entity.state)
+            assertEquals("sensor.temperature", entity.entityId)
+        }
+
+        @Test
+        fun `Given boolean state when deserializing then returns empty state`() {
+            val entity = kotlinJsonMapper.decodeFromString<Entity>(entityJson("true"))
+            assertEquals("", entity.state)
+        }
+
+        @Test
+        fun `Given null state when deserializing then returns empty state`() {
+            val entity = kotlinJsonMapper.decodeFromString<Entity>(entityJson("null"))
+            assertEquals("", entity.state)
+        }
+
+        @Test
+        fun `Given string state when serializing round-trip then preserves state`() {
+            val entity = createEntity(state = "unavailable")
+            val json = kotlinJsonMapper.encodeToString(entity)
+            val deserialized = kotlinJsonMapper.decodeFromString<Entity>(json)
+            assertEquals("unavailable", deserialized.state)
+        }
+    }
+
+    @Nested
+    inner class GetIcon {
+        @Test
+        fun `Given blank state and non-string state attribute when getting icon then does not throw`() {
+            val context = mockk<Context>()
+            val entity = createEntity(
+                entityId = "sensor.test",
+                state = "",
+                attributes = mapOf("state" to 42),
+            )
+            assertDoesNotThrow { entity.getIcon(context) }
+        }
+    }
+
+    @Nested
     inner class ApplyCompressedStateDiff {
         @Test
         fun `Given empty diff when applying then returns entity with same values`() {
@@ -69,7 +143,7 @@ class EntityTest {
         @Test
         fun `Given diff with state change when applying then updates state`() {
             val entity = createEntity(state = "on")
-            val diff = CompressedStateDiff(plus = CompressedEntityState(state = "off"))
+            val diff = CompressedStateDiff(plus = CompressedEntityState(state = JsonPrimitive("off")))
 
             val result = entity.applyCompressedStateDiff(diff)
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6454 caused by a custom integration that has a state attributes not a string. This PR goes a little further to avoid future issue coming from custom integrations. The idea is to warn with all the needed details and fallback to an empty state so that users can open the logs and see issue (and the associated `entity_id`) and report it to the maintainer. 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
KTlint did some changes in `Entity` that I have been ignoring for a long time but I think it is fine to add it to this PR.