### PR TITLE
Fix EntityWidget showing "null null" instead of last known value

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidget.kt
@@ -37,7 +37,7 @@ class EntityWidget : BaseWidgetProvider<StaticWidgetEntity, StaticWidgetDao>() {
         internal const val TOGGLE_ENTITY =
             "io.homeassistant.companion.android.widgets.entity.EntityWidget.TOGGLE_ENTITY"
 
-        private data class ResolvedText(val text: CharSequence?, val exception: Boolean = false)
+        private data class ResolvedText(val text: CharSequence?, val error: Boolean = false)
     }
 
     override fun getWidgetProvider(context: Context): ComponentName = ComponentName(context, EntityWidget::class.java)
@@ -120,7 +120,7 @@ class EntityWidget : BaseWidgetProvider<StaticWidgetEntity, StaticWidgetDao>() {
                 )
                 setViewVisibility(
                     R.id.widgetStaticError,
-                    if (resolvedText.exception) View.VISIBLE else View.GONE,
+                    if (resolvedText.error) View.VISIBLE else View.GONE,
                 )
                 setOnClickPendingIntent(
                     R.id.widgetTextLayout,
@@ -154,7 +154,6 @@ class EntityWidget : BaseWidgetProvider<StaticWidgetEntity, StaticWidgetDao>() {
         appWidgetId: Int,
     ): ResolvedText {
         var entity: Entity? = null
-        var entityCaughtException = false
         try {
             entity = if (suggestedEntity != null && suggestedEntity.entityId == entityId) {
                 suggestedEntity
@@ -165,7 +164,6 @@ class EntityWidget : BaseWidgetProvider<StaticWidgetEntity, StaticWidgetDao>() {
             throw e
         } catch (e: Exception) {
             Timber.e(e, "Unable to fetch entity")
-            entityCaughtException = true
         }
         val entityOptions = if (
             entity?.canSupportPrecision() == true &&
@@ -184,7 +182,7 @@ class EntityWidget : BaseWidgetProvider<StaticWidgetEntity, StaticWidgetDao>() {
         }
 
         if (entity == null) {
-            return ResolvedText(dao.get(appWidgetId)?.lastUpdate, entityCaughtException)
+            return ResolvedText(dao.get(appWidgetId)?.lastUpdate, true)
         }
 
         if (attributeIds == null) {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetTest.kt
@@ -150,7 +150,7 @@ class EntityWidgetTest {
     }
 
     @Test
-    fun `Given entity returns null without exception and attribute configured and cached value when resolving then shows cached value without error icon`() = runTest {
+    fun `Given entity returns null without exception and attribute configured and cached value when resolving then shows cached value with error icon`() = runTest {
         coEvery { dao.get(appWidgetId) } returns createWidgetEntity(attributeIds = "unit_of_measurement", lastUpdate = "5 W")
         coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
         coEvery { integrationRepository.getEntity(entityId) } returns null
@@ -158,7 +158,7 @@ class EntityWidgetTest {
         val (text, errorIcon) = resolveWidgetViews(widget.getWidgetRemoteViews(context, appWidgetId))
 
         assertEquals("5 W", text.text.toString())
-        assertEquals(View.GONE, errorIcon.visibility)
+        assertEquals(View.VISIBLE, errorIcon.visibility)
         coVerify(exactly = 0) { dao.updateWidgetLastUpdate(any(), any()) }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary

When an `EntityWidget` is configured with an additional attribute (e.g., `unit_of_measurement`), the widget displayed "**null null**" whenever the Home Assistant server is unreachable, instead of showing the last known value with an error indicator.

 Three issues compound in `resolveTextToShow()`:
 1. Kotlin's String?.plus() coerces null to the literal string "null", so entity?.friendlyState(...) produces "null" when the server is unreachable and entity is null.
 2. listOf<String?>(null).joinToString() renders missing attribute values as "null" rather than skipping them.
 3. This corrupted "null null" string is persisted to the last_update cache column, overwriting the last valid value.

Fixes:
 - Added an early return when `entity == null`, falling back to the cached lastUpdate and preserving the entityCaughtException flag so the red error icon appears.
 - Changed map { ... } to mapNotNull { ... } when collecting attribute values, so attributes missing from the entity's current state are skipped rather than rendered as "null".
 - Remove DAO inserts when no new state was fetched

<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
Before:
![before](https://github.com/user-attachments/assets/1514a27a-6489-41a2-b75e-ae3d57dfa3ce)
After:
![after](https://github.com/user-attachments/assets/b9c8fae2-85f6-47c8-a59d-2679c7c3c928)

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
This PR is my first contribution to HA. I’ve been a long-time Home Assistant user and am very grateful for the project. Please feel free to let me know if you’d like any changes.