### PR TITLE
Make draft release to upload files and promote right after

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -104,6 +104,8 @@ jobs:
       - name: Publish Pre-Release
         if: github.event.inputs.beta == 'true'
         run: gh release edit ${{ steps.rel_number.outputs.version }} --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy to Firebase
         env:


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
As @jpelgrom found out our release workflow is not working properly since we've updated the action responsible to create the release and the fact that we are using immutable release.

This PR first makes a draft, upload the file and then promote the release that locks the release with the immutable flag.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

I'm not able to test the changes without actually making a release which should happen this week.