### PR TITLE
Use goAsync to invoke the WebSocketManager.start

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketBroadcastReceiver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketBroadcastReceiver.kt
@@ -3,16 +3,16 @@ package io.homeassistant.companion.android.websocket
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import io.homeassistant.companion.android.common.util.launchAsync
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.SupervisorJob
 
 class WebsocketBroadcastReceiver : BroadcastReceiver() {
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + Job())
+    private val receiverScope: CoroutineScope = CoroutineScope(Dispatchers.Default + SupervisorJob())
 
     override fun onReceive(context: Context, intent: Intent) {
-        ioScope.launch {
+        launchAsync(receiverScope) {
             WebsocketManager.start(context)
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The call to `WebSocketManager.start` can be a bit slow since it needs to cancel previous job and send await. We should do that using `goAsync` to let know the system that it is still alive. 

<img width="458" height="233" alt="image" src="https://github.com/user-attachments/assets/f46d8fac-2c4a-417c-9fe7-2442e19d5bba" />
(last 7 days)

It seems to be mostly on old devices (bellow Android 12)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

Based on https://github.com/home-assistant/android/pull/6467