### PR TITLE
Make sure to use repository English translation instead of Lokalise

### DIFF
--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -10,6 +10,11 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Record commit before pull
+      id: before-pull
+      shell: bash
+      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
     - name: Pull from Lokalise
       uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
       with:
@@ -26,6 +31,14 @@ runs:
           add_newline_eof: true
           replace_breaks: true
           export_empty_as: skip
+
+    - name: Verify no commit was created by pull
+      shell: bash
+      run: |
+        if [ "$(git rev-parse HEAD)" != "${{ steps.before-pull.outputs.sha }}" ]; then
+          echo "::error::Lokalise pull action created an unexpected commit"
+          exit 1
+        fi
 
     - name: Generate locales_config.xml
       shell: bash

--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Pull from Lokalise
       uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
-      with: &lokalise-pull-config
+      with:
         api_token: ${{ inputs.lokalise-token }}
         project_id: ${{ inputs.lokalise-project }}
         custom_github_token: "FAKE_GH_TOKEN"
@@ -51,7 +51,20 @@ runs:
     - name: Retry pull from Lokalise
       if: steps.first-sync-check.outputs.dirty == 'true'
       uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
-      with: *lokalise-pull-config
+      with:
+        api_token: ${{ inputs.lokalise-token }}
+        project_id: ${{ inputs.lokalise-project }}
+        custom_github_token: "FAKE_GH_TOKEN"
+        file_format: xml
+        async_mode: true
+        skip_include_tags: true
+        skip_original_filenames: true
+        additional_params: |
+          original_filenames: false
+          bundle_structure: common/src/main/res/values-%LANG_ISO%/strings.%FORMAT%
+          add_newline_eof: true
+          replace_breaks: true
+          export_empty_as: skip
 
     - name: Verify source strings are in sync with Lokalise
       if: steps.first-sync-check.outputs.dirty == 'true'

--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -27,54 +27,13 @@ runs:
           replace_breaks: true
           export_empty_as: skip
 
-    - name: Check source strings are in sync with Lokalise
-      id: first-sync-check
+    # Source strings (English) are managed in git, not Lokalise.
+    # Restore the file in case Lokalise overwrote it.
+    - name: Revert source strings to git version
       shell: bash
       run: |
-        if ! git diff --quiet common/src/main/res/values/strings.xml; then
-          echo "::warning::Source strings were modified by Lokalise pull, retrying in 30s"
-          echo "dirty=true" >> "$GITHUB_OUTPUT"
-          git checkout common/src/main/res/values/strings.xml
-        fi
-
-    # Source strings out of sync usually means Lokalise hasn't processed the
-    # GitHub webhook yet (propagation delay) or the webhook token has expired.
-    # Wait 1 minute to give Lokalise time to sync, then retry.
-    # If it still fails, check the webhook configuration in Lokalise.
-    # Proceeding with dirty source strings would leave uncommitted changes in git
-    # and lead to a wrong version name within the app.
-    - name: Wait for Lokalise to sync
-      if: steps.first-sync-check.outputs.dirty == 'true'
-      shell: bash
-      run: sleep 60
-
-    - name: Retry pull from Lokalise
-      if: steps.first-sync-check.outputs.dirty == 'true'
-      uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
-      with:
-        api_token: ${{ inputs.lokalise-token }}
-        project_id: ${{ inputs.lokalise-project }}
-        custom_github_token: "FAKE_GH_TOKEN"
-        file_format: xml
-        async_mode: true
-        skip_include_tags: true
-        skip_original_filenames: true
-        additional_params: |
-          original_filenames: false
-          bundle_structure: common/src/main/res/values-%LANG_ISO%/strings.%FORMAT%
-          add_newline_eof: true
-          replace_breaks: true
-          export_empty_as: skip
-
-    - name: Verify source strings are in sync with Lokalise
-      if: steps.first-sync-check.outputs.dirty == 'true'
-      shell: bash
-      run: |
-        if ! git diff --quiet common/src/main/res/values/strings.xml; then
-          echo "::error::Source strings (common/src/main/res/values/strings.xml) were modified by Lokalise pull after retry, Lokalise is out of sync"
-          git diff common/src/main/res/values/strings.xml
-          exit 1
-        fi
+        git checkout common/src/main/res/values/strings.xml
+        git status
 
     - name: Generate locales_config.xml
       shell: bash

--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -10,14 +10,9 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Record commit before pull
-      id: before-pull
-      shell: bash
-      run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
     - name: Pull from Lokalise
       uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
-      with:
+      with: &lokalise-pull-config
         api_token: ${{ inputs.lokalise-token }}
         project_id: ${{ inputs.lokalise-project }}
         custom_github_token: "FAKE_GH_TOKEN"
@@ -32,11 +27,39 @@ runs:
           replace_breaks: true
           export_empty_as: skip
 
-    - name: Verify no commit was created by pull
+    - name: Check source strings are in sync with Lokalise
+      id: first-sync-check
       shell: bash
       run: |
-        if [ "$(git rev-parse HEAD)" != "${{ steps.before-pull.outputs.sha }}" ]; then
-          echo "::error::Lokalise pull action created an unexpected commit"
+        if ! git diff --quiet common/src/main/res/values/strings.xml; then
+          echo "::warning::Source strings were modified by Lokalise pull, retrying in 30s"
+          echo "dirty=true" >> "$GITHUB_OUTPUT"
+          git checkout common/src/main/res/values/strings.xml
+        fi
+
+    # Source strings out of sync usually means Lokalise hasn't processed the
+    # GitHub webhook yet (propagation delay) or the webhook token has expired.
+    # Wait 1 minute to give Lokalise time to sync, then retry.
+    # If it still fails, check the webhook configuration in Lokalise.
+    # Proceeding with dirty source strings would leave uncommitted changes in git
+    # and lead to a wrong version name within the app.
+    - name: Wait for Lokalise to sync
+      if: steps.first-sync-check.outputs.dirty == 'true'
+      shell: bash
+      run: sleep 60
+
+    - name: Retry pull from Lokalise
+      if: steps.first-sync-check.outputs.dirty == 'true'
+      uses: lokalise/lokalise-pull-action@a4968e06b7f44c32317b162d825ed17abb5772d0 # v5.0.1
+      with: *lokalise-pull-config
+
+    - name: Verify source strings are in sync with Lokalise
+      if: steps.first-sync-check.outputs.dirty == 'true'
+      shell: bash
+      run: |
+        if ! git diff --quiet common/src/main/res/values/strings.xml; then
+          echo "::error::Source strings (common/src/main/res/values/strings.xml) were modified by Lokalise pull after retry, Lokalise is out of sync"
+          git diff common/src/main/res/values/strings.xml
           exit 1
         fi
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
https://github.com/home-assistant/android/pull/1397 made sure that we were not overriding the English translation that we have in the repository even if Lokalise have a different version using `unzip -n` that skip file that already exists. Recently I've migrated to the Lokalise Github action #6659 and I didn't know this, because of that change we are currently creating release with wrong version name as pointed out by @jpelgrom in https://github.com/home-assistant/android/pull/6659#issuecomment-4196534670.

I reverted to the previous behavior by simply checking out the strings.xml back to revert any changes made by Lokalize while downloading the other translations.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
We might need to document this somewhere that English is not in Lokalize? Maybe it is already  and I didn't read it.