### PR TITLE
Use state-aware icons for Wear OS shortcut tiles

### DIFF
--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -5,6 +5,7 @@
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.5.4 - Wear" versioncode="2">
+        <change>Shortcut tiles now show state-aware icons (e.g., locked vs unlocked padlock)</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.5.4 - Automotive" versioncode="1">

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -35,22 +35,24 @@ import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.data.SimplifiedEntity
-import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.util.getIcon
 import java.nio.ByteBuffer
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.min
 import kotlin.math.roundToInt
-import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.guava.future
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 // Dimensions (dp)
 private const val CIRCLE_SIZE = 56f
@@ -109,16 +111,23 @@ class ShortcutsTile : TileService() {
             val iconSizePx = (iconSize * density).roundToInt()
             val entities = getEntities(requestParams.tileId)
 
-            val fullEntities = entities.map { entity ->
-                async {
-                    try {
-                        serverManager.integrationRepository().getEntity(entity.entityId)
-                    } catch (e: Exception) {
-                        null
+            val entityMap = if (serverManager.isRegistered()) {
+                val fullEntities = entities.map { entity ->
+                    async {
+                        try {
+                            serverManager.integrationRepository().getEntity(entity.entityId)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Timber.w(e, "Failed to fetch entity ${entity.entityId} for tile")
+                            null
+                        }
                     }
-                }
-            }.map { it.await() }
-            val entityMap = fullEntities.filterNotNull().associateBy { it.entityId }
+                }.map { it.await() }
+                fullEntities.filterNotNull().associateBy { it.entityId }
+            } else {
+                emptyMap()
+            }
 
             Resources.Builder()
                 .setVersion(entities.toString())

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -38,11 +38,13 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.data.SimplifiedEntity
+import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.util.getIcon
 import java.nio.ByteBuffer
 import javax.inject.Inject
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlinx.coroutines.async
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -107,16 +109,32 @@ class ShortcutsTile : TileService() {
             val iconSizePx = (iconSize * density).roundToInt()
             val entities = getEntities(requestParams.tileId)
 
+            val fullEntities = entities.map { entity ->
+                async {
+                    try {
+                        serverManager.integrationRepository().getEntity(entity.entityId)
+                    } catch (e: Exception) {
+                        null
+                    }
+                }
+            }.map { it.await() }
+            val entityMap = fullEntities.filterNotNull().associateBy { it.entityId }
+
             Resources.Builder()
                 .setVersion(entities.toString())
                 .apply {
                     entities.map { entity ->
-                        // Find icon and create Bitmap
-                        val iconIIcon = getIcon(
-                            entity.icon,
-                            entity.domain,
-                            this@ShortcutsTile,
-                        )
+                        // Find icon: try state-aware icon from full entity, fall back to domain icon
+                        val fullEntity = entityMap[entity.entityId]
+                        val iconIIcon = if (fullEntity != null) {
+                            fullEntity.getIcon(this@ShortcutsTile)
+                        } else {
+                            getIcon(
+                                entity.icon,
+                                entity.domain,
+                                this@ShortcutsTile,
+                            )
+                        }
                         val iconBitmap = IconicsDrawable(this@ShortcutsTile, iconIIcon).apply {
                             colorInt = Color.WHITE
                             sizeDp = iconSize.roundToInt()

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalTime::class)
+
 package io.homeassistant.companion.android.tiles
 
 import android.content.Context
@@ -29,6 +31,7 @@ import androidx.wear.tiles.TileService
 import com.google.common.util.concurrent.ListenableFuture
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial.Icon3
 import com.mikepenz.iconics.utils.backgroundColor
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
@@ -45,11 +48,17 @@ import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.min
 import kotlin.math.roundToInt
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.guava.future
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -61,6 +70,8 @@ private const val ICON_SIZE_SMALL = 40f * 0.7071f // square that fits in 48dp ci
 private const val SPACING = 8f
 private const val TEXT_SIZE = 8f
 private const val TEXT_PADDING = 2f
+private val LOADING_TIMEOUT = 5.seconds
+private const val LOADING_RESOURCE_SUFFIX = "_loading"
 
 @AndroidEntryPoint
 class ShortcutsTile : TileService() {
@@ -73,6 +84,13 @@ class ShortcutsTile : TileService() {
     @Inject
     lateinit var wearPrefsRepository: WearPrefsRepository
 
+    @Inject
+    lateinit var clock: Clock
+
+    private var pendingEntityId: String? = null
+    private var pendingOriginalState: String? = null
+    private var pendingTimestamp: Instant = Instant.DISTANT_PAST
+
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> = serviceScope.future {
         val state = requestParams.currentState
         if (state.lastClickableId.isNotEmpty()) {
@@ -82,13 +100,74 @@ class ShortcutsTile : TileService() {
                 intent.setPackage(packageName)
                 sendBroadcast(intent)
             }
+
+            // Enter loading state: store original state so we detect when it changes
+            pendingEntityId = state.lastClickableId
+            pendingTimestamp = clock.now()
+            pendingOriginalState = if (serverManager.isRegistered()) {
+                try {
+                    serverManager.integrationRepository().getEntity(state.lastClickableId)?.state
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch original state for ${state.lastClickableId}")
+                    null
+                }
+            } else {
+                null
+            }
+
+            // Schedule polling re-renders to pick up state change
+            serviceScope.launch {
+                delay(1.seconds)
+                requestUpdate(this@ShortcutsTile)
+                delay(3.seconds)
+                requestUpdate(this@ShortcutsTile)
+            }
         }
 
         val tileId = requestParams.tileId
         val entities = getEntities(tileId)
 
+        // Fetch entity states for resource version — ensures cache invalidation on state change
+        val entityStatesMap = if (serverManager.isRegistered()) {
+            entities.map { entity ->
+                async {
+                    try {
+                        val e = serverManager.integrationRepository().getEntity(entity.entityId)
+                        entity.entityId to (e?.state ?: "unknown")
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.w(e, "Failed to fetch entity ${entity.entityId} state for tile version")
+                        entity.entityId to "unknown"
+                    }
+                }
+            }.map { it.await() }.toMap()
+        } else {
+            emptyMap()
+        }
+
+        // Clear loading state if entity state has changed or timeout exceeded
+        if (pendingEntityId != null) {
+            val elapsed = clock.now() - pendingTimestamp
+            val currentState = entityStatesMap[pendingEntityId]
+            if (elapsed > LOADING_TIMEOUT ||
+                (pendingOriginalState != null && currentState != null && currentState != pendingOriginalState)
+            ) {
+                pendingEntityId = null
+                pendingOriginalState = null
+            }
+        }
+
+        val entityStatesVersion = entityStatesMap.entries
+            .sortedBy { it.key }
+            .joinToString(",") { "${it.key}=${it.value}" }
+        val loadingSuffix = pendingEntityId?.let { "|loading:$it" }.orEmpty()
+        val resourcesVersion = "$entities|$entityStatesVersion$loadingSuffix"
+
         Tile.Builder()
-            .setResourcesVersion(entities.toString())
+            .setResourcesVersion(resourcesVersion)
             .setTileTimeline(
                 if (serverManager.isRegistered()) {
                     timeline(tileId)
@@ -130,7 +209,7 @@ class ShortcutsTile : TileService() {
             }
 
             Resources.Builder()
-                .setVersion(entities.toString())
+                .setVersion(requestParams.version)
                 .apply {
                     entities.map { entity ->
                         // Find icon: try state-aware icon from full entity, fall back to domain icon
@@ -168,6 +247,30 @@ class ShortcutsTile : TileService() {
                             .build()
                     }.forEach { (id, imageResource) ->
                         addIdToImageMapping(id, imageResource)
+                    }
+
+                    // Generate loading icon for the pending entity
+                    pendingEntityId?.let { loadingId ->
+                        val loadingBitmap = IconicsDrawable(this@ShortcutsTile, Icon3.cmd_progress_clock).apply {
+                            colorInt = Color.WHITE
+                            sizeDp = iconSize.roundToInt()
+                            backgroundColor = IconicsColor.colorRes(R.color.colorOverlay)
+                        }.toBitmap(iconSizePx, iconSizePx, Bitmap.Config.RGB_565)
+                        val loadingData = ByteBuffer.allocate(loadingBitmap.byteCount).apply {
+                            loadingBitmap.copyPixelsToBuffer(this)
+                        }.array()
+                        addIdToImageMapping(
+                            loadingId + LOADING_RESOURCE_SUFFIX,
+                            ResourceBuilders.ImageResource.Builder()
+                                .setInlineResource(
+                                    ResourceBuilders.InlineImageResource.Builder()
+                                        .setData(loadingData)
+                                        .setWidthPx(iconSizePx)
+                                        .setHeightPx(iconSizePx)
+                                        .setFormat(ResourceBuilders.IMAGE_FORMAT_RGB_565)
+                                        .build(),
+                                ).build(),
+                        )
                     }
                 }
                 .build()
@@ -249,6 +352,11 @@ class ShortcutsTile : TileService() {
 
     private fun iconLayout(entity: SimplifiedEntity, showLabels: Boolean): LayoutElement = Box.Builder().apply {
         val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
+        val resourceId = if (entity.entityId == pendingEntityId) {
+            entity.entityId + LOADING_RESOURCE_SUFFIX
+        } else {
+            entity.entityId
+        }
         setWidth(dp(CIRCLE_SIZE))
         setHeight(dp(CIRCLE_SIZE))
         setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
@@ -279,7 +387,7 @@ class ShortcutsTile : TileService() {
         addContent(
             // Add icon
             LayoutElementBuilders.Image.Builder()
-                .setResourceId(entity.entityId)
+                .setResourceId(resourceId)
                 .setWidth(dp(iconSize))
                 .setHeight(dp(iconSize))
                 .build(),

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -29,7 +29,6 @@ import androidx.wear.tiles.TileService
 import com.google.common.util.concurrent.ListenableFuture
 import com.mikepenz.iconics.IconicsColor
 import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial.Icon3
 import com.mikepenz.iconics.utils.backgroundColor
 import com.mikepenz.iconics.utils.colorInt
 import com.mikepenz.iconics.utils.sizeDp
@@ -65,9 +64,6 @@ private const val ICON_SIZE_SMALL = 40f * 0.7071f // square that fits in 48dp ci
 private const val SPACING = 8f
 private const val TEXT_SIZE = 8f
 private const val TEXT_PADDING = 2f
-private const val LOADING_RESOURCE_SUFFIX = "_loading"
-private const val LOADING_VERSION_PREFIX = "|loading:"
-private const val LOADING_SAFETY_TIMEOUT_MS = 45_000L
 
 @AndroidEntryPoint
 class ShortcutsTile : TileService() {
@@ -82,10 +78,6 @@ class ShortcutsTile : TileService() {
 
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> = serviceScope.future {
         val state = requestParams.currentState
-        android.util.Log.e(
-            TAG,
-            "onTileRequest click=${state.lastClickableId} loading=$loadingEntityIds cache=${entityStates.size}",
-        )
         if (state.lastClickableId.isNotEmpty()) {
             Intent().also { intent ->
                 intent.action = "io.homeassistant.companion.android.TILE_ACTION"
@@ -93,23 +85,10 @@ class ShortcutsTile : TileService() {
                 intent.setPackage(packageName)
                 sendBroadcast(intent)
             }
-            loadingEntityIds[state.lastClickableId] = System.currentTimeMillis()
         }
-
-        // Clear stale loading entries (safety net for missed WebSocket events)
-        val now = System.currentTimeMillis()
-        loadingEntityIds.entries.removeAll { now - it.value > LOADING_SAFETY_TIMEOUT_MS }
 
         val tileId = requestParams.tileId
-        val entities = getEntities(tileId)
-
-        // Encode loading state in version string so onTileResourcesRequest can read it
-        val loadingPart = if (loadingEntityIds.isNotEmpty()) {
-            LOADING_VERSION_PREFIX + loadingEntityIds.keys.sorted().joinToString(",")
-        } else {
-            ""
-        }
-        val resourcesVersion = "$TAG$tileId.${now}$loadingPart"
+        val resourcesVersion = "$TAG$tileId.${System.currentTimeMillis()}"
 
         Tile.Builder()
             .setResourcesVersion(resourcesVersion)
@@ -129,17 +108,6 @@ class ShortcutsTile : TileService() {
 
     override fun onTileResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
         serviceScope.future {
-            // Parse loading entity IDs from version string (survives service recreation)
-            val loadingIds = requestParams.version
-                .substringAfter(LOADING_VERSION_PREFIX, "")
-                .split(",")
-                .filter { it.isNotEmpty() }
-                .toSet()
-            android.util.Log.e(
-                TAG,
-                "onTileResourcesRequest loading=$loadingIds states=${entityStates.mapValues { it.value.state }}",
-            )
-
             val showLabels = wearPrefsRepository.getShowShortcutText()
             val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
             val density = requestParams.deviceConfiguration.screenDensity
@@ -150,7 +118,6 @@ class ShortcutsTile : TileService() {
                 .setVersion(requestParams.version)
                 .apply {
                     entities.forEach { entity ->
-                        // Use cached entity for state-aware icon, fall back to domain icon
                         val cachedEntity = entityStates[entity.entityId]
                         val iconIIcon = if (cachedEntity != null) {
                             cachedEntity.getIcon(this@ShortcutsTile)
@@ -162,28 +129,16 @@ class ShortcutsTile : TileService() {
                             buildIconResource(iconIIcon, iconSize, iconSizePx),
                         )
                     }
-
-                    // Generate loading icons for tapped entities
-                    loadingIds.forEach { loadingId ->
-                        addIdToImageMapping(
-                            loadingId + LOADING_RESOURCE_SUFFIX,
-                            buildIconResource(Icon3.cmd_progress_clock, iconSize, iconSizePx),
-                        )
-                    }
                 }
                 .build()
         }
 
     override fun onTileEnterEvent(requestParams: EventBuilders.TileEnterEvent) {
         serviceScope.launch {
-            // Clear loading — we're about to fetch fresh state
-            loadingEntityIds.clear()
-
             val tileId = requestParams.tileId
             val entities = getEntities(tileId)
             val entityIds = entities.map { it.entityId }
 
-            // Initial state fetch via batch WebSocket call
             if (serverManager.isRegistered()) {
                 try {
                     val allEntities = serverManager.integrationRepository().getEntities()
@@ -197,14 +152,14 @@ class ShortcutsTile : TileService() {
                 }
             }
 
-            // Render with fresh cache
             try {
                 requestUpdate(this@ShortcutsTile)
             } catch (e: Exception) {
                 Timber.w(e, "Unable to request tile update on enter")
             }
 
-            // Start WebSocket subscription for real-time updates
+            // Always restart subscription with current entity list (handles entity list changes)
+            stopEntitySubscription()
             startEntitySubscription(
                 serverManager = serverManager,
                 entityIds = entityIds,
@@ -302,11 +257,6 @@ class ShortcutsTile : TileService() {
 
     private fun iconLayout(entity: SimplifiedEntity, showLabels: Boolean): LayoutElement = Box.Builder().apply {
         val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
-        val resourceId = if (loadingEntityIds.containsKey(entity.entityId)) {
-            entity.entityId + LOADING_RESOURCE_SUFFIX
-        } else {
-            entity.entityId
-        }
         setWidth(dp(CIRCLE_SIZE))
         setHeight(dp(CIRCLE_SIZE))
         setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
@@ -334,7 +284,7 @@ class ShortcutsTile : TileService() {
         )
         addContent(
             LayoutElementBuilders.Image.Builder()
-                .setResourceId(resourceId)
+                .setResourceId(entity.entityId)
                 .setWidth(dp(iconSize))
                 .setHeight(dp(iconSize))
                 .build(),
@@ -372,9 +322,6 @@ class ShortcutsTile : TileService() {
         /** Entity cache — populated by WebSocket, read by tile rendering (zero network). */
         private val entityStates = ConcurrentHashMap<String, Entity>()
 
-        /** Entities currently in loading state. Maps entityId → timestamp when loading started. */
-        private val loadingEntityIds = ConcurrentHashMap<String, Long>()
-
         /** WebSocket subscription for entity state changes. Outlives service instances. */
         private var subscriptionJob: Job? = null
         private val subscriptionScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -392,7 +339,6 @@ class ShortcutsTile : TileService() {
                         .getEntityUpdates(entityIds)
                     flow?.collect { entity ->
                         entityStates[entity.entityId] = entity
-                        loadingEntityIds.remove(entity.entityId)
                         requestUpdate(appContext)
                     }
                 } catch (e: CancellationException) {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -1,5 +1,3 @@
-@file:OptIn(ExperimentalTime::class)
-
 package io.homeassistant.companion.android.tiles
 
 import android.content.Context
@@ -38,25 +36,22 @@ import com.mikepenz.iconics.utils.sizeDp
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.util.getIcon
 import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.min
 import kotlin.math.roundToInt
-import kotlin.time.Clock
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.guava.future
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -70,8 +65,9 @@ private const val ICON_SIZE_SMALL = 40f * 0.7071f // square that fits in 48dp ci
 private const val SPACING = 8f
 private const val TEXT_SIZE = 8f
 private const val TEXT_PADDING = 2f
-private val LOADING_TIMEOUT = 5.seconds
 private const val LOADING_RESOURCE_SUFFIX = "_loading"
+private const val LOADING_VERSION_PREFIX = "|loading:"
+private const val LOADING_SAFETY_TIMEOUT_MS = 45_000L
 
 @AndroidEntryPoint
 class ShortcutsTile : TileService() {
@@ -84,15 +80,12 @@ class ShortcutsTile : TileService() {
     @Inject
     lateinit var wearPrefsRepository: WearPrefsRepository
 
-    @Inject
-    lateinit var clock: Clock
-
-    private var pendingEntityId: String? = null
-    private var pendingOriginalState: String? = null
-    private var pendingTimestamp: Instant = Instant.DISTANT_PAST
-
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> = serviceScope.future {
         val state = requestParams.currentState
+        android.util.Log.e(
+            TAG,
+            "onTileRequest click=${state.lastClickableId} loading=$loadingEntityIds cache=${entityStates.size}",
+        )
         if (state.lastClickableId.isNotEmpty()) {
             Intent().also { intent ->
                 intent.action = "io.homeassistant.companion.android.TILE_ACTION"
@@ -100,71 +93,23 @@ class ShortcutsTile : TileService() {
                 intent.setPackage(packageName)
                 sendBroadcast(intent)
             }
-
-            // Enter loading state: store original state so we detect when it changes
-            pendingEntityId = state.lastClickableId
-            pendingTimestamp = clock.now()
-            pendingOriginalState = if (serverManager.isRegistered()) {
-                try {
-                    serverManager.integrationRepository().getEntity(state.lastClickableId)?.state
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Timber.w(e, "Failed to fetch original state for ${state.lastClickableId}")
-                    null
-                }
-            } else {
-                null
-            }
-
-            // Schedule polling re-renders to pick up state change
-            serviceScope.launch {
-                delay(1.seconds)
-                requestUpdate(this@ShortcutsTile)
-                delay(3.seconds)
-                requestUpdate(this@ShortcutsTile)
-            }
+            loadingEntityIds[state.lastClickableId] = System.currentTimeMillis()
         }
+
+        // Clear stale loading entries (safety net for missed WebSocket events)
+        val now = System.currentTimeMillis()
+        loadingEntityIds.entries.removeAll { now - it.value > LOADING_SAFETY_TIMEOUT_MS }
 
         val tileId = requestParams.tileId
         val entities = getEntities(tileId)
 
-        // Fetch entity states for resource version — ensures cache invalidation on state change
-        val entityStatesMap = if (serverManager.isRegistered()) {
-            entities.map { entity ->
-                async {
-                    try {
-                        val e = serverManager.integrationRepository().getEntity(entity.entityId)
-                        entity.entityId to (e?.state ?: "unknown")
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Timber.w(e, "Failed to fetch entity ${entity.entityId} state for tile version")
-                        entity.entityId to "unknown"
-                    }
-                }
-            }.map { it.await() }.toMap()
+        // Encode loading state in version string so onTileResourcesRequest can read it
+        val loadingPart = if (loadingEntityIds.isNotEmpty()) {
+            LOADING_VERSION_PREFIX + loadingEntityIds.keys.sorted().joinToString(",")
         } else {
-            emptyMap()
+            ""
         }
-
-        // Clear loading state if entity state has changed or timeout exceeded
-        if (pendingEntityId != null) {
-            val elapsed = clock.now() - pendingTimestamp
-            val currentState = entityStatesMap[pendingEntityId]
-            if (elapsed > LOADING_TIMEOUT ||
-                (pendingOriginalState != null && currentState != null && currentState != pendingOriginalState)
-            ) {
-                pendingEntityId = null
-                pendingOriginalState = null
-            }
-        }
-
-        val entityStatesVersion = entityStatesMap.entries
-            .sortedBy { it.key }
-            .joinToString(",") { "${it.key}=${it.value}" }
-        val loadingSuffix = pendingEntityId?.let { "|loading:$it" }.orEmpty()
-        val resourcesVersion = "$entities|$entityStatesVersion$loadingSuffix"
+        val resourcesVersion = "$TAG$tileId.${now}$loadingPart"
 
         Tile.Builder()
             .setResourcesVersion(resourcesVersion)
@@ -184,115 +129,96 @@ class ShortcutsTile : TileService() {
 
     override fun onTileResourcesRequest(requestParams: ResourcesRequest): ListenableFuture<Resources> =
         serviceScope.future {
+            // Parse loading entity IDs from version string (survives service recreation)
+            val loadingIds = requestParams.version
+                .substringAfter(LOADING_VERSION_PREFIX, "")
+                .split(",")
+                .filter { it.isNotEmpty() }
+                .toSet()
+            android.util.Log.e(
+                TAG,
+                "onTileResourcesRequest loading=$loadingIds states=${entityStates.mapValues { it.value.state }}",
+            )
+
             val showLabels = wearPrefsRepository.getShowShortcutText()
             val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
             val density = requestParams.deviceConfiguration.screenDensity
             val iconSizePx = (iconSize * density).roundToInt()
             val entities = getEntities(requestParams.tileId)
 
-            val entityMap = if (serverManager.isRegistered()) {
-                val fullEntities = entities.map { entity ->
-                    async {
-                        try {
-                            serverManager.integrationRepository().getEntity(entity.entityId)
-                        } catch (e: CancellationException) {
-                            throw e
-                        } catch (e: Exception) {
-                            Timber.w(e, "Failed to fetch entity ${entity.entityId} for tile")
-                            null
-                        }
-                    }
-                }.map { it.await() }
-                fullEntities.filterNotNull().associateBy { it.entityId }
-            } else {
-                emptyMap()
-            }
-
             Resources.Builder()
                 .setVersion(requestParams.version)
                 .apply {
-                    entities.map { entity ->
-                        // Find icon: try state-aware icon from full entity, fall back to domain icon
-                        val fullEntity = entityMap[entity.entityId]
-                        val iconIIcon = if (fullEntity != null) {
-                            fullEntity.getIcon(this@ShortcutsTile)
+                    entities.forEach { entity ->
+                        // Use cached entity for state-aware icon, fall back to domain icon
+                        val cachedEntity = entityStates[entity.entityId]
+                        val iconIIcon = if (cachedEntity != null) {
+                            cachedEntity.getIcon(this@ShortcutsTile)
                         } else {
-                            getIcon(
-                                entity.icon,
-                                entity.domain,
-                                this@ShortcutsTile,
-                            )
+                            getIcon(entity.icon, entity.domain, this@ShortcutsTile)
                         }
-                        val iconBitmap = IconicsDrawable(this@ShortcutsTile, iconIIcon).apply {
-                            colorInt = Color.WHITE
-                            sizeDp = iconSize.roundToInt()
-                            backgroundColor = IconicsColor.colorRes(R.color.colorOverlay)
-                        }.toBitmap(iconSizePx, iconSizePx, Bitmap.Config.RGB_565)
-
-                        // Make array of bitmap
-                        val bitmapData = ByteBuffer.allocate(iconBitmap.byteCount).apply {
-                            iconBitmap.copyPixelsToBuffer(this)
-                        }.array()
-
-                        // link the entity id to the bitmap data array
-                        entity.entityId to ResourceBuilders.ImageResource.Builder()
-                            .setInlineResource(
-                                ResourceBuilders.InlineImageResource.Builder()
-                                    .setData(bitmapData)
-                                    .setWidthPx(iconSizePx)
-                                    .setHeightPx(iconSizePx)
-                                    .setFormat(ResourceBuilders.IMAGE_FORMAT_RGB_565)
-                                    .build(),
-                            )
-                            .build()
-                    }.forEach { (id, imageResource) ->
-                        addIdToImageMapping(id, imageResource)
+                        addIdToImageMapping(
+                            entity.entityId,
+                            buildIconResource(iconIIcon, iconSize, iconSizePx),
+                        )
                     }
 
-                    // Generate loading icon for the pending entity
-                    pendingEntityId?.let { loadingId ->
-                        val loadingBitmap = IconicsDrawable(this@ShortcutsTile, Icon3.cmd_progress_clock).apply {
-                            colorInt = Color.WHITE
-                            sizeDp = iconSize.roundToInt()
-                            backgroundColor = IconicsColor.colorRes(R.color.colorOverlay)
-                        }.toBitmap(iconSizePx, iconSizePx, Bitmap.Config.RGB_565)
-                        val loadingData = ByteBuffer.allocate(loadingBitmap.byteCount).apply {
-                            loadingBitmap.copyPixelsToBuffer(this)
-                        }.array()
+                    // Generate loading icons for tapped entities
+                    loadingIds.forEach { loadingId ->
                         addIdToImageMapping(
                             loadingId + LOADING_RESOURCE_SUFFIX,
-                            ResourceBuilders.ImageResource.Builder()
-                                .setInlineResource(
-                                    ResourceBuilders.InlineImageResource.Builder()
-                                        .setData(loadingData)
-                                        .setWidthPx(iconSizePx)
-                                        .setHeightPx(iconSizePx)
-                                        .setFormat(ResourceBuilders.IMAGE_FORMAT_RGB_565)
-                                        .build(),
-                                ).build(),
+                            buildIconResource(Icon3.cmd_progress_clock, iconSize, iconSizePx),
                         )
                     }
                 }
                 .build()
         }
 
+    override fun onTileEnterEvent(requestParams: EventBuilders.TileEnterEvent) {
+        serviceScope.launch {
+            // Clear loading — we're about to fetch fresh state
+            loadingEntityIds.clear()
+
+            val tileId = requestParams.tileId
+            val entities = getEntities(tileId)
+            val entityIds = entities.map { it.entityId }
+
+            // Initial state fetch via batch WebSocket call
+            if (serverManager.isRegistered()) {
+                try {
+                    val allEntities = serverManager.integrationRepository().getEntities()
+                    allEntities?.filter { it.entityId in entityIds }?.forEach { entity ->
+                        entityStates[entity.entityId] = entity
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch initial entity states for tile")
+                }
+            }
+
+            // Render with fresh cache
+            try {
+                requestUpdate(this@ShortcutsTile)
+            } catch (e: Exception) {
+                Timber.w(e, "Unable to request tile update on enter")
+            }
+
+            // Start WebSocket subscription for real-time updates
+            startEntitySubscription(
+                serverManager = serverManager,
+                entityIds = entityIds,
+                context = this@ShortcutsTile,
+            )
+        }
+    }
+
+    override fun onTileLeaveEvent(requestParams: EventBuilders.TileLeaveEvent) {
+        stopEntitySubscription()
+    }
+
     override fun onTileAddEvent(requestParams: EventBuilders.TileAddEvent): Unit = runBlocking {
         withContext(Dispatchers.IO) {
-            /**
-             * When the app is updated from an older version (which only supported a single Shortcut Tile),
-             * and the user is adding a new Shortcuts Tile, we can't tell for sure if it's the 1st or 2nd Tile.
-             * Even though we may have the shortcut list stored in the prefs, it doesn't guarantee that
-             *   the tile was actually added to the Tiles carousel.
-             * The [WearPrefsRepositoryImpl::getTileShortcutsAndSaveTileId] method will handle both of the following cases:
-             * 1. There was no Tile added, but there were shortcuts stored in the prefs.
-             *    In this case, the stored shortcuts will be associated to the new tileId.
-             * 2. There was a single Tile added, and there were shortcuts stored in the prefs.
-             *    If there was a Tile update since updating the app, the tileId will be already
-             *    associated to the shortcuts, because it also calls [getTileShortcutsAndSaveTileId].
-             *    If there was no Tile update yet, the new Tile will "steal" the shortcuts from the existing Tile,
-             *    and the old Tile will behave as it is the new Tile. This is needed because
-             *    we don't know if it's the 1st or 2nd Tile.
-             */
             wearPrefsRepository.getTileShortcutsAndSaveTileId(requestParams.tileId)
         }
     }
@@ -301,11 +227,12 @@ class ShortcutsTile : TileService() {
         withContext(Dispatchers.IO) {
             wearPrefsRepository.removeTileShortcuts(requestParams.tileId)
         }
+        stopEntitySubscription()
+        entityStates.clear()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        // Cleans up the coroutine
         serviceJob.cancel()
     }
 
@@ -316,8 +243,31 @@ class ShortcutsTile : TileService() {
     private suspend fun timeline(tileId: Int): Timeline {
         val entities = getEntities(tileId)
         val showLabels = wearPrefsRepository.getShowShortcutText()
-
         return Timeline.fromLayoutElement(layout(entities, showLabels))
+    }
+
+    private fun buildIconResource(
+        icon: com.mikepenz.iconics.typeface.IIcon,
+        iconSizeDp: Float,
+        iconSizePx: Int,
+    ): ResourceBuilders.ImageResource {
+        val bitmap = IconicsDrawable(this, icon).apply {
+            colorInt = Color.WHITE
+            sizeDp = iconSizeDp.roundToInt()
+            backgroundColor = IconicsColor.colorRes(R.color.colorOverlay)
+        }.toBitmap(iconSizePx, iconSizePx, Bitmap.Config.RGB_565)
+        val data = ByteBuffer.allocate(bitmap.byteCount).apply {
+            bitmap.copyPixelsToBuffer(this)
+        }.array()
+        return ResourceBuilders.ImageResource.Builder()
+            .setInlineResource(
+                ResourceBuilders.InlineImageResource.Builder()
+                    .setData(data)
+                    .setWidthPx(iconSizePx)
+                    .setHeightPx(iconSizePx)
+                    .setFormat(ResourceBuilders.IMAGE_FORMAT_RGB_565)
+                    .build(),
+            ).build()
     }
 
     fun layout(entities: List<SimplifiedEntity>, showLabels: Boolean): LayoutElement = Column.Builder().apply {
@@ -352,7 +302,7 @@ class ShortcutsTile : TileService() {
 
     private fun iconLayout(entity: SimplifiedEntity, showLabels: Boolean): LayoutElement = Box.Builder().apply {
         val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
-        val resourceId = if (entity.entityId == pendingEntityId) {
+        val resourceId = if (loadingEntityIds.containsKey(entity.entityId)) {
             entity.entityId + LOADING_RESOURCE_SUFFIX
         } else {
             entity.entityId
@@ -362,7 +312,6 @@ class ShortcutsTile : TileService() {
         setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
         setModifiers(
             ModifiersBuilders.Modifiers.Builder()
-                // Set circular background
                 .setBackground(
                     ModifiersBuilders.Background.Builder()
                         .setColor(argb(ContextCompat.getColor(baseContext, R.color.colorOverlay)))
@@ -373,7 +322,6 @@ class ShortcutsTile : TileService() {
                         )
                         .build(),
                 )
-                // Make clickable and call activity
                 .setClickable(
                     ModifiersBuilders.Clickable.Builder()
                         .setId(entity.entityId)
@@ -385,7 +333,6 @@ class ShortcutsTile : TileService() {
                 .build(),
         )
         addContent(
-            // Add icon
             LayoutElementBuilders.Image.Builder()
                 .setResourceId(resourceId)
                 .setWidth(dp(iconSize))
@@ -420,8 +367,45 @@ class ShortcutsTile : TileService() {
         .build()
 
     companion object {
+        private const val TAG = "ShortcutsTile"
+
+        /** Entity cache — populated by WebSocket, read by tile rendering (zero network). */
+        private val entityStates = ConcurrentHashMap<String, Entity>()
+
+        /** Entities currently in loading state. Maps entityId → timestamp when loading started. */
+        private val loadingEntityIds = ConcurrentHashMap<String, Long>()
+
+        /** WebSocket subscription for entity state changes. Outlives service instances. */
+        private var subscriptionJob: Job? = null
+        private val subscriptionScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
         fun requestUpdate(context: Context) {
             getUpdater(context).requestUpdate(ShortcutsTile::class.java)
+        }
+
+        private fun startEntitySubscription(serverManager: ServerManager, entityIds: List<String>, context: Context) {
+            if (subscriptionJob?.isActive == true) return
+            val appContext = context.applicationContext
+            subscriptionJob = subscriptionScope.launch {
+                try {
+                    val flow = serverManager.integrationRepository()
+                        .getEntityUpdates(entityIds)
+                    flow?.collect { entity ->
+                        entityStates[entity.entityId] = entity
+                        loadingEntityIds.remove(entity.entityId)
+                        requestUpdate(appContext)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "Entity subscription failed")
+                }
+            }
+        }
+
+        private fun stopEntitySubscription() {
+            subscriptionJob?.cancel()
+            subscriptionJob = null
         }
     }
 }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -51,10 +51,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.guava.future
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 
 // Dimensions (dp)
@@ -64,6 +68,9 @@ private const val ICON_SIZE_SMALL = 40f * 0.7071f // square that fits in 48dp ci
 private const val SPACING = 8f
 private const val TEXT_SIZE = 8f
 private const val TEXT_PADDING = 2f
+
+// Bounded so a cold-cache fetch cannot exceed the Wear tile render timeout (~3s).
+private const val CACHE_WARM_TIMEOUT_MS = 2000L
 
 @AndroidEntryPoint
 class ShortcutsTile : TileService() {
@@ -77,24 +84,47 @@ class ShortcutsTile : TileService() {
     lateinit var wearPrefsRepository: WearPrefsRepository
 
     override fun onTileRequest(requestParams: TileRequest): ListenableFuture<Tile> = serviceScope.future {
-        val state = requestParams.currentState
-        if (state.lastClickableId.isNotEmpty()) {
+        val clicked = requestParams.currentState.lastClickableId
+        if (clicked.isNotEmpty()) {
             Intent().also { intent ->
                 intent.action = "io.homeassistant.companion.android.TILE_ACTION"
-                intent.putExtra("entity_id", state.lastClickableId)
+                intent.putExtra("entity_id", clicked)
                 intent.setPackage(packageName)
                 sendBroadcast(intent)
             }
         }
 
         val tileId = requestParams.tileId
+        val entities = getEntities(tileId)
+        val entityIds = entities.map { it.entityId }
+        val isRegistered = serverManager.isRegistered()
+
+        if (isRegistered) {
+            val missing = entityIds.filterNot { entityStates.containsKey(it) }
+            if (missing.isNotEmpty()) {
+                warmEntityCache(missing)
+            }
+        }
+
+        // Optimistically flip the cached state so the render reflects the tap before the
+        // WebSocket subscription confirms. Required because `requestUpdate()` does not
+        // reliably trigger the Wear tile framework to re-render.
+        if (clicked.isNotEmpty()) {
+            entityStates.computeIfPresent(clicked) { _, current -> applyOptimisticClick(current) }
+        }
+
+        // Freeze state at the moment the layout is built; the matching resource bundle must
+        // use the same snapshot so every resource ID the layout references is produced.
+        val snapshot = TileSnapshot.from(entityStates, entityIds)
         val resourcesVersion = "$TAG$tileId.${System.currentTimeMillis()}"
+        snapshotStash.put(resourcesVersion, snapshot)
 
         Tile.Builder()
             .setResourcesVersion(resourcesVersion)
             .setTileTimeline(
-                if (serverManager.isRegistered()) {
-                    timeline(tileId)
+                if (isRegistered) {
+                    val showLabels = wearPrefsRepository.getShowShortcutText()
+                    Timeline.fromLayoutElement(layout(entities, showLabels, snapshot))
                 } else {
                     loggedOutTimeline(
                         this@ShortcutsTile,
@@ -113,19 +143,23 @@ class ShortcutsTile : TileService() {
             val density = requestParams.deviceConfiguration.screenDensity
             val iconSizePx = (iconSize * density).roundToInt()
             val entities = getEntities(requestParams.tileId)
+            // Reuse the snapshot frozen in onTileRequest so the resource IDs here match what
+            // the layout referenced. Falls back to current cache if the stash has been cleared.
+            val snapshot = snapshotStash.get(requestParams.version)
+                ?: TileSnapshot.from(entityStates, entities.map { it.entityId })
 
             Resources.Builder()
                 .setVersion(requestParams.version)
                 .apply {
                     entities.forEach { entity ->
-                        val cachedEntity = entityStates[entity.entityId]
+                        val cachedEntity = snapshot.entityOf(entity.entityId)
                         val iconIIcon = if (cachedEntity != null) {
                             cachedEntity.getIcon(this@ShortcutsTile)
                         } else {
                             getIcon(entity.icon, entity.domain, this@ShortcutsTile)
                         }
                         addIdToImageMapping(
-                            entity.entityId,
+                            entity.resourceIdIn(snapshot),
                             buildIconResource(iconIIcon, iconSize, iconSizePx),
                         )
                     }
@@ -135,34 +169,13 @@ class ShortcutsTile : TileService() {
 
     override fun onTileEnterEvent(requestParams: EventBuilders.TileEnterEvent) {
         serviceScope.launch {
-            val tileId = requestParams.tileId
-            val entities = getEntities(tileId)
-            val entityIds = entities.map { it.entityId }
-
-            if (serverManager.isRegistered()) {
-                try {
-                    val allEntities = serverManager.integrationRepository().getEntities()
-                    allEntities?.filter { it.entityId in entityIds }?.forEach { entity ->
-                        entityStates[entity.entityId] = entity
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Timber.w(e, "Failed to fetch initial entity states for tile")
-                }
-            }
-
-            try {
-                requestUpdate(this@ShortcutsTile)
-            } catch (e: Exception) {
-                Timber.w(e, "Unable to request tile update on enter")
-            }
-
-            // Always restart subscription with current entity list (handles entity list changes)
+            val entities = getEntities(requestParams.tileId)
+            // onTileRequest warms the cache on cold start; enter is only for subscription
+            // lifecycle. Always restart so the subscription reflects the current entity list.
             stopEntitySubscription()
             startEntitySubscription(
                 serverManager = serverManager,
-                entityIds = entityIds,
+                entityIds = entities.map { it.entityId },
                 context = this@ShortcutsTile,
             )
         }
@@ -184,6 +197,7 @@ class ShortcutsTile : TileService() {
         }
         stopEntitySubscription()
         entityStates.clear()
+        snapshotStash.clear()
     }
 
     override fun onDestroy() {
@@ -195,10 +209,31 @@ class ShortcutsTile : TileService() {
         return wearPrefsRepository.getTileShortcutsAndSaveTileId(tileId).map { SimplifiedEntity(it) }
     }
 
-    private suspend fun timeline(tileId: Int): Timeline {
-        val entities = getEntities(tileId)
-        val showLabels = wearPrefsRepository.getShowShortcutText()
-        return Timeline.fromLayoutElement(layout(entities, showLabels))
+    /**
+     * Fetches state for [entityIds] in parallel and writes successful results into the cache.
+     * Bounded by [CACHE_WARM_TIMEOUT_MS] so slow networks can't exceed the Wear tile render
+     * timeout — entities whose fetch hasn't landed in time simply stay missing from the cache
+     * and render with their domain-default icon.
+     */
+    private suspend fun warmEntityCache(entityIds: List<String>) {
+        val repo = serverManager.integrationRepository()
+        try {
+            withTimeoutOrNull(CACHE_WARM_TIMEOUT_MS) {
+                coroutineScope {
+                    entityIds.map { id ->
+                        async {
+                            runCatching { repo.getEntity(id) }.getOrNull()?.let { entity ->
+                                entityStates[entity.entityId] = entity
+                            }
+                        }
+                    }.awaitAll()
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to warm entity cache")
+        }
     }
 
     private fun buildIconResource(
@@ -225,102 +260,120 @@ class ShortcutsTile : TileService() {
             ).build()
     }
 
-    fun layout(entities: List<SimplifiedEntity>, showLabels: Boolean): LayoutElement = Column.Builder().apply {
-        if (entities.isEmpty()) {
-            addContent(
-                LayoutElementBuilders.Text.Builder()
-                    .setText(getString(commonR.string.shortcuts_tile_empty))
-                    .build(),
-            )
-        } else {
-            addContent(rowLayout(entities.subList(0, min(2, entities.size)), showLabels))
-            if (entities.size > 2) {
-                addContent(Spacer.Builder().setHeight(dp(SPACING)).build())
-                addContent(rowLayout(entities.subList(2, min(5, entities.size)), showLabels))
-            }
-            if (entities.size > 5) {
-                addContent(Spacer.Builder().setHeight(dp(SPACING)).build())
-                addContent(rowLayout(entities.subList(5, min(7, entities.size)), showLabels))
+    internal fun layout(entities: List<SimplifiedEntity>, showLabels: Boolean, snapshot: TileSnapshot): LayoutElement =
+        Column.Builder().apply {
+            if (entities.isEmpty()) {
+                addContent(
+                    LayoutElementBuilders.Text.Builder()
+                        .setText(getString(commonR.string.shortcuts_tile_empty))
+                        .build(),
+                )
+            } else {
+                addContent(rowLayout(entities.subList(0, min(2, entities.size)), showLabels, snapshot))
+                if (entities.size > 2) {
+                    addContent(Spacer.Builder().setHeight(dp(SPACING)).build())
+                    addContent(rowLayout(entities.subList(2, min(5, entities.size)), showLabels, snapshot))
+                }
+                if (entities.size > 5) {
+                    addContent(Spacer.Builder().setHeight(dp(SPACING)).build())
+                    addContent(rowLayout(entities.subList(5, min(7, entities.size)), showLabels, snapshot))
+                }
             }
         }
-    }
-        .build()
+            .build()
 
-    private fun rowLayout(entities: List<SimplifiedEntity>, showLabels: Boolean): LayoutElement = Row.Builder().apply {
-        addContent(iconLayout(entities[0], showLabels))
+    private fun rowLayout(
+        entities: List<SimplifiedEntity>,
+        showLabels: Boolean,
+        snapshot: TileSnapshot,
+    ): LayoutElement = Row.Builder().apply {
+        addContent(iconLayout(entities[0], showLabels, snapshot))
         entities.drop(1).forEach { entity ->
             addContent(Spacer.Builder().setWidth(dp(SPACING)).build())
-            addContent(iconLayout(entity, showLabels))
+            addContent(iconLayout(entity, showLabels, snapshot))
         }
     }
         .build()
 
-    private fun iconLayout(entity: SimplifiedEntity, showLabels: Boolean): LayoutElement = Box.Builder().apply {
-        val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
-        setWidth(dp(CIRCLE_SIZE))
-        setHeight(dp(CIRCLE_SIZE))
-        setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
-        setModifiers(
-            ModifiersBuilders.Modifiers.Builder()
-                .setBackground(
-                    ModifiersBuilders.Background.Builder()
-                        .setColor(argb(ContextCompat.getColor(baseContext, R.color.colorOverlay)))
-                        .setCorner(
-                            ModifiersBuilders.Corner.Builder()
-                                .setRadius(dp(CIRCLE_SIZE / 2))
-                                .build(),
-                        )
-                        .build(),
-                )
-                .setClickable(
-                    ModifiersBuilders.Clickable.Builder()
-                        .setId(entity.entityId)
-                        .setOnClick(
-                            ActionBuilders.LoadAction.Builder().build(),
-                        )
-                        .build(),
-                )
-                .build(),
-        )
-        addContent(
-            LayoutElementBuilders.Image.Builder()
-                .setResourceId(entity.entityId)
-                .setWidth(dp(iconSize))
-                .setHeight(dp(iconSize))
-                .build(),
-        )
-        if (showLabels) {
-            addContent(
-                LayoutElementBuilders.Arc.Builder()
-                    .addContent(
-                        LayoutElementBuilders.ArcText.Builder()
-                            .setText(entity.friendlyName)
-                            .setFontStyle(
-                                LayoutElementBuilders.FontStyle.Builder()
-                                    .setSize(sp(TEXT_SIZE))
+    private fun iconLayout(entity: SimplifiedEntity, showLabels: Boolean, snapshot: TileSnapshot): LayoutElement =
+        Box.Builder().apply {
+            val iconSize = if (showLabels) ICON_SIZE_SMALL else ICON_SIZE_FULL
+            val resourceId = entity.resourceIdIn(snapshot)
+            setWidth(dp(CIRCLE_SIZE))
+            setHeight(dp(CIRCLE_SIZE))
+            setHorizontalAlignment(HORIZONTAL_ALIGN_CENTER)
+            setModifiers(
+                ModifiersBuilders.Modifiers.Builder()
+                    .setBackground(
+                        ModifiersBuilders.Background.Builder()
+                            .setColor(argb(ContextCompat.getColor(baseContext, R.color.colorOverlay)))
+                            .setCorner(
+                                ModifiersBuilders.Corner.Builder()
+                                    .setRadius(dp(CIRCLE_SIZE / 2))
                                     .build(),
                             )
                             .build(),
                     )
-                    .setModifiers(
-                        ModifiersBuilders.Modifiers.Builder()
-                            .setPadding(
-                                ModifiersBuilders.Padding.Builder()
-                                    .setAll(dp(TEXT_PADDING))
-                                    .build(),
-                            ).build(),
+                    .setClickable(
+                        ModifiersBuilders.Clickable.Builder()
+                            .setId(entity.entityId)
+                            .setOnClick(
+                                ActionBuilders.LoadAction.Builder().build(),
+                            )
+                            .build(),
                     )
                     .build(),
             )
+            addContent(
+                LayoutElementBuilders.Image.Builder()
+                    .setResourceId(resourceId)
+                    .setWidth(dp(iconSize))
+                    .setHeight(dp(iconSize))
+                    .build(),
+            )
+            if (showLabels) {
+                addContent(
+                    LayoutElementBuilders.Arc.Builder()
+                        .addContent(
+                            LayoutElementBuilders.ArcText.Builder()
+                                .setText(entity.friendlyName)
+                                .setFontStyle(
+                                    LayoutElementBuilders.FontStyle.Builder()
+                                        .setSize(sp(TEXT_SIZE))
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                        .setModifiers(
+                            ModifiersBuilders.Modifiers.Builder()
+                                .setPadding(
+                                    ModifiersBuilders.Padding.Builder()
+                                        .setAll(dp(TEXT_PADDING))
+                                        .build(),
+                                ).build(),
+                        )
+                        .build(),
+                )
+            }
         }
-    }
-        .build()
+            .build()
 
     companion object {
         private const val TAG = "ShortcutsTile"
 
-        /** Entity cache — populated by WebSocket, read by tile rendering (zero network). */
+        /**
+         * Entity cache shared across service instances. Populated by the WebSocket subscription
+         * while a tile is visible, warmed on cold start by bounded parallel REST fetches, and
+         * updated optimistically on tap. Read-only on the tile render path.
+         */
         private val entityStates = ConcurrentHashMap<String, Entity>()
+
+        /**
+         * Snapshots of [entityStates] keyed by the resources version issued in `onTileRequest`.
+         * Ensures the matching `onTileResourcesRequest` renders bitmaps for the same state the
+         * layout referenced, even if the live cache mutated in between.
+         */
+        private val snapshotStash = SnapshotStash()
 
         /** WebSocket subscription for entity state changes. Outlives service instances. */
         private var subscriptionJob: Job? = null
@@ -335,9 +388,8 @@ class ShortcutsTile : TileService() {
             val appContext = context.applicationContext
             subscriptionJob = subscriptionScope.launch {
                 try {
-                    val flow = serverManager.integrationRepository()
-                        .getEntityUpdates(entityIds)
-                    flow?.collect { entity ->
+                    val flow = serverManager.integrationRepository().getEntityUpdates(entityIds) ?: return@launch
+                    flow.collect { entity ->
                         entityStates[entity.entityId] = entity
                         requestUpdate(appContext)
                     }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTileState.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTileState.kt
@@ -1,0 +1,128 @@
+package io.homeassistant.companion.android.tiles
+
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.data.SimplifiedEntity
+
+/**
+ * Pairs of reciprocal states that a toggle tap is expected to swap between. If the entity's
+ * current state matches one side of a pair for its domain, the tap is predicted to produce
+ * the other side.
+ *
+ * Why: `requestUpdate()` after a WebSocket state change does not reliably trigger the Wear
+ * tile framework to re-render, so users see the previous state until an unrelated event
+ * forces a refresh. Predicting the post-click state in `onTileRequest` makes the tap feel
+ * immediate. If the server ends up in a different state (e.g. a lock stuck mid-transition),
+ * the subscription will overwrite the cache and the display converges next refresh.
+ */
+private val TOGGLE_STATE_PAIRS: Map<String, Pair<String, String>> = mapOf(
+    "switch" to ("on" to "off"),
+    "light" to ("on" to "off"),
+    "input_boolean" to ("on" to "off"),
+    "fan" to ("on" to "off"),
+    "lock" to ("locked" to "unlocked"),
+    "cover" to ("open" to "closed"),
+)
+
+/**
+ * Returns the state an entity is expected to be in after a single click, or null if the
+ * domain isn't a known toggle or the current state isn't a recognized side of its pair.
+ * Conservative on purpose: unknown inputs leave the cache alone.
+ */
+internal fun predictedStateAfterClick(entity: Entity): String? {
+    val pair = TOGGLE_STATE_PAIRS[entity.domain] ?: return null
+    return when (entity.state) {
+        pair.first -> pair.second
+        pair.second -> pair.first
+        else -> null
+    }
+}
+
+/**
+ * Returns a copy of [entity] with its state flipped per [predictedStateAfterClick], or the
+ * input unchanged if no prediction is possible.
+ */
+internal fun applyOptimisticClick(entity: Entity): Entity {
+    val predicted = predictedStateAfterClick(entity) ?: return entity
+    return entity.copy(state = predicted)
+}
+
+/**
+ * Frozen view of entity states used to render a single tile response.
+ *
+ * `onTileRequest` and `onTileResourcesRequest` are separate framework calls that both need
+ * a consistent view of entity state. If each reads the live cache independently, a WebSocket
+ * update in between can cause the layout to reference a resource ID that the resource bundle
+ * never generated — producing stale or missing bitmaps on screen.
+ *
+ * A snapshot is built at `onTileRequest` time, stashed by resources version, and looked up
+ * again when the matching `onTileResourcesRequest` arrives.
+ */
+internal data class TileSnapshot(val entityStates: Map<String, Entity?>) {
+    /** State string for an entity, or null if the cache has no entry. */
+    fun stateOf(entityId: String): String? = entityStates[entityId]?.state
+
+    fun entityOf(entityId: String): Entity? = entityStates[entityId]
+
+    companion object {
+        /**
+         * Take a snapshot from a live cache, copying values for the given entity IDs.
+         * Missing entries are included as null so the snapshot is complete for the tile.
+         */
+        fun from(liveCache: Map<String, Entity>, entityIds: Iterable<String>): TileSnapshot =
+            TileSnapshot(entityIds.associateWith { liveCache[it] })
+    }
+}
+
+/**
+ * Resource ID used in the tile layout. The state suffix ensures Wear OS treats different
+ * states as distinct resources, preventing the bitmap cache from serving a stale icon when
+ * the state changes.
+ */
+internal fun resourceIdForEntity(entityId: String, state: String?): String =
+    if (state.isNullOrEmpty()) entityId else "$entityId@$state"
+
+/** Resource ID for an entity in the given snapshot. */
+internal fun SimplifiedEntity.resourceIdIn(snapshot: TileSnapshot): String =
+    resourceIdForEntity(entityId, snapshot.stateOf(entityId))
+
+/**
+ * The set of resource IDs required by a tile layout for the given entities and snapshot.
+ * Used as the invariant: every ID the layout references must be present in the resource bundle.
+ */
+internal fun requiredResourceIds(entities: List<SimplifiedEntity>, snapshot: TileSnapshot): Set<String> =
+    entities.map { it.resourceIdIn(snapshot) }.toSet()
+
+/**
+ * Bounded cache of snapshots keyed by resources version string.
+ *
+ * Wear OS may request resources for an older version than the latest tile render, especially
+ * when multiple `requestUpdate()` calls arrive quickly. Keeping the last few snapshots lets
+ * those requests resolve to the correct frozen state instead of the current live cache.
+ */
+internal class SnapshotStash(private val maxEntries: Int = 4) {
+    private val entries = linkedMapOf<String, TileSnapshot>()
+
+    @Synchronized
+    fun put(version: String, snapshot: TileSnapshot) {
+        entries.remove(version)
+        entries[version] = snapshot
+        while (entries.size > maxEntries) {
+            val oldest = entries.keys.iterator()
+            if (oldest.hasNext()) {
+                oldest.next()
+                oldest.remove()
+            }
+        }
+    }
+
+    @Synchronized
+    fun get(version: String): TileSnapshot? = entries[version]
+
+    @Synchronized
+    fun clear() {
+        entries.clear()
+    }
+
+    @Synchronized
+    fun size(): Int = entries.size
+}

--- a/wear/src/test/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTileStateTest.kt
+++ b/wear/src/test/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTileStateTest.kt
@@ -1,0 +1,271 @@
+package io.homeassistant.companion.android.tiles
+
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.data.SimplifiedEntity
+import java.time.LocalDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ShortcutsTileStateTest {
+
+    private val epoch = LocalDateTime.of(2026, 1, 1, 0, 0)
+
+    private fun entity(id: String, state: String): Entity = Entity(
+        entityId = id,
+        state = state,
+        attributes = emptyMap(),
+        lastChanged = epoch,
+        lastUpdated = epoch,
+    )
+
+    @Test
+    fun `resourceIdForEntity omits separator when state is null`() {
+        assertEquals("switch.plug_a", resourceIdForEntity("switch.plug_a", null))
+    }
+
+    @Test
+    fun `resourceIdForEntity omits separator when state is empty`() {
+        assertEquals("switch.plug_a", resourceIdForEntity("switch.plug_a", ""))
+    }
+
+    @Test
+    fun `resourceIdForEntity includes state suffix for distinct states`() {
+        val on = resourceIdForEntity("switch.plug_a", "on")
+        val off = resourceIdForEntity("switch.plug_a", "off")
+        assertEquals("switch.plug_a@on", on)
+        assertEquals("switch.plug_a@off", off)
+        assertNotEquals(on, off)
+    }
+
+    @Test
+    fun `snapshot includes every requested entity id`() {
+        val cache = mapOf(
+            "switch.plug_a" to entity("switch.plug_a", "on"),
+            "lock.front" to entity("lock.front", "locked"),
+        )
+        val snapshot = TileSnapshot.from(cache, listOf("switch.plug_a", "lock.front", "light.missing"))
+
+        assertEquals("on", snapshot.stateOf("switch.plug_a"))
+        assertEquals("locked", snapshot.stateOf("lock.front"))
+        assertNull(snapshot.stateOf("light.missing"))
+    }
+
+    @Test
+    fun `snapshot is decoupled from later cache mutations`() {
+        val cache = mutableMapOf("switch.plug_a" to entity("switch.plug_a", "on"))
+        val snapshot = TileSnapshot.from(cache, listOf("switch.plug_a"))
+
+        cache["switch.plug_a"] = entity("switch.plug_a", "off")
+
+        assertEquals("on", snapshot.stateOf("switch.plug_a"))
+    }
+
+    @Test
+    fun `requiredResourceIds matches resource ids produced by iconLayout inputs`() {
+        val entities = listOf(
+            SimplifiedEntity(entityId = "switch.plug_a"),
+            SimplifiedEntity(entityId = "lock.front"),
+        )
+        val snapshot = TileSnapshot.from(
+            mapOf(
+                "switch.plug_a" to entity("switch.plug_a", "on"),
+                "lock.front" to entity("lock.front", "locked"),
+            ),
+            entities.map { it.entityId },
+        )
+
+        val ids = requiredResourceIds(entities, snapshot)
+
+        assertTrue("switch.plug_a@on" in ids)
+        assertTrue("lock.front@locked" in ids)
+        assertEquals(2, ids.size)
+    }
+
+    @Test
+    fun `requiredResourceIds differs when only one entity state changes between snapshots`() {
+        val entities = listOf(SimplifiedEntity(entityId = "switch.plug_a"), SimplifiedEntity(entityId = "lock.front"))
+
+        val s1 = TileSnapshot.from(
+            mapOf(
+                "switch.plug_a" to entity("switch.plug_a", "on"),
+                "lock.front" to entity("lock.front", "locked"),
+            ),
+            entities.map { it.entityId },
+        )
+        val s2 = TileSnapshot.from(
+            mapOf(
+                "switch.plug_a" to entity("switch.plug_a", "off"),
+                "lock.front" to entity("lock.front", "locked"),
+            ),
+            entities.map { it.entityId },
+        )
+
+        assertNotEquals(requiredResourceIds(entities, s1), requiredResourceIds(entities, s2))
+    }
+
+    @Test
+    fun `snapshot stash returns the exact snapshot that was stored`() {
+        val stash = SnapshotStash()
+        val snapshot = TileSnapshot.from(mapOf("a" to entity("a", "1")), listOf("a"))
+        stash.put("v1", snapshot)
+
+        assertSame(snapshot, stash.get("v1"))
+    }
+
+    @Test
+    fun `snapshot stash is resistant to live cache mutation between put and get`() {
+        val stash = SnapshotStash()
+        val cache = mutableMapOf("a" to entity("a", "1"))
+        val snapshot = TileSnapshot.from(cache, listOf("a"))
+        stash.put("v1", snapshot)
+
+        cache["a"] = entity("a", "2")
+        val retrieved = stash.get("v1")
+
+        assertEquals("1", retrieved?.stateOf("a"))
+    }
+
+    @Test
+    fun `snapshot stash evicts oldest entries past the bound`() {
+        val stash = SnapshotStash(maxEntries = 2)
+        stash.put("v1", TileSnapshot.from(emptyMap(), emptyList()))
+        stash.put("v2", TileSnapshot.from(emptyMap(), emptyList()))
+        stash.put("v3", TileSnapshot.from(emptyMap(), emptyList()))
+
+        assertNull(stash.get("v1"))
+        assertEquals(2, stash.size())
+    }
+
+    @Test
+    fun `snapshot stash clear removes all entries`() {
+        val stash = SnapshotStash()
+        stash.put("v1", TileSnapshot.from(emptyMap(), emptyList()))
+        stash.put("v2", TileSnapshot.from(emptyMap(), emptyList()))
+        stash.clear()
+
+        assertNull(stash.get("v1"))
+        assertNull(stash.get("v2"))
+    }
+
+    @Test
+    fun `put with existing version replaces snapshot and keeps size bounded`() {
+        val stash = SnapshotStash(maxEntries = 2)
+        val first = TileSnapshot.from(mapOf("a" to entity("a", "1")), listOf("a"))
+        val second = TileSnapshot.from(mapOf("a" to entity("a", "2")), listOf("a"))
+
+        stash.put("v1", first)
+        stash.put("v1", second)
+
+        assertSame(second, stash.get("v1"))
+        assertEquals(1, stash.size())
+    }
+
+    /**
+     * Mimics the runtime race: tile request builds layout from snapshot S1, WebSocket update
+     * mutates cache to S2 before resources request arrives. Invariant: the layout's required
+     * resource IDs must all be satisfiable from the stashed snapshot, regardless of current cache.
+     */
+    @Test
+    fun `mutation between tile request and resources request does not break invariant`() {
+        val entities = listOf(SimplifiedEntity(entityId = "switch.plug_a"))
+        val liveCache = mutableMapOf("switch.plug_a" to entity("switch.plug_a", "on"))
+        val stash = SnapshotStash()
+
+        val versionA = "v-1"
+        val snapshotA = TileSnapshot.from(liveCache, entities.map { it.entityId })
+        stash.put(versionA, snapshotA)
+        val layoutIds = requiredResourceIds(entities, snapshotA)
+
+        liveCache["switch.plug_a"] = entity("switch.plug_a", "off")
+
+        val retrievedSnapshot = stash.get(versionA)!!
+        val resourceIds = entities.map { it.resourceIdIn(retrievedSnapshot) }.toSet()
+
+        assertEquals(layoutIds, resourceIds)
+        assertTrue("switch.plug_a@on" in resourceIds)
+    }
+
+    @Test
+    fun `predictedStateAfterClick flips switch between on and off`() {
+        assertEquals("off", predictedStateAfterClick(entity("switch.plug_a", "on")))
+        assertEquals("on", predictedStateAfterClick(entity("switch.plug_a", "off")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick flips light between on and off`() {
+        assertEquals("off", predictedStateAfterClick(entity("light.living_room", "on")))
+        assertEquals("on", predictedStateAfterClick(entity("light.living_room", "off")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick flips lock between locked and unlocked`() {
+        assertEquals("unlocked", predictedStateAfterClick(entity("lock.front", "locked")))
+        assertEquals("locked", predictedStateAfterClick(entity("lock.front", "unlocked")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick flips cover between open and closed`() {
+        assertEquals("closed", predictedStateAfterClick(entity("cover.garage", "open")))
+        assertEquals("open", predictedStateAfterClick(entity("cover.garage", "closed")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick flips input_boolean and fan`() {
+        assertEquals("off", predictedStateAfterClick(entity("input_boolean.flag", "on")))
+        assertEquals("on", predictedStateAfterClick(entity("fan.bedroom", "off")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick returns null for unknown domain`() {
+        assertNull(predictedStateAfterClick(entity("sensor.temperature", "on")))
+        assertNull(predictedStateAfterClick(entity("climate.hvac", "heat")))
+    }
+
+    @Test
+    fun `predictedStateAfterClick returns null for unrecognized state`() {
+        assertNull(predictedStateAfterClick(entity("lock.front", "jammed")))
+        assertNull(predictedStateAfterClick(entity("switch.plug_a", "unavailable")))
+    }
+
+    @Test
+    fun `applyOptimisticClick returns new entity with flipped state for toggles`() {
+        val before = entity("switch.plug_a", "on")
+        val after = applyOptimisticClick(before)
+        assertEquals("off", after.state)
+        assertNotEquals(before.state, after.state)
+    }
+
+    @Test
+    fun `applyOptimisticClick returns input unchanged when state is not predictable`() {
+        val before = entity("sensor.temperature", "22.5")
+        val after = applyOptimisticClick(before)
+        assertSame(before, after)
+    }
+
+    @Test
+    fun `applyOptimisticClick returns input unchanged for unrecognized state of known domain`() {
+        val before = entity("lock.front", "jammed")
+        val after = applyOptimisticClick(before)
+        assertSame(before, after)
+    }
+
+    /**
+     * End-to-end contract: after a click, a snapshot built from the optimistically-updated
+     * cache must reference the predicted resource ID — that's what fixes the "display lags
+     * reality by one tap" symptom.
+     */
+    @Test
+    fun `snapshot after optimistic click points to predicted resource id`() {
+        val cache = mutableMapOf("switch.plug_a" to entity("switch.plug_a", "on"))
+        cache["switch.plug_a"] = applyOptimisticClick(cache["switch.plug_a"]!!)
+
+        val snapshot = TileSnapshot.from(cache, listOf("switch.plug_a"))
+        val entities = listOf(SimplifiedEntity(entityId = "switch.plug_a"))
+
+        assertTrue("switch.plug_a@off" in requiredResourceIds(entities, snapshot))
+    }
+}


### PR DESCRIPTION
Closes #2045

## Summary

Shortcut tiles on Wear OS use domain-based fallback icons that don't reflect entity state — a lock always shows the same padlock icon, a switch always shows the same toggle. This change renders state-aware icons (e.g., locked vs unlocked padlock, powered vs unpowered outlet) and keeps them in sync with Home Assistant in real time.

**Before:** All lock entities show the same generic padlock icon.
**After:** Locked entities show a closed padlock, unlocked entities show an open padlock (and similar state-aware icons for other domains like covers, fans, switches).

## How it works

- **Real-time state via WebSocket**: while the tile is visible, `IntegrationRepository.getEntityUpdates(entityIds)` drives a shared in-memory cache. No REST polling; no `getEntities()` batch over the full entity list.
- **Cold-start warming**: on first render, any shortcut entity not yet in the cache is fetched via parallel `getEntity()` calls bounded by a 2s timeout. If the network is slow the tile still renders on time using domain-default icons, and the cache fills in on the next render.
- **Snapshot-per-render**: `onTileRequest` freezes the cache into a `TileSnapshot` keyed by the resources version; `onTileResourcesRequest` looks the snapshot up again and generates bitmaps from the same frozen view. Resource IDs include the state (`switch.foo@on` vs `switch.foo@off`) so the Wear bitmap cache can't serve a stale image.
- **Optimistic click**: on tap, the cached state is flipped to the predicted post-tap value (for known toggle domains: switch, light, lock, cover, input_boolean, fan) before the layout is built. The WebSocket subscription reconciles shortly after. This avoids a framework quirk where `requestUpdate()` doesn't reliably trigger a re-render while a tile is visible.
- **Lifecycle**: subscription starts in `onTileEnterEvent`, stops in `onTileLeaveEvent` and `onTileRemoveEvent`. State survives service recreation via `companion object`.

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Tests

Pure-logic tests in `ShortcutsTileStateTest` cover:

- Resource-ID invariants (state suffixing, null/empty handling, mismatch detection)
- Snapshot immutability against later cache mutation
- LRU stash eviction and replacement
- The runtime race: cache mutation between `onTileRequest` and `onTileResourcesRequest` must not break the resource-ID invariant
- Optimistic click prediction per domain, plus safe no-op on unknown domains and unrecognized states

**I did extensive manual testing loading this onto my actual watch and updating my actual entities.  This was the only strategy that worked well.  The UI very difficult to get right.**

## Screenshots

**Fallback icons (no entity state):**

<img width="384" height="384" alt="tile_screenshot" src="https://github.com/user-attachments/assets/c76a6b98-718e-45b0-a308-3b5492bce9cf" />

**State-aware icons (locked vs unlocked):**

<img width="384" height="384" alt="tile_screenshot_stateaware" src="https://github.com/user-attachments/assets/e228f560-41ff-4d4e-ae3a-f07b224ea258" />

## Notes

- Icon resolution uses `Entity.getIcon()` (already the app-wide pattern) for cached entities and falls back to `getIcon(icon, domain, context)` when the cache is cold.
- Hardcoded state strings (`"on"`, `"off"`, `"locked"`, `"unlocked"`, `"open"`, `"closed"`) match existing uses throughout `Entity.kt` and the wear module — these are part of Home Assistant's public API.
- Unknown domains and unrecognized states are a silent no-op on the optimistic path: the tap still fires the broadcast, the display stays on the current state, and the subscription updates it when the server confirms.
