### PR TITLE
Add native Android media controls for HA media_player entities

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -404,7 +404,7 @@
         errorLine2="     ~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="89"
+            line="90"
             column="6"/>
     </issue>
 
@@ -646,7 +646,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="539"
+            line="554"
             column="17"/>
     </issue>
 
@@ -657,7 +657,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="539"
+            line="554"
             column="17"/>
     </issue>
 
@@ -1607,6 +1607,61 @@
             file="src/full/kotlin/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt"
             line="53"
             column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;Server> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `servers: ImmutableList&lt;Server>` or create an `@Immutable` wrapper for this class: `@Immutable data class ServersList(val items: List&lt;Server>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    servers: List&lt;Server>,"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="62"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;Entity> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `sortedEntities: ImmutableList&lt;Entity>` or create an `@Immutable` wrapper for this class: `@Immutable data class SortedEntitiesList(val items: List&lt;Entity>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    sortedEntities: List&lt;Entity>,"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="63"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;EntityRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `entityRegistry: ImmutableList&lt;EntityRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class EntityRegistryList(val items: List&lt;EntityRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    entityRegistry: List&lt;EntityRegistryResponse>,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="64"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;DeviceRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `deviceRegistry: ImmutableList&lt;DeviceRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class DeviceRegistryList(val items: List&lt;DeviceRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    deviceRegistry: List&lt;DeviceRegistryResponse>,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="65"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;AreaRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `areaRegistry: ImmutableList&lt;AreaRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class AreaRegistryList(val items: List&lt;AreaRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    areaRegistry: List&lt;AreaRegistryResponse>,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="66"
+            column="19"/>
     </issue>
 
     <issue

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -319,6 +320,18 @@
                 android:value="${applicationId}/io.homeassistant.companion.android.controls.HaControlsPanelActivity" />
             <intent-filter>
                 <action android:name="android.service.controls.ControlsProviderService"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".mediacontrol.HaMediaSessionService"
+            android:exported="true"
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="ExportedService">
+            <!-- Exported so system media controllers can bind to the session.
+                 Connections are filtered in MediaSession.Callback#onConnect. -->
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService"/>
             </intent-filter>
         </service>
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/mediacontrol/HaMediaSessionService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/mediacontrol/HaMediaSessionService.kt
@@ -1,0 +1,295 @@
+package io.homeassistant.companion.android.mediacontrol
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap.CompressFormat
+import android.os.Looper
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSession
+import androidx.media3.session.MediaSessionService
+import coil3.imageLoader
+import coil3.request.ImageRequest
+import coil3.toBitmap
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.MEDIA_PLAYER_DOMAIN
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlRepository
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlState
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.servers.firstUrlOrNull
+import io.homeassistant.companion.android.util.sensitive
+import java.io.ByteArrayOutputStream
+import javax.inject.Inject
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * A [MediaSessionService] that exposes a Home Assistant media_player entity as a native
+ * Android media control in the notification shade.
+ *
+ * It creates a [HaRemoteMediaPlayer] that reports HA entity state and translates user
+ * interactions (play/pause/seek/next/previous) into HA service calls.
+ */
+@AndroidEntryPoint
+class HaMediaSessionService : MediaSessionService() {
+
+    @Inject
+    lateinit var mediaControlRepository: MediaControlRepository
+
+    @Inject
+    lateinit var serverManager: ServerManager
+
+    private var mediaSession: MediaSession? = null
+    private var player: HaRemoteMediaPlayer? = null
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    private var observationJob: Job? = null
+    private var currentArtworkUrl: String? = null
+    private var currentArtworkBytes: ByteArray? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        Timber.d("HaMediaSessionService created")
+
+        val commandCallback = object : HaRemoteMediaPlayer.CommandCallback {
+            override fun onPlayRequested() {
+                callMediaAction("media_play")
+            }
+
+            override fun onPauseRequested() {
+                callMediaAction("media_pause")
+            }
+
+            override fun onSeekRequested(positionMs: Long) {
+                callMediaAction(
+                    action = "media_seek",
+                    extraData = mapOf("seek_position" to positionMs / 1000.0),
+                )
+            }
+
+            override fun onNextRequested() {
+                callMediaAction("media_next_track")
+            }
+
+            override fun onPreviousRequested() {
+                callMediaAction("media_previous_track")
+            }
+        }
+
+        val newPlayer = HaRemoteMediaPlayer(Looper.getMainLooper(), commandCallback)
+        player = newPlayer
+
+        val session = MediaSession.Builder(this, newPlayer)
+            .setCallback(MediaSessionCallback())
+            .build()
+        mediaSession = session
+        addSession(session)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val result = super.onStartCommand(intent, flags, startId)
+        val configChanged = intent?.action == ACTION_RESTART_OBSERVATION
+        if (configChanged || observationJob?.isActive != true) {
+            Timber.d("Starting observation (configChanged=%s, jobActive=%s)", configChanged, observationJob?.isActive)
+            startObservingState()
+        }
+        return result
+    }
+
+    /**
+     * Cancels any existing entity state observation and starts a new one,
+     * re-reading the current configuration from preferences.
+     */
+    private fun startObservingState() {
+        observationJob?.cancel()
+        currentArtworkUrl = null
+        currentArtworkBytes = null
+        val currentPlayer = player ?: return
+        observationJob = serviceScope.launch(Dispatchers.IO) {
+            while (true) {
+                ensureActive()
+                val isConfigured = mediaControlRepository.getConfiguredServerId() != null &&
+                    mediaControlRepository.getConfiguredEntityId() != null
+                if (!isConfigured) {
+                    Timber.d("No media control entity configured, stopping service")
+                    withContext(Dispatchers.Main) { stopSelf() }
+                    return@launch
+                }
+                mediaControlRepository.observeMediaControlState().collect { state ->
+                    if (state == null) {
+                        withContext(Dispatchers.Main) {
+                            currentPlayer.updateState(state = null, artworkPngBytes = null)
+                        }
+                        return@collect
+                    }
+                    loadArtworkAndUpdatePlayer(state)
+                }
+                // Flow completed (WebSocket not ready, connection lost, etc) — retry
+                Timber.d("Media control observation completed, retrying in %s", OBSERVATION_RETRY_DELAY)
+                delay(OBSERVATION_RETRY_DELAY)
+            }
+        }
+    }
+
+    override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? = mediaSession
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        val currentPlayer = mediaSession?.player
+        if (currentPlayer == null || !currentPlayer.playWhenReady || currentPlayer.mediaItemCount == 0) {
+            stopSelf()
+        }
+    }
+
+    override fun onDestroy() {
+        Timber.d("HaMediaSessionService destroyed")
+        serviceScope.cancel()
+        mediaSession?.run {
+            player.release()
+            release()
+        }
+        mediaSession = null
+        player = null
+        super.onDestroy()
+    }
+
+    /**
+     * Restricts media session connections to trusted controllers (same app, system,
+     * or apps with MEDIA_CONTENT_CONTROL / notification listener access).
+     */
+    @OptIn(UnstableApi::class)
+    private inner class MediaSessionCallback : MediaSession.Callback {
+        override fun onConnect(
+            session: MediaSession,
+            controller: MediaSession.ControllerInfo,
+        ): MediaSession.ConnectionResult {
+            if (!controller.isTrusted) {
+                Timber.w(
+                    "Rejecting connection from untrusted media controller package=%s",
+                    sensitive(controller.packageName),
+                )
+                return MediaSession.ConnectionResult.reject()
+            }
+            return MediaSession.ConnectionResult.accept(
+                MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS,
+                MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS,
+            )
+        }
+    }
+
+    private fun callMediaAction(action: String, extraData: Map<String, Any> = emptyMap()) {
+        serviceScope.launch(Dispatchers.IO) {
+            val serverId = mediaControlRepository.getConfiguredServerId()
+            val entityId = mediaControlRepository.getConfiguredEntityId()
+            if (serverId == null || entityId == null) {
+                Timber.w("Cannot call media action %s: no configured entity", action)
+                return@launch
+            }
+
+            val actionData = hashMapOf<String, Any>("entity_id" to entityId)
+            actionData.putAll(extraData)
+
+            try {
+                serverManager.integrationRepository(serverId)
+                    .callAction(MEDIA_PLAYER_DOMAIN, action, actionData)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to call media action $action")
+            }
+        }
+    }
+
+    private suspend fun loadArtworkAndUpdatePlayer(state: MediaControlState) {
+        val artworkUrl = resolveArtworkUrl(state)
+        val pngBytes = if (artworkUrl != null && artworkUrl != currentArtworkUrl) {
+            val bytes = loadBitmapAsPng(artworkUrl)
+            if (bytes != null) {
+                currentArtworkUrl = artworkUrl
+                currentArtworkBytes = bytes
+            }
+            bytes ?: currentArtworkBytes
+        } else if (artworkUrl == null) {
+            currentArtworkUrl = null
+            currentArtworkBytes = null
+            null
+        } else {
+            currentArtworkBytes
+        }
+
+        withContext(Dispatchers.Main) {
+            player?.updateState(state = state, artworkPngBytes = pngBytes)
+        }
+    }
+
+    private suspend fun resolveArtworkUrl(state: MediaControlState): String? {
+        val entityPictureUrl = state.entityPictureUrl ?: return null
+        if (entityPictureUrl.startsWith("http")) return entityPictureUrl
+
+        val baseUrl = try {
+            serverManager.connectionStateProvider(state.serverId)
+                .urlFlow()
+                .firstUrlOrNull()
+                ?.toString()
+                ?.removeSuffix("/")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IllegalStateException) {
+            Timber.e(e, "Server does not exist for artwork URL resolution")
+            null
+        } ?: return null
+
+        return "$baseUrl$entityPictureUrl"
+    }
+
+    internal companion object {
+        const val ACTION_RESTART_OBSERVATION =
+            "io.homeassistant.companion.android.mediacontrol.RESTART_OBSERVATION"
+        val OBSERVATION_RETRY_DELAY = 5.seconds
+        private const val ARTWORK_SIZE_PX = 512
+
+        /**
+         * Starts the service if a media_player entity is configured.
+         * Should be called from a foreground context (e.g. Activity) to avoid
+         * Android 15+ restrictions on starting mediaPlayback foreground services from background.
+         */
+        suspend fun startIfConfigured(context: Context, mediaControlRepository: MediaControlRepository) {
+            val serverId = mediaControlRepository.getConfiguredServerId()
+            val entityId = mediaControlRepository.getConfiguredEntityId()
+            if (serverId != null && entityId != null) {
+                Timber.d("Media control entity configured, starting HaMediaSessionService")
+                context.startService(Intent(context, HaMediaSessionService::class.java))
+            }
+        }
+    }
+
+    /** Loads album art and compresses to PNG bytes on the IO dispatcher. */
+    private suspend fun loadBitmapAsPng(url: String): ByteArray? = withContext(Dispatchers.IO) {
+        try {
+            val request = ImageRequest.Builder(this@HaMediaSessionService)
+                .data(url)
+                .size(ARTWORK_SIZE_PX)
+                .build()
+            val result = imageLoader.execute(request)
+            result.image?.toBitmap()?.let { bitmap ->
+                val stream = ByteArrayOutputStream()
+                bitmap.compress(CompressFormat.PNG, 100, stream)
+                stream.toByteArray()
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to load album art from ${sensitive(url)}")
+            null
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/mediacontrol/HaRemoteMediaPlayer.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/mediacontrol/HaRemoteMediaPlayer.kt
@@ -1,0 +1,157 @@
+package io.homeassistant.companion.android.mediacontrol
+
+import android.os.Looper
+import androidx.annotation.OptIn
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.SimpleBasePlayer
+import androidx.media3.common.util.UnstableApi
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlState
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaPlaybackState
+
+/**
+ * A [SimpleBasePlayer] that acts as a remote control proxy for a Home Assistant media_player entity.
+ * It does not play audio itself — it reports state and translates playback commands into callbacks.
+ */
+@OptIn(UnstableApi::class)
+class HaRemoteMediaPlayer(looper: Looper, private val commandCallback: CommandCallback) : SimpleBasePlayer(looper) {
+
+    /** Callback interface for translating player commands into HA service calls. */
+    interface CommandCallback {
+        fun onPlayRequested()
+        fun onPauseRequested()
+        fun onSeekRequested(positionMs: Long)
+        fun onNextRequested()
+        fun onPreviousRequested()
+    }
+
+    private var mediaState: MediaControlState? = null
+    private var artworkBytes: ByteArray? = null
+
+    /**
+     * Updates the internal state from a new [MediaControlState] and triggers a state refresh.
+     * @param artworkPngBytes Pre-compressed PNG bytes for album art (compress off main thread).
+     */
+    fun updateState(state: MediaControlState?, artworkPngBytes: ByteArray?) {
+        mediaState = state
+        artworkBytes = artworkPngBytes
+        invalidateState()
+    }
+
+    override fun getState(): State {
+        val state = mediaState ?: return buildIdleState()
+
+        val availableCommands = buildAvailableCommands(state)
+
+        val playbackState = when (state.playbackState) {
+            is MediaPlaybackState.Playing -> STATE_READY
+            is MediaPlaybackState.Paused -> STATE_READY
+            is MediaPlaybackState.Buffering -> STATE_BUFFERING
+            is MediaPlaybackState.Idle -> STATE_ENDED
+            is MediaPlaybackState.Off -> STATE_IDLE
+        }
+
+        val isPlaying = state.playbackState is MediaPlaybackState.Playing
+
+        val metadataBuilder = MediaMetadata.Builder()
+            .setTitle(state.title)
+            .setArtist(state.artist)
+            .setAlbumTitle(state.albumName)
+        artworkBytes?.let {
+            metadataBuilder.setArtworkData(it, MediaMetadata.PICTURE_TYPE_FRONT_COVER)
+        }
+
+        val durationUs = state.mediaDurationSeconds
+            ?.let { (it * 1_000_000).toLong() }
+            ?: DURATION_UNSET_US
+        val positionMs = state.mediaPositionSeconds
+            ?.let { (it * 1000).toLong() }
+            ?: 0L
+
+        val currentItem = MediaItemData.Builder(state.entityId)
+            .setMediaMetadata(metadataBuilder.build())
+            .setDurationUs(durationUs)
+            .build()
+
+        // 3-item playlist with current at index 1 so SimpleBasePlayer's seekToNext/seekToPrevious
+        // find valid adjacent items instead of ignoring the seek on a single-item playlist.
+        val playlist = listOf(
+            MediaItemData.Builder(PLACEHOLDER_PREVIOUS_ID).build(),
+            currentItem,
+            MediaItemData.Builder(PLACEHOLDER_NEXT_ID).build(),
+        )
+
+        return State.Builder()
+            .setAvailableCommands(availableCommands)
+            .setPlaybackState(playbackState)
+            .setPlayWhenReady(isPlaying, PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
+            .setPlaybackParameters(PlaybackParameters(PLAYBACK_SPEED))
+            .setCurrentMediaItemIndex(CURRENT_ITEM_INDEX)
+            .setContentPositionMs(positionMs)
+            .setPlaylist(playlist)
+            .build()
+    }
+
+    override fun handleSetPlayWhenReady(playWhenReady: Boolean): ListenableFuture<*> {
+        if (playWhenReady) {
+            commandCallback.onPlayRequested()
+        } else {
+            commandCallback.onPauseRequested()
+        }
+        return Futures.immediateVoidFuture()
+    }
+
+    override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
+        when (seekCommand) {
+            Player.COMMAND_SEEK_TO_NEXT,
+            Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM,
+            -> commandCallback.onNextRequested()
+
+            Player.COMMAND_SEEK_TO_PREVIOUS,
+            Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM,
+            -> commandCallback.onPreviousRequested()
+
+            else -> {
+                if (mediaState?.supportsSeek == true) {
+                    commandCallback.onSeekRequested(positionMs)
+                }
+            }
+        }
+        return Futures.immediateVoidFuture()
+    }
+
+    private fun buildIdleState(): State = State.Builder()
+        .setAvailableCommands(Player.Commands.EMPTY)
+        .setPlaybackState(STATE_IDLE)
+        .setPlayWhenReady(false, PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
+        .build()
+
+    private fun buildAvailableCommands(state: MediaControlState): Player.Commands {
+        val builder = Player.Commands.Builder()
+        if (state.supportsPlay || state.supportsPause) builder.add(Player.COMMAND_PLAY_PAUSE)
+        if (state.supportsSeek) builder.add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+        builder.add(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)
+        if (state.supportsPreviousTrack) {
+            builder.add(Player.COMMAND_SEEK_TO_PREVIOUS)
+            builder.add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+        }
+        if (state.supportsNextTrack) {
+            builder.add(Player.COMMAND_SEEK_TO_NEXT)
+            builder.add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+        }
+        builder.add(Player.COMMAND_GET_METADATA)
+        builder.add(Player.COMMAND_GET_TIMELINE)
+        return builder.build()
+    }
+
+    private companion object {
+        const val DURATION_UNSET_US = androidx.media3.common.C.TIME_UNSET
+        const val CURRENT_ITEM_INDEX = 1
+        const val PLAYBACK_SPEED = 1.0f
+        const val PLACEHOLDER_PREVIOUS_ID = "__ha_previous__"
+        const val PLACEHOLDER_NEXT_ID = "__ha_next__"
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -40,6 +40,7 @@ import io.homeassistant.companion.android.settings.developer.DeveloperSettingsFr
 import io.homeassistant.companion.android.settings.gestures.GesturesFragment
 import io.homeassistant.companion.android.settings.language.LanguagesProvider
 import io.homeassistant.companion.android.settings.license.LicensesFragment
+import io.homeassistant.companion.android.settings.mediacontrol.MediaControlSettingsFragment
 import io.homeassistant.companion.android.settings.notification.NotificationChannelFragment
 import io.homeassistant.companion.android.settings.notification.NotificationHistoryFragment
 import io.homeassistant.companion.android.settings.qs.ManageTilesFragment
@@ -229,6 +230,21 @@ class SettingsFragment(
                     }
                     return@setOnPreferenceClickListener true
                 }
+            }
+
+            findPreference<PreferenceCategory>("media_controls")?.let {
+                it.isVisible = true
+            }
+            findPreference<Preference>("manage_media_controls")?.setOnPreferenceClickListener {
+                parentFragmentManager.commit {
+                    replace(
+                        R.id.content,
+                        MediaControlSettingsFragment::class.java,
+                        null,
+                    )
+                    addToBackStack(getString(commonR.string.media_controls))
+                }
+                return@setOnPreferenceClickListener true
             }
 
             if (!isAutomotive && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsFragment.kt
@@ -1,0 +1,35 @@
+package io.homeassistant.companion.android.settings.mediacontrol
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.settings.addHelpMenuProvider
+import io.homeassistant.companion.android.settings.mediacontrol.views.MediaControlSettingsView
+
+@AndroidEntryPoint
+class MediaControlSettingsFragment : Fragment() {
+    private val viewModel: MediaControlSettingsViewModel by viewModels()
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                MediaControlSettingsView(viewModel = viewModel)
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        addHelpMenuProvider("https://companion.home-assistant.io/docs/integrations/android-media-controls")
+    }
+
+    override fun onResume() {
+        super.onResume()
+        activity?.title = getString(commonR.string.media_controls)
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsViewModel.kt
@@ -1,0 +1,189 @@
+package io.homeassistant.companion.android.settings.mediacontrol
+
+import android.app.Application
+import android.content.Intent
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.MEDIA_PLAYER_DOMAIN
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.mediacontrol.HaMediaSessionService
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+data class MediaControlSettingsUiState(
+    val servers: List<Server> = emptyList(),
+    val entities: List<Entity> = emptyList(),
+    val entityRegistry: List<EntityRegistryResponse> = emptyList(),
+    val deviceRegistry: List<DeviceRegistryResponse> = emptyList(),
+    val areaRegistry: List<AreaRegistryResponse> = emptyList(),
+    val selectedServerId: Int = ServerManager.SERVER_ID_ACTIVE,
+    val selectedEntityId: String = "",
+    val isConfigured: Boolean = false,
+)
+
+@HiltViewModel
+class MediaControlSettingsViewModel @Inject constructor(
+    private val serverManager: ServerManager,
+    private val mediaControlRepository: MediaControlRepository,
+    application: Application,
+) : AndroidViewModel(application) {
+
+    private val _uiState = MutableStateFlow(MediaControlSettingsUiState())
+    val uiState: StateFlow<MediaControlSettingsUiState> = _uiState.asStateFlow()
+
+    private val entities = mutableMapOf<Int, List<Entity>>()
+    private val entityRegistries = mutableMapOf<Int, List<EntityRegistryResponse>>()
+    private val deviceRegistries = mutableMapOf<Int, List<DeviceRegistryResponse>>()
+    private val areaRegistries = mutableMapOf<Int, List<AreaRegistryResponse>>()
+
+    private data class ServerRegistries(
+        val serverId: Int,
+        val entities: List<Entity>,
+        val entityRegistry: List<EntityRegistryResponse>,
+        val deviceRegistry: List<DeviceRegistryResponse>,
+        val areaRegistry: List<AreaRegistryResponse>,
+    )
+
+    init {
+        viewModelScope.launch(Dispatchers.IO) {
+            val loadedServers = serverManager.servers()
+            _uiState.update { it.copy(servers = loadedServers) }
+            val results = loadedServers.map { server ->
+                async {
+                    ServerRegistries(
+                        serverId = server.id,
+                        entities = loadMediaPlayerEntities(server.id),
+                        entityRegistry = loadRegistry(server.id, "entity registry") {
+                            serverManager.webSocketRepository(it).getEntityRegistry()
+                        },
+                        deviceRegistry = loadRegistry(server.id, "device registry") {
+                            serverManager.webSocketRepository(it).getDeviceRegistry()
+                        },
+                        areaRegistry = loadRegistry(server.id, "area registry") {
+                            serverManager.webSocketRepository(it).getAreaRegistry()
+                        },
+                    )
+                }
+            }.awaitAll()
+            results.forEach { registries ->
+                entities[registries.serverId] = registries.entities
+                entityRegistries[registries.serverId] = registries.entityRegistry
+                deviceRegistries[registries.serverId] = registries.deviceRegistry
+                areaRegistries[registries.serverId] = registries.areaRegistry
+            }
+
+            val configuredServerId = mediaControlRepository.getConfiguredServerId()
+            val configuredEntityId = mediaControlRepository.getConfiguredEntityId()
+
+            if (configuredServerId != null && configuredEntityId != null) {
+                _uiState.update {
+                    it.copy(
+                        selectedServerId = configuredServerId,
+                        selectedEntityId = configuredEntityId,
+                        isConfigured = true,
+                    )
+                }
+            } else {
+                _uiState.update {
+                    it.copy(selectedServerId = serverManager.getServer()?.id ?: 0)
+                }
+            }
+            loadEntities(_uiState.value.selectedServerId)
+        }
+    }
+
+    fun selectServerId(serverId: Int) {
+        if (serverId != _uiState.value.selectedServerId) {
+            _uiState.update {
+                it.copy(selectedServerId = serverId, selectedEntityId = "")
+            }
+            loadEntities(serverId)
+        }
+    }
+
+    fun selectEntityId(entityId: String) {
+        _uiState.update { it.copy(selectedEntityId = entityId) }
+    }
+
+    /** Saves the current entity selection and starts the media session service. */
+    fun saveConfiguration() {
+        viewModelScope.launch {
+            val state = _uiState.value
+            mediaControlRepository.setConfiguredEntity(
+                serverId = state.selectedServerId,
+                entityId = state.selectedEntityId,
+            )
+            _uiState.update { it.copy(isConfigured = true) }
+            startService()
+        }
+    }
+
+    /** Clears the configuration and stops the media session service. */
+    fun clearConfiguration() {
+        viewModelScope.launch {
+            mediaControlRepository.setConfiguredEntity(serverId = null, entityId = null)
+            _uiState.update { it.copy(selectedEntityId = "", isConfigured = false) }
+            stopService()
+        }
+    }
+
+    private fun loadEntities(serverId: Int) {
+        _uiState.update {
+            it.copy(
+                entities = entities[serverId] ?: emptyList(),
+                entityRegistry = entityRegistries[serverId] ?: emptyList(),
+                deviceRegistry = deviceRegistries[serverId] ?: emptyList(),
+                areaRegistry = areaRegistries[serverId] ?: emptyList(),
+            )
+        }
+    }
+
+    private fun startService() {
+        val context = getApplication<Application>()
+        val intent = Intent(context, HaMediaSessionService::class.java)
+        intent.action = HaMediaSessionService.ACTION_RESTART_OBSERVATION
+        context.startService(intent)
+    }
+
+    private fun stopService() {
+        val context = getApplication<Application>()
+        val intent = Intent(context, HaMediaSessionService::class.java)
+        context.stopService(intent)
+    }
+
+    private suspend fun loadMediaPlayerEntities(serverId: Int): List<Entity> = try {
+        serverManager.integrationRepository(serverId).getEntities().orEmpty()
+            .filter { it.domain == MEDIA_PLAYER_DOMAIN }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.e(e, "Couldn't load media_player entities for server")
+        emptyList()
+    }
+
+    private suspend fun <T> loadRegistry(serverId: Int, name: String, loader: suspend (Int) -> List<T>?): List<T> =
+        try {
+            loader(serverId).orEmpty()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Couldn't load $name for server")
+            emptyList()
+        }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt
@@ -1,0 +1,183 @@
+package io.homeassistant.companion.android.settings.mediacontrol.views
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.compose.composable.HAFilledButton
+import io.homeassistant.companion.android.common.compose.composable.HAPlainButton
+import io.homeassistant.companion.android.common.compose.theme.HATextStyle
+import io.homeassistant.companion.android.common.compose.theme.HATheme
+import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
+import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.settings.mediacontrol.MediaControlSettingsViewModel
+import io.homeassistant.companion.android.util.compose.ServerExposedDropdownMenu
+import io.homeassistant.companion.android.util.compose.entity.EntityPicker
+import io.homeassistant.companion.android.util.safeBottomPaddingValues
+
+/** Outer composable that extracts state from the ViewModel and delegates to the stateless content. */
+@Composable
+fun MediaControlSettingsView(viewModel: MediaControlSettingsViewModel, modifier: Modifier = Modifier) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    HATheme {
+        MediaControlSettingsContent(
+            servers = uiState.servers,
+            entities = uiState.entities,
+            entityRegistry = uiState.entityRegistry,
+            deviceRegistry = uiState.deviceRegistry,
+            areaRegistry = uiState.areaRegistry,
+            selectedServerId = uiState.selectedServerId,
+            selectedEntityId = uiState.selectedEntityId,
+            isConfigured = uiState.isConfigured,
+            onServerSelected = viewModel::selectServerId,
+            onEntitySelected = viewModel::selectEntityId,
+            onEntityCleared = { viewModel.selectEntityId("") },
+            onSave = viewModel::saveConfiguration,
+            onClear = viewModel::clearConfiguration,
+            modifier = modifier,
+        )
+    }
+}
+
+@Composable
+internal fun MediaControlSettingsContent(
+    servers: List<Server>,
+    entities: List<Entity>,
+    entityRegistry: List<EntityRegistryResponse>,
+    deviceRegistry: List<DeviceRegistryResponse>,
+    areaRegistry: List<AreaRegistryResponse>,
+    selectedServerId: Int,
+    selectedEntityId: String,
+    isConfigured: Boolean,
+    onServerSelected: (Int) -> Unit,
+    onEntitySelected: (String) -> Unit,
+    onEntityCleared: () -> Unit,
+    onSave: () -> Unit,
+    onClear: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scrollState = rememberScrollState()
+    val colorScheme = LocalHAColorScheme.current
+    val saveEnabled = selectedEntityId.isNotBlank() &&
+        servers.any { it.id == selectedServerId } &&
+        entities.any { it.entityId == selectedEntityId }
+
+    Box(
+        modifier = modifier.verticalScroll(scrollState),
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(safeBottomPaddingValues(applyHorizontal = false))
+                .padding(all = 16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.media_control_description),
+                style = HATextStyle.Body,
+                color = colorScheme.colorTextSecondary,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            if (servers.size > 1 || servers.none { it.id == selectedServerId }) {
+                ServerExposedDropdownMenu(
+                    servers = servers,
+                    current = selectedServerId,
+                    onSelected = onServerSelected,
+                    title = R.string.server,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+
+            EntityPicker(
+                entities = entities,
+                selectedEntityId = selectedEntityId,
+                onEntitySelectedId = onEntitySelected,
+                onEntityCleared = onEntityCleared,
+                addButtonText = stringResource(R.string.media_control_select_entity),
+                entityRegistry = entityRegistry,
+                deviceRegistry = deviceRegistry,
+                areaRegistry = areaRegistry,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            HAFilledButton(
+                text = stringResource(R.string.save),
+                onClick = onSave,
+                enabled = saveEnabled,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (isConfigured) {
+                Spacer(modifier = Modifier.height(8.dp))
+                HAPlainButton(
+                    text = stringResource(R.string.media_control_clear),
+                    onClick = onClear,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun MediaControlSettingsContentPreview() {
+    HAThemeForPreview {
+        MediaControlSettingsContent(
+            servers = emptyList(),
+            entities = emptyList(),
+            entityRegistry = emptyList(),
+            deviceRegistry = emptyList(),
+            areaRegistry = emptyList(),
+            selectedServerId = 0,
+            selectedEntityId = "",
+            isConfigured = false,
+            onServerSelected = {},
+            onEntitySelected = {},
+            onEntityCleared = {},
+            onSave = {},
+            onClear = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MediaControlSettingsContentConfiguredPreview() {
+    HAThemeForPreview {
+        MediaControlSettingsContent(
+            servers = emptyList(),
+            entities = emptyList(),
+            entityRegistry = emptyList(),
+            deviceRegistry = emptyList(),
+            areaRegistry = emptyList(),
+            selectedServerId = 1,
+            selectedEntityId = "media_player.living_room",
+            isConfigured = true,
+            onServerSelected = {},
+            onEntitySelected = {},
+            onEntityCleared = {},
+            onSave = {},
+            onClear = {},
+        )
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -97,6 +97,7 @@ import io.homeassistant.companion.android.assist.AssistActivity
 import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.barcode.BarcodeScannerActivity
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlRepository
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.common.data.keychain.NamedKeyChain
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
@@ -125,6 +126,7 @@ import io.homeassistant.companion.android.databinding.DialogAuthenticationBindin
 import io.homeassistant.companion.android.improv.ui.ImprovPermissionDialog
 import io.homeassistant.companion.android.improv.ui.ImprovSetupDialog
 import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.mediacontrol.HaMediaSessionService
 import io.homeassistant.companion.android.nfc.WriteNfcTag
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
@@ -254,6 +256,9 @@ class WebViewActivity :
 
     @Inject
     lateinit var entityAddToHandler: EntityAddToHandler
+
+    @Inject
+    lateinit var mediaControlRepository: MediaControlRepository
 
     @Inject
     lateinit var dataSourceFactory: DataSource.Factory
@@ -1205,6 +1210,7 @@ class WebViewActivity :
         lifecycleScope.launch {
             SensorWorker.start(this@WebViewActivity)
             WebsocketManager.start(this@WebViewActivity)
+            HaMediaSessionService.startIfConfigured(this@WebViewActivity, mediaControlRepository)
 
             WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
 

--- a/app/src/main/res/drawable/ic_play_circle_outline.xml
+++ b/app/src/main/res/drawable/ic_play_circle_outline.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="24dp"
+    android:width="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="@color/colorAccent" android:pathData="M10,16.5L16,12L10,7.5V16.5M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,20C7.58,20 4,16.42 4,12C4,7.58 7.58,4 12,4C16.42,4 20,7.58 20,12C20,16.42 16.42,20 12,20Z" />
+</vector>

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,6 +2,7 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2026.3.7 - Main" versioncode="3">
+        <change>Add native media controls in notification shade for HA media player entities</change>
         <change>Expanded wake word support to continue conversations after using your wake word to open Assist</change>
         <change>Assist conversations started with a wake word now auto-close after 30 seconds of inactivity</change>
         <change>Bug fixes and dependency updates</change>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -156,6 +156,16 @@
             android:summary="@string/aa_favorites_summary" />
     </PreferenceCategory>
     <PreferenceCategory
+        android:key="media_controls"
+        android:title="@string/media_controls"
+        app:isPreferenceVisible="false">
+        <Preference
+            android:key="manage_media_controls"
+            android:icon="@drawable/ic_play_circle_outline"
+            android:title="@string/media_controls"
+            android:summary="@string/media_controls_summary" />
+    </PreferenceCategory>
+    <PreferenceCategory
         android:key="device_controls"
         android:title="@string/controls_setting_category"
         app:isPreferenceVisible="false">

--- a/app/src/test/kotlin/io/homeassistant/companion/android/mediacontrol/HaRemoteMediaPlayerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/mediacontrol/HaRemoteMediaPlayerTest.kt
@@ -1,0 +1,254 @@
+package io.homeassistant.companion.android.mediacontrol
+
+import android.os.Looper
+import androidx.media3.common.Player
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlState
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaPlaybackState
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = dagger.hilt.android.testing.HiltTestApplication::class)
+class HaRemoteMediaPlayerTest {
+
+    private val commandCallback: HaRemoteMediaPlayer.CommandCallback = mockk(relaxed = true)
+    private lateinit var player: HaRemoteMediaPlayer
+
+    @Before
+    fun setUp() {
+        player = HaRemoteMediaPlayer(Looper.getMainLooper(), commandCallback)
+    }
+
+    private fun createState(
+        playbackState: MediaPlaybackState = MediaPlaybackState.Playing,
+        title: String? = "Test Title",
+        artist: String? = "Test Artist",
+        albumName: String? = "Test Album",
+        entityPictureUrl: String? = null,
+        mediaDurationSeconds: Double? = 300.0,
+        mediaPositionSeconds: Double? = 120.0,
+        supportsPause: Boolean = true,
+        supportsPlay: Boolean = true,
+        supportsSeek: Boolean = true,
+        supportsPreviousTrack: Boolean = true,
+        supportsNextTrack: Boolean = true,
+    ) = MediaControlState(
+        entityId = "media_player.test",
+        serverId = 1,
+        playbackState = playbackState,
+        title = title,
+        artist = artist,
+        albumName = albumName,
+        entityPictureUrl = entityPictureUrl,
+        mediaDurationSeconds = mediaDurationSeconds,
+        mediaPositionSeconds = mediaPositionSeconds,
+        supportsPause = supportsPause,
+        supportsPlay = supportsPlay,
+        supportsSeek = supportsSeek,
+        supportsPreviousTrack = supportsPreviousTrack,
+        supportsNextTrack = supportsNextTrack,
+    )
+
+    // -- getState tests --
+
+    @Test
+    fun `Given null state when getState then return idle state`() {
+        player.updateState(state = null, artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_IDLE, player.playbackState)
+        assertFalse(player.playWhenReady)
+    }
+
+    @Test
+    fun `Given playing state when getState then return ready with playWhenReady true`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Playing), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_READY, player.playbackState)
+        assertTrue(player.playWhenReady)
+    }
+
+    @Test
+    fun `Given paused state when getState then return ready with playWhenReady false`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Paused), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_READY, player.playbackState)
+        assertFalse(player.playWhenReady)
+    }
+
+    @Test
+    fun `Given buffering state when getState then return buffering`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Buffering), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_BUFFERING, player.playbackState)
+    }
+
+    @Test
+    fun `Given idle state when getState then return ended`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Idle), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_ENDED, player.playbackState)
+    }
+
+    @Test
+    fun `Given off state when getState then return idle`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Off), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(Player.STATE_IDLE, player.playbackState)
+    }
+
+    @Test
+    fun `Given state with metadata when getState then metadata is populated`() {
+        player.updateState(
+            state = createState(title = "My Song", artist = "My Artist", albumName = "My Album"),
+            artworkPngBytes = null,
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        val metadata = player.mediaMetadata
+        assertEquals("My Song", metadata.title?.toString())
+        assertEquals("My Artist", metadata.artist?.toString())
+        assertEquals("My Album", metadata.albumTitle?.toString())
+    }
+
+    @Test
+    fun `Given state with duration and position when getState then timeline has correct values`() {
+        player.updateState(
+            state = createState(mediaDurationSeconds = 300.0, mediaPositionSeconds = 120.0),
+            artworkPngBytes = null,
+        )
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(300_000L, player.duration)
+        assertEquals(120_000L, player.currentPosition)
+    }
+
+    // -- Available commands tests --
+
+    @Test
+    fun `Given play and pause supported when getState then play_pause command available`() {
+        player.updateState(state = createState(supportsPlay = true, supportsPause = true), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(player.availableCommands.contains(Player.COMMAND_PLAY_PAUSE))
+    }
+
+    @Test
+    fun `Given seek supported when getState then seek commands available`() {
+        player.updateState(state = createState(supportsSeek = true), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(player.availableCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+    }
+
+    @Test
+    fun `Given any state when getState then GET_CURRENT_MEDIA_ITEM always available`() {
+        player.updateState(state = createState(supportsSeek = false, mediaDurationSeconds = null), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(player.availableCommands.contains(Player.COMMAND_GET_CURRENT_MEDIA_ITEM))
+    }
+
+    @Test
+    fun `Given seek not supported when getState then seek command not available`() {
+        player.updateState(state = createState(supportsSeek = false, mediaDurationSeconds = 300.0), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertFalse(player.availableCommands.contains(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+    }
+
+    @Test
+    fun `Given next track supported when getState then next command available`() {
+        player.updateState(state = createState(supportsNextTrack = true), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(player.availableCommands.contains(Player.COMMAND_SEEK_TO_NEXT))
+    }
+
+    @Test
+    fun `Given previous track supported when getState then previous command available`() {
+        player.updateState(state = createState(supportsPreviousTrack = true), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertTrue(player.availableCommands.contains(Player.COMMAND_SEEK_TO_PREVIOUS))
+    }
+
+    // -- Command callback tests --
+
+    @Test
+    fun `Given player when play requested then callback onPlayRequested called`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Paused), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        player.play()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify { commandCallback.onPlayRequested() }
+    }
+
+    @Test
+    fun `Given player when pause requested then callback onPauseRequested called`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Playing), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        player.pause()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify { commandCallback.onPauseRequested() }
+    }
+
+    @Test
+    fun `Given player when seek requested then callback onSeekRequested called with position`() {
+        player.updateState(state = createState(), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        player.seekTo(60_000L)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify { commandCallback.onSeekRequested(positionMs = 60_000L) }
+    }
+
+    @Test
+    fun `Given player when next track requested then callback onNextRequested called`() {
+        player.updateState(state = createState(), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        player.seekToNext()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify { commandCallback.onNextRequested() }
+    }
+
+    @Test
+    fun `Given player when previous track requested then callback onPreviousRequested called`() {
+        player.updateState(state = createState(), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        player.seekToPrevious()
+        shadowOf(Looper.getMainLooper()).idle()
+
+        verify { commandCallback.onPreviousRequested() }
+    }
+
+    @Test
+    fun `Given active state when getState then playback speed is 1 for seek bar tracking`() {
+        player.updateState(state = createState(playbackState = MediaPlaybackState.Playing), artworkPngBytes = null)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertEquals(1.0f, player.playbackParameters.speed)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/mediacontrol/MediaControlSettingsViewModelTest.kt
@@ -1,0 +1,143 @@
+package io.homeassistant.companion.android.settings.mediacontrol
+
+import android.app.Application
+import io.homeassistant.companion.android.common.data.mediacontrol.MediaControlRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(ConsoleLogExtension::class)
+class MediaControlSettingsViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val serverManager: ServerManager = mockk(relaxed = true)
+    private val mediaControlRepository: MediaControlRepository = mockk(relaxed = true)
+    private val application: Application = mockk(relaxed = true)
+
+    private lateinit var viewModel: MediaControlSettingsViewModel
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        coEvery { serverManager.servers() } returns emptyList()
+        coEvery { serverManager.getServer(any<Int>()) } returns null
+        coEvery { serverManager.integrationRepository(any()) } returns mockk(relaxed = true)
+        coEvery { serverManager.webSocketRepository(any()) } returns mockk(relaxed = true)
+        coEvery { mediaControlRepository.getConfiguredServerId() } returns null
+        coEvery { mediaControlRepository.getConfiguredEntityId() } returns null
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): MediaControlSettingsViewModel {
+        return MediaControlSettingsViewModel(
+            serverManager = serverManager,
+            mediaControlRepository = mediaControlRepository,
+            application = application,
+        )
+    }
+
+    @Nested
+    inner class EntitySelectionTest {
+
+        @Test
+        fun `Given viewModel when selectEntityId called then selectedEntityId is updated`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+
+            viewModel.selectEntityId("media_player.bedroom")
+
+            assertEquals("media_player.bedroom", viewModel.uiState.value.selectedEntityId)
+        }
+
+        @Test
+        fun `Given viewModel when selectEntityId with empty then selectedEntityId is empty`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+            viewModel.selectEntityId("media_player.test")
+
+            viewModel.selectEntityId("")
+
+            assertEquals("", viewModel.uiState.value.selectedEntityId)
+        }
+    }
+
+    @Nested
+    inner class ServerSelectionTest {
+
+        @Test
+        fun `Given entity selected when switching server then entity is cleared`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+            viewModel.selectEntityId("media_player.living_room")
+
+            viewModel.selectServerId(99)
+
+            assertEquals("", viewModel.uiState.value.selectedEntityId)
+        }
+
+        @Test
+        fun `Given entity selected when same server reselected then entity is preserved`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+            viewModel.selectEntityId("media_player.living_room")
+
+            viewModel.selectServerId(viewModel.uiState.value.selectedServerId)
+
+            assertEquals("media_player.living_room", viewModel.uiState.value.selectedEntityId)
+        }
+    }
+
+    @Nested
+    inner class SaveConfigurationTest {
+
+        @Test
+        fun `Given entity selected when saveConfiguration called then repository is updated`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+            viewModel.selectEntityId("media_player.living_room")
+
+            viewModel.saveConfiguration()
+
+            coVerify {
+                mediaControlRepository.setConfiguredEntity(
+                    serverId = any(),
+                    entityId = "media_player.living_room",
+                )
+            }
+            assertTrue(viewModel.uiState.value.isConfigured)
+        }
+    }
+
+    @Nested
+    inner class ClearConfigurationTest {
+
+        @Test
+        fun `Given viewModel when clearConfiguration called then repository cleared and state reset`() = runTest(testDispatcher) {
+            viewModel = createViewModel()
+
+            viewModel.clearConfiguration()
+
+            coVerify {
+                mediaControlRepository.setConfiguredEntity(serverId = null, entityId = null)
+            }
+            assertEquals("", viewModel.uiState.value.selectedEntityId)
+            assertFalse(viewModel.uiState.value.isConfigured)
+        }
+    }
+}

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -96,7 +96,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="319"
+            line="330"
             column="27"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="917"
+            line="928"
             column="27"/>
     </issue>
 
@@ -349,7 +349,7 @@
         errorLine2="     ~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="70"
+            line="71"
             column="6"/>
     </issue>
 
@@ -360,7 +360,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="434"
+            line="445"
             column="13"/>
     </issue>
 
@@ -1460,7 +1460,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="254"
+            line="269"
             column="13"/>
     </issue>
 
@@ -1471,7 +1471,7 @@
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="292"
+            line="307"
             column="29"/>
     </issue>
 
@@ -1482,7 +1482,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="400"
+            line="415"
             column="17"/>
     </issue>
 
@@ -1493,7 +1493,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="400"
+            line="415"
             column="17"/>
     </issue>
 
@@ -1504,7 +1504,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="433"
+            line="448"
             column="13"/>
     </issue>
 
@@ -1515,7 +1515,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="529"
+            line="544"
             column="13"/>
     </issue>
 
@@ -1526,7 +1526,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="539"
+            line="554"
             column="17"/>
     </issue>
 
@@ -1537,7 +1537,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="539"
+            line="554"
             column="17"/>
     </issue>
 
@@ -1548,7 +1548,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/SettingsFragment.kt"
-            line="561"
+            line="576"
             column="13"/>
     </issue>
 
@@ -3237,6 +3237,61 @@
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/matter/views/MatterCommissioningView.kt"
             line="53"
             column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;Server> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `servers: ImmutableList&lt;Server>` or create an `@Immutable` wrapper for this class: `@Immutable data class ServersList(val items: List&lt;Server>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    servers: List&lt;Server>,"
+        errorLine2="             ~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="62"
+            column="14"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;Entity> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `sortedEntities: ImmutableList&lt;Entity>` or create an `@Immutable` wrapper for this class: `@Immutable data class SortedEntitiesList(val items: List&lt;Entity>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    sortedEntities: List&lt;Entity>,"
+        errorLine2="                    ~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="63"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;EntityRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `entityRegistry: ImmutableList&lt;EntityRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class EntityRegistryList(val items: List&lt;EntityRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    entityRegistry: List&lt;EntityRegistryResponse>,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="64"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;DeviceRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `deviceRegistry: ImmutableList&lt;DeviceRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class DeviceRegistryList(val items: List&lt;DeviceRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    deviceRegistry: List&lt;DeviceRegistryResponse>,"
+        errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="65"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="ComposeUnstableCollections"
+        message="The Compose Compiler cannot infer the stability of a parameter if a List&lt;AreaRegistryResponse> is used in it, even if the item type is stable.&#xA;You should use Kotlinx Immutable Collections instead: `areaRegistry: ImmutableList&lt;AreaRegistryResponse>` or create an `@Immutable` wrapper for this class: `@Immutable data class AreaRegistryList(val items: List&lt;AreaRegistryResponse>)`&#xA;See https://slackhq.github.io/compose-lints/rules/#avoid-using-unstable-collections for more information."
+        errorLine1="    areaRegistry: List&lt;AreaRegistryResponse>,"
+        errorLine2="                  ~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/mediacontrol/views/MediaControlSettingsView.kt"
+            line="66"
+            column="19"/>
     </issue>
 
     <issue

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_REMOTE_MESSAGING"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
@@ -239,6 +240,18 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.service.controls.ControlsProviderService"/>
+            </intent-filter>
+        </service>
+
+        <service
+            android:name=".mediacontrol.HaMediaSessionService"
+            android:exported="true"
+            android:foregroundServiceType="mediaPlayback"
+            tools:ignore="ExportedService">
+            <!-- Exported so system media controllers can bind to the session.
+                 Connections are filtered in MediaSession.Callback#onConnect. -->
+            <intent-filter>
+                <action android:name="androidx.media3.session.MediaSessionService"/>
             </intent-filter>
         </service>
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -140,7 +140,12 @@ object EntityExt {
     const val LIGHT_SUPPORT_BRIGHTNESS_DEPR = 1
     const val LIGHT_SUPPORT_COLOR_TEMP_DEPR = 2
     const val ALARM_CONTROL_PANEL_SUPPORT_ARM_AWAY = 2
+    const val MEDIA_PLAYER_SUPPORT_PAUSE = 1
+    const val MEDIA_PLAYER_SUPPORT_SEEK = 2
     const val MEDIA_PLAYER_SUPPORT_VOLUME_SET = 4
+    const val MEDIA_PLAYER_SUPPORT_PREVIOUS_TRACK = 16
+    const val MEDIA_PLAYER_SUPPORT_NEXT_TRACK = 32
+    const val MEDIA_PLAYER_SUPPORT_PLAY = 16384
 
     val DOMAINS_PRESS = listOf("button", "input_button")
     val DOMAINS_TOGGLE = listOf(
@@ -1276,3 +1281,55 @@ fun Entity.isActive() = when {
     (domain == CAMERA_DOMAIN) -> state == "streaming"
     else -> true
 }
+
+/** Returns the bitmask of supported features for this entity, or 0 if unavailable. */
+private fun Entity.supportedFeatures(): Int = (attributes["supported_features"] as? Number)?.toInt() ?: 0
+
+/** Whether this media_player entity supports pause. */
+internal fun Entity.supportsPause(): Boolean = domain == MEDIA_PLAYER_DOMAIN &&
+    (supportedFeatures() and EntityExt.MEDIA_PLAYER_SUPPORT_PAUSE != 0)
+
+/** Whether this media_player entity supports seek. */
+internal fun Entity.supportsSeek(): Boolean = domain == MEDIA_PLAYER_DOMAIN &&
+    (supportedFeatures() and EntityExt.MEDIA_PLAYER_SUPPORT_SEEK != 0)
+
+/** Whether this media_player entity supports previous track. */
+internal fun Entity.supportsPreviousTrack(): Boolean = domain == MEDIA_PLAYER_DOMAIN &&
+    (supportedFeatures() and EntityExt.MEDIA_PLAYER_SUPPORT_PREVIOUS_TRACK != 0)
+
+/** Whether this media_player entity supports next track. */
+internal fun Entity.supportsNextTrack(): Boolean = domain == MEDIA_PLAYER_DOMAIN &&
+    (supportedFeatures() and EntityExt.MEDIA_PLAYER_SUPPORT_NEXT_TRACK != 0)
+
+/** Whether this media_player entity supports play. */
+internal fun Entity.supportsPlay(): Boolean = domain == MEDIA_PLAYER_DOMAIN &&
+    (supportedFeatures() and EntityExt.MEDIA_PLAYER_SUPPORT_PLAY != 0)
+
+/** Returns the media title, if available. */
+internal fun Entity.getMediaTitle(): String? =
+    if (domain == MEDIA_PLAYER_DOMAIN) attributes["media_title"]?.toString() else null
+
+/** Returns the media artist, falling back to album artist if available. */
+internal fun Entity.getMediaArtist(): String? = if (domain ==
+    MEDIA_PLAYER_DOMAIN
+) {
+    (attributes["media_artist"] ?: attributes["media_album_artist"])?.toString()
+} else {
+    null
+}
+
+/** Returns the media album name, if available. */
+internal fun Entity.getMediaAlbumName(): String? =
+    if (domain == MEDIA_PLAYER_DOMAIN) attributes["media_album_name"]?.toString() else null
+
+/** Returns the current media position in seconds, if available. */
+internal fun Entity.getMediaPosition(): Double? =
+    if (domain == MEDIA_PLAYER_DOMAIN) attributes["media_position"]?.toString()?.toDoubleOrNull() else null
+
+/** Returns the media duration in seconds, if available. */
+internal fun Entity.getMediaDuration(): Double? =
+    if (domain == MEDIA_PLAYER_DOMAIN) attributes["media_duration"]?.toString()?.toDoubleOrNull() else null
+
+/** Returns the entity_picture attribute URL, if available. */
+internal fun Entity.getEntityPictureUrl(): String? =
+    if (domain == MEDIA_PLAYER_DOMAIN) attributes["entity_picture"]?.toString() else null

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlModule.kt
@@ -1,0 +1,14 @@
+package io.homeassistant.companion.android.common.data.mediacontrol
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class MediaControlModule {
+
+    @Binds
+    abstract fun bindMediaControlRepository(impl: MediaControlRepositoryImpl): MediaControlRepository
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepository.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.common.data.mediacontrol
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Manages the configuration and state observation for a single media_player entity
+ * used to drive native Android media controls in the notification shade.
+ */
+interface MediaControlRepository {
+
+    /** Emits the current [MediaControlState] whenever the configured entity's state changes. Emits null when not configured. */
+    fun observeMediaControlState(): Flow<MediaControlState?>
+
+    /** Returns the currently configured server ID, or null if not configured. */
+    suspend fun getConfiguredServerId(): Int?
+
+    /** Returns the currently configured entity ID, or null if not configured. */
+    suspend fun getConfiguredEntityId(): String?
+
+    /** Sets the configured media_player entity. Pass null values to clear the configuration. */
+    suspend fun setConfiguredEntity(serverId: Int?, entityId: String?)
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepositoryImpl.kt
@@ -1,0 +1,111 @@
+package io.homeassistant.companion.android.common.data.mediacontrol
+
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.applyCompressedStateDiff
+import io.homeassistant.companion.android.common.data.integration.getEntityPictureUrl
+import io.homeassistant.companion.android.common.data.integration.getMediaAlbumName
+import io.homeassistant.companion.android.common.data.integration.getMediaArtist
+import io.homeassistant.companion.android.common.data.integration.getMediaDuration
+import io.homeassistant.companion.android.common.data.integration.getMediaPosition
+import io.homeassistant.companion.android.common.data.integration.getMediaTitle
+import io.homeassistant.companion.android.common.data.integration.supportsNextTrack
+import io.homeassistant.companion.android.common.data.integration.supportsPause
+import io.homeassistant.companion.android.common.data.integration.supportsPlay
+import io.homeassistant.companion.android.common.data.integration.supportsPreviousTrack
+import io.homeassistant.companion.android.common.data.integration.supportsSeek
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+import timber.log.Timber
+
+internal class MediaControlRepositoryImpl @Inject constructor(
+    private val prefsRepository: PrefsRepository,
+    private val serverManager: ServerManager,
+) : MediaControlRepository {
+
+    override fun observeMediaControlState(): Flow<MediaControlState?> = flow<MediaControlState?> {
+        val serverId = prefsRepository.getMediaControlServerId()
+        val entityId = prefsRepository.getMediaControlEntityId()
+        if (serverId == null || entityId == null) {
+            emit(null)
+            return@flow
+        }
+
+        try {
+            val stateFlow = serverManager.webSocketRepository(serverId)
+                .getCompressedStateAndChanges(listOf(entityId))
+            if (stateFlow == null) {
+                Timber.w("WebSocket subscription returned null for entity $entityId")
+                emit(null)
+                return@flow
+            }
+
+            var currentEntity: Entity? = null
+            stateFlow.collect { event ->
+                event.added?.get(entityId)?.let {
+                    currentEntity = it.toEntity(entityId)
+                }
+                event.changed?.get(entityId)?.let { diff ->
+                    currentEntity = currentEntity?.applyCompressedStateDiff(diff)
+                }
+                event.removed?.let { removed ->
+                    if (entityId in removed) {
+                        currentEntity = null
+                    }
+                }
+
+                val entity = currentEntity
+                if (entity != null) {
+                    emit(entity.toMediaControlState(serverId = serverId))
+                } else {
+                    emit(null)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to subscribe to media control entity $entityId")
+            emit(null)
+        }
+    }.distinctUntilChanged()
+
+    override suspend fun getConfiguredServerId(): Int? = prefsRepository.getMediaControlServerId()
+
+    override suspend fun getConfiguredEntityId(): String? = prefsRepository.getMediaControlEntityId()
+
+    override suspend fun setConfiguredEntity(serverId: Int?, entityId: String?) {
+        prefsRepository.setMediaControlServerId(serverId)
+        prefsRepository.setMediaControlEntityId(entityId)
+    }
+}
+
+private fun Entity.toMediaControlState(serverId: Int): MediaControlState {
+    val playbackState = when (state) {
+        "playing" -> MediaPlaybackState.Playing
+        "paused" -> MediaPlaybackState.Paused
+        "buffering" -> MediaPlaybackState.Buffering
+        "idle", "standby" -> MediaPlaybackState.Idle
+        else -> MediaPlaybackState.Off
+    }
+
+    return MediaControlState(
+        entityId = entityId,
+        serverId = serverId,
+        playbackState = playbackState,
+        title = getMediaTitle(),
+        artist = getMediaArtist(),
+        albumName = getMediaAlbumName(),
+        entityPictureUrl = getEntityPictureUrl(),
+        mediaDurationSeconds = getMediaDuration(),
+        mediaPositionSeconds = getMediaPosition(),
+        supportsPause = supportsPause(),
+        supportsPlay = supportsPlay(),
+        supportsSeek = supportsSeek(),
+        supportsPreviousTrack = supportsPreviousTrack(),
+        supportsNextTrack = supportsNextTrack(),
+    )
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlState.kt
@@ -1,0 +1,33 @@
+package io.homeassistant.companion.android.common.data.mediacontrol
+
+/**
+ * Represents the playback state of a media player entity used for native Android media controls.
+ */
+sealed interface MediaPlaybackState {
+    data object Playing : MediaPlaybackState
+    data object Paused : MediaPlaybackState
+    data object Idle : MediaPlaybackState
+    data object Buffering : MediaPlaybackState
+    data object Off : MediaPlaybackState
+}
+
+/**
+ * Captures all the information from a Home Assistant media_player entity that is needed
+ * to populate an Android MediaSession.
+ */
+data class MediaControlState(
+    val entityId: String,
+    val serverId: Int,
+    val playbackState: MediaPlaybackState,
+    val title: String?,
+    val artist: String?,
+    val albumName: String?,
+    val entityPictureUrl: String?,
+    val mediaDurationSeconds: Double?,
+    val mediaPositionSeconds: Double?,
+    val supportsPause: Boolean,
+    val supportsPlay: Boolean,
+    val supportsSeek: Boolean,
+    val supportsPreviousTrack: Boolean,
+    val supportsNextTrack: Boolean,
+)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -140,4 +140,16 @@ interface PrefsRepository {
     suspend fun getSelectedWakeWord(): String?
 
     suspend fun setSelectedWakeWord(wakeWord: String)
+
+    /** Returns the server ID of the configured media control entity, or null if not configured. */
+    suspend fun getMediaControlServerId(): Int?
+
+    /** Sets the server ID for the media control entity. Pass null to clear. */
+    suspend fun setMediaControlServerId(serverId: Int?)
+
+    /** Returns the entity ID of the configured media control entity, or null if not configured. */
+    suspend fun getMediaControlEntityId(): String?
+
+    /** Sets the entity ID for the media control entity. Pass null to clear. */
+    suspend fun setMediaControlEntityId(entityId: String?)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -46,6 +46,8 @@ private const val PREF_CHANGE_LOG_POPUP_ENABLED = "change_log_popup_enabled"
 private const val PREF_SHOW_PRIVACY_HINT = "show_privacy_hint"
 private const val PREF_WAKE_WORD_ENABLED = "wake_word_enabled"
 private const val PREF_SELECTED_WAKE_WORD = "selected_wake_word"
+private const val PREF_MEDIA_CONTROL_SERVER_ID = "media_control_server_id"
+private const val PREF_MEDIA_CONTROL_ENTITY_ID = "media_control_entity_id"
 
 /**
  * This class ensure that when we use the local storage in [PrefsRepositoryImpl] the migrations has been made
@@ -356,6 +358,11 @@ internal class PrefsRepositoryImpl @Inject constructor(
             localStorage().remove(CONTROLS_PANEL_SERVER)
             setControlsPanelPath(null)
         }
+
+        if (getMediaControlServerId() == serverId) {
+            setMediaControlServerId(null)
+            setMediaControlEntityId(null)
+        }
     }
 
     override suspend fun showPrivacyHint(): Boolean {
@@ -380,5 +387,29 @@ internal class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setSelectedWakeWord(wakeWord: String) {
         localStorage().putString(PREF_SELECTED_WAKE_WORD, wakeWord)
+    }
+
+    override suspend fun getMediaControlServerId(): Int? {
+        return localStorage().getInt(PREF_MEDIA_CONTROL_SERVER_ID)
+    }
+
+    override suspend fun setMediaControlServerId(serverId: Int?) {
+        if (serverId == null) {
+            localStorage().remove(PREF_MEDIA_CONTROL_SERVER_ID)
+        } else {
+            localStorage().putInt(PREF_MEDIA_CONTROL_SERVER_ID, serverId)
+        }
+    }
+
+    override suspend fun getMediaControlEntityId(): String? {
+        return localStorage().getString(PREF_MEDIA_CONTROL_ENTITY_ID)
+    }
+
+    override suspend fun setMediaControlEntityId(entityId: String?) {
+        if (entityId == null) {
+            localStorage().remove(PREF_MEDIA_CONTROL_ENTITY_ID)
+        } else {
+            localStorage().putString(PREF_MEDIA_CONTROL_ENTITY_ID, entityId)
+        }
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -451,6 +451,11 @@
     <string name="manual_setup">Enter address manually</string>
     <string name="manual_title">What is your Home Assistant address?</string>
     <string name="matter_commissioning_cancelled">Unable to add Matter device?</string>
+    <string name="media_controls">Media controls</string>
+    <string name="media_controls_summary">Control a media player entity from the notification shade</string>
+    <string name="media_control_description">Select a media_player entity to show as a native media control in the notification shade. You can control playback without opening the app.</string>
+    <string name="media_control_select_entity">Select media player entity</string>
+    <string name="media_control_clear">Clear configuration</string>
     <string name="matter_commissioning_unavailable">Matter is currently unavailable</string>
     <string name="matter_shared_title">Add Matter device</string>
     <string name="matter_shared_status_not_registered">Please connect to your Home Assistant server before adding a Matter device.</string>

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/mediacontrol/MediaControlRepositoryImplTest.kt
@@ -1,0 +1,348 @@
+package io.homeassistant.companion.android.common.data.mediacontrol
+
+import app.cash.turbine.test
+import io.homeassistant.companion.android.common.data.integration.EntityExt
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedEntityState
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.CompressedStateChangedEvent
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ConsoleLogExtension::class)
+class MediaControlRepositoryImplTest {
+
+    private val prefsRepository: PrefsRepository = mockk(relaxed = true)
+    private val serverManager: ServerManager = mockk(relaxed = true)
+    private val webSocketRepository: WebSocketRepository = mockk(relaxed = true)
+
+    private lateinit var repository: MediaControlRepositoryImpl
+
+    @BeforeEach
+    fun setUp() {
+        coEvery { serverManager.webSocketRepository(any()) } returns webSocketRepository
+        repository = MediaControlRepositoryImpl(
+            prefsRepository = prefsRepository,
+            serverManager = serverManager,
+        )
+    }
+
+    @Nested
+    inner class ObserveMediaControlStateTest {
+
+        @Test
+        fun `Given no configured entity when observing then emit null`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns null
+            coEvery { prefsRepository.getMediaControlEntityId() } returns null
+
+            repository.observeMediaControlState().test {
+                assertNull(awaitItem())
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given configured entity when state arrives then emit MediaControlState`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 1
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.test"
+
+            val entityState = CompressedEntityState(
+                state = JsonPrimitive("playing"),
+                attributes = mapOf(
+                    "friendly_name" to "Test Player",
+                    "media_title" to "Test Song",
+                    "media_artist" to "Test Artist",
+                    "supported_features" to
+                        (EntityExt.MEDIA_PLAYER_SUPPORT_PLAY or EntityExt.MEDIA_PLAYER_SUPPORT_PAUSE),
+                ),
+                lastChanged = 1000.0,
+                lastUpdated = 1000.0,
+            )
+            val event = CompressedStateChangedEvent(
+                added = mapOf("media_player.test" to entityState),
+            )
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(listOf("media_player.test"))
+            } returns flowOf(event)
+
+            repository.observeMediaControlState().test {
+                val state = awaitItem()
+                assertEquals("media_player.test", state?.entityId)
+                assertEquals(1, state?.serverId)
+                assertEquals(MediaPlaybackState.Playing, state?.playbackState)
+                assertEquals("Test Song", state?.title)
+                assertEquals("Test Artist", state?.artist)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given configured entity when entity removed then emit null`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 1
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.test"
+
+            val event = CompressedStateChangedEvent(
+                removed = listOf("media_player.test"),
+            )
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(listOf("media_player.test"))
+            } returns flowOf(event)
+
+            repository.observeMediaControlState().test {
+                assertNull(awaitItem())
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given configured entity when websocket returns null then emit null`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 1
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.test"
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(listOf("media_player.test"))
+            } returns null
+
+            repository.observeMediaControlState().test {
+                assertNull(awaitItem())
+                awaitComplete()
+            }
+        }
+    }
+
+    @Nested
+    inner class PlaybackStateMappingTest {
+
+        private fun configureEntity() {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 1
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.test"
+        }
+
+        private fun entityWithState(state: String, attributes: Map<String, Any?> = emptyMap()) = CompressedEntityState(
+            state = JsonPrimitive(state),
+            attributes = attributes,
+            lastChanged = 1000.0,
+            lastUpdated = 1000.0,
+        )
+
+        @Test
+        fun `Given paused state then maps to Paused`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("paused"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Paused, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given buffering state then maps to Buffering`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("buffering"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Buffering, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given idle state then maps to Idle`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("idle"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Idle, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given standby state then maps to Idle`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("standby"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Idle, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given off state then maps to Off`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("off"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Off, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given unknown state then maps to Off`() = runTest {
+            configureEntity()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityWithState("unavailable"))))
+
+            repository.observeMediaControlState().test {
+                assertEquals(MediaPlaybackState.Off, awaitItem()?.playbackState)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given entity with partial attributes then null fields are null`() = runTest {
+            configureEntity()
+            val entityState = entityWithState("playing", attributes = mapOf("media_title" to "Only Title"))
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityState)))
+
+            repository.observeMediaControlState().test {
+                val state = awaitItem()!!
+                assertEquals("Only Title", state.title)
+                assertNull(state.artist)
+                assertNull(state.albumName)
+                assertNull(state.entityPictureUrl)
+                assertNull(state.mediaDurationSeconds)
+                assertNull(state.mediaPositionSeconds)
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given entity with all attributes then all fields populated`() = runTest {
+            configureEntity()
+            val entityState = entityWithState(
+                "playing",
+                attributes = mapOf(
+                    "media_title" to "Song",
+                    "media_artist" to "Artist",
+                    "media_album_name" to "Album",
+                    "entity_picture" to "/api/picture",
+                    "media_duration" to 300.0,
+                    "media_position" to 120.5,
+                    "supported_features" to (
+                        EntityExt.MEDIA_PLAYER_SUPPORT_PAUSE or
+                            EntityExt.MEDIA_PLAYER_SUPPORT_SEEK or
+                            EntityExt.MEDIA_PLAYER_SUPPORT_PREVIOUS_TRACK or
+                            EntityExt.MEDIA_PLAYER_SUPPORT_NEXT_TRACK or
+                            EntityExt.MEDIA_PLAYER_SUPPORT_PLAY
+                        ),
+                ),
+            )
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns flowOf(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityState)))
+
+            repository.observeMediaControlState().test {
+                val state = awaitItem()!!
+                assertEquals("Song", state.title)
+                assertEquals("Artist", state.artist)
+                assertEquals("Album", state.albumName)
+                assertEquals("/api/picture", state.entityPictureUrl)
+                assertEquals(300.0, state.mediaDurationSeconds)
+                assertEquals(120.5, state.mediaPositionSeconds)
+                assertTrue(state.supportsPause)
+                assertTrue(state.supportsPlay)
+                assertTrue(state.supportsSeek)
+                assertTrue(state.supportsPreviousTrack)
+                assertTrue(state.supportsNextTrack)
+                awaitComplete()
+            }
+        }
+    }
+
+    @Nested
+    inner class DistinctUntilChangedTest {
+
+        @Test
+        fun `Given duplicate state emissions then only first is emitted`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 1
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.test"
+
+            val entityState = CompressedEntityState(
+                state = JsonPrimitive("playing"),
+                attributes = mapOf("media_title" to "Song"),
+                lastChanged = 1000.0,
+                lastUpdated = 1000.0,
+            )
+            val stateFlow = MutableSharedFlow<CompressedStateChangedEvent>()
+            coEvery {
+                webSocketRepository.getCompressedStateAndChanges(any())
+            } returns stateFlow
+
+            repository.observeMediaControlState().test {
+                // Emit the same entity state twice — distinctUntilChanged should filter the duplicate
+                stateFlow.emit(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityState)))
+                val first = awaitItem()
+                assertEquals("Song", first?.title)
+
+                stateFlow.emit(CompressedStateChangedEvent(added = mapOf("media_player.test" to entityState)))
+                expectNoEvents()
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
+
+    @Nested
+    inner class ConfigurationTest {
+
+        @Test
+        fun `Given server id when getConfiguredServerId then delegates to prefs`() = runTest {
+            coEvery { prefsRepository.getMediaControlServerId() } returns 42
+
+            assertEquals(42, repository.getConfiguredServerId())
+        }
+
+        @Test
+        fun `Given entity id when getConfiguredEntityId then delegates to prefs`() = runTest {
+            coEvery { prefsRepository.getMediaControlEntityId() } returns "media_player.kitchen"
+
+            assertEquals("media_player.kitchen", repository.getConfiguredEntityId())
+        }
+
+        @Test
+        fun `Given values when setConfiguredEntity then updates both prefs`() = runTest {
+            repository.setConfiguredEntity(serverId = 5, entityId = "media_player.office")
+
+            coVerify { prefsRepository.setMediaControlServerId(5) }
+            coVerify { prefsRepository.setMediaControlEntityId("media_player.office") }
+        }
+
+        @Test
+        fun `Given null values when setConfiguredEntity then clears both prefs`() = runTest {
+            repository.setConfiguredEntity(serverId = null, entityId = null)
+
+            coVerify { prefsRepository.setMediaControlServerId(null) }
+            coVerify { prefsRepository.setMediaControlEntityId(null) }
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I wanted to be able to control a media player entity natively on Android without having to open the app or navigate to a widget. So this feature exposes a Home Assistant `media_player` entity as native Android Media Controls ([described here](https://developer.android.com/media/implement/surfaces/mobile)) in the notification shade, the same UI used by other media players on Android. 
The media controls show the currently playing track info and play position with album art. Prev/next track, play/pause and seek controls work and are forwarded to the media_player entity (if the entity supports them). 
A new "Media controls" setting is added under "Companion app" to choose which media_player entity to expose in the media controls, if any. One entity at a time can be selected.
Unit tests are added to test playback state mapping, state flow, settings and everything else I could think of.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="1080" height="2400" alt="notification_shade_media_controls" src="https://github.com/user-attachments/assets/f755fdf9-815f-4e86-beca-4442a86d3eb5" />
<img width="1080" height="2400" alt="settings_media_controls_entry_dark" src="https://github.com/user-attachments/assets/56b1308d-8052-47e9-85b8-f29e6f99a4c2" />
<img width="1080" height="2400" alt="media_controls_settings_dark" src="https://github.com/user-attachments/assets/5c0a6e06-1dea-4bfd-b965-a44740b55008" />

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation PR: https://github.com/home-assistant/companion.home-assistant/pull/1304
