### PR TITLE
Only store strings.zip as artifact in PR workflow

### DIFF
--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -49,8 +49,3 @@ runs:
       shell: bash
       run: zip -r strings.zip common/src/main/res/values/strings.xml common/src/main/res/values-*/strings.xml
 
-    - name: Archive Translations
-      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      with:
-        name: strings
-        path: strings.zip

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,6 +54,13 @@ jobs:
             exit 1
           fi
 
+      - name: Archive Translations
+        if: steps.changes.outputs.skip != 'true'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: strings
+          path: strings.zip
+
   yamllint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

The fix in #6668 did not work on the push workflow because it has tries to upload the same file twice. Since this is only relevant for test I've mode the upload only when validating the setup of the transaltions.

> ##[endgroup***
With the provided path, there will be 1 file uploaded
Artifact name is valid!
Root directory input is valid!
##[error***Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run