### PR TITLE
Bring back strings.zip

### DIFF
--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -48,3 +48,9 @@ runs:
     - name: Zip Translations
       shell: bash
       run: zip -r strings.zip common/src/main/res/values/strings.xml common/src/main/res/values-*/strings.xml
+
+    - name: Archive Translations
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: strings
+        path: strings.zip


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While fixing the translation download issue in #6659 I've removed the storage of it into the `strings.zip`. This PR does bring it back and address this comments https://github.com/home-assistant/android/pull/6659/changes#r3021808539.