### PR TITLE
Use lazy publication in ServerConnectionInfo to avoid any locks

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/server/ServerConnectionInfo.kt
@@ -63,19 +63,19 @@ data class ServerConnectionInfo(
 ) {
     // Keep the parsing of the URLs from String to HttpUrl to avoid doing it multiple times
     @get:Ignore
-    internal val externalHttpUrl: HttpUrl? by lazy { externalUrl.toHttpUrlOrNull() }
+    internal val externalHttpUrl: HttpUrl? by lazy(LazyThreadSafetyMode.PUBLICATION) { externalUrl.toHttpUrlOrNull() }
 
     @get:Ignore
-    internal val internalHttpUrl: HttpUrl? by lazy { internalUrl?.toHttpUrlOrNull() }
+    internal val internalHttpUrl: HttpUrl? by lazy(LazyThreadSafetyMode.PUBLICATION) { internalUrl?.toHttpUrlOrNull() }
 
     @get:Ignore
-    internal val cloudHttpUrl: HttpUrl? by lazy { cloudUrl?.toHttpUrlOrNull() }
+    internal val cloudHttpUrl: HttpUrl? by lazy(LazyThreadSafetyMode.PUBLICATION) { cloudUrl?.toHttpUrlOrNull() }
 
     @get:Ignore
-    internal val cloudhookHttpUrl: HttpUrl? by lazy { cloudhookUrl?.toHttpUrlOrNull() }
+    internal val cloudhookHttpUrl: HttpUrl? by lazy(LazyThreadSafetyMode.PUBLICATION) { cloudhookUrl?.toHttpUrlOrNull() }
 
     @get:Ignore
-    internal val httpUrls: List<HttpUrl> by lazy {
+    internal val httpUrls: List<HttpUrl> by lazy(LazyThreadSafetyMode.PUBLICATION) {
         listOfNotNull(
             externalHttpUrl,
             internalHttpUrl,
@@ -88,7 +88,7 @@ data class ServerConnectionInfo(
      * Indicates whether at least one URL is configured and parsable.
      */
     @get:Ignore
-    val hasAtLeastOneUrl: Boolean by lazy {
+    val hasAtLeastOneUrl: Boolean by lazy(LazyThreadSafetyMode.PUBLICATION) {
         httpUrls.isNotEmpty()
     }
 
@@ -114,7 +114,7 @@ data class ServerConnectionInfo(
      * @return `true` if the server is registered with valid URLs
      */
     @get:Ignore
-    val isRegistered: Boolean by lazy {
+    val isRegistered: Boolean by lazy(LazyThreadSafetyMode.PUBLICATION) {
         !webhookId.isNullOrBlank() && httpUrls.isNotEmpty()
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Since 2026.2.3 we have ANR that points to `isRegister`, it seems impossible that the simple parsing of a URL is blocking the Main thread, but the parsing of the URL is made within a `lazy` block and in its default mode `LazyThreadSafetyMode.SYNCHRONIZED` it encapsulate the parsing into a synchronized block which doesn't fit well into a coroutine since the coroutine is going to hang and not being suspended which is forbidden for the Main thread.

We are calling `isRegistered` in many places so it is possible that it cause the ANR, but it is not covering the whole story there and something should probably not be done in the Main thread. Merging the PR about widgets using Default dispatcher should help more.

This PR simply change the lazy mode to `LazyThreadSafetyMode.PUBLICATION`

> Initializer function can be called several times on concurrent access to an uninitialized Lazy instance value, but only one computed value will be used as the value of a Lazy instance and will be visible by all threads.

In the context it is perfectly fine since running the lazy blocks multiple times would always produce the same result and only cost some computations.