### PR TITLE
Fix change server button not showing with Auto(motive) favorites

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/vehicle/TemplateComponents.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/vehicle/TemplateComponents.kt
@@ -204,7 +204,7 @@ fun getDomainList(
                                     domains,
                                     entityList,
                                     allEntities,
-                                ) { },
+                                ),
                             )
                         }
                     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -163,7 +163,7 @@ class MainVehicleScreen(
                 domains,
                 flowOf(),
                 allEntities,
-            ) { onChangeServer(it) }.getEntityGridItems(favoritesEntities)
+            ).getEntityGridItems(favoritesEntities, canSwitchServers)
         } else {
             var builder = ItemList.Builder()
             if (domains.isNotEmpty() && domainsAdded) {
@@ -189,19 +189,18 @@ class MainVehicleScreen(
                     entityRegistry,
                 ).build(),
             )
-
-            if (canSwitchServers) {
-                builder.addItem(
-                    getChangeServerGridItem(
-                        carContext,
-                        lifecycleScope,
-                        screenManager,
-                        serverManager,
-                        serverId,
-                    ) { onChangeServer(it) }.build(),
-                )
-            }
             builder
+        }
+        if (canSwitchServers) {
+            listBuilder.addItem(
+                getChangeServerGridItem(
+                    carContext,
+                    lifecycleScope,
+                    screenManager,
+                    serverManager,
+                    serverId,
+                ) { onChangeServer(it) }.build(),
+            )
         }
         val refreshAction = Action.Builder()
             .setIcon(


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes an issue where the 'Change server' button was not visible in the Android Auto(motive) interface when favorites were used.

This issue was caused by the changes in commit 8daf0857d5676b7134d15debae087823f9548b0a moving the server count check to be dependent on the lifecycle in `EntityGridVehicleScreen`. For favorites, a function in this screen is called statically so the lifecycle is never started, and the server count will never be updated.

This PR fixes the issue by adjusting `MainVehicleScreen`  to always be responsible for showing the 'Change server' button. The related code is removed from `EntityGridVehicleScreen, and the function is passed info on whether or not it will be shown to the list so the maximum item count can be adjusted accordingly.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="798" height="478" alt="Android Auto interface for Home Assistant, showing a grid with buttons labeled 'Alarm sound (unavailable)', 'Navigation', 'All entities' and 'Change server'" src="https://github.com/user-attachments/assets/dce90a67-c4c1-41a2-a955-71d6463bd54b" />


## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
It's probably worth untangling more in these screens and seeing if we can add some kind of tests, but that is out of scope for now I think. This is a quick bug fix that can be included in the next release.