### PR TITLE
fix: pre-initialize mTLS flag from cert SAN/CN to handle TLS session resumption in Wear OS onboarding

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -164,6 +164,14 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
 
     init {
         viewModelScope.launch {
+            // Pre-set the mTLS flag before emitting the auth URL to handle TLS session
+            // resumption. See preInitializeTLSClientAuthState for details.
+            try {
+                webViewClient.preInitializeTLSClientAuthState(rawUrl.toHttpUrl().host)
+            } catch (_: IllegalArgumentException) {
+                // Malformed URL: this is a best-effort pre-initialisation;
+                // buildAuthUrl below will surface the error to the user.
+            }
             buildAuthUrl(rawUrl)
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -17,6 +17,7 @@ import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserRequest
 import io.homeassistant.companion.android.onboarding.connection.navigation.ConnectionRoute
+import io.homeassistant.companion.android.util.CheckTLSClientAuthNeededUseCase
 import io.homeassistant.companion.android.util.HAWebChromeClient
 import io.homeassistant.companion.android.util.HAWebViewClient
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
@@ -71,6 +72,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     webViewClientFactory: HAWebViewClientFactory,
     private val connectivityCheckRepository: ConnectivityCheckRepository,
     private val fileChooserManager: FileChooserManager,
+    private val checkTLSClientAuthNeededUseCase: CheckTLSClientAuthNeededUseCase,
 ) : ViewModel(),
     FrontendConnectionErrorStateProvider {
 
@@ -80,11 +82,13 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         webViewClientFactory: HAWebViewClientFactory,
         connectivityCheckRepository: ConnectivityCheckRepository,
         fileChooserManager: FileChooserManager,
+        checkTLSClientAuthNeededUseCase: CheckTLSClientAuthNeededUseCase,
     ) : this(
         savedStateHandle.toRoute<ConnectionRoute>().url,
         webViewClientFactory,
         connectivityCheckRepository,
         fileChooserManager,
+        checkTLSClientAuthNeededUseCase,
     )
 
     /**
@@ -243,7 +247,9 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                         ConnectionNavigationEvent.Authenticated(
                             url = effectiveUrl.value,
                             authCode = code,
-                            requiredMTLS = isTLSClientAuthNeeded,
+                            // The WebView may have resumed a TLS session without a
+                            // CertificateRequest, so also check the loaded certificate chain.
+                            requiredMTLS = isTLSClientAuthNeeded || checkTLSClientAuthNeededUseCase(rawHttpUrl?.host),
                         ),
                     )
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/CheckTLSClientAuthNeededUseCase.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/CheckTLSClientAuthNeededUseCase.kt
@@ -1,0 +1,120 @@
+package io.homeassistant.companion.android.util
+
+import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
+import java.net.InetAddress
+import java.net.UnknownHostException
+import java.security.cert.CertificateParsingException
+import java.security.cert.X509Certificate
+import javax.inject.Inject
+import javax.security.auth.x500.X500Principal
+
+// SAN (Subject Alternative Name) type codes per RFC 5280 section 4.2.1.6
+private const val SAN_TYPE_DNS_NAME = 2
+private const val SAN_TYPE_IP_ADDRESS = 7
+
+/**
+ * Checks whether the in-memory client certificate chain covers the target host, which indicates
+ * the server requires a TLS client certificate.
+ *
+ * This is needed to handle TLS session resumption: when the WebView reuses a TLS session that was
+ * established earlier in the same process, the server does not issue a new `CertificateRequest`,
+ * so [android.webkit.WebViewClient.onReceivedClientCertRequest] is never invoked and the
+ * WebViewClient's own flag stays false — even if the server requires a client certificate.
+ *
+ * The check inspects the certificate kept in memory by the [KeyChainRepository] and verifies it
+ * against the host via its Subject Alternative Names (SANs), falling back to the Common Name
+ * (CN) when no SANs are present. Matching the host avoids a false positive when the user has
+ * multiple servers where only one requires mTLS.
+ *
+ * If the app was force-stopped first (clearing in-memory state) no TLS session can be resumed
+ * either, so [android.webkit.WebViewClient.onReceivedClientCertRequest] fires naturally on the
+ * fresh handshake and the WebViewClient's flag is set without this check.
+ *
+ * @param targetHost the hostname of the server being connected to, or `null` if the URL could not
+ * be parsed. A `null` (or blank) host never matches, so the result is `false`.
+ */
+class CheckTLSClientAuthNeededUseCase @Inject constructor(private val keyChainRepository: KeyChainRepository) {
+    suspend operator fun invoke(targetHost: String?): Boolean {
+        if (targetHost.isNullOrEmpty()) return false
+        val cert = keyChainRepository.getClientCertProvider().certificate?.chain?.firstOrNull()
+            ?: return false
+        return certCoversHost(cert, targetHost)
+    }
+
+    /**
+     * Returns `true` if [cert] is valid for [host].
+     *
+     * Checks Subject Alternative Names (SANs) first — both DNS names (with wildcard support)
+     * and IP addresses. Falls back to the Common Name (CN) in the Subject DN if no SANs are
+     * present, matching the behaviour of legacy TLS stacks.
+     */
+    private fun certCoversHost(cert: X509Certificate, host: String): Boolean {
+        val sans: Collection<List<*>>? = try {
+            cert.subjectAlternativeNames
+        } catch (_: CertificateParsingException) {
+            null
+        }
+
+        return if (!sans.isNullOrEmpty()) {
+            sans.any { san ->
+                if (san.size < 2) return@any false
+                val type = san[0] as? Int ?: return@any false
+                when (type) {
+                    SAN_TYPE_DNS_NAME -> { // dNSName — returned as String
+                        val value = san[1] as? String ?: return@any false
+                        hostMatchesSan(host, value)
+                    }
+                    SAN_TYPE_IP_ADDRESS -> {
+                        // iPAddress — the standard Java X.509 API returns this as a String
+                        // (dotted-quad or colon-hex), but some providers (e.g. BouncyCastle)
+                        // return a ByteArray; handle both defensively.
+                        // Normalize both sides through InetAddress so that different textual
+                        // representations of the same address compare equal (e.g. "::1" vs
+                        // "0:0:0:0:0:0:0:1").
+                        val sanAddress = try {
+                            when (val ipEntry = san[1]) {
+                                is ByteArray -> InetAddress.getByAddress(ipEntry)
+                                is String -> InetAddress.getByName(ipEntry)
+                                else -> return@any false
+                            }
+                        } catch (_: UnknownHostException) {
+                            return@any false
+                        }
+                        val hostAddress = try {
+                            InetAddress.getByName(host)
+                        } catch (_: UnknownHostException) {
+                            return@any false
+                        }
+                        hostAddress == sanAddress
+                    }
+                    else -> false
+                }
+            }
+        } else {
+            // Fallback: extract CN from the Subject DN.
+            // getName(RFC2253) uses comma as AVA separator; commas inside values are escaped
+            // as \, which we don't need to handle because hostnames never contain commas.
+            val dn = cert.subjectX500Principal.getName(X500Principal.RFC2253)
+            val cn = dn.splitToSequence(",")
+                .map { it.trim() }
+                .firstOrNull { it.startsWith("CN=", ignoreCase = true) }
+                ?.let { it.substring(it.indexOf('=') + 1).trim() }
+                ?.takeIf { it.isNotEmpty() }
+            cn != null && hostMatchesSan(host, cn)
+        }
+    }
+
+    /**
+     * Matches [host] against a SAN value that may contain a leading wildcard.
+     *
+     * A wildcard (`*.example.com`) covers any single label: `foo.example.com` matches but
+     * `foo.bar.example.com` and `example.com` do not (per RFC 2818 §3.1).
+     */
+    private fun hostMatchesSan(host: String, san: String): Boolean {
+        if (!san.startsWith("*.")) return host.equals(san, ignoreCase = true)
+        val suffix = san.substring(1) // ".example.com"
+        if (!host.endsWith(suffix, ignoreCase = true)) return false
+        val wildcardLabel = host.substring(0, host.length - suffix.length)
+        return wildcardLabel.isNotEmpty() && !wildcardLabel.contains('.')
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
@@ -12,14 +12,22 @@ import android.webkit.WebViewClient
 import androidx.annotation.VisibleForTesting
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import java.lang.ref.WeakReference
+import java.net.InetAddress
+import java.net.UnknownHostException
 import java.security.PrivateKey
 import java.security.cert.CertificateException
+import java.security.cert.CertificateParsingException
 import java.security.cert.X509Certificate
+import javax.security.auth.x500.X500Principal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
+
+// SAN (Subject Alternative Name) type codes per RFC 5280 section 4.2.1.6
+private const val SAN_TYPE_DNS_NAME = 2
+private const val SAN_TYPE_IP_ADDRESS = 7
 
 /*
  * [TLSWebViewClient] is on the onboarding module for convenience, since we don't have yet
@@ -39,6 +47,117 @@ open class TLSWebViewClient(private var keyChainRepository: KeyChainRepository) 
 
     private var key: PrivateKey? = null
     private var chain: Array<X509Certificate>? = null
+
+    /**
+     * Pre-initializes [isTLSClientAuthNeeded] by verifying whether the currently loaded
+     * certificate chain covers [targetHost], to handle TLS session resumption.
+     *
+     * Normally [isTLSClientAuthNeeded] is set when [onReceivedClientCertRequest] fires during
+     * a full TLS handshake. However, when TLS session resumption occurs (the WebView reuses an
+     * existing session from the same process), the server does not issue a new
+     * `CertificateRequest`, so [onReceivedClientCertRequest] is never called — even if the
+     * server requires a client certificate.
+     *
+     * This is the root cause of the Wear OS onboarding mTLS failure: the main app WebView
+     * establishes a TLS session while the user is connected; the onboarding WebView immediately
+     * resumes it, bypassing the callback that would reveal the mTLS requirement to the
+     * navigation layer.
+     *
+     * The fix inspects the in-memory certificate chain (if any) and checks whether it covers
+     * [targetHost] via its Subject Alternative Names (SANs), or its Common Name (CN) as a
+     * fallback. This avoids a false positive when the user has multiple servers where only one
+     * requires mTLS: the loaded cert will not match the non-mTLS server's hostname.
+     *
+     * If the app was force-stopped first (clearing in-memory state) no TLS session can be
+     * resumed either, so [onReceivedClientCertRequest] will fire naturally on the fresh handshake.
+     *
+     * Must be called **before** the WebView starts loading (i.e. before the URL is emitted).
+     * Idempotent: if the flag is already `true` (set by a real handshake) this is a no-op.
+     *
+     * @param targetHost the hostname of the server being connected to (e.g. "myha.example.com")
+     */
+    fun preInitializeTLSClientAuthState(targetHost: String) {
+        if (isTLSClientAuthNeeded) return
+        val cert = keyChainRepository.getCertificateChain()?.firstOrNull() ?: return
+        isTLSClientAuthNeeded = certCoversHost(cert, targetHost)
+    }
+
+    /**
+     * Returns `true` if [cert] is valid for [host].
+     *
+     * Checks Subject Alternative Names (SANs) first — both DNS names (with wildcard support)
+     * and IP addresses. Falls back to the Common Name (CN) in the Subject DN if no SANs are
+     * present, matching the behaviour of legacy TLS stacks.
+     */
+    private fun certCoversHost(cert: X509Certificate, host: String): Boolean {
+        val sans: Collection<List<*>>? = try {
+            cert.subjectAlternativeNames
+        } catch (_: CertificateParsingException) {
+            null
+        }
+
+        return if (!sans.isNullOrEmpty()) {
+            sans.any { san ->
+                if (san.size < 2) return@any false
+                val type = san[0] as? Int ?: return@any false
+                when (type) {
+                    SAN_TYPE_DNS_NAME -> { // dNSName — returned as String
+                        val value = san[1] as? String ?: return@any false
+                        hostMatchesSan(host, value)
+                    }
+                    SAN_TYPE_IP_ADDRESS -> {
+                        // iPAddress — the standard Java X.509 API returns this as a String
+                        // (dotted-quad or colon-hex), but some providers (e.g. BouncyCastle)
+                        // return a ByteArray; handle both defensively.
+                        // Normalize both sides through InetAddress so that different textual
+                        // representations of the same address compare equal (e.g. "::1" vs
+                        // "0:0:0:0:0:0:0:1").
+                        val sanAddress = try {
+                            when (val ipEntry = san[1]) {
+                                is ByteArray -> InetAddress.getByAddress(ipEntry)
+                                is String -> InetAddress.getByName(ipEntry)
+                                else -> return@any false
+                            }
+                        } catch (_: UnknownHostException) {
+                            return@any false
+                        }
+                        val hostAddress = try {
+                            InetAddress.getByName(host)
+                        } catch (_: UnknownHostException) {
+                            return@any false
+                        }
+                        hostAddress == sanAddress
+                    }
+                    else -> false
+                }
+            }
+        } else {
+            // Fallback: extract CN from the Subject DN.
+            // getName(RFC2253) uses comma as AVA separator; commas inside values are escaped
+            // as \, which we don't need to handle because hostnames never contain commas.
+            val dn = cert.subjectX500Principal.getName(X500Principal.RFC2253)
+            val cn = dn.splitToSequence(",")
+                .map { it.trim() }
+                .firstOrNull { it.startsWith("CN=", ignoreCase = true) }
+                ?.let { it.substring(it.indexOf('=') + 1).trim() }
+                ?.takeIf { it.isNotEmpty() }
+            cn != null && hostMatchesSan(host, cn)
+        }
+    }
+
+    /**
+     * Matches [host] against a SAN value that may contain a leading wildcard.
+     *
+     * A wildcard (`*.example.com`) covers any single label: `foo.example.com` matches but
+     * `foo.bar.example.com` and `example.com` do not (per RFC 2818 §3.1).
+     */
+    private fun hostMatchesSan(host: String, san: String): Boolean {
+        if (!san.startsWith("*.")) return host.equals(san, ignoreCase = true)
+        val suffix = san.substring(1) // ".example.com"
+        if (!host.endsWith(suffix, ignoreCase = true)) return false
+        val wildcardLabel = host.substring(0, host.length - suffix.length)
+        return wildcardLabel.isNotEmpty() && !wildcardLabel.contains('.')
+    }
 
     private fun getActivity(context: Context?): Activity? {
         if (context == null) {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -24,7 +24,10 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
+import java.net.InetAddress
 import java.net.URL
+import java.security.cert.CertificateParsingException
+import java.security.cert.X509Certificate
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -707,4 +710,242 @@ class ConnectionViewModelTest {
         verify { filePathCallback.onReceiveValue(null) }
         assertNull(viewModel.pendingFileChooser.value)
     }
+
+    // --- preInitializeTLSClientAuthState / cert-host matching tests ---
+
+    @Test
+    fun `Given cert with exact DNS SAN matching target host when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "homeassistant.local"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with wildcard DNS SAN matching target host when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://ha.example.com",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with DNS SAN for a different host when initializing then isTLSClientAuthNeeded remains false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "other-server.example.com"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given no certificate chain in memory when initializing then isTLSClientAuthNeeded remains false`() = runTest {
+        every { keyChainRepository.getCertificateChain() } returns null
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with CN matching target host and no SANs when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns null
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with wildcard SAN that does not cover a multi-label subdomain when initializing then isTLSClientAuthNeeded remains false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            // *.example.com covers foo.example.com but not foo.bar.example.com
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://foo.bar.example.com",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with wildcard SAN that does not cover apex domain when initializing then isTLSClientAuthNeeded remains false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            // *.example.com covers foo.example.com but not example.com itself (RFC 2818 §3.1)
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://example.com",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with non-matching SANs and matching CN when initializing then isTLSClientAuthNeeded remains false`() = runTest {
+        // When SANs are present, the CN must not be used as fallback even if it would match —
+        // this is the standard behaviour defined in RFC 2818 §3.1.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "other-server.example.com"))
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertFalse(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with IP address SAN as ByteArray matching target host when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        // Some providers (e.g. BouncyCastle) return iPAddress (type 7) as a ByteArray.
+        val ipBytes = InetAddress.getByName("192.168.1.100").address
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, ipBytes))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://192.168.1.100",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with IP address SAN as String matching target host when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        // The standard Java X.509 API returns iPAddress (type 7) as a String (dotted-quad or colon-hex).
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, "192.168.1.100"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://192.168.1.100",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with IPv6 SAN in expanded form matching target host in compressed form when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        // InetAddress equality normalizes different textual forms of the same IPv6 address.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, "0:0:0:0:0:0:0:1"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "https://[::1]",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert with DNS SAN in mixed case when initializing then isTLSClientAuthNeeded is pre-set to true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "HomeAssistant.Local"))
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
+    @Test
+    fun `Given cert whose subjectAlternativeNames throws CertificateParsingException when initializing then falls back to CN matching`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } throws CertificateParsingException("bad extension")
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        every { keyChainRepository.getCertificateChain() } returns arrayOf(cert)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+        )
+        advanceUntilIdle()
+
+        assertTrue(viewModel.webViewClient.isTLSClientAuthNeeded)
+    }
+
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -19,6 +19,7 @@ import io.homeassistant.companion.android.common.data.keychain.KeyChainRepositor
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
+import io.homeassistant.companion.android.util.CheckTLSClientAuthNeededUseCase
 import io.homeassistant.companion.android.util.HAWebViewClient
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
 import io.mockk.coEvery
@@ -28,6 +29,7 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import java.net.URL
+import java.security.cert.X509Certificate
 import kotlin.reflect.KClass
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -95,7 +97,7 @@ class ConnectionViewModelTest {
     @ParameterizedTest
     @ValueSource(strings = ["http://homeassistant.local:8123", "https://cloud.ui.nabu.casa"])
     fun `Given a valid http url when buildAuthUrl then urlFlow emits correct auth url and isLoading is false`(baseUrl: String) = runTest {
-        val viewModel = ConnectionViewModel(baseUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel(baseUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val urlFlow = viewModel.urlFlow.testIn(backgroundScope)
@@ -126,7 +128,7 @@ class ConnectionViewModelTest {
     @ValueSource(strings = ["http://homeassistant.local:8123", "https://cloud.ui.nabu.casa"])
     fun `Given a valid http url with suffix when buildAuthUrl then urlFlow emits correct auth url with path stripped`(baseUrl: String) = runTest {
         val suffix = "/hello?query=param&isHA=true#segment"
-        val viewModel = ConnectionViewModel("$baseUrl$suffix", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel("$baseUrl$suffix", webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val urlFlow = viewModel.urlFlow.testIn(backgroundScope)
@@ -143,7 +145,7 @@ class ConnectionViewModelTest {
     @Test
     fun `Given a malformed url when buildAuthUrl then errorFlow emits malformed url error`() = runTest {
         val malformedUrl = "not_a_url"
-        val viewModel = ConnectionViewModel(malformedUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel(malformedUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -172,7 +174,7 @@ class ConnectionViewModelTest {
         val authCode = "test_auth_code"
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -207,6 +209,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -235,6 +238,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -261,6 +265,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -287,6 +292,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -313,6 +319,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -339,6 +346,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -362,6 +370,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -386,6 +395,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         turbineScope {
@@ -409,7 +419,7 @@ class ConnectionViewModelTest {
     fun `Given auth callback uri without code when shouldRedirect then no event and returns false`() = runTest {
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = null)
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -437,7 +447,7 @@ class ConnectionViewModelTest {
             isOpaque = true,
         )
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -458,7 +468,7 @@ class ConnectionViewModelTest {
 
     @Test
     fun `Given unmatching uri and webview not null when shouldRedirect is invoked then open in external browser and return true`() = runTest {
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         // Used to parse the rawUrl given in the constructor of ConnectionViewModel
         mockUriParse()
@@ -545,7 +555,7 @@ class ConnectionViewModelTest {
         val connectivityFlow = MutableSharedFlow<ConnectivityCheckState>()
         every { connectivityCheckRepository.runChecks(rawUrl) } returns connectivityFlow
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
         val webView = mockWebView()
 
         advanceUntilIdle()
@@ -586,7 +596,7 @@ class ConnectionViewModelTest {
 
         every { connectivityCheckRepository.runChecks(rawUrl) } returnsMany listOf(first, second)
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
 
         // When: first click on "Run checks"
         viewModel.runConnectivityChecks()
@@ -615,7 +625,7 @@ class ConnectionViewModelTest {
         val connectivityFlow = MutableSharedFlow<ConnectivityCheckState>()
         every { connectivityCheckRepository.runChecks(rawUrl) } returns connectivityFlow
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager, CheckTLSClientAuthNeededUseCase(keyChainRepository))
         advanceUntilIdle()
 
         assertNull(viewModel.errorFlow.value)
@@ -642,6 +652,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
@@ -667,6 +678,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
@@ -695,6 +707,7 @@ class ConnectionViewModelTest {
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
         )
 
         val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
@@ -713,5 +726,138 @@ class ConnectionViewModelTest {
 
         verify { filePathCallback.onReceiveValue(null) }
         assertNull(viewModel.pendingFileChooser.value)
+    }
+
+    @Test
+    fun `Given cert in memory covering the target host and client flag false when auth completes then Authenticated emits requiredMTLS true`() = runTest {
+        // Session resumption case: no CertificateRequest fires, so the client flag stays false,
+        // but the loaded certificate chain covers the host the user connected to.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "homeassistant.local"))
+        }
+        val provider = mockk<ClientCertProvider> {
+            every { certificate } returns ClientCertificate(mockk(), arrayOf(cert))
+        }
+        coEvery { keyChainRepository.getClientCertProvider() } returns provider
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+            val errorFlow = viewModel.errorFlow.testIn(backgroundScope)
+
+            assertNull(errorFlow.awaitItem())
+
+            viewModel.getWebViewClient().isTLSClientAuthNeeded = false
+
+            val result = viewModel.getWebViewClient().shouldOverrideUrlLoading(
+                null,
+                stringUri,
+            )
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertTrue(event is ConnectionNavigationEvent.Authenticated)
+            assertEquals(authCode, (event as ConnectionNavigationEvent.Authenticated).authCode)
+            assertEquals("http://homeassistant.local:8123", event.url)
+            assertTrue(event.requiredMTLS)
+            errorFlow.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given cert in memory not covering the target host and client flag false when auth completes then Authenticated emits requiredMTLS false`() = runTest {
+        // Multiple servers where only one requires mTLS: the loaded cert is for another host,
+        // so the check must not mark this connection as requiring a client certificate.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "other-server.example.com"))
+        }
+        val provider = mockk<ClientCertProvider> {
+            every { certificate } returns ClientCertificate(mockk(), arrayOf(cert))
+        }
+        coEvery { keyChainRepository.getClientCertProvider() } returns provider
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+            val errorFlow = viewModel.errorFlow.testIn(backgroundScope)
+
+            assertNull(errorFlow.awaitItem())
+
+            viewModel.getWebViewClient().isTLSClientAuthNeeded = false
+
+            val result = viewModel.getWebViewClient().shouldOverrideUrlLoading(
+                null,
+                stringUri,
+            )
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertTrue(event is ConnectionNavigationEvent.Authenticated)
+            assertEquals(authCode, (event as ConnectionNavigationEvent.Authenticated).authCode)
+            assertEquals("http://homeassistant.local:8123", event.url)
+            assertFalse(event.requiredMTLS)
+            errorFlow.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given cert in memory covering the target host and client flag true when auth completes then Authenticated emits requiredMTLS true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "homeassistant.local"))
+        }
+        val provider = mockk<ClientCertProvider> {
+            every { certificate } returns ClientCertificate(mockk(), arrayOf(cert))
+        }
+        coEvery { keyChainRepository.getClientCertProvider() } returns provider
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+            CheckTLSClientAuthNeededUseCase(keyChainRepository),
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+            val errorFlow = viewModel.errorFlow.testIn(backgroundScope)
+
+            assertNull(errorFlow.awaitItem())
+
+            viewModel.getWebViewClient().isTLSClientAuthNeeded = true
+
+            val result = viewModel.getWebViewClient().shouldOverrideUrlLoading(
+                null,
+                stringUri,
+            )
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertTrue(event is ConnectionNavigationEvent.Authenticated)
+            assertEquals(authCode, (event as ConnectionNavigationEvent.Authenticated).authCode)
+            assertEquals("http://homeassistant.local:8123", event.url)
+            assertTrue(event.requiredMTLS)
+            errorFlow.expectNoEvents()
+        }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/CheckTLSClientAuthNeededUseCaseTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/CheckTLSClientAuthNeededUseCaseTest.kt
@@ -1,0 +1,223 @@
+package io.homeassistant.companion.android.util
+
+import io.homeassistant.companion.android.common.data.keychain.ClientCertProvider
+import io.homeassistant.companion.android.common.data.keychain.ClientCertificate
+import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import java.net.InetAddress
+import java.security.cert.CertificateParsingException
+import java.security.cert.X509Certificate
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [CheckTLSClientAuthNeededUseCase].
+ */
+class CheckTLSClientAuthNeededUseCaseTest {
+
+    private val keyChainRepository: KeyChainRepository = mockk(relaxed = true)
+
+    private val useCase = CheckTLSClientAuthNeededUseCase(keyChainRepository)
+
+    private fun stubLoadedCertificate(cert: X509Certificate?) {
+        val clientCertificate = cert?.let { ClientCertificate(mockk(), arrayOf(it)) }
+        val provider = mockk<ClientCertProvider> {
+            every { certificate } returns clientCertificate
+        }
+        coEvery { keyChainRepository.getClientCertProvider() } returns provider
+    }
+
+    @Test
+    fun `Given cert with exact DNS SAN matching target host when checking then returns true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "homeassistant.local"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with wildcard DNS SAN matching target host when checking then returns true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("ha.example.com"))
+    }
+
+    @Test
+    fun `Given cert with DNS SAN for a different host when checking then returns false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "other-server.example.com"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given no certificate chain in memory when checking then returns false`() = runTest {
+        stubLoadedCertificate(null)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given null or blank target host when checking then returns false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "homeassistant.local"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase(null))
+        assertFalse(useCase(""))
+    }
+
+    @Test
+    fun `Given cert with CN matching target host and no SANs when checking then returns true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns null
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with only an empty CN when checking then returns false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns null
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=,O=Home Assistant"
+            }
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with wildcard SAN that does not cover a multi-label subdomain when checking then returns false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            // *.example.com covers foo.example.com but not foo.bar.example.com
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("foo.bar.example.com"))
+    }
+
+    @Test
+    fun `Given cert with wildcard SAN that does not cover apex domain when checking then returns false`() = runTest {
+        val cert = mockk<X509Certificate> {
+            // *.example.com covers foo.example.com but not example.com itself (RFC 2818 §3.1)
+            every { subjectAlternativeNames } returns listOf(listOf(2, "*.example.com"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("example.com"))
+    }
+
+    @Test
+    fun `Given cert with non-matching SANs and matching CN when checking then returns false`() = runTest {
+        // When SANs are present, the CN must not be used as fallback even if it would match —
+        // this is the standard behaviour defined in RFC 2818 §3.1.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "other-server.example.com"))
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with IP address SAN as ByteArray matching target host when checking then returns true`() = runTest {
+        // Some providers (e.g. BouncyCastle) return iPAddress (type 7) as a ByteArray.
+        val ipBytes = InetAddress.getByName("192.168.1.100").address
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, ipBytes))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("192.168.1.100"))
+    }
+
+    @Test
+    fun `Given cert with IP address SAN as String matching target host when checking then returns true`() = runTest {
+        // The standard Java X.509 API returns iPAddress (type 7) as a String (dotted-quad or colon-hex).
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, "192.168.1.100"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("192.168.1.100"))
+    }
+
+    @Test
+    fun `Given cert with IPv6 SAN in expanded form matching target host in compressed form when checking then returns true`() = runTest {
+        // InetAddress equality normalizes different textual forms of the same IPv6 address.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(7, "0:0:0:0:0:0:0:1"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("::1"))
+    }
+
+    @Test
+    fun `Given cert with DNS SAN in mixed case when checking then returns true`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2, "HomeAssistant.Local"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert whose subjectAlternativeNames throws CertificateParsingException when checking then falls back to CN matching`() = runTest {
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } throws CertificateParsingException("bad extension")
+            every { subjectX500Principal } returns mockk {
+                every { getName("RFC2253") } returns "CN=homeassistant.local,O=Home Assistant"
+            }
+        }
+        stubLoadedCertificate(cert)
+
+        assertTrue(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with a malformed SAN entry when checking then returns false`() = runTest {
+        // A SAN entry must have at least a type and a value (RFC 5280 section 4.2.1.6).
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(2))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+
+    @Test
+    fun `Given cert with a SAN of an unrelated type when checking then returns false`() = runTest {
+        // Type 1 is rfc822Name (email), which is irrelevant for hostname matching.
+        val cert = mockk<X509Certificate> {
+            every { subjectAlternativeNames } returns listOf(listOf(1, "someone@example.com"))
+        }
+        stubLoadedCertificate(cert)
+
+        assertFalse(useCase("homeassistant.local"))
+    }
+}


### PR DESCRIPTION
## Problem

When setting up a Wear OS device through the Home Assistant phone app, the mTLS certificate
selection screen is silently skipped, causing the watch to register without a client certificate
and the server to respond with `HTTP 400`.

The root cause is **TLS session resumption**:

1. The main HA app WebView authenticates with the server — a TLS session ticket is created.
2. The user opens the Wear OS onboarding flow (either from the watch or via the phone app).
3. The onboarding WebView connects to the _same_ host; the OS TLS stack resumes the existing session (abbreviated handshake — no new `CertificateRequest` from the server).
4. `WebViewClient.onReceivedClientCertRequest()` is never invoked.
5. `TLSWebViewClient.isTLSClientAuthNeeded` remains `false`.
6. `requiredMTLS = false` is passed through `ConnectionNavigationEvent.Authenticated` → `OnboardingNavigation` skips `wearMTLSScreen`.
7. The watch is registered without a cert → server returns `400 Bad Request`.

## Fix

`TLSWebViewClient` gains `preInitializeTLSClientAuthState(targetHost: String)` that checks the in-memory certificate chain (if any) and tests whether it covers `targetHost` by matching against the certificate Subject Alternative Names (SANs):

- **dNSName** entries (type 2) with full wildcard support per RFC 2818 §3.1
- **iPAddress** entries (type 7) for IP-addressed instances
- **Common Name (CN)** fallback for legacy certificates that lack SANs

Matching against the certificate SANs — rather than mere private-key presence — eliminates the false positive identified in review: if a user has multiple servers where only Server A requires mTLS, the cert for Server A will **not** match Server B hostname, so the mTLS screen is suppressed correctly.

## Files changed

- `app/.../util/TLSWebViewClient.kt` — `preInitializeTLSClientAuthState()` + `certCoversHost()` + `hostMatchesSan()` helpers
- `app/.../onboarding/connection/ConnectionViewModel.kt` — Extract host from `rawUrl` and pass to `preInitializeTLSClientAuthState()`
- `app/.../onboarding/connection/ConnectionViewModelTest.kt` — 13 cert-host matching tests

## Review comments addressed

- certCoversHost is private (no @VisibleForTesting)
- Catches CertificateParsingException instead of generic Exception
- Catches IllegalArgumentException in ConnectionViewModel (cancellation-safe)
- Named SAN type constants instead of magic numbers (RFC 5280 §4.2.1.6)
- IP SAN handled as both ByteArray (BouncyCastle) and String (standard Java)
- Verbose comments in ConnectionViewModel trimmed
- Fork-specific CI workflow commits removed — zero CI changes
- Rebased onto latest home-assistant:main