### PR TITLE
Remove unwanted ioScope (that is main) from WebViewActivity

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -154,13 +154,10 @@ import io.homeassistant.companion.android.webview.externalbus.NavigateTo
 import io.homeassistant.companion.android.webview.externalbus.ShowSidebar
 import io.homeassistant.companion.android.webview.insecure.BlockInsecureFragment
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import timber.log.Timber
@@ -189,7 +186,6 @@ class WebViewActivity :
         private const val CONNECTION_DELAY = 10000L
     }
 
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.Main + Job())
     private val requestPermissions =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) {
             if (it.any { result -> result.value }) {
@@ -509,7 +505,7 @@ class WebViewActivity :
 
                     setWebViewZoom()
                     if (moreInfoEntity != "" && view?.progress == 100 && isConnected) {
-                        ioScope.launch {
+                        lifecycleScope.launch {
                             val owner = "onPageFinished:$moreInfoEntity"
                             if (moreInfoMutex.tryLock(owner)) {
                                 delay(2000L)
@@ -1712,10 +1708,10 @@ class WebViewActivity :
                 alert.setMessage(commonR.string.tls_cert_not_found_message)
                 alert.setTitle(commonR.string.tls_cert_title)
                 alert.setPositiveButton(android.R.string.ok) { _, _ ->
-                    ioScope.launch {
+                    lifecycleScope.launch {
                         serverManager.getServer(presenter.getActiveServer())?.let {
                             serverManager.removeServer(it.id)
-                            withContext(Dispatchers.Main) { relaunchApp() }
+                            relaunchApp()
                         }
                     }
                 }
@@ -1729,18 +1725,18 @@ class WebViewActivity :
                 alert.setMessage(commonR.string.tls_cert_expired_message)
                 alert.setTitle(commonR.string.tls_cert_title)
                 alert.setPositiveButton(android.R.string.ok) { _, _ ->
-                    ioScope.launch {
+                    lifecycleScope.launch {
                         keyChainRepository.clear()
+                        relaunchApp()
                     }
-                    relaunchApp()
                 }
             } else if (errorType == ErrorType.AUTHENTICATION) {
                 alert.setMessage(commonR.string.error_auth_revoked)
                 alert.setPositiveButton(android.R.string.ok) { _, _ ->
-                    ioScope.launch {
+                    lifecycleScope.launch {
                         serverManager.getServer(presenter.getActiveServer())?.let {
                             serverManager.removeServer(it.id)
-                            withContext(Dispatchers.Main) { relaunchApp() }
+                            relaunchApp()
                         }
                     }
                 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
There was a `ioScope` attributes in the WebViewActivity not tied to any lifecycle and actually using the Main Dispatcher. This PR clean this up to make it easier to follow what's going on.