### PR TITLE
Fix race condition with coil RemoteViewsTarget

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -180,6 +180,8 @@ class CameraWidget : AppWidgetProvider() {
                         // Wait for the image to be loaded before returning the RemoteViews
                         // to avoid concurrent modifications between Coil and updateAppWidget.
                         context.imageLoader.enqueue(request).job.join()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e, "Unable to fetch image")
                     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/common/RemoteViewsTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/common/RemoteViewsTarget.kt
@@ -7,8 +7,14 @@ import coil3.target.Target
 import coil3.toBitmap
 
 /**
- * Load images into RemoteViews with Coil
- * (based on https://coil-kt.github.io/coil/recipes/#remote-views)
+ * [Target] implementation to load images into a [RemoteViews] ImageView with Coil.
+ *
+ * This target only mutates the provided [remoteViews] instance by setting the bitmap on
+ * [imageViewResId]. It does **not** call [android.appwidget.AppWidgetManager.updateAppWidget].
+ * Callers are responsible for triggering the widget update themselves after the request
+ * completes (for example, in the surrounding widget update logic).
+ *
+ * Based on https://coil-kt.github.io/coil/recipes/#remote-views
  */
 class RemoteViewsTarget(private val remoteViews: RemoteViews, @IdRes private val imageViewResId: Int) : Target {
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidget.kt
@@ -264,6 +264,8 @@ class MediaPlayerControlsWidget : BaseWidgetProvider<MediaPlayerControlsWidgetEn
                         // Wait for the image to be loaded before returning the RemoteViews
                         // to avoid concurrent modifications between Coil and updateAppWidget.
                         context.imageLoader.enqueue(request).job.join()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e, "Unable to load image")
                     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Raw Sentry issue


# NullPointerException: Attempt to invoke virtual method 'int android.widget.RemoteViews$Action.getActionTag()' on a null object reference

**Issue ID:** 7362406096
**Project:** android
**Date:** 3/25/2026, 5:00:18 PM
## Issue Summary
NPE in RemoteViews Action during Widget Update under Low Memory
**What's wrong:** NullPointerException occurs when accessing **RemoteViews$Action.getActionTag()**.
**In the trace:** Repeated **Low Memory** warnings preceded the crash, suggesting resource pressure.
**Possible cause:** The **MediaPlayerControlsWidget** update logic likely attempts to process a null **RemoteViews Action** due to memory pressure.

## Tags

- **device:** Redmi Note 8 Pro
- **device.class:** medium
- **device.family:** Redmi
- **dist:** 21150
- **environment:** production
- **handled:** no
- **installerStore:** com.android.vending
- **isSideLoaded:** false
- **level:** fatal
- **mechanism:** UncaughtExceptionHandler
- **os:** Android 11
- **os.build:** RP1A.200720.011
- **os.name:** Android
- **os.rooted:** no
- **release:** io.homeassistant.companion.android@2026.3.6

## Exceptions

### Exception 1
**Type:** DiagnosticCoroutineContextException
### Exception 2
**Type:** NullPointerException
**Value:** Attempt to invoke virtual method 'int android.widget.RemoteViews$Action.getActionTag()' on a null object reference

#### Stacktrace

```
 writeActionsToParcel in RemoteViews.java [Line 3767] (Not in app)
 writeToParcel in RemoteViews.java [Line 3742] (Not in app)
 updateAppWidgetIds in IAppWidgetService.java [Line 989] (Not in app)
 updateAppWidget in AppWidgetManager.java [Line 531] (Not in app)
 updateAppWidget in AppWidgetManager.java [Line 604] (Not in app)
 onEntityStateChanged in MediaPlayerControlsWidget.kt [Line 452] (In app)
 invokeSuspend in unknown file [Line 15] (In app)
 resumeWith in ContinuationImpl.kt [Line 34] (Not in app)
 run in DispatchedTask.kt [Line 98] (Not in app)
 runSafely in CoroutineScheduler.kt [Line 586] (Not in app)
 executeTask in CoroutineScheduler.kt [Line 829] (Not in app)
 runWorker in CoroutineScheduler.kt [Line 717] (Not in app)
 run in CoroutineScheduler.kt [Line 704] (Not in app)
```

----


## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR fixe a race condition while using coil to load image into RemoteView. It was not an issue before we migrated the widget worker out of main in https://github.com/home-assistant/android/pull/6415 because everything was happening in Main.

The issue is that now we (in MediaPlayerWidget since camera had some logic to not return the view) return a RemoteView and call update while we also dispatched the load of the image that is also going to call update with the RemoteView but modified. Because of that the framework crashes since it is modified while potentially being drawn.

To address the issue we simply make the creation of the RemoteView sequential and we only update once the image is loaded fully. 

I fixed a StrictMode issue because Coil is loading the image into the HW directly but for remote view we need a software image since it is serialized.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
