### PR TITLE
Skip car intent for car_ui notifications on non-Automotive minimal flavor

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1186,7 +1186,7 @@ class MessagingManager @Inject constructor(
                         carIntent.hashCode(),
                         carIntent,
                         PendingIntent.FLAG_IMMUTABLE,
-                    )
+                    ),
                 )
             }
             builder.extend(carExtender.build())

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -44,6 +44,7 @@ import androidx.core.graphics.scale
 import androidx.core.net.toUri
 import androidx.core.text.isDigitsOnly
 import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.common.R as commonR
@@ -67,6 +68,7 @@ import io.homeassistant.companion.android.common.notifications.parseVibrationPat
 import io.homeassistant.companion.android.common.notifications.prepareText
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
 import io.homeassistant.companion.android.common.util.getActiveNotification
+import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
 import io.homeassistant.companion.android.common.util.toJsonObject
 import io.homeassistant.companion.android.common.util.tts.TextToSpeechClient
@@ -1173,21 +1175,21 @@ class MessagingManager @Inject constructor(
         data: Map<String, String>,
     ): Boolean {
         if (data[CAR_UI]?.toBoolean() == true && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val carIntent = Intent(Intent.ACTION_VIEW).apply {
-                component = ComponentName(context, HaCarAppService::class.java)
-            }
-            builder.extend(
-                CarAppExtender.Builder()
-                    .setContentIntent(
-                        CarPendingIntent.getCarApp(
-                            context,
-                            carIntent.hashCode(),
-                            carIntent,
-                            PendingIntent.FLAG_IMMUTABLE,
-                        ),
+            val carExtender = CarAppExtender.Builder()
+            if (context.isAutomotive() || BuildConfig.FLAVOR == "full") {
+                val carIntent = Intent(Intent.ACTION_VIEW).apply {
+                    component = ComponentName(context, HaCarAppService::class.java)
+                }
+                carExtender.setContentIntent(
+                    CarPendingIntent.getCarApp(
+                        context,
+                        carIntent.hashCode(),
+                        carIntent,
+                        PendingIntent.FLAG_IMMUTABLE,
                     )
-                    .build(),
-            )
+                )
+            }
+            builder.extend(carExtender.build())
             return true
         }
         return false


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fix #6676 by not providing an intent to the app's car service when using the minimal flavor on a non-Automotive device.

 - The _service_ exists, but it's not referenced in the manifest as you need the UI library. The available UIs are for Automotive (full and minimal support) or projected (= Android Auto, full only).
 - The _extender_ is still set, as you might want phone notifications showing in a car interface when using the minimal app.

(I suppose we could include the projected library with minimal, as the library is open source, but Android Auto itself is closed source and there are no open source projection apps AFAIK. It makes little sense why we would bundle something that can only be used with closed source in a flavor trying to be 100% open source.)

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
I don't think this very specific exception needs documenting.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
