### PR TITLE
Fix bottom sheet peek-to-expanded jump on show

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/FragmentExtensions.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/FragmentExtensions.kt
@@ -1,11 +1,8 @@
 package io.homeassistant.companion.android.util
 
-import android.view.View
 import android.view.WindowManager
-import android.widget.FrameLayout
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
-import com.google.android.material.R
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -18,16 +15,21 @@ val Fragment.isStarted: Boolean
     get() = lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
 
 /**
- * Set the layout for a BottomSheetDialogFragment to a shared default for the app,
+ * Set the layout for a [BottomSheetDialogFragment] to a shared default for the app,
  * and expand it to full size by default instead of peek height only.
+ *
+ * Configures the behavior before the dialog is shown so the sheet starts directly
+ * in the expanded state, avoiding a visible peek-then-expand animation.
  */
 fun BottomSheetDialogFragment.setLayoutAndExpandedByDefault() {
-    dialog?.setOnShowListener {
-        val dialog = it as BottomSheetDialog
-        dialog.window?.setDimAmount(0.03f)
-        dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
-        val bottomSheet = dialog.findViewById<View>(R.id.design_bottom_sheet) as FrameLayout
-        val bottomSheetBehavior = BottomSheetBehavior.from(bottomSheet)
-        bottomSheetBehavior.state = BottomSheetBehavior.STATE_EXPANDED
+    (dialog as? BottomSheetDialog)?.let { bottomSheetDialog ->
+        bottomSheetDialog.behavior.apply {
+            skipCollapsed = true
+            state = BottomSheetBehavior.STATE_EXPANDED
+        }
+        bottomSheetDialog.window?.apply {
+            setDimAmount(0.03f)
+            setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
+        }
     }
 }


### PR DESCRIPTION
## Summary

When opening a bottom sheet (e.g. the server chooser via 3-finger swipe up), the sheet visibly jumps from peek height to expanded. This is because `setLayoutAndExpandedByDefault()` configures `STATE_EXPANDED` in an `onShowListener`, which fires *after* the sheet has already started its show animation at peek height.

This changes the approach to configure the `BottomSheetBehavior` directly in `onViewCreated` (before `onStart` shows the dialog), so the sheet starts directly in the expanded state without an intermediate peek. Also adds `skipCollapsed` so dismissal goes straight to hidden instead of stopping at collapsed.

Affects all callers: `ServerChooserFragment`, `ImprovSetupDialog`, and `ImprovPermissionDialog`.

## Checklist

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes

No tests added — the fix is about *when* behavior properties are configured (before vs after dialog show), which is a timing concern that can't be meaningfully validated in a unit test. Tested manually on device.

Note: to test this on a debug build, I had to temporarily set `WIPFeature.USE_FRONTEND_V2 = false` because the new Compose frontend (`FrontendScreen`/`HAWebView`) doesn't have gesture detection yet — the swipe listener is only set up in the legacy `WebViewActivity` path.