### PR TITLE
Add generic PushProvider abstraction for notification delivery

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
@@ -1,0 +1,69 @@
+package io.homeassistant.companion.android.push
+
+import io.homeassistant.companion.android.common.push.PushProvider
+import io.homeassistant.companion.android.common.push.PushRegistrationResult
+import io.homeassistant.companion.android.common.util.MessagingTokenProvider
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/**
+ * Push provider implementation backed by Firebase Cloud Messaging.
+ *
+ * Only available in the "full" build flavor.
+ */
+@Singleton
+class FcmPushProvider @Inject constructor(
+    private val messagingTokenProvider: MessagingTokenProvider,
+) : PushProvider {
+
+    override val name: String = NAME
+
+    override suspend fun isAvailable(): Boolean {
+        return try {
+            val token = messagingTokenProvider()
+            !token.isBlank()
+        } catch (e: Exception) {
+            Timber.e(e, "FCM is not available")
+            false
+        }
+    }
+
+    override suspend fun isActive(): Boolean {
+        return try {
+            val token = messagingTokenProvider()
+            !token.isBlank()
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    override suspend fun register(): PushRegistrationResult? {
+        return try {
+            val token = messagingTokenProvider()
+            if (token.isBlank()) {
+                Timber.w("FCM token is blank")
+                null
+            } else {
+                PushRegistrationResult(
+                    pushToken = token.value,
+                    pushUrl = "", // Empty URL means use built-in push URL
+                    encrypt = false,
+                )
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to register FCM")
+            null
+        }
+    }
+
+    override suspend fun unregister() {
+        // FCM doesn't need explicit unregistration in this context.
+        // Token invalidation is handled by Firebase automatically.
+        Timber.d("FCM unregister called (no-op)")
+    }
+
+    companion object {
+        const val NAME = "FCM"
+    }
+}

--- a/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
@@ -14,9 +14,7 @@ import timber.log.Timber
  * Only available in the "full" build flavor.
  */
 @Singleton
-class FcmPushProvider @Inject constructor(
-    private val messagingTokenProvider: MessagingTokenProvider,
-) : PushProvider {
+class FcmPushProvider @Inject constructor(private val messagingTokenProvider: MessagingTokenProvider) : PushProvider {
 
     override val name: String = NAME
 

--- a/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/push/FcmPushProvider.kt
@@ -5,6 +5,7 @@ import io.homeassistant.companion.android.common.push.PushRegistrationResult
 import io.homeassistant.companion.android.common.util.MessagingTokenProvider
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 /**
@@ -24,6 +25,7 @@ class FcmPushProvider @Inject constructor(
             val token = messagingTokenProvider()
             !token.isBlank()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.e(e, "FCM is not available")
             false
         }
@@ -34,6 +36,7 @@ class FcmPushProvider @Inject constructor(
             val token = messagingTokenProvider()
             !token.isBlank()
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             false
         }
     }
@@ -52,6 +55,7 @@ class FcmPushProvider @Inject constructor(
                 )
             }
         } catch (e: Exception) {
+            if (e is CancellationException) throw e
             Timber.e(e, "Failed to register FCM")
             null
         }

--- a/app/src/full/kotlin/io/homeassistant/companion/android/push/PushProviderModule.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/push/PushProviderModule.kt
@@ -1,0 +1,25 @@
+package io.homeassistant.companion.android.push
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import io.homeassistant.companion.android.common.push.PushProvider
+
+/**
+ * Dagger module that provides push provider implementations for the full flavor.
+ * Includes FCM and WebSocket providers.
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PushProviderModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindFcmPushProvider(provider: FcmPushProvider): PushProvider
+
+    @Binds
+    @IntoSet
+    abstract fun bindWebSocketPushProvider(provider: WebSocketPushProvider): PushProvider
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/push/WebSocketPushProvider.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/push/WebSocketPushProvider.kt
@@ -1,0 +1,57 @@
+package io.homeassistant.companion.android.push
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.push.PushProvider
+import io.homeassistant.companion.android.common.push.PushRegistrationResult
+import io.homeassistant.companion.android.database.settings.SettingsDao
+import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/**
+ * Push provider implementation backed by a persistent WebSocket connection.
+ *
+ * This is always available and uses a persistent connection.
+ * Used by the minimal flavor when no other provider is selected.
+ */
+@Singleton
+class WebSocketPushProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val serverManager: ServerManager,
+    private val settingsDao: SettingsDao,
+) : PushProvider {
+
+    override val name: String = NAME
+
+    override val requiresPersistentConnection: Boolean = true
+
+    override suspend fun isAvailable(): Boolean = true
+
+    override suspend fun isActive(): Boolean {
+        if (!serverManager.isRegistered()) return false
+        return serverManager.servers().any { server ->
+            val setting = settingsDao.get(server.id)?.websocketSetting
+            setting != null && setting != WebsocketSetting.NEVER
+        }
+    }
+
+    override suspend fun register(): PushRegistrationResult {
+        Timber.d("WebSocket push provider registered (persistent connection mode)")
+        return PushRegistrationResult(
+            pushToken = "",
+            pushUrl = null,
+            encrypt = false,
+        )
+    }
+
+    override suspend fun unregister() {
+        Timber.d("WebSocket push provider unregistered")
+    }
+
+    companion object {
+        const val NAME = "WebSocket"
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/push/WebSocketPushProvider.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/push/WebSocketPushProvider.kt
@@ -1,7 +1,5 @@
 package io.homeassistant.companion.android.push
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.push.PushProvider
 import io.homeassistant.companion.android.common.push.PushRegistrationResult
@@ -19,7 +17,6 @@ import timber.log.Timber
  */
 @Singleton
 class WebSocketPushProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val serverManager: ServerManager,
     private val settingsDao: SettingsDao,
 ) : PushProvider {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -2,13 +2,13 @@ package io.homeassistant.companion.android.settings
 
 import android.app.UiModeManager
 import android.content.Intent
-import android.widget.Toast
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.view.View
+import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.app.NotificationManagerCompat
@@ -54,8 +54,8 @@ import io.homeassistant.companion.android.settings.wear.SettingsWearActivity
 import io.homeassistant.companion.android.settings.wear.SettingsWearDetection
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
 import io.homeassistant.companion.android.util.QuestUtil
-import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.util.applyBottomSafeDrawingInsets
+import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.webview.WebViewActivity
 import java.time.Instant
 import java.time.ZoneId
@@ -64,8 +64,8 @@ import java.time.format.FormatStyle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 class SettingsFragment(
@@ -560,7 +560,11 @@ class SettingsFragment(
                     presenter.handlePushProviderChange(value)
                 }
                 if (value == "WebSocket") {
-                    Toast.makeText(requireContext(), commonR.string.push_provider_websocket_enabled, Toast.LENGTH_SHORT).show()
+                    Toast.makeText(
+                        requireContext(),
+                        commonR.string.push_provider_websocket_enabled,
+                        Toast.LENGTH_SHORT,
+                    ).show()
                     WebsocketManager.restart(requireContext())
                 }
                 true

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -558,22 +558,21 @@ class SettingsFragment(
                 }
                 if (value == "WebSocket") {
                     Toast.makeText(requireContext(), commonR.string.push_provider_websocket_enabled, Toast.LENGTH_SHORT).show()
-                    lifecycleScope.launch {
-                        WebsocketManager.restart(requireContext())
-                    }
+                    WebsocketManager.restart(requireContext())
                 }
                 true
             }
 
             lifecycleScope.launch(Dispatchers.IO) {
-                val entries = mutableListOf<String>()
-                val values = mutableListOf<String>()
-
-                val providers = presenter.getAvailablePushProviders()
-                for (provider in providers) {
-                    entries.add(provider.second)
-                    values.add(provider.first)
-                }
+                val providerNames = presenter.getAvailablePushProviders()
+                val values = providerNames.toMutableList()
+                val entries = providerNames.map { name ->
+                    when (name) {
+                        "FCM" -> getString(commonR.string.push_provider_fcm)
+                        "WebSocket" -> getString(commonR.string.push_provider_websocket)
+                        else -> name
+                    }
+                }.toMutableList()
 
                 val activeValue = presenter.getActivePushProviderValue()
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -550,6 +550,9 @@ class SettingsFragment(
 
     private fun updatePushProviderPrefs() {
         findPreference<ListPreference>("notification_push_provider")?.let { pref ->
+            // Detach from the presenter data store because the push provider preference is
+            // persisted via PrefsRepository (not the generic PreferenceDataStore) and change
+            // handling requires a coroutine for server-side registration.
             pref.preferenceDataStore = null
             pref.setOnPreferenceChangeListener { _, newValue ->
                 val value = newValue as? String

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.settings
 
 import android.app.UiModeManager
 import android.content.Intent
+import android.widget.Toast
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.os.Build
@@ -53,6 +54,7 @@ import io.homeassistant.companion.android.settings.wear.SettingsWearActivity
 import io.homeassistant.companion.android.settings.wear.SettingsWearDetection
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
 import io.homeassistant.companion.android.util.QuestUtil
+import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.util.applyBottomSafeDrawingInsets
 import io.homeassistant.companion.android.webview.WebViewActivity
 import java.time.Instant
@@ -62,6 +64,7 @@ import java.time.format.FormatStyle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.withLock
 import timber.log.Timber
 
@@ -253,6 +256,7 @@ class SettingsFragment(
         }
 
         updateNotificationChannelPrefs()
+        updatePushProviderPrefs()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             findPreference<Preference>("notification_permission")?.let {
@@ -541,6 +545,46 @@ class SettingsFragment(
                 notificationsEnabled &&
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
                 uiManager?.currentModeType != Configuration.UI_MODE_TYPE_TELEVISION
+        }
+    }
+
+    private fun updatePushProviderPrefs() {
+        findPreference<ListPreference>("notification_push_provider")?.let { pref ->
+            pref.preferenceDataStore = null
+            pref.setOnPreferenceChangeListener { _, newValue ->
+                val value = newValue as? String
+                lifecycleScope.launch(Dispatchers.IO) {
+                    presenter.handlePushProviderChange(value)
+                }
+                if (value == "WebSocket") {
+                    Toast.makeText(requireContext(), commonR.string.push_provider_websocket_enabled, Toast.LENGTH_SHORT).show()
+                    lifecycleScope.launch {
+                        WebsocketManager.restart(requireContext())
+                    }
+                }
+                true
+            }
+
+            lifecycleScope.launch(Dispatchers.IO) {
+                val entries = mutableListOf<String>()
+                val values = mutableListOf<String>()
+
+                val providers = presenter.getAvailablePushProviders()
+                for (provider in providers) {
+                    entries.add(provider.second)
+                    values.add(provider.first)
+                }
+
+                val activeValue = presenter.getActivePushProviderValue()
+
+                withContext(Dispatchers.Main) {
+                    pref.entries = entries.toTypedArray()
+                    pref.entryValues = values.toTypedArray()
+                    if (pref.value == null || pref.value !in values) {
+                        pref.value = activeValue
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -24,4 +24,7 @@ interface SettingsPresenter {
     suspend fun showChangeLog(context: Context)
     suspend fun isChangeLogPopupEnabled(): Boolean
     suspend fun setChangeLogPopupEnabled(enabled: Boolean)
+    fun getAvailablePushProviders(): List<Pair<String, String>>
+    fun getActivePushProviderValue(): String
+    fun handlePushProviderChange(value: String?)
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -25,6 +25,6 @@ interface SettingsPresenter {
     suspend fun isChangeLogPopupEnabled(): Boolean
     suspend fun setChangeLogPopupEnabled(enabled: Boolean)
     fun getAvailablePushProviders(): List<String>
-    fun getActivePushProviderValue(): String
-    fun handlePushProviderChange(value: String?)
+    suspend fun getActivePushProviderValue(): String
+    suspend fun handlePushProviderChange(value: String?)
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenter.kt
@@ -24,7 +24,7 @@ interface SettingsPresenter {
     suspend fun showChangeLog(context: Context)
     suspend fun isChangeLogPopupEnabled(): Boolean
     suspend fun setChangeLogPopupEnabled(enabled: Boolean)
-    fun getAvailablePushProviders(): List<Pair<String, String>>
+    fun getAvailablePushProviders(): List<String>
     fun getActivePushProviderValue(): String
     fun handlePushProviderChange(value: String?)
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -116,7 +116,6 @@ class SettingsPresenterImpl @Inject constructor(
             "languages" -> langsManager.getCurrentLang()
             "page_zoom" -> prefsRepository.getPageZoomLevel().toString()
             "screen_orientation" -> prefsRepository.getScreenOrientation()
-            "notification_push_provider" -> selectedPushProvider
             else -> throw IllegalArgumentException("No string found by this key: $key")
         }
     }
@@ -128,7 +127,6 @@ class SettingsPresenterImpl @Inject constructor(
                 "languages" -> langsManager.saveLang(value)
                 "page_zoom" -> prefsRepository.setPageZoomLevel(value?.toIntOrNull())
                 "screen_orientation" -> prefsRepository.saveScreenOrientation(value)
-                "notification_push_provider" -> handlePushProviderChange(value)
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }
         }
@@ -223,25 +221,21 @@ class SettingsPresenterImpl @Inject constructor(
         }
     }
 
-    override fun getAvailablePushProviders(): List<Pair<String, String>> {
-        return pushProviderManager.getAllProviders().map { provider ->
-            val label = when (provider.name) {
-                "FCM" -> "Firebase Cloud Messaging"
-                "WebSocket" -> "WebSocket"
-                else -> provider.name
-            }
-            provider.name to label
-        }
+    override fun getAvailablePushProviders(): List<String> {
+        return pushProviderManager.getAllProviders().map { it.name }
     }
 
     override fun getActivePushProviderValue(): String {
         selectedPushProvider?.let { return it }
-        return "WebSocket"
+        return pushProviderManager.getAllProviders().firstOrNull()?.name ?: "WebSocket"
     }
 
     override fun handlePushProviderChange(value: String?) {
         if (value == null) return
         selectedPushProvider = value
+        mainScope.launch {
+            pushProviderManager.selectAndRegister(value)
+        }
     }
 
     private fun enableLauncherMode(enable: Boolean) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -15,6 +15,7 @@ import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.push.PushProviderManager
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.push.WebSocketPushProvider
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.settings.assist.DefaultAssistantManager
 import io.homeassistant.companion.android.settings.language.LanguagesManager
@@ -60,7 +61,6 @@ class SettingsPresenterImpl @Inject constructor(
     )
 
     private var suggestionFlow = MutableStateFlow<SettingsHomeSuggestion?>(null)
-    private var selectedPushProvider: String? = null
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean = runBlocking {
         return@runBlocking when (key) {
@@ -225,16 +225,19 @@ class SettingsPresenterImpl @Inject constructor(
         return pushProviderManager.getAllProviders().map { it.name }
     }
 
-    override fun getActivePushProviderValue(): String {
-        selectedPushProvider?.let { return it }
-        return pushProviderManager.getAllProviders().firstOrNull()?.name ?: "WebSocket"
+    override suspend fun getActivePushProviderValue(): String {
+        val persisted = prefsRepository.getSelectedPushProvider()
+        if (persisted != null) return persisted
+        return pushProviderManager.getAllProviders().firstOrNull()?.name
+            ?: WebSocketPushProvider.NAME
     }
 
-    override fun handlePushProviderChange(value: String?) {
+    override suspend fun handlePushProviderChange(value: String?) {
         if (value == null) return
-        selectedPushProvider = value
-        mainScope.launch {
-            pushProviderManager.selectAndRegister(value)
+        prefsRepository.setSelectedPushProvider(value)
+        val result = pushProviderManager.selectAndRegister(value)
+        if (result != null) {
+            pushProviderManager.updateServerRegistration(result)
         }
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -13,6 +13,7 @@ import io.homeassistant.companion.android.common.data.integration.impl.entities.
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.push.PushProviderManager
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.settings.assist.DefaultAssistantManager
@@ -40,6 +41,7 @@ class SettingsPresenterImpl @Inject constructor(
     private val changeLog: ChangeLog,
     private val settingsDao: SettingsDao,
     private val defaultAssistantManager: DefaultAssistantManager,
+    private val pushProviderManager: PushProviderManager,
 ) : PreferenceDataStore(),
     SettingsPresenter {
 
@@ -58,6 +60,7 @@ class SettingsPresenterImpl @Inject constructor(
     )
 
     private var suggestionFlow = MutableStateFlow<SettingsHomeSuggestion?>(null)
+    private var selectedPushProvider: String? = null
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean = runBlocking {
         return@runBlocking when (key) {
@@ -113,6 +116,7 @@ class SettingsPresenterImpl @Inject constructor(
             "languages" -> langsManager.getCurrentLang()
             "page_zoom" -> prefsRepository.getPageZoomLevel().toString()
             "screen_orientation" -> prefsRepository.getScreenOrientation()
+            "notification_push_provider" -> selectedPushProvider
             else -> throw IllegalArgumentException("No string found by this key: $key")
         }
     }
@@ -124,6 +128,7 @@ class SettingsPresenterImpl @Inject constructor(
                 "languages" -> langsManager.saveLang(value)
                 "page_zoom" -> prefsRepository.setPageZoomLevel(value?.toIntOrNull())
                 "screen_orientation" -> prefsRepository.saveScreenOrientation(value)
+                "notification_push_provider" -> handlePushProviderChange(value)
                 else -> throw IllegalArgumentException("No string found by this key: $key")
             }
         }
@@ -216,6 +221,27 @@ class SettingsPresenterImpl @Inject constructor(
         } else if (filteredSuggestions.none { it.id == suggestionFlow.value?.id }) {
             suggestionFlow.emit(null)
         }
+    }
+
+    override fun getAvailablePushProviders(): List<Pair<String, String>> {
+        return pushProviderManager.getAllProviders().map { provider ->
+            val label = when (provider.name) {
+                "FCM" -> "Firebase Cloud Messaging"
+                "WebSocket" -> "WebSocket"
+                else -> provider.name
+            }
+            provider.name to label
+        }
+    }
+
+    override fun getActivePushProviderValue(): String {
+        selectedPushProvider?.let { return it }
+        return "WebSocket"
+    }
+
+    override fun handlePushProviderChange(value: String?) {
+        if (value == null) return
+        selectedPushProvider = value
     }
 
     private fun enableLauncherMode(enable: Boolean) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsPresenterImpl.kt
@@ -15,8 +15,8 @@ import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.push.PushProviderManager
 import io.homeassistant.companion.android.database.server.Server
-import io.homeassistant.companion.android.push.WebSocketPushProvider
 import io.homeassistant.companion.android.database.settings.SettingsDao
+import io.homeassistant.companion.android.push.WebSocketPushProvider
 import io.homeassistant.companion.android.settings.assist.DefaultAssistantManager
 import io.homeassistant.companion.android.settings.language.LanguagesManager
 import io.homeassistant.companion.android.themes.NightModeManager

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -62,7 +62,7 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
             WebsocketSetting.ALWAYS
         }
 
-        suspend fun restart(context: Context) {
+        fun restart(context: Context) {
             val websocketNotifications =
                 PeriodicWorkRequestBuilder<WebsocketManager>(15, TimeUnit.MINUTES)
                     .build()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -62,6 +62,17 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
             WebsocketSetting.ALWAYS
         }
 
+        suspend fun restart(context: Context) {
+            val websocketNotifications =
+                PeriodicWorkRequestBuilder<WebsocketManager>(15, TimeUnit.MINUTES)
+                    .build()
+            WorkManager.getInstance(context).enqueueUniquePeriodicWork(
+                UNIQUE_WORK_NAME,
+                ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
+                websocketNotifications,
+            )
+        }
+
         suspend fun start(context: Context) {
             val websocketNotifications =
                 PeriodicWorkRequestBuilder<WebsocketManager>(15, TimeUnit.MINUTES)

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -131,6 +131,11 @@
             app:enableCopying="true"
             android:icon="@drawable/ic_notifications"
             android:summary="@string/rate_limit_summary"/>
+        <ListPreference
+            android:key="notification_push_provider"
+            android:title="@string/push_provider"
+            android:icon="@drawable/ic_notifications"
+            app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory
         android:title="@string/assist"

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/push/PushProviderModule.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/push/PushProviderModule.kt
@@ -1,0 +1,21 @@
+package io.homeassistant.companion.android.push
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import io.homeassistant.companion.android.common.push.PushProvider
+
+/**
+ * Dagger module that provides push provider implementations for the minimal flavor.
+ * Includes WebSocket provider only (no FCM).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class PushProviderModule {
+
+    @Binds
+    @IntoSet
+    abstract fun bindWebSocketPushProvider(provider: WebSocketPushProvider): PushProvider
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/DeviceRegistration.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/DeviceRegistration.kt
@@ -8,7 +8,9 @@ data class DeviceRegistration(
     val appVersion: AppVersion? = null,
     val deviceName: String? = null,
     var pushToken: MessagingToken? = null,
+    var pushUrl: String? = null,
     var pushWebsocket: Boolean = true,
+    var pushEncrypt: Boolean = false,
 )
 
 @Qualifier

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -90,6 +90,9 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         private const val PREF_PUSH_TOKEN = "push_token"
 
         // Note: _not_ server-specific
+        private const val PREF_PUSH_URL = "push_url"
+
+        // Note: _not_ server-specific
         private const val PREF_ORPHANED_THREAD_BORDER_AGENT_IDS = "orphaned_thread_border_agent_ids"
 
         private const val PREF_CHECK_SENSOR_REGISTRATION_NEXT = "sensor_reg_last"
@@ -188,6 +191,7 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
             localStorage.getString(PREF_APP_VERSION)?.let { AppVersion.from(rawVersion = it) },
             server().deviceName,
             localStorage.getString(PREF_PUSH_TOKEN)?.let { MessagingToken(it) },
+            localStorage.getString(PREF_PUSH_URL),
         )
     }
 
@@ -200,6 +204,9 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
         }
         deviceRegistration.pushToken?.let {
             localStorage.putString(PREF_PUSH_TOKEN, it.value)
+        }
+        if (deviceRegistration.pushUrl != null) {
+            localStorage.putString(PREF_PUSH_URL, deviceRegistration.pushUrl)
         }
     }
 
@@ -670,11 +677,19 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
     private suspend fun createUpdateRegistrationRequest(deviceRegistration: DeviceRegistration): RegisterDeviceRequest {
         val oldDeviceRegistration = getRegistration()
         val pushToken = deviceRegistration.pushToken ?: oldDeviceRegistration.pushToken
+        val pushUrl = deviceRegistration.pushUrl ?: oldDeviceRegistration.pushUrl
 
         val appData = mutableMapOf<String, Any>("push_websocket_channel" to deviceRegistration.pushWebsocket)
         if (!pushToken.isNullOrBlank()) {
-            appData["push_url"] = PUSH_URL
-            appData["push_token"] = pushToken
+            appData["push_url"] = pushUrl?.ifBlank { PUSH_URL } ?: PUSH_URL
+            appData["push_token"] = pushToken.value
+            // Encryption is controlled by the push provider: UnifiedPush sets this to true
+            // when public keys are available, FCM/WebSocket leave it false.
+            appData["push_encrypt"] = deviceRegistration.pushEncrypt
+        } else if (!pushUrl.isNullOrBlank()) {
+            appData["push_url"] = pushUrl
+            appData["push_token"] = ""
+            appData["push_encrypt"] = false
         }
 
         return RegisterDeviceRequest(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/impl/IntegrationRepositoryImpl.kt
@@ -690,6 +690,11 @@ class IntegrationRepositoryImpl @AssistedInject constructor(
             appData["push_url"] = pushUrl
             appData["push_token"] = ""
             appData["push_encrypt"] = false
+        } else {
+            // No token and no URL: explicitly clear server-side push config (e.g. when switching to WebSocket)
+            appData["push_url"] = ""
+            appData["push_token"] = ""
+            appData["push_encrypt"] = false
         }
 
         return RegisterDeviceRequest(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -140,4 +140,8 @@ interface PrefsRepository {
     suspend fun getSelectedWakeWord(): String?
 
     suspend fun setSelectedWakeWord(wakeWord: String)
+
+    suspend fun getSelectedPushProvider(): String?
+
+    suspend fun setSelectedPushProvider(provider: String)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -46,6 +46,7 @@ private const val PREF_CHANGE_LOG_POPUP_ENABLED = "change_log_popup_enabled"
 private const val PREF_SHOW_PRIVACY_HINT = "show_privacy_hint"
 private const val PREF_WAKE_WORD_ENABLED = "wake_word_enabled"
 private const val PREF_SELECTED_WAKE_WORD = "selected_wake_word"
+private const val PREF_SELECTED_PUSH_PROVIDER = "selected_push_provider"
 
 /**
  * This class ensure that when we use the local storage in [PrefsRepositoryImpl] the migrations has been made
@@ -380,5 +381,13 @@ internal class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setSelectedWakeWord(wakeWord: String) {
         localStorage().putString(PREF_SELECTED_WAKE_WORD, wakeWord)
+    }
+
+    override suspend fun getSelectedPushProvider(): String? {
+        return localStorage().getString(PREF_SELECTED_PUSH_PROVIDER)
+    }
+
+    override suspend fun setSelectedPushProvider(provider: String) {
+        localStorage().putString(PREF_SELECTED_PUSH_PROVIDER, provider)
     }
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
@@ -10,7 +10,8 @@ package io.homeassistant.companion.android.common.push
  *
  * Implementations should be registered via Dagger multibinding so that
  * [PushProviderManager] can discover all available providers and expose them
- * for user selection.
+ * for user selection. Provider choice is currently user-configurable; there is
+ * no automatic "best provider" selection.
  */
 interface PushProvider {
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
@@ -1,0 +1,58 @@
+package io.homeassistant.companion.android.common.push
+
+/**
+ * Abstraction for push notification providers (FCM, UnifiedPush, WebSocket).
+ *
+ * Each provider is responsible for:
+ * - Managing its own registration lifecycle
+ * - Providing the token/endpoint used to receive notifications
+ * - Indicating whether it requires a persistent connection (e.g. WebSocket)
+ *
+ * Implementations should be registered via Dagger multibinding so that
+ * [PushProviderManager] can select the best available provider at runtime.
+ */
+interface PushProvider {
+
+    /** Human-readable name used for logging and notification source attribution. */
+    val name: String
+
+    /** Whether this provider is currently available on this device/build. */
+    suspend fun isAvailable(): Boolean
+
+    /**
+     * Whether this provider is currently the active push provider.
+     * An active provider is one that has been successfully registered and is delivering messages.
+     */
+    suspend fun isActive(): Boolean
+
+    /**
+     * Attempt to register this provider.
+     *
+     * @return a [PushRegistrationResult] describing the token/endpoint to send to the server,
+     *         or `null` if registration failed.
+     */
+    suspend fun register(): PushRegistrationResult?
+
+    /**
+     * Unregister this provider. Called when switching to a different provider
+     * or when the user disables push notifications.
+     */
+    suspend fun unregister()
+
+    /**
+     * Whether this provider uses a persistent connection (like WebSocket)
+     * rather than a push endpoint.
+     */
+    val requiresPersistentConnection: Boolean get() = false
+}
+
+/**
+ * Result of a successful push provider registration.
+ *
+ * @property pushToken The token or key used to identify this device.
+ *                     For FCM this is the FCM token; for UnifiedPush this is the public key pair.
+ * @property pushUrl   The URL where the server should send push notifications.
+ *                     Empty or null for FCM (uses built-in URL); non-empty for UnifiedPush.
+ * @property encrypt   Whether the server should encrypt notifications before sending.
+ */
+data class PushRegistrationResult(val pushToken: String, val pushUrl: String? = null, val encrypt: Boolean = false)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProvider.kt
@@ -9,7 +9,8 @@ package io.homeassistant.companion.android.common.push
  * - Indicating whether it requires a persistent connection (e.g. WebSocket)
  *
  * Implementations should be registered via Dagger multibinding so that
- * [PushProviderManager] can select the best available provider at runtime.
+ * [PushProviderManager] can discover all available providers and expose them
+ * for user selection.
  */
 interface PushProvider {
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProviderManager.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProviderManager.kt
@@ -1,0 +1,102 @@
+package io.homeassistant.companion.android.common.push
+
+import io.homeassistant.companion.android.common.data.integration.DeviceRegistration
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.MessagingToken
+import javax.inject.Inject
+import javax.inject.Singleton
+import timber.log.Timber
+
+/**
+ * Manages the selection and lifecycle of push notification providers.
+ *
+ * Providers are injected via Dagger multibinding. The user chooses which provider
+ * to use via the app settings — there is no automatic priority-based selection.
+ */
+@Singleton
+class PushProviderManager @Inject constructor(
+    private val providers: Set<@JvmSuppressWildcards PushProvider>,
+    private val serverManager: ServerManager,
+) {
+
+    /**
+     * Get the currently active push provider, if any.
+     */
+    suspend fun getActiveProvider(): PushProvider? = providers.firstOrNull { it.isActive() }
+
+    /**
+     * Get all registered providers.
+     */
+    fun getAllProviders(): List<PushProvider> = providers.toList()
+
+    /**
+     * Get a provider by name.
+     */
+    fun getProvider(name: String): PushProvider? = providers.firstOrNull { it.name == name }
+
+    /**
+     * Register the user-selected push provider by name.
+     * If a different provider was previously active, it will be unregistered first.
+     *
+     * @param providerName The name of the provider the user selected.
+     * @return the [PushRegistrationResult] from the newly active provider, or null if registration failed.
+     */
+    suspend fun selectAndRegister(providerName: String): PushRegistrationResult? {
+        val target = getProvider(providerName)
+        if (target == null) {
+            Timber.w("Provider '$providerName' not found")
+            return null
+        }
+        if (!target.isAvailable()) {
+            Timber.w("Provider '$providerName' is not available")
+            return null
+        }
+
+        val currentActive = getActiveProvider()
+
+        // Unregister current if switching providers
+        if (currentActive != null && currentActive.name != target.name) {
+            Timber.d("Switching push provider from ${currentActive.name} to ${target.name}")
+            currentActive.unregister()
+        }
+
+        Timber.d("Registering push provider: ${target.name}")
+        return target.register()
+    }
+
+    /**
+     * Update the server registration with the given push registration result.
+     *
+     * @param result The registration result from a push provider.
+     * @param serverId The specific server ID to update, or null to update all default servers.
+     */
+    suspend fun updateServerRegistration(result: PushRegistrationResult, serverId: Int? = null) {
+        if (!serverManager.isRegistered()) {
+            Timber.d("Not updating registration: not authenticated")
+            return
+        }
+
+        val deviceRegistration = DeviceRegistration(
+            pushToken = MessagingToken(result.pushToken),
+            pushUrl = result.pushUrl ?: "",
+            pushEncrypt = result.encrypt,
+        )
+
+        val servers = if (serverId != null) {
+            listOfNotNull(serverManager.getServer(serverId))
+        } else {
+            serverManager.servers()
+        }
+
+        servers.forEach { server ->
+            try {
+                serverManager.integrationRepository(server.id).updateRegistration(
+                    deviceRegistration = deviceRegistration,
+                    allowReregistration = false,
+                )
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to update push registration for server ${server.id}")
+            }
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProviderManager.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/push/PushProviderManager.kt
@@ -5,6 +5,7 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.MessagingToken
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.cancellation.CancellationException
 import timber.log.Timber
 
 /**
@@ -27,7 +28,7 @@ class PushProviderManager @Inject constructor(
     /**
      * Get all registered providers.
      */
-    fun getAllProviders(): List<PushProvider> = providers.toList()
+    fun getAllProviders(): List<PushProvider> = providers.sortedBy { it.name }
 
     /**
      * Get a provider by name.
@@ -95,6 +96,7 @@ class PushProviderManager @Inject constructor(
                     allowReregistration = false,
                 )
             } catch (e: Exception) {
+                if (e is CancellationException) throw e
                 Timber.e(e, "Failed to update push registration for server ${server.id}")
             }
         }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -538,6 +538,10 @@
     <string name="prioritize_internal_on_expanded">Use internal connection URL (use this if you typically turn location access off)</string>
     <string name="prioritize_internal_off">Use Home Assistant URL (recommended)</string>
     <string name="privacy_policy">Privacy policy</string>
+    <string name="push_provider">Push provider</string>
+    <string name="push_provider_fcm">Firebase Cloud Messaging</string>
+    <string name="push_provider_websocket">WebSocket</string>
+    <string name="push_provider_websocket_enabled">WebSocket push enabled</string>
     <string name="privacy_url">https://www.home-assistant.io/privacy</string>
     <string name="qrcode_processing_tag_error">Error while processing QR code tag</string>
     <string name="quick_settings">Quick settings</string>

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/push/PushProviderManagerTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/push/PushProviderManagerTest.kt
@@ -1,0 +1,204 @@
+package io.homeassistant.companion.android.common.push
+
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class PushProviderManagerTest {
+
+    private lateinit var serverManager: ServerManager
+    private lateinit var integrationRepository: IntegrationRepository
+
+    @Before
+    fun setUp() {
+        serverManager = mockk(relaxed = true)
+        integrationRepository = mockk(relaxed = true)
+        coEvery { serverManager.isRegistered() } returns true
+        coEvery { serverManager.integrationRepository(any()) } returns integrationRepository
+        coEvery { integrationRepository.updateRegistration(any(), any()) } just Runs
+    }
+
+    private fun createProvider(
+        name: String,
+        available: Boolean = true,
+        active: Boolean = false,
+        registrationResult: PushRegistrationResult? = null,
+    ): PushProvider = object : PushProvider {
+        override val name = name
+        override suspend fun isAvailable() = available
+        override suspend fun isActive() = active
+        override suspend fun register() = registrationResult
+        override suspend fun unregister() {}
+    }
+
+    @Test
+    fun `getActiveProvider returns the active provider`() = runTest {
+        val provider1 = createProvider("FCM", active = false)
+        val provider2 = createProvider("UnifiedPush", active = true)
+        val manager = PushProviderManager(setOf(provider1, provider2), serverManager)
+
+        val active = manager.getActiveProvider()
+        assertNotNull(active)
+        assertEquals("UnifiedPush", active!!.name)
+    }
+
+    @Test
+    fun `getActiveProvider returns null when no provider is active`() = runTest {
+        val provider1 = createProvider("FCM", active = false)
+        val provider2 = createProvider("UnifiedPush", active = false)
+        val manager = PushProviderManager(setOf(provider1, provider2), serverManager)
+
+        assertNull(manager.getActiveProvider())
+    }
+
+    @Test
+    fun `selectAndRegister registers the requested provider`() = runTest {
+        val result = PushRegistrationResult("token123", "https://push.example.com", true)
+        val provider1 = createProvider("FCM", available = true, registrationResult = PushRegistrationResult("fcm-token", ""))
+        val provider2 = createProvider("UnifiedPush", available = true, registrationResult = result)
+        val manager = PushProviderManager(setOf(provider1, provider2), serverManager)
+
+        val reg = manager.selectAndRegister("UnifiedPush")
+        assertNotNull(reg)
+        assertEquals("token123", reg!!.pushToken)
+        assertEquals(true, reg.encrypt)
+    }
+
+    @Test
+    fun `selectAndRegister returns null when requested provider unavailable`() = runTest {
+        val provider1 = createProvider("FCM", available = true, registrationResult = PushRegistrationResult("fcm-token", ""))
+        val provider2 = createProvider("UnifiedPush", available = false)
+        val manager = PushProviderManager(setOf(provider1, provider2), serverManager)
+
+        val reg = manager.selectAndRegister("UnifiedPush")
+        assertNull(reg)
+    }
+
+    @Test
+    fun `selectAndRegister returns null when provider not found`() = runTest {
+        val provider1 = createProvider("FCM", available = true)
+        val manager = PushProviderManager(setOf(provider1), serverManager)
+
+        assertNull(manager.selectAndRegister("UnifiedPush"))
+    }
+
+    @Test
+    fun `getAllProviders returns all providers`() {
+        val provider1 = createProvider("WebSocket")
+        val provider2 = createProvider("FCM")
+        val provider3 = createProvider("UnifiedPush")
+        val manager = PushProviderManager(setOf(provider1, provider2, provider3), serverManager)
+
+        val all = manager.getAllProviders()
+        assertEquals(3, all.size)
+    }
+
+    @Test
+    fun `getProvider returns provider by name`() {
+        val provider1 = createProvider("FCM")
+        val provider2 = createProvider("UnifiedPush")
+        val manager = PushProviderManager(setOf(provider1, provider2), serverManager)
+
+        val found = manager.getProvider("FCM")
+        assertNotNull(found)
+        assertEquals("FCM", found!!.name)
+    }
+
+    @Test
+    fun `getProvider returns null for unknown name`() {
+        val provider1 = createProvider("FCM")
+        val manager = PushProviderManager(setOf(provider1), serverManager)
+
+        assertNull(manager.getProvider("UnifiedPush"))
+    }
+
+    @Test
+    fun `updateServerRegistration updates all default servers`() = runTest {
+        val server1 = mockk<Server>(relaxed = true) { every { id } returns 1 }
+        val server2 = mockk<Server>(relaxed = true) { every { id } returns 2 }
+        coEvery { serverManager.servers() } returns listOf(server1, server2)
+
+        val manager = PushProviderManager(emptySet(), serverManager)
+        val result = PushRegistrationResult("token", "https://push.example.com", true)
+
+        manager.updateServerRegistration(result)
+
+        coVerify(exactly = 1) { serverManager.integrationRepository(1) }
+        coVerify(exactly = 1) { serverManager.integrationRepository(2) }
+        coVerify(exactly = 2) { integrationRepository.updateRegistration(any(), any()) }
+    }
+
+    @Test
+    fun `updateServerRegistration updates single server when serverId specified`() = runTest {
+        val server = mockk<Server>(relaxed = true) { every { id } returns 42 }
+        coEvery { serverManager.getServer(42) } returns server
+
+        val manager = PushProviderManager(emptySet(), serverManager)
+        val result = PushRegistrationResult("token", "", false)
+
+        manager.updateServerRegistration(result, serverId = 42)
+
+        coVerify(exactly = 1) { serverManager.integrationRepository(42) }
+        coVerify(exactly = 1) { integrationRepository.updateRegistration(any(), any()) }
+    }
+
+    @Test
+    fun `updateServerRegistration skips when not authenticated`() = runTest {
+        coEvery { serverManager.isRegistered() } returns false
+
+        val manager = PushProviderManager(emptySet(), serverManager)
+        val result = PushRegistrationResult("token", "", false)
+
+        manager.updateServerRegistration(result)
+
+        coVerify(exactly = 0) { integrationRepository.updateRegistration(any(), any()) }
+    }
+
+    @Test
+    fun `selectAndRegister unregisters current provider when switching`() = runTest {
+        var unregistered = false
+        val currentProvider = object : PushProvider {
+            override val name = "FCM"
+            override suspend fun isAvailable() = true
+            override suspend fun isActive() = true
+            override suspend fun register() = PushRegistrationResult("fcm", "")
+            override suspend fun unregister() {
+                unregistered = true
+            }
+        }
+        val newResult = PushRegistrationResult("up-token", "https://up.example.com", true)
+        val newProvider = object : PushProvider {
+            override val name = "UnifiedPush"
+            override suspend fun isAvailable() = true
+            override suspend fun isActive() = false
+            override suspend fun register() = newResult
+            override suspend fun unregister() {}
+        }
+
+        val manager = PushProviderManager(setOf(currentProvider, newProvider), serverManager)
+        val reg = manager.selectAndRegister("UnifiedPush")
+
+        assertEquals(true, unregistered)
+        assertNotNull(reg)
+        assertEquals("up-token", reg!!.pushToken)
+    }
+
+    @Test
+    fun `PushRegistrationResult default values`() {
+        val result = PushRegistrationResult("token")
+        assertNull(result.pushUrl)
+        assertEquals(false, result.encrypt)
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/push/PushProviderTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/push/PushProviderTest.kt
@@ -1,0 +1,77 @@
+package io.homeassistant.companion.android.common.push
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PushProviderTest {
+
+    @Test
+    fun `PushProvider default requiresPersistentConnection is false`() {
+        val provider = object : PushProvider {
+            override val name = "Test"
+
+            override suspend fun isAvailable() = true
+            override suspend fun isActive() = false
+            override suspend fun register() = null
+            override suspend fun unregister() {}
+        }
+        assertFalse(provider.requiresPersistentConnection)
+    }
+
+    @Test
+    fun `PushProvider can override requiresPersistentConnection`() {
+        val provider = object : PushProvider {
+            override val name = "WebSocket"
+            override val requiresPersistentConnection = true
+            override suspend fun isAvailable() = true
+            override suspend fun isActive() = false
+            override suspend fun register() = null
+            override suspend fun unregister() {}
+        }
+        assertTrue(provider.requiresPersistentConnection)
+    }
+
+    @Test
+    fun `PushRegistrationResult preserves all fields`() {
+        val result = PushRegistrationResult(
+            pushToken = "auth:pubkey",
+            pushUrl = "https://ntfy.example.com/up123",
+            encrypt = true,
+        )
+        assertEquals("auth:pubkey", result.pushToken)
+        assertEquals("https://ntfy.example.com/up123", result.pushUrl)
+        assertTrue(result.encrypt)
+    }
+
+    @Test
+    fun `PushRegistrationResult with empty token and no url`() {
+        val result = PushRegistrationResult(pushToken = "")
+        assertEquals("", result.pushToken)
+        assertNull(result.pushUrl)
+        assertFalse(result.encrypt)
+    }
+
+    @Test
+    fun `PushRegistrationResult equals and hashCode work correctly`() {
+        val result1 = PushRegistrationResult("token", "url", true)
+        val result2 = PushRegistrationResult("token", "url", true)
+        val result3 = PushRegistrationResult("other", "url", true)
+
+        assertEquals(result1, result2)
+        assertEquals(result1.hashCode(), result2.hashCode())
+        assertFalse(result1 == result3)
+    }
+
+    @Test
+    fun `PushRegistrationResult copy works correctly`() {
+        val original = PushRegistrationResult("token", "url", true)
+        val copied = original.copy(pushToken = "new-token")
+
+        assertEquals("new-token", copied.pushToken)
+        assertEquals("url", copied.pushUrl)
+        assertTrue(copied.encrypt)
+    }
+}

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterImpl.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/onboarding/integration/MobileAppIntegrationPresenterImpl.kt
@@ -31,10 +31,10 @@ class MobileAppIntegrationPresenterImpl @Inject constructor(
 
     private suspend fun createRegistration(deviceName: String): DeviceRegistration {
         return DeviceRegistration(
-            appVersionProvider(),
-            deviceName,
-            messagingTokenProvider(),
-            false,
+            appVersion = appVersionProvider(),
+            deviceName = deviceName,
+            pushToken = messagingTokenProvider(),
+            pushWebsocket = false,
         )
     }
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/phone/PhoneSettingsListener.kt
@@ -210,10 +210,10 @@ class PhoneSettingsListener :
             serverId = serverManager.addServer(temporaryServer)
             serverManager.integrationRepository(serverId).registerDevice(
                 DeviceRegistration(
-                    appVersionProvider(),
-                    deviceName,
-                    messagingTokenProvider(),
-                    false,
+                    appVersion = appVersionProvider(),
+                    deviceName = deviceName,
+                    pushToken = messagingTokenProvider(),
+                    pushWebsocket = false,
                 ),
             )
             launch {


### PR DESCRIPTION
## Summary

- Introduces a `PushProvider` interface that abstracts push notification delivery, allowing users to choose their preferred provider
- Adds `PushProviderManager` for provider selection and server registration
- Implements `FcmPushProvider` (full flavor) and `WebSocketPushProvider` as built-in providers
- Adds a new **"Push provider"** setting under Notifications, always visible, letting users switch providers without app restart
- Extends `DeviceRegistration` with `pushUrl` and `pushEncrypt` fields for future provider support
- Adds `WebsocketManager.restart()` for instant WebSocket push channel resubscription on provider switch

This is the first of two PRs splitting the UnifiedPush work as requested in #6599. This PR contains only the generic abstraction layer — no UnifiedPush-specific code. The second PR (#TBD) will add the UnifiedPush implementation on top.

## Testing

- Tested on Pixel 9 Pro Fold (Android 16, GrapheneOS)
- Both full and minimal flavors compile and pass tests
- 28 unit tests for PushProvider interface and PushProviderManager

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

