### PR TITLE
Introduce FailFastExtension/Rule to reset handler

### DIFF
--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
@@ -4,10 +4,12 @@ import androidx.core.net.toUri
 import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
+import io.homeassistant.companion.android.util.FailFastRule
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.assertNotNull
@@ -20,6 +22,9 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(application = HiltTestApplication::class)
 class LinkHandlerTest {
+
+    @get:Rule
+    val failFastRule = FailFastRule()
 
     private val serverManager: ServerManager = mockk()
     private val handler = LinkHandlerImpl(serverManager)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.turbineScope
 import io.homeassistant.companion.android.common.data.HomeAssistantVersion
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.homeassistant.companion.android.util.FailFastExtension
 import io.mockk.CapturingSlot
 import io.mockk.Ordering
 import io.mockk.Runs
@@ -29,7 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import timber.log.Timber
 
-@ExtendWith(ConsoleLogExtension::class)
+@ExtendWith(ConsoleLogExtension::class, FailFastExtension::class)
 class HomeAssistantSearcherImplTest {
 
     private lateinit var nsdManager: NsdManager

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearRepositoryTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/wear/SettingsWearRepositoryTest.kt
@@ -8,6 +8,7 @@ import io.homeassistant.companion.android.common.data.integration.impl.Integrati
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.homeassistant.companion.android.util.FailFastExtension
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import retrofit2.Response
 
-@ExtendWith(ConsoleLogExtension::class)
+@ExtendWith(ConsoleLogExtension::class, FailFastExtension::class)
 class SettingsWearRepositoryTest {
 
     private val authenticationService: AuthenticationService = mockk()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/FailFastExtension.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/FailFastExtension.kt
@@ -1,0 +1,62 @@
+package io.homeassistant.companion.android.util
+
+import io.homeassistant.companion.android.common.util.DefaultFailFastHandler
+import io.homeassistant.companion.android.common.util.FailFast
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * A JUnit Jupiter extension that resets the [FailFast] handler to [DefaultFailFastHandler]
+ * after each test.
+ *
+ * Tests that override the [FailFast] handler (e.g., to capture exceptions or suppress crashes)
+ * must ensure the handler is restored after the test to avoid leaking state to other tests.
+ * This extension automates that cleanup.
+ *
+ * ### Usage:
+ * ```kotlin
+ * @ExtendWith(FailFastExtension::class)
+ * class MyTest {
+ *     @Test
+ *     fun myTest() {
+ *          FailFast.setHandler { throwable, _ -> /* custom handler */ }
+ *         // FailFast handler is automatically reset after each test
+ *     }
+ * }
+ * ```
+ *
+ * @see FailFastRule for JUnit 4 tests
+ */
+class FailFastExtension : AfterEachCallback {
+    override fun afterEach(context: ExtensionContext) {
+        FailFast.setHandler(DefaultFailFastHandler)
+    }
+}
+
+/**
+ * A JUnit 4 test rule that resets the [FailFast] handler to [DefaultFailFastHandler]
+ * after each test.
+ *
+ * ### Usage:
+ * ```kotlin
+ * class MyTest {
+ *     @get:Rule
+ *     val failFastRule = FailFastRule()
+ *
+ *     @Test
+ *     fun myTest() {
+ *          FailFast.setHandler { throwable, _ -> /* custom handler */ }
+ *         // FailFast handler is automatically reset after each test
+ *     }
+ * }
+ * ```
+ *
+ * @see FailFastExtension for JUnit Jupiter tests
+ */
+class FailFastRule : TestWatcher() {
+    override fun finished(description: Description?) {
+        FailFast.setHandler(DefaultFailFastHandler)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/webview/addto/EntityAddToHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/webview/addto/EntityAddToHandlerTest.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.homeassistant.companion.android.util.FailFastExtension
 import io.homeassistant.companion.android.widgets.camera.CameraWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.entity.EntityWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.mediaplayer.MediaPlayerControlsWidgetConfigureActivity
@@ -40,7 +41,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 @ExperimentalCoroutinesApi
-@ExtendWith(ConsoleLogExtension::class)
+@ExtendWith(ConsoleLogExtension::class, FailFastExtension::class)
 class EntityAddToHandlerTest {
 
     private lateinit var serverManager: ServerManager

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/BaseGlanceEntityWidgetReceiverTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/BaseGlanceEntityWidgetReceiverTest.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.widget.TodoWidgetDao
 import io.homeassistant.companion.android.database.widget.TodoWidgetEntity
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.homeassistant.companion.android.util.FailFastExtension
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coJustRun
@@ -41,7 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 private data class FakeGlanceId(val id: Int) : GlanceId
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(ConsoleLogExtension::class)
+@ExtendWith(ConsoleLogExtension::class, FailFastExtension::class)
 class BaseGlanceEntityWidgetReceiverTest {
 
     val mockedDao: TodoWidgetDao = mockk()

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketCoreImplTest.kt
@@ -11,8 +11,7 @@ import io.homeassistant.companion.android.common.data.websocket.WebSocketState
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketConstants.SUBSCRIBE_TYPE_SUBSCRIBE_EVENTS
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.MessageSocketResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.StateChangedEvent
-import io.homeassistant.companion.android.common.util.DefaultFailFastHandler
-import io.homeassistant.companion.android.common.util.FailFast
+import io.homeassistant.companion.android.common.util.FailFastExtension
 import io.homeassistant.companion.android.common.util.MapAnySerializer
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
 import io.homeassistant.companion.android.database.server.Server
@@ -58,7 +57,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.assertNull
@@ -68,7 +66,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(ConsoleLogExtension::class)
+@ExtendWith(ConsoleLogExtension::class, FailFastExtension::class)
 class WebSocketCoreImplTest {
     private lateinit var mockOkHttpClient: OkHttpClient
     private lateinit var mockConnection: WebSocket
@@ -81,11 +79,6 @@ class WebSocketCoreImplTest {
      * Values are between 5 and 25.
      */
     private fun deterministicDelay(index: Long): Long = ((sin(index.toDouble()) + 1.5) * 10).toLong()
-
-    @BeforeEach
-    fun setup() {
-        FailFast.setHandler(DefaultFailFastHandler)
-    }
 
     @AfterEach
     fun tearDown() {

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/FailFastExtension.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/FailFastExtension.kt
@@ -1,0 +1,60 @@
+package io.homeassistant.companion.android.common.util
+
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * A JUnit Jupiter extension that resets the [FailFast] handler to [DefaultFailFastHandler]
+ * after each test.
+ *
+ * Tests that override the [FailFast] handler (e.g., to capture exceptions or suppress crashes)
+ * must ensure the handler is restored after the test to avoid leaking state to other tests.
+ * This extension automates that cleanup.
+ *
+ * ### Usage:
+ * ```kotlin
+ * @ExtendWith(FailFastExtension::class)
+ * class MyTest {
+ *     @Test
+ *     fun myTest() {
+ *          FailFast.setHandler { throwable, _ -> /* custom handler */ }
+ *         // FailFast handler is automatically reset after each test
+ *     }
+ * }
+ * ```
+ *
+ * @see FailFastRule for JUnit 4 tests
+ */
+class FailFastExtension : AfterEachCallback {
+    override fun afterEach(context: ExtensionContext) {
+        FailFast.setHandler(DefaultFailFastHandler)
+    }
+}
+
+/**
+ * A JUnit 4 test rule that resets the [FailFast] handler to [DefaultFailFastHandler]
+ * after each test.
+ *
+ * ### Usage:
+ * ```kotlin
+ * class MyTest {
+ *     @get:Rule
+ *     val failFastRule = FailFastRule()
+ *
+ *     @Test
+ *     fun myTest() {
+ *          FailFast.setHandler { throwable, _ -> /* custom handler */ }
+ *         // FailFast handler is automatically reset after each test
+ *     }
+ * }
+ * ```
+ *
+ * @see FailFastExtension for JUnit Jupiter tests
+ */
+class FailFastRule : TestWatcher() {
+    override fun finished(description: Description?) {
+        FailFast.setHandler(DefaultFailFastHandler)
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/FailFastTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/FailFastTest.kt
@@ -5,17 +5,15 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.extension.ExtendWith
 
+@ExtendWith(FailFastExtension::class)
 class FailFastTest {
     private var exceptionCaught: Throwable? = null
 
     @BeforeEach
     fun setUp() {
-        FailFast.setHandler(object : FailFastHandler {
-            override fun handleException(throwable: Throwable, additionalMessage: String?) {
-                exceptionCaught = throwable
-            }
-        })
+        FailFast.setHandler { throwable, additionalMessage -> exceptionCaught = throwable }
     }
 
     @AfterEach


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
To avoid leaking a custom handler to another test we should reset the FailFast handler to the default one. This PR introduce a Junit extension/rule so that it does that automatically. Unfortunately we need to duplicate it since the FailFast code is within common (we could extract failFast into its own module and introduce a failFast test module or add it to the testing module BUT it is quite complex and I preferred to duplicate the small code).