### PR TITLE
UrlFlow and errorFlow are initialized with the state value and eagerly started

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -24,7 +24,6 @@ import io.homeassistant.companion.android.util.HAWebChromeClient
 import io.homeassistant.companion.android.util.HAWebViewClient
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
 import javax.inject.Inject
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.Job
@@ -35,7 +34,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.WhileSubscribed
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -49,9 +47,6 @@ import timber.log.Timber
 /** Maximum time to wait for the frontend to load before showing a timeout error. */
 @VisibleForTesting
 val CONNECTION_TIMEOUT = 10.seconds
-
-/** Delay before stopping shared flows after the last subscriber disconnects. */
-private val SUBSCRIPTION_STOP_DELAY = 500.milliseconds
 
 /**
  * ViewModel for frontend screen.
@@ -144,12 +139,12 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     override val urlFlow: StateFlow<String?> =
         _viewState.map { it.url }
             .distinctUntilChanged()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIPTION_STOP_DELAY), null)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, _viewState.value.url)
 
     override val errorFlow: StateFlow<FrontendConnectionError?> =
         _viewState.map { state -> (state as? FrontendViewState.Error)?.error }
             .distinctUntilChanged()
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(SUBSCRIPTION_STOP_DELAY), null)
+            .stateIn(viewModelScope, SharingStarted.Eagerly, (_viewState.value as? FrontendViewState.Error)?.error)
 
     /** Flow of scripts to be evaluated in the WebView. */
     val scriptsToEvaluate: Flow<WebViewScript> = frontendMessageHandler.scriptsToEvaluate()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -275,6 +275,37 @@ class FrontendViewModelTest {
     }
 
     @Nested
+    inner class DerivedFlows {
+
+        @Test
+        fun `Given url manager returns success when urlFlow is subscribed then urlFlow value matches viewState url`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val viewModel = createViewModel()
+
+            val job = backgroundScope.launch { viewModel.urlFlow.collect {} }
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+
+            assertEquals(testUrlWithAuth, viewModel.urlFlow.value)
+            job.cancel()
+        }
+
+        @Test
+        fun `Given error state then errorFlow value matches viewState error`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.ServerNotFound(serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.errorFlow.value is FrontendConnectionError.UnreachableError)
+        }
+    }
+
+    @Nested
     inner class ErrorFlow {
 
         @Test
@@ -284,15 +315,9 @@ class FrontendViewModelTest {
             )
 
             val viewModel = createViewModel()
-
-            // Subscribe to errorFlow to activate the stateIn with WhileSubscribed
-            val errors = mutableListOf<FrontendConnectionError?>()
-            val job = backgroundScope.launch { viewModel.errorFlow.collect { errors.add(it) } }
-
             advanceUntilIdle()
 
-            assertTrue(errors.any { it is FrontendConnectionError.UnreachableError })
-            job.cancel()
+            assertTrue(viewModel.errorFlow.value is FrontendConnectionError.UnreachableError)
         }
 
         @Test
@@ -301,15 +326,10 @@ class FrontendViewModelTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns urlResults
 
             val viewModel = createViewModel()
-
-            // Subscribe to errorFlow to activate the stateIn with WhileSubscribed
-            val errors = mutableListOf<FrontendConnectionError?>()
-            val job = backgroundScope.launch { viewModel.errorFlow.collect { errors.add(it) } }
-
             advanceUntilIdle()
 
             // Verify error exists
-            assertTrue(errors.any { it != null })
+            assertTrue(viewModel.errorFlow.value != null)
 
             // Setup successful response for retry
             urlResults.value = UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId)
@@ -317,9 +337,8 @@ class FrontendViewModelTest {
             viewModel.onRetry()
             advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
 
-            // Error should be cleared - the last emitted error should be null
-            assertTrue(errors.last() == null)
-            job.cancel()
+            // Error should be cleared
+            assertEquals(null, viewModel.errorFlow.value)
         }
 
         @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -278,22 +278,20 @@ class FrontendViewModelTest {
     inner class DerivedFlows {
 
         @Test
-        fun `Given url manager returns success when urlFlow is subscribed then urlFlow value matches viewState url`() = runTest {
+        fun `Given url manager returns success then urlFlow value matches viewState url without subscribers`() = runTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
             )
 
             val viewModel = createViewModel()
-
-            val job = backgroundScope.launch { viewModel.urlFlow.collect {} }
             advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
 
+            // No collector on urlFlow — value must still be up to date (SharingStarted.Eagerly)
             assertEquals(testUrlWithAuth, viewModel.urlFlow.value)
-            job.cancel()
         }
 
         @Test
-        fun `Given error state then errorFlow value matches viewState error`() = runTest {
+        fun `Given error state then errorFlow value matches viewState error without subscribers`() = runTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.ServerNotFound(serverId),
             )


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
From https://github.com/home-assistant/android/pull/6687, the `FrontendViewModel.urlFlow` and `errorFlow` are always returning null if it doesn't have any subscriber and invoking `.value` on it. It is because of the `stateIn` `WhileSubscribe` behavior instead we should initialize with the state behavior and always collect to update this field. It is important since we are using `.value` in few places so we need to make sure it reflect the current state (We could still have a race but regarding of where it is used I think we are fine).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.