### PR TITLE
Set setShowsUserInterface(false) for non-UI notification actions

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1608,12 +1608,13 @@ class MessagingManager @Inject constructor(
                             eventIntent,
                             PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
                         )
-                        val action: NotificationCompat.Action = NotificationCompat.Action.Builder(
+                        val action = NotificationCompat.Action.Builder(
                             R.drawable.ic_baseline_reply_24,
                             notificationAction.title,
                             replyPendingIntent,
                         )
                             .addRemoteInput(remoteInput)
+                            .setShowsUserInterface(false)
                             .build()
                         builder.addAction(action)
                     }
@@ -1625,11 +1626,14 @@ class MessagingManager @Inject constructor(
                             eventIntent,
                             PendingIntent.FLAG_IMMUTABLE,
                         )
-                        builder.addAction(
+                        val action = NotificationCompat.Action.Builder(
                             commonR.drawable.ic_stat_ic_notification,
                             notificationAction.title,
                             actionPendingIntent,
                         )
+                            .setShowsUserInterface(false)
+                            .build()
+                        builder.addAction(action)
                     }
                 }
             }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #6461 

As a (former) Pebble user I couldn't help myself and had to pick up this simple change to make notification actions available on these watches.

Tested the change on a boring Wear OS smartwatch and normal phone as well to confirm there is no other impact.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

```yaml
action: notify.mobile_app_pixel_7a_dev
data:
  message: Test notification for actions
  data:
    actions:
      - action: ALARM
        title: Sound alarm
      - action: REPLY
        title: Send reply
  title: Hello from Home Assistant
```

generated a notification:

https://github.com/user-attachments/assets/e507febb-b11a-4c74-9b44-4a6698618726

results in event:

<img width="454" height="349" alt="image" src="https://github.com/user-attachments/assets/83feb26e-0015-46c4-836a-7f7f094ecfde" />


## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->