### PR TITLE
Define CommandMessage pattern and implement first messages

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
@@ -1,0 +1,65 @@
+package io.homeassistant.companion.android.frontend.externalbus.outgoing
+
+import io.homeassistant.companion.android.frontend.externalbus.frontendExternalBusJson
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+
+/**
+ * Outgoing command message sent to the Home Assistant frontend via the external bus.
+ *
+ * Command messages instruct the frontend to perform an action.
+ *
+ * The Home Assistant frontend uses `"type": "command"` for all commands, distinguishing them
+ * only by the `command` string field. This means kotlinx.serialization's sealed polymorphism
+ * cannot give each command its own subtype (all would need the same `@SerialName("command")`).
+ *
+ * Instead, this single private class handles serialization, and each command is exposed as a
+ * top-level factory: [NavigateToMessage] uses `operator fun invoke` for constructor-like syntax,
+ * and [ShowSidebarMessage] is a pre-built instance. Call sites read naturally:
+ * ```
+ * send(NavigateTo(path = "/dashboard", replace = true))
+ * send(ShowSidebar)
+ * ```
+ */
+@Serializable
+@SerialName("command")
+private data class CommandMessage(
+    override val id: Int? = null,
+    val command: String,
+    val payload: JsonElement? = null,
+) : OutgoingExternalBusMessage
+
+/**
+ * Creates a navigation command to navigate the frontend to the given path.
+ *
+ * When [replace] is `true`, the current history entry is replaced instead of
+ * pushing a new one (useful for resetting to the default dashboard).
+ *
+ * Requires Home Assistant 2025.6 or later. Callers must check the server version
+ * before sending this command.
+ *
+ * @see CommandMessage
+ */
+object NavigateToMessage {
+    operator fun invoke(path: String, replace: Boolean = false): OutgoingExternalBusMessage = CommandMessage(
+        command = "navigate",
+        payload = frontendExternalBusJson.encodeToJsonElement(
+            NavigatePayload(path = path, options = NavigateOptions(replace = replace)),
+        ),
+    )
+
+    @Serializable
+    private data class NavigatePayload(val path: String, val options: NavigateOptions = NavigateOptions())
+
+    @Serializable
+    private data class NavigateOptions(val replace: Boolean = false)
+}
+
+/**
+ * Command to toggle the frontend sidebar visibility.
+ *
+ * @see CommandMessage
+ */
+val ShowSidebarMessage: OutgoingExternalBusMessage = CommandMessage(command = "sidebar/show")

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
@@ -1,0 +1,45 @@
+package io.homeassistant.companion.android.frontend.externalbus.outgoing
+
+import io.homeassistant.companion.android.frontend.externalbus.frontendExternalBusJson
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ConsoleLogExtension::class)
+class CommandMessageTest {
+
+    @Test
+    fun `Given NavigateToMessage with replace when serializing then produces correct JSON`() {
+        val message = NavigateToMessage(path = "/", replace = true)
+
+        val json = frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(message)
+
+        assertEquals(
+            """{"type":"command","id":null,"command":"navigate","payload":{"path":"/","options":{"replace":true}}}""",
+            json,
+        )
+    }
+
+    @Test
+    fun `Given NavigateToMessage without replace when serializing then defaults replace to false`() {
+        val message = NavigateToMessage(path = "/lovelace/dashboard")
+
+        val json = frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(message)
+
+        assertEquals(
+            """{"type":"command","id":null,"command":"navigate","payload":{"path":"/lovelace/dashboard","options":{"replace":false}}}""",
+            json,
+        )
+    }
+
+    @Test
+    fun `Given ShowSidebarMessage when serializing then produces correct JSON without payload`() {
+        val json = frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(ShowSidebarMessage)
+
+        assertEquals(
+            """{"type":"command","id":null,"command":"sidebar/show","payload":null}""",
+            json,
+        )
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Come up with a pattern to define with a strong type the Commands that we send to the frontend that uses the `command` JSON discriminator. Since a sealed class member cannot have twice the same discriminator (otherwise it cannot de-serialize properly), I had to come up with this pattern where we override the `invoke` operator of an object to keep a nice API.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I don't like it but I didn't find any other way for the Payload to be a JsonElement, using a template breaks the serialization engine.

This PR is based on #6708 and need to be rebased once #6708 has been merged.