### PR TITLE
Use broadcast instead of startService to send command

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
@@ -75,7 +75,7 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
     private var lastTriggerTime: Instant? = null
     private var isServiceReady = false
 
-    private val commandReceiver = object : BroadcastReceiver() {
+    private val actionReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {
             handleAction(intent.action)
         }
@@ -87,7 +87,7 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
         Timber.d("VoiceInteractionService is ready")
         ContextCompat.registerReceiver(
             this,
-            commandReceiver,
+            actionReceiver,
             IntentFilter().apply {
                 addAction(ACTION_START_LISTENING)
                 addAction(ACTION_STOP_LISTENING)
@@ -109,7 +109,7 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
         super.onShutdown()
         isServiceReady = false
         Timber.d("VoiceInteractionService is shutting down")
-        unregisterReceiver(commandReceiver)
+        unregisterReceiver(actionReceiver)
         // Don't use stopListening() as it launches a coroutine that may not complete before cancel
         serviceScope.cancel()
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionServiceTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionServiceTest.kt
@@ -106,7 +106,7 @@ class AssistVoiceInteractionServiceTest {
     }
 
     @Test
-    fun `Given service when onReady then register command receiver for all actions`() = runTest {
+    fun `Given service when onReady then register action receiver for all actions`() = runTest {
         service.onReady()
         advanceUntilIdle()
 
@@ -117,7 +117,7 @@ class AssistVoiceInteractionServiceTest {
     }
 
     @Test
-    fun `Given service ready when onShutdown then unregister command receiver`() = runTest {
+    fun `Given service ready when onShutdown then unregister action receiver`() = runTest {
         service.onReady()
         advanceUntilIdle()
 
@@ -446,12 +446,12 @@ class AssistVoiceInteractionServiceTest {
         }
         .toSet()
 
-    private fun assertAction(action: String, command: (Context) -> Unit) {
+    private fun assertAction(action: String, actionFunction: (Context) -> Unit) {
         val context = mockk<Context>(relaxed = true)
         every { context.packageName } returns "io.homeassistant.companion.android"
         val intentSlot = slot<Intent>()
 
-        command(context)
+        actionFunction(context)
 
         verify { context.sendBroadcast(capture(intentSlot)) }
         assertEquals(action, intentSlot.captured.action)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The PR is based on an observed crash coming from Sentry

```
java.lang.RuntimeException: Unable to destroy activity {io.homeassistant.companion.android/io.homeassistant.companion.android.assist.AssistActivity}: android.app.BackgroundServiceStartNotAllowedException: Not allowed to start service Intent { act=io.homeassistant.companion.android.RESUME_LISTENING cmp=io.homeassistant.companion.android/.assist.service.AssistVoiceInteractionService }: app is in background uid UidRecord{93ebf16 u0a409 CEM  bg:+3m27s242ms idle change:procstate procs:0 seq(82363255,82348714)}
    at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5528)
    at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5564)
    at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
    at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2393)
    at android.os.Handler.dispatchMessage(Handler.java:111)
    at android.os.Looper.loopOnce(Looper.java:238)
    at android.os.Looper.loop(Looper.java:357)
    at android.app.ActivityThread.main(ActivityThread.java:8088)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)

android.app.BackgroundServiceStartNotAllowedException: Not allowed to start service Intent { act=io.homeassistant.companion.android.RESUME_LISTENING cmp=io.homeassistant.companion.android/.assist.service.AssistVoiceInteractionService }: app is in background uid UidRecord{93ebf16 u0a409 CEM  bg:+3m27s242ms idle change:procstate procs:0 seq(82363255,82348714)}
    at android.app.ContextImpl.startServiceCommon(ContextImpl.java:1928)
    at android.app.ContextImpl.startService(ContextImpl.java:1884)
    at android.content.ContextWrapper.startService(ContextWrapper.java:817)
    at android.content.ContextWrapper.startService(ContextWrapper.java:817)
    at io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService$Companion.resumeListening(AssistVoiceInteractionService.kt:363)
    at io.homeassistant.companion.android.assist.AssistActivity.onDestroy(AssistActivity.kt:160)
    at android.app.Activity.performDestroy(Activity.java:8748)
    at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1421)
    at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:5515)
    at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:5564)
    at android.app.servertransaction.DestroyActivityItem.execute(DestroyActivityItem.java:47)
    at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2393)
    at android.os.Handler.dispatchMessage(Handler.java:111)
    at android.os.Looper.loopOnce(Looper.java:238)
    at android.os.Looper.loop(Looper.java:357)
    at android.app.ActivityThread.main(ActivityThread.java:8088)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
```

This is because we call `startService` to send a command where we could instead use a simple broadcast to communicate with the already started service. I tested on both Android 9 and 16 and it worked like before. 

We don't need the startService since it is done already by the system when setting the app as default digital assistant.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.