### PR TITLE
Make sure the camera bitmap is not going above the memory limit

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -173,7 +173,7 @@ class CameraWidget : AppWidgetProvider() {
                                 .diskCachePolicy(CachePolicy.DISABLED)
                                 .memoryCachePolicy(CachePolicy.DISABLED)
                                 .networkCachePolicy(CachePolicy.READ_ONLY)
-                                .size(getWidgetSize(AppWidgetManager.getInstance(context), appWidgetId))
+                                .size(getWidgetBitmapSize(AppWidgetManager.getInstance(context), appWidgetId))
                                 .precision(Precision.INEXACT)
                                 .build(),
                         ).image?.toBitmap()?.let {
@@ -281,7 +281,7 @@ class CameraWidget : AppWidgetProvider() {
      * under roughly 90% of that limit to leave headroom for other bitmap work in the same
      * RemoteViews.
      */
-    private fun getWidgetSize(appWidgetManager: AppWidgetManager, appWidgetId: Int): Size {
+    private fun getWidgetBitmapSize(appWidgetManager: AppWidgetManager, appWidgetId: Int): Size {
         val res = Resources.getSystem()
         val screenWidth = res.displayMetrics.widthPixels
         val screenHeight = res.displayMetrics.heightPixels


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In the last beta I found out in Sentry that some users were trying to load a quite big image in the widget, but the widget framework has a strong limit on the size available that depends on the device. This PR is trying to avoid this crash by putting the imagine within the acceptable bounds defined by the system. I kept 10% of margin just in case but in theory we shouldn't need it.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Raw error from Sentry

# IllegalArgumentException: RemoteViews for widget update exceeds maximum bitmap memory usage (used: 16588800, max: 14400000)

**Project:** android
**Date:** 3/30/2026, 8:38:09 AM
## Issue Summary
Widget Bitmap Memory Exceeded During Update
**What's wrong:** Widget update failed due to **RemoteViews bitmap memory overuse**.
**In the trace:** The failure originated from an **in-app** call within **CameraWidget.kt** line 86.
**Possible cause:** The **CameraWidget** is likely generating **bitmaps too large** for the system's **14.4MB** limit.

## Tags

- **device:** TLG01_EEA
- **device.class:** medium
- **device.family:** TLG01_EEA
- **dist:** 21192
- **environment:** production
- **handled:** no
- **installerStore:** com.android.vending
- **isSideLoaded:** false
- **level:** fatal
- **mechanism:** UncaughtExceptionHandler
- **os:** Android 13
- **os.build:** V1.05_20240227
- **os.name:** Android
- **os.rooted:** no
- **release:** io.homeassistant.companion.android@2026.3.7

## Exceptions

### Exception 1
**Type:** RemoteException
**Value:** Remote stack trace:
	at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetInstanceLocked(AppWidgetServiceImpl.java:1872)
	at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetIds(AppWidgetServiceImpl.java:1691)
	at com.android.server.appwidget.AppWidgetServiceImpl.updateAppWidgetIds(AppWidgetServiceImpl.java:1434)
	at com.android.internal.appwidget.IAppWidgetService$Stub.onTransact(IAppWidgetService.java:408)
	at android.os.Binder.execTransactInternal(Binder.java:1280)


### Exception 2
**Type:** DiagnosticCoroutineContextException
### Exception 3
**Type:** IllegalArgumentException
**Value:** RemoteViews for widget update exceeds maximum bitmap memory usage (used: 16588800, max: 14400000)

#### Stacktrace

```
 createExceptionOrNull in Parcel.java [Line 3015] (Not in app)
 createException in Parcel.java [Line 2995] (Not in app)
 readException in Parcel.java [Line 2978] (Not in app)
 readException in Parcel.java [Line 2920] (Not in app)
 updateAppWidgetIds in IAppWidgetService.java [Line 841] (Not in app)
 updateAppWidget in AppWidgetManager.java [Line 540] (Not in app)
 updateAppWidget in AppWidgetManager.java [Line 613] (Not in app)
 updateAppWidget in CameraWidget.kt [Line 86] (In app)
 access$updateAppWidget in CameraWidget.kt [Line 44] (In app)
 invokeSuspend in unknown file [Line 15] (In app)
 resumeWith in ContinuationImpl.kt [Line 34] (Not in app)
 afterResume in Scopes.kt [Line 35] (Not in app)
 resumeWith in AbstractCoroutine.kt [Line 101] (Not in app)
 resumeWith in ContinuationImpl.kt [Line 47] (Not in app)
 run in DispatchedTask.kt [Line 100] (Not in app)
 runSafely in CoroutineScheduler.kt [Line 586] (Not in app)
```
