### PR TITLE
Set taskAffinity for Wear OS Assist to something else

### DIFF
--- a/wear/src/main/AndroidManifest.xml
+++ b/wear/src/main/AndroidManifest.xml
@@ -121,7 +121,8 @@
             android:label="@string/ha_assist"
             android:launchMode="singleTask"
             android:theme="@style/Theme.HomeAssistant.SplashThemeAssist"
-            android:exported="true">
+            android:exported="true"
+            android:taskAffinity="io.homeassistant.companion.android.assist">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -242,7 +243,7 @@
                 <action android:name="io.homeassistant.companion.android.TILE_ACTION" />
             </intent-filter>
         </receiver>
-        
+
         <!-- Complications -->
         <service android:name=".complications.EntityStateDataSourceService"
             android:exported="true"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Following a message on [how Samsung watches sometimes open Assist when tapping on the main HA icon](https://discord.com/channels/330944238910963714/1346948551892009101/1474131033858510919), and a [hunch that setting a different task might help](https://discord.com/channels/330944238910963714/1346948551892009101/1474131708830814289), I've tested it and confirms that helps!

 - Set the `taskAffinity` attribute for Assist on Wear OS to a different value to other parts of the app to resolve an issue where on Samsung watches the main icon could launch Assist instead.
 - This may result in Assist showing up as a different 'app' in task switchers which is fine in my opinion.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
Before

https://github.com/user-attachments/assets/01b7302a-345a-4982-8dde-fac15167a318

After

https://github.com/user-attachments/assets/0f1615cc-5491-4b11-9a74-259beeb71504

(Ignore the speed, Compose on Wear with debug is extremely slow)

This now makes Assist show up separately in the task switcher which Samsung watches have
<img width="396" height="396" alt="Task switcher on a watch showing both Home Assistant and Assist items" src="https://github.com/user-attachments/assets/3ff9798e-6cff-4010-b6a7-53a926163663" />

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->