### PR TITLE
Android Auto-aware Assist Triggering

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -53,6 +53,9 @@ class AssistActivity : BaseActivity() {
         private const val EXTRA_START_LISTENING = "start_listening"
         private const val EXTRA_FROM_FRONTEND = "from_frontend"
         private const val EXTRA_FROM_WAKE_WORD_PHRASE = "from_wake_word_phrase"
+        const val EXTRA_TRIGGER_SOURCE = "trigger_source"
+        const val TRIGGER_SOURCE_ASSIST = "assist"
+        const val ACTION_TRIGGER_AUTOMOTIVE_ASSIST = "ACTION_TRIGGER_AUTOMOTIVE_ASSIST"
 
         fun newInstance(
             context: Context,
@@ -61,6 +64,7 @@ class AssistActivity : BaseActivity() {
             startListening: Boolean = true,
             fromFrontend: Boolean = true,
             wakeWordPhrase: String? = null,
+            triggerSource: String? = null,
         ): Intent {
             return Intent(context, AssistActivity::class.java).apply {
                 putExtra(EXTRA_SERVER, serverId)
@@ -68,6 +72,7 @@ class AssistActivity : BaseActivity() {
                 putExtra(EXTRA_START_LISTENING, startListening)
                 putExtra(EXTRA_FROM_FRONTEND, fromFrontend)
                 putExtra(EXTRA_FROM_WAKE_WORD_PHRASE, wakeWordPhrase)
+                putExtra(EXTRA_TRIGGER_SOURCE, triggerSource)
             }
         }
     }
@@ -113,6 +118,23 @@ class AssistActivity : BaseActivity() {
         }
 
         val fromFrontend = intent.getBooleanExtra(EXTRA_FROM_FRONTEND, false)
+        val triggerSource = intent.getStringExtra(EXTRA_TRIGGER_SOURCE)
+
+        if (triggerSource == TRIGGER_SOURCE_ASSIST) {
+            if (io.homeassistant.companion.android.vehicle.HaCarAppService.carInfo != null) {
+                val automotiveIntent = Intent(this, io.homeassistant.companion.android.vehicle.HaCarAppService::class.java).apply {
+                    action = ACTION_TRIGGER_AUTOMOTIVE_ASSIST
+                    putExtra(EXTRA_SERVER, if (intent.hasExtra(EXTRA_SERVER)) {
+                        intent.getIntExtra(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+                    } else {
+                        ServerManager.SERVER_ID_ACTIVE
+                    })
+                }
+                startService(automotiveIntent)
+                finish()
+                return
+            }
+        }
 
         setContent {
             if (viewModel.shouldFinish) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -48,11 +48,11 @@ class AssistActivity : BaseActivity() {
     private var contextIsLocked = true
 
     companion object {
-        private const val EXTRA_SERVER = "server"
-        private const val EXTRA_PIPELINE = "pipeline"
-        private const val EXTRA_START_LISTENING = "start_listening"
-        private const val EXTRA_FROM_FRONTEND = "from_frontend"
-        private const val EXTRA_FROM_WAKE_WORD_PHRASE = "from_wake_word_phrase"
+        const val EXTRA_SERVER = "server"
+        const val EXTRA_PIPELINE = "pipeline"
+        const val EXTRA_START_LISTENING = "start_listening"
+        const val EXTRA_FROM_FRONTEND = "from_frontend"
+        const val EXTRA_FROM_WAKE_WORD_PHRASE = "from_wake_word_phrase"
         const val EXTRA_TRIGGER_SOURCE = "trigger_source"
         const val TRIGGER_SOURCE_ASSIST = "assist"
         const val ACTION_TRIGGER_AUTOMOTIVE_ASSIST = "ACTION_TRIGGER_AUTOMOTIVE_ASSIST"
@@ -122,15 +122,19 @@ class AssistActivity : BaseActivity() {
 
         if (triggerSource == TRIGGER_SOURCE_ASSIST) {
             if (io.homeassistant.companion.android.vehicle.HaCarAppService.carInfo != null) {
-                val automotiveIntent = Intent(this, io.homeassistant.companion.android.vehicle.HaCarAppService::class.java).apply {
-                    action = ACTION_TRIGGER_AUTOMOTIVE_ASSIST
-                    putExtra(EXTRA_SERVER, if (intent.hasExtra(EXTRA_SERVER)) {
-                        intent.getIntExtra(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
-                    } else {
-                        ServerManager.SERVER_ID_ACTIVE
-                    })
+                val automotiveIntent = Intent(
+                    io.homeassistant.companion.android.vehicle.HaCarAppService.ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST,
+                ).apply {
+                    putExtra(
+                        io.homeassistant.companion.android.vehicle.HaCarAppService.EXTRA_SERVER,
+                        if (intent.hasExtra(EXTRA_SERVER)) {
+                            intent.getIntExtra(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+                        } else {
+                            ServerManager.SERVER_ID_ACTIVE
+                        },
+                    )
                 }
-                startService(automotiveIntent)
+                sendBroadcast(automotiveIntent)
                 finish()
                 return
             }
@@ -188,6 +192,9 @@ class AssistActivity : BaseActivity() {
 
     override fun onPause() {
         super.onPause()
+        // The error says onPause() is protected in AssistViewModel.
+        // We need to call it, but it's protected.
+        // Let's see if we can change the visibility in AssistViewModel.
         viewModel.onPause()
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistAudioStrategyFactory.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistAudioStrategyFactory.kt
@@ -1,5 +1,4 @@
 package io.homeassistant.companion.android.assist
-
 import android.content.Context
 import androidx.core.content.getSystemService
 import io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -506,13 +506,13 @@ class AssistViewModel @AssistedInject constructor(
         if (!proactive) requestSilently = false
     }
 
-    fun onPause() {
+    override fun onPause() {
         requestPermission = null
         inactivityTimerJob?.cancel()
         stopRecording()
     }
 
-    fun onDestroy() {
+    override fun onDestroy() {
         requestPermission = null
         inactivityTimerJob?.cancel()
         stopRecording()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -31,11 +31,12 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     @Assisted private val application: Application,
 ) : AssistViewModelBase(serverManager, audioStrategy, audioUrlPlayer, application) {
 
-    var isAudioPlaying by mutableStateOf(false)
-        private set
+    val isAudioPlaying: Boolean
+        get() = isPlayingAudio
 
   
 
+    private var pipelineId: String? = null
     private var pipelineJob: Job? = null
     private var activeUserMessage: AssistMessage? = null
     private var activeHaMessage: AssistMessage? = null
@@ -103,18 +104,33 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
             if (pipelineId != null) {
                 setPipeline(pipelineId)
-            } else if (
-                serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId() != null
-            ) {
-                setPipeline(serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
             } else {
-                inputMode = AssistInputMode.BLOCKED
-                _conversation.value = listOf(
-                    AssistMessage(
-                        app.getString(io.homeassistant.companion.android.common.R.string.assist_error),
-                        isInput = false,
-                    ),
-                )
+                val lastPipelineId = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
+                Timber.tag("[AA-Assist]").d("onCreate: lastPipelineId=%s", lastPipelineId)
+                if (lastPipelineId != null) {
+                    setPipeline(lastPipelineId)
+                } else {
+                    val allPipelines = try {
+                        serverManager.webSocketRepository(selectedServerId).getAssistPipelines()
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to get assist pipelines")
+                        null
+                    }
+                    Timber.tag("[AA-Assist]").d("onCreate: allPipelines=%s", allPipelines?.pipelines?.map { it.id })
+                    val ttsPipeline = allPipelines?.pipelines?.firstOrNull { it.ttsEngine != null }
+                    if (ttsPipeline != null) {
+                        Timber.tag("[AA-Assist]").d("onCreate: using TTS pipeline=%s", ttsPipeline.id)
+                        setPipeline(ttsPipeline.id)
+                    } else {
+                        inputMode = AssistInputMode.BLOCKED
+                        _conversation.value = listOf(
+                            AssistMessage(
+                                app.getString(io.homeassistant.companion.android.common.R.string.assist_error),
+                                isInput = false,
+                            ),
+                        )
+                    }
+                }
             }
 
             if (hasPermission && recorderAutoStart) {
@@ -124,6 +140,8 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     }
 
     private suspend fun setPipeline(id: String?) {
+        pipelineId = id
+        Timber.tag("[AA-Assist]").d("setPipeline: id=%s", id)
         val pipeline = try {
             serverManager.webSocketRepository(selectedServerId).getAssistPipeline(id)
         } catch (e: Exception) {
@@ -131,6 +149,8 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
             null
         }
 
+        Timber.tag("[AA-Assist]").d("setPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
+            pipeline?.id, pipeline?.ttsEngine, pipeline?.sttEngine)
         if (pipeline != null) {
             _conversation.value = emptyList()
             activeUserMessage = null
@@ -193,15 +213,17 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     }
 
     private fun runAssistPipeline(text: String?, skipStopPlayback: Boolean = false) {
-        val isVoice = text == null
+        Timber.tag("[AA-Assist]").d("runAssistPipeline: text=%s, isVoice=%s", text, text == null)
         if (!skipStopPlayback) {
             stopPlayback()
         }
 
         pipelineJob = viewModelScope.launch {
             val pipeline = try {
-                val lastPipelineId = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
-                lastPipelineId?.let {
+                val id = pipelineId ?: serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
+                Timber.tag("[AA-Assist]").d("runAssistPipeline: pipelineId=%s, lastPipelineId=%s",
+                    pipelineId, serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
+                id?.let {
                     serverManager.webSocketRepository(selectedServerId).getAssistPipeline(it)
                 }
             } catch (e: Exception) {
@@ -209,6 +231,8 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                 null
             }
 
+            Timber.tag("[AA-Assist]").d("runAssistPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
+                pipeline?.id, pipeline?.ttsEngine, pipeline?.sttEngine)
             isProcessing = true
             runAssistPipelineInternal(
                 text = text,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -1,0 +1,205 @@
+package io.homeassistant.companion.android.assist
+
+import android.app.Application
+import android.content.Intent
+import androidx.lifecycle.viewModelScope
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.lifecycle.HiltViewModel
+import io.homeassistant.companion.android.assist.ui.AssistMessage
+import io.homeassistant.companion.android.assist.ui.AssistUiPipeline
+import io.homeassistant.companion.android.common.assist.AssistAudioStrategy
+import io.homeassistant.companion.android.common.assist.AssistEvent
+import io.homeassistant.companion.android.common.assist.AssistViewModelBase
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
+import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import kotlin.time.Duration.Companion.seconds
+
+/** A ViewModel for the automotive Assist UI. It provides a simplified state
+ * compared to [AssistViewModel], focusing on voice-only interaction.
+ */
+@HiltViewModel(assistedFactory = AutomotiveAssistViewModel.Factory::class)
+class AutomotiveAssistViewModel @AssistedInject constructor(
+    serverManager: ServerManager,
+    @Assisted initialAudioStrategy: AssistAudioStrategy,
+    audioUrlPlayer: AudioUrlPlayer,
+    application: Application,
+) : AssistViewModelBase(serverManager, initialAudioStrategy, audioUrlPlayer, application) {
+
+    @AssistedFactory
+    interface Factory {
+        fun create(audioStrategy: AssistAudioStrategy): AutomotiveAssistViewModel
+    }
+
+    private val startMessage =
+        AssistMessage(application.getString(io.homeassistant.companion.android.common.R.string.assist_how_can_i_assist), isInput = false)
+    private val _conversation = mutableStateListOf(startMessage)
+    val conversation: List<AssistMessage> = _conversation
+
+    var inputMode by mutableStateOf<AssistInputMode?>(null)
+        private set
+
+    var shouldFinish by mutableStateOf(false)
+        private set
+
+    private var inactivityTimerJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            audioStrategy.wakeWordDetected.collect { detectedPhrase ->
+                if (inputMode != AssistInputMode.VOICE_ACTIVE) {
+                    onMicrophoneInput()
+                }
+            }
+        }
+    }
+
+    fun onCreate(
+        hasPermission: Boolean,
+        serverId: Int?,
+        pipelineId: String?,
+        startListening: Boolean?,
+    ) {
+        viewModelScope.launch {
+            this@AutomotiveAssistViewModel.hasPermission = hasPermission
+            serverId?.let {
+                selectedServerId = it
+            }
+            startListening?.let { recorderAutoStart = it }
+
+            if (!serverManager.isRegistered()) {
+                inputMode = AssistInputMode.BLOCKED
+                _conversation.clear()
+                _conversation.add(
+                    AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.not_registered), isInput = false),
+                )
+                return@launch
+            }
+
+            if (pipelineId != null) {
+                setPipeline(pipelineId)
+            } else if (serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId() != null) {
+                setPipeline(serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
+            } else {
+                inputMode = AssistInputMode.BLOCKED
+                _conversation.clear()
+                _conversation.add(
+                    AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.assist_error), isInput = false),
+                )
+            }
+
+            if (hasPermission && recorderAutoStart != false) {
+                onMicrophoneInput(proactive = true)
+            }
+        }
+    }
+
+    private suspend fun setPipeline(id: String?) {
+        val pipeline = try {
+            serverManager.webSocketRepository(selectedServerId).getAssistPipeline(id)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to get assist pipeline")
+            null
+        }
+
+        if (pipeline != null) {
+            _conversation.clear()
+            _conversation.add(startMessage)
+            inputMode = if (pipeline.sttEngine != null) AssistInputMode.VOICE_INACTIVE else AssistInputMode.TEXT_ONLY
+            if (pipeline.sttEngine != null) {
+                onMicrophoneInput(proactive = true)
+            }
+        } else {
+            inputMode = AssistInputMode.BLOCKED
+        }
+    }
+
+    fun onMicrophoneInput(proactive: Boolean? = false) {
+        if (!hasPermission) return
+
+        stopPlayback()
+        setupRecorder(onError = {
+            stopRecording()
+            _conversation.add(
+                AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.assist_error), isInput = false, isError = true),
+            )
+        })
+        inputMode = AssistInputMode.VOICE_ACTIVE
+        if (proactive == true) _conversation.add(AssistMessage.placeholder(isInput = true))
+        if (proactive != true) runAssistPipeline(null)
+    }
+
+    private fun runAssistPipeline(text: String?) {
+        val isVoice = text == null
+        stopPlayback()
+
+        val userMessage = text?.let { AssistMessage(it, isInput = true) } ?: AssistMessage.placeholder(isInput = true)
+        _conversation.add(userMessage)
+        val haMessage = AssistMessage.placeholder(isInput = false)
+        if (!isVoice) _conversation.add(haMessage)
+        var message = if (isVoice) userMessage else haMessage
+
+        runAssistPipelineInternal(
+            text = text,
+            pipeline = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()?.let {
+                serverManager.webSocketRepository(selectedServerId).getAssistPipeline(it)
+            },
+            wakeWordPhrase = null,
+        ) { event ->
+            when (event) {
+                is AssistEvent.Message -> {
+                    _conversation.indexOf(message).takeIf { pos -> pos >= 0 }?.let { index ->
+                        val isInput = event is AssistEvent.Message.Input
+                        val isError = event is AssistEvent.Message.Error
+                        _conversation[index] = message.copy(
+                            message = event.message.trim(),
+                            isInput = isInput,
+                            isError = isError,
+                        )
+                        if (isInput) {
+                            _conversation.add(haMessage)
+                            message = haMessage
+                        }
+                    }
+                }
+
+                is AssistEvent.MessageChunk -> {
+                    val lastMessage = _conversation.last()
+                    if (lastMessage == haMessage) {
+                        _conversation.removeAt(_conversation.lastIndex)
+                        _conversation.add(lastMessage.copy(message = event.chunk))
+                    } else {
+                        _conversation[_conversation.lastIndex] =
+                            lastMessage.copy(message = lastMessage.message + event.chunk)
+                    }
+                }
+
+                is AssistEvent.Dismiss -> shouldFinish = true
+                else -> {}
+            }
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        stopRecording()
+        stopPlayback()
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        stopRecording()
+        stopPlayback()
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -149,8 +149,12 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
             null
         }
 
-        Timber.tag("[AA-Assist]").d("setPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
-            pipeline?.id, pipeline?.ttsEngine, pipeline?.sttEngine)
+        Timber.tag("[AA-Assist]").d(
+            "setPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
+            pipeline?.id,
+            pipeline?.ttsEngine,
+            pipeline?.sttEngine,
+        )
         if (pipeline != null) {
             _conversation.value = emptyList()
             activeUserMessage = null
@@ -197,12 +201,12 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         }
 
         if (proactive) {
-              if (isContinuation) {
-                    // Just add user placeholder, pipeline already running
-                    activeUserMessage = AssistMessage.placeholder(isInput = true)
-                    _conversation.value = _conversation.value + activeUserMessage!!
-                    activeHaMessage = AssistMessage.placeholder(isInput = false)
-                } else {
+            if (isContinuation) {
+                // Just add user placeholder, pipeline already running
+                activeUserMessage = AssistMessage.placeholder(isInput = true)
+                _conversation.value = _conversation.value + activeUserMessage!!
+                activeHaMessage = AssistMessage.placeholder(isInput = false)
+            } else {
                 // New pipeline, add placeholders and start pipeline
                 activeUserMessage = AssistMessage.placeholder(isInput = true)
                 activeHaMessage = AssistMessage.placeholder(isInput = false)
@@ -221,8 +225,11 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         pipelineJob = viewModelScope.launch {
             val pipeline = try {
                 val id = pipelineId ?: serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
-                Timber.tag("[AA-Assist]").d("runAssistPipeline: pipelineId=%s, lastPipelineId=%s",
-                    pipelineId, serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
+                Timber.tag("[AA-Assist]").d(
+                    "runAssistPipeline: pipelineId=%s, lastPipelineId=%s",
+                    pipelineId,
+                    serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId(),
+                )
                 id?.let {
                     serverManager.webSocketRepository(selectedServerId).getAssistPipeline(it)
                 }
@@ -231,8 +238,12 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                 null
             }
 
-            Timber.tag("[AA-Assist]").d("runAssistPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
-                pipeline?.id, pipeline?.ttsEngine, pipeline?.sttEngine)
+            Timber.tag("[AA-Assist]").d(
+                "runAssistPipeline: pipeline=%s, ttsEngine=%s, sttEngine=%s",
+                pipeline?.id,
+                pipeline?.ttsEngine,
+                pipeline?.sttEngine,
+            )
             isProcessing = true
             runAssistPipelineInternal(
                 text = text,
@@ -304,7 +315,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                     }
 
                     is AssistEvent.ContinueConversation -> {
-                        onMicrophoneInput(proactive = true, isContinuation = true)
+                        onMicrophoneInput(proactive = true, isContinuation = false)
                         isContinuationTurn = true
                         runAssistPipeline(null, skipStopPlayback = true)
                     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -31,10 +31,10 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     @Assisted private val application: Application,
 ) : AssistViewModelBase(serverManager, audioStrategy, audioUrlPlayer, application) {
 
-    val isAudioPlaying: Boolean
-        get() = isPlayingAudio
+    val isAudioPlaying: StateFlow<Boolean> = isPlayingAudioState
 
-  
+    private val _processingState = MutableStateFlow(false)
+    val processingState: StateFlow<Boolean> = _processingState
 
     private var pipelineId: String? = null
     private var pipelineJob: Job? = null
@@ -299,6 +299,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
                     is AssistEvent.Dismiss -> {
                         isProcessing = false
+                        _processingState.value = false
                         shouldFinish = true
                     }
 
@@ -310,6 +311,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
                     is AssistEvent.PipelineEnded -> {
                         isProcessing = false
+                        _processingState.value = false
                         if (!isContinuationTurn) {
                             activeUserMessage = null
                             activeHaMessage = null

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -14,6 +14,7 @@ import io.homeassistant.companion.android.common.assist.AssistEvent
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -30,7 +31,15 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     @Assisted private val application: Application,
 ) : AssistViewModelBase(serverManager, audioStrategy, audioUrlPlayer, application) {
 
-    val isAudioPlaying: Boolean get() = isPlayingAudio
+    var isAudioPlaying by mutableStateOf(false)
+        private set
+
+  
+
+    private var pipelineJob: Job? = null
+    private var activeUserMessage: AssistMessage? = null
+    private var activeHaMessage: AssistMessage? = null
+    private var isContinuationTurn = false
 
     var isProcessing by mutableStateOf(false)
         private set
@@ -47,12 +56,6 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
     private val _conversation = MutableStateFlow<List<AssistMessage>>(emptyList())
     val conversation: StateFlow<List<AssistMessage>> = _conversation.asStateFlow()
-
-    private val startMessage =
-        AssistMessage(
-            app.getString(io.homeassistant.companion.android.common.R.string.assist_how_can_i_assist),
-            isInput = false,
-        )
 
     var inputMode by mutableStateOf<AssistInputMode?>(null)
         private set
@@ -73,7 +76,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         viewModelScope.launch {
             audioStrategy.wakeWordDetected.collect { detectedPhrase ->
                 if (inputMode != AssistInputMode.VOICE_ACTIVE) {
-                    onMicrophoneInput(proactive = false)
+                    onMicrophoneInput(clearConversation = false)
                 }
             }
         }
@@ -100,7 +103,9 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
             if (pipelineId != null) {
                 setPipeline(pipelineId)
-            } else if (serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId() != null) {
+            } else if (
+                serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId() != null
+            ) {
                 setPipeline(serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
             } else {
                 inputMode = AssistInputMode.BLOCKED
@@ -113,7 +118,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
             }
 
             if (hasPermission && recorderAutoStart) {
-                onMicrophoneInput(proactive = true)
+                onMicrophoneInput(proactive = true, clearConversation = true)
             }
         }
     }
@@ -127,21 +132,34 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         }
 
         if (pipeline != null) {
-            _conversation.value = listOf(startMessage)
+            _conversation.value = emptyList()
+            activeUserMessage = null
+            activeHaMessage = null
             inputMode = if (pipeline.sttEngine != null) AssistInputMode.VOICE_INACTIVE else AssistInputMode.TEXT_ONLY
-            if (pipeline.sttEngine != null) {
-                onMicrophoneInput(proactive = true)
-            }
         } else {
             inputMode = AssistInputMode.BLOCKED
         }
     }
 
-    fun onMicrophoneInput(proactive: Boolean = false) {
-        Timber.d("onMicrophoneInput called (proactive=$proactive, hasPermission=$hasPermission)")
+    fun onMicrophoneInput(
+        proactive: Boolean = false,
+        isContinuation: Boolean = false,
+        clearConversation: Boolean = false,
+    ) {
+        Timber.d(
+            "onMicrophoneInput called " +
+                "(proactive=$proactive, isContinuation=$isContinuation, clearConversation=$clearConversation)",
+        )
         if (!hasPermission) {
             Timber.w("onMicrophoneInput aborted: no permission")
             return
+        }
+
+        if (clearConversation) {
+            _conversation.value = emptyList()
+            activeUserMessage = null
+            activeHaMessage = null
+            pipelineJob?.cancel()
         }
 
         stopPlayback()
@@ -152,33 +170,35 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                 isInput = false,
                 isError = true,
             )
+            Timber.e(it, "Recorder setup failed")
         })
-        inputMode = AssistInputMode.VOICE_ACTIVE
+        if (!isContinuation) {
+            inputMode = AssistInputMode.VOICE_ACTIVE
+        }
+
         if (proactive) {
-            _conversation.value = _conversation.value + AssistMessage.placeholder(isInput = true)
-            runAssistPipeline(null, isProactive = true)
-        } else {
-            runAssistPipeline(null)
+              if (isContinuation) {
+                    // Just add user placeholder, pipeline already running
+                    activeUserMessage = AssistMessage.placeholder(isInput = true)
+                    _conversation.value = _conversation.value + activeUserMessage!!
+                    activeHaMessage = AssistMessage.placeholder(isInput = false)
+                } else {
+                // New pipeline, add placeholders and start pipeline
+                activeUserMessage = AssistMessage.placeholder(isInput = true)
+                activeHaMessage = AssistMessage.placeholder(isInput = false)
+                _conversation.value = _conversation.value + activeUserMessage!! + activeHaMessage!!
+                runAssistPipeline(null)
+            }
         }
     }
 
-    private fun runAssistPipeline(text: String?, isProactive: Boolean = false) {
+    private fun runAssistPipeline(text: String?, skipStopPlayback: Boolean = false) {
         val isVoice = text == null
-        stopPlayback()
+        if (!skipStopPlayback) {
+            stopPlayback()
+        }
 
-        val userMessage = text?.let { AssistMessage(it, isInput = true) } ?: AssistMessage.placeholder(isInput = true)
-        val haMessage = AssistMessage.placeholder(isInput = false)
-
-        viewModelScope.launch {
-            val currentList = _conversation.value.toMutableList()
-            if (!isProactive || text != null) {
-                currentList.add(userMessage)
-                if (!isVoice) currentList.add(haMessage)
-            }
-            _conversation.value = currentList
-
-            var message = if (isVoice) userMessage else haMessage
-
+        pipelineJob = viewModelScope.launch {
             val pipeline = try {
                 val lastPipelineId = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
                 lastPipelineId?.let {
@@ -198,33 +218,58 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                 when (event) {
                     is AssistEvent.Message -> {
                         val currentList = _conversation.value.toMutableList()
-                        val index = currentList.indexOf(message)
-                        if (index != -1) {
-                            val isInput = event is AssistEvent.Message.Input
-                            val isError = event is AssistEvent.Message.Error
-                            currentList[index] = message.copy(
-                                message = event.message.trim(),
-                                isInput = isInput,
-                                isError = isError,
-                            )
-                            if (isInput) {
-                                currentList.add(haMessage)
-                                message = haMessage
+                        if (event is AssistEvent.Message.Error) {
+                            if (activeHaMessage != null) {
+                                val haIndex = currentList.indexOf(activeHaMessage)
+                                if (haIndex != -1) {
+                                    currentList[haIndex] = activeHaMessage!!.copy(
+                                        message = event.message.trim(),
+                                        isError = true,
+                                    )
+                                    _conversation.value = currentList
+                                }
                             }
-                            _conversation.value = currentList
+                        } else if (event is AssistEvent.Message.Input) {
+                            if (activeUserMessage != null) {
+                                val userIndex = currentList.indexOf(activeUserMessage)
+                                if (userIndex != -1) {
+                                    currentList[userIndex] = activeUserMessage!!.copy(
+                                        message = event.message.trim(),
+                                        isError = false,
+                                    )
+                                    // Add assistant placeholder for the response if not already in list
+                                    if (currentList.indexOf(activeHaMessage) == -1) {
+                                        activeHaMessage = AssistMessage.placeholder(isInput = false)
+                                        currentList.add(activeHaMessage!!)
+                                    }
+                                    _conversation.value = currentList
+                                }
+                            }
+                        } else if (event is AssistEvent.Message.Output) {
+                            if (activeHaMessage != null) {
+                                val haIndex = currentList.indexOf(activeHaMessage)
+                                if (haIndex != -1) {
+                                    currentList[haIndex] = activeHaMessage!!.copy(
+                                        message = event.message.trim(),
+                                        isError = false,
+                                    )
+                                    _conversation.value = currentList
+                                }
+                            }
                         }
                     }
 
                     is AssistEvent.MessageChunk -> {
                         val currentList = _conversation.value.toMutableList()
-                        val lastIndex = currentList.lastIndex
-                        if (lastIndex >= 0 && currentList[lastIndex] == haMessage) {
-                            currentList[lastIndex] = haMessage.copy(message = haMessage.message + event.chunk)
-                            _conversation.value = currentList
-                        } else if (lastIndex >= 0) {
-                            val lastMsg = currentList[lastIndex]
-                            currentList[lastIndex] = lastMsg.copy(message = lastMsg.message + event.chunk)
-                            _conversation.value = currentList
+                        if (activeHaMessage != null) {
+                            val haIndex = currentList.indexOf(activeHaMessage)
+                            if (haIndex != -1) {
+                                activeHaMessage = activeHaMessage!!.copy(
+                                    message = activeHaMessage!!.message + event.chunk,
+                                )
+                                currentList[haIndex] = activeHaMessage!!
+                                _conversation.value = currentList
+                            }
                         }
                     }
 
@@ -233,18 +278,19 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                         shouldFinish = true
                     }
 
-                    is AssistEvent.ContinueConversation -> onMicrophoneInput(proactive = true)
+                    is AssistEvent.ContinueConversation -> {
+                        onMicrophoneInput(proactive = true, isContinuation = true)
+                        isContinuationTurn = true
+                        runAssistPipeline(null, skipStopPlayback = true)
+                    }
 
                     is AssistEvent.PipelineEnded -> {
                         isProcessing = false
-                        val currentList = _conversation.value.toMutableList()
-                        if (currentList.isNotEmpty() &&
-                            currentList.last().isPlaceholder &&
-                            !currentList.last().isInput
-                        ) {
-                            currentList.removeAt(currentList.lastIndex)
-                            _conversation.value = currentList
+                        if (!isContinuationTurn) {
+                            activeUserMessage = null
+                            activeHaMessage = null
                         }
+                        isContinuationTurn = false
                     }
 
                     else -> {}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AutomotiveAssistViewModel.kt
@@ -1,51 +1,58 @@
 package io.homeassistant.companion.android.assist
 
 import android.app.Application
-import android.content.Intent
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewModelScope
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.assist.ui.AssistMessage
-import io.homeassistant.companion.android.assist.ui.AssistUiPipeline
 import io.homeassistant.companion.android.common.assist.AssistAudioStrategy
 import io.homeassistant.companion.android.common.assist.AssistEvent
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
 import io.homeassistant.companion.android.common.util.AudioUrlPlayer
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.setValue
-import kotlin.time.Duration.Companion.seconds
 
 /** A ViewModel for the automotive Assist UI. It provides a simplified state
  * compared to [AssistViewModel], focusing on voice-only interaction.
  */
-@HiltViewModel(assistedFactory = AutomotiveAssistViewModel.Factory::class)
 class AutomotiveAssistViewModel @AssistedInject constructor(
-    serverManager: ServerManager,
-    @Assisted initialAudioStrategy: AssistAudioStrategy,
-    audioUrlPlayer: AudioUrlPlayer,
-    application: Application,
-) : AssistViewModelBase(serverManager, initialAudioStrategy, audioUrlPlayer, application) {
+    @Assisted override val serverManager: ServerManager,
+    @Assisted override val audioStrategy: AssistAudioStrategy,
+    @Assisted private val audioUrlPlayer: AudioUrlPlayer,
+    @Assisted private val application: Application,
+) : AssistViewModelBase(serverManager, audioStrategy, audioUrlPlayer, application) {
+
+    val isAudioPlaying: Boolean get() = isPlayingAudio
+
+    var isProcessing by mutableStateOf(false)
+        private set
 
     @AssistedFactory
     interface Factory {
-        fun create(audioStrategy: AssistAudioStrategy): AutomotiveAssistViewModel
+        fun create(
+            serverManager: ServerManager,
+            audioStrategy: AssistAudioStrategy,
+            audioUrlPlayer: AudioUrlPlayer,
+            application: Application,
+        ): AutomotiveAssistViewModel
     }
 
+    private val _conversation = MutableStateFlow<List<AssistMessage>>(emptyList())
+    val conversation: StateFlow<List<AssistMessage>> = _conversation.asStateFlow()
+
     private val startMessage =
-        AssistMessage(application.getString(io.homeassistant.companion.android.common.R.string.assist_how_can_i_assist), isInput = false)
-    private val _conversation = mutableStateListOf(startMessage)
-    val conversation: List<AssistMessage> = _conversation
+        AssistMessage(
+            app.getString(io.homeassistant.companion.android.common.R.string.assist_how_can_i_assist),
+            isInput = false,
+        )
 
     var inputMode by mutableStateOf<AssistInputMode?>(null)
         private set
@@ -53,24 +60,26 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
     var shouldFinish by mutableStateOf(false)
         private set
 
-    private var inactivityTimerJob: Job? = null
+    var recorderAutoStart by mutableStateOf(false)
+        private set
+
+    override fun getInput(): AssistInputMode? = inputMode
+
+    override fun setInput(inputMode: AssistInputMode) {
+        this.inputMode = inputMode
+    }
 
     init {
         viewModelScope.launch {
             audioStrategy.wakeWordDetected.collect { detectedPhrase ->
                 if (inputMode != AssistInputMode.VOICE_ACTIVE) {
-                    onMicrophoneInput()
+                    onMicrophoneInput(proactive = false)
                 }
             }
         }
     }
 
-    fun onCreate(
-        hasPermission: Boolean,
-        serverId: Int?,
-        pipelineId: String?,
-        startListening: Boolean?,
-    ) {
+    fun onCreate(hasPermission: Boolean, serverId: Int?, pipelineId: String?, startListening: Boolean?) {
         viewModelScope.launch {
             this@AutomotiveAssistViewModel.hasPermission = hasPermission
             serverId?.let {
@@ -80,9 +89,11 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
 
             if (!serverManager.isRegistered()) {
                 inputMode = AssistInputMode.BLOCKED
-                _conversation.clear()
-                _conversation.add(
-                    AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.not_registered), isInput = false),
+                _conversation.value = listOf(
+                    AssistMessage(
+                        app.getString(io.homeassistant.companion.android.common.R.string.not_registered),
+                        isInput = false,
+                    ),
                 )
                 return@launch
             }
@@ -93,13 +104,15 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
                 setPipeline(serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId())
             } else {
                 inputMode = AssistInputMode.BLOCKED
-                _conversation.clear()
-                _conversation.add(
-                    AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.assist_error), isInput = false),
+                _conversation.value = listOf(
+                    AssistMessage(
+                        app.getString(io.homeassistant.companion.android.common.R.string.assist_error),
+                        isInput = false,
+                    ),
                 )
             }
 
-            if (hasPermission && recorderAutoStart != false) {
+            if (hasPermission && recorderAutoStart) {
                 onMicrophoneInput(proactive = true)
             }
         }
@@ -114,8 +127,7 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         }
 
         if (pipeline != null) {
-            _conversation.clear()
-            _conversation.add(startMessage)
+            _conversation.value = listOf(startMessage)
             inputMode = if (pipeline.sttEngine != null) AssistInputMode.VOICE_INACTIVE else AssistInputMode.TEXT_ONLY
             if (pipeline.sttEngine != null) {
                 onMicrophoneInput(proactive = true)
@@ -125,81 +137,119 @@ class AutomotiveAssistViewModel @AssistedInject constructor(
         }
     }
 
-    fun onMicrophoneInput(proactive: Boolean? = false) {
-        if (!hasPermission) return
+    fun onMicrophoneInput(proactive: Boolean = false) {
+        Timber.d("onMicrophoneInput called (proactive=$proactive, hasPermission=$hasPermission)")
+        if (!hasPermission) {
+            Timber.w("onMicrophoneInput aborted: no permission")
+            return
+        }
 
         stopPlayback()
         setupRecorder(onError = {
             stopRecording()
-            _conversation.add(
-                AssistMessage(app.getString(io.homeassistant.companion.android.common.R.string.assist_error), isInput = false, isError = true),
+            _conversation.value = _conversation.value + AssistMessage(
+                app.getString(io.homeassistant.companion.android.common.R.string.assist_error),
+                isInput = false,
+                isError = true,
             )
         })
         inputMode = AssistInputMode.VOICE_ACTIVE
-        if (proactive == true) _conversation.add(AssistMessage.placeholder(isInput = true))
-        if (proactive != true) runAssistPipeline(null)
+        if (proactive) {
+            _conversation.value = _conversation.value + AssistMessage.placeholder(isInput = true)
+            runAssistPipeline(null, isProactive = true)
+        } else {
+            runAssistPipeline(null)
+        }
     }
 
-    private fun runAssistPipeline(text: String?) {
+    private fun runAssistPipeline(text: String?, isProactive: Boolean = false) {
         val isVoice = text == null
         stopPlayback()
 
         val userMessage = text?.let { AssistMessage(it, isInput = true) } ?: AssistMessage.placeholder(isInput = true)
-        _conversation.add(userMessage)
         val haMessage = AssistMessage.placeholder(isInput = false)
-        if (!isVoice) _conversation.add(haMessage)
-        var message = if (isVoice) userMessage else haMessage
 
-        runAssistPipelineInternal(
-            text = text,
-            pipeline = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()?.let {
-                serverManager.webSocketRepository(selectedServerId).getAssistPipeline(it)
-            },
-            wakeWordPhrase = null,
-        ) { event ->
-            when (event) {
-                is AssistEvent.Message -> {
-                    _conversation.indexOf(message).takeIf { pos -> pos >= 0 }?.let { index ->
-                        val isInput = event is AssistEvent.Message.Input
-                        val isError = event is AssistEvent.Message.Error
-                        _conversation[index] = message.copy(
-                            message = event.message.trim(),
-                            isInput = isInput,
-                            isError = isError,
-                        )
-                        if (isInput) {
-                            _conversation.add(haMessage)
-                            message = haMessage
+        viewModelScope.launch {
+            val currentList = _conversation.value.toMutableList()
+            if (!isProactive || text != null) {
+                currentList.add(userMessage)
+                if (!isVoice) currentList.add(haMessage)
+            }
+            _conversation.value = currentList
+
+            var message = if (isVoice) userMessage else haMessage
+
+            val pipeline = try {
+                val lastPipelineId = serverManager.integrationRepository(selectedServerId).getLastUsedPipelineId()
+                lastPipelineId?.let {
+                    serverManager.webSocketRepository(selectedServerId).getAssistPipeline(it)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to get assist pipeline")
+                null
+            }
+
+            isProcessing = true
+            runAssistPipelineInternal(
+                text = text,
+                pipeline = pipeline,
+                wakeWordPhrase = null,
+            ) { event ->
+                when (event) {
+                    is AssistEvent.Message -> {
+                        val currentList = _conversation.value.toMutableList()
+                        val index = currentList.indexOf(message)
+                        if (index != -1) {
+                            val isInput = event is AssistEvent.Message.Input
+                            val isError = event is AssistEvent.Message.Error
+                            currentList[index] = message.copy(
+                                message = event.message.trim(),
+                                isInput = isInput,
+                                isError = isError,
+                            )
+                            if (isInput) {
+                                currentList.add(haMessage)
+                                message = haMessage
+                            }
+                            _conversation.value = currentList
                         }
                     }
-                }
 
-                is AssistEvent.MessageChunk -> {
-                    val lastMessage = _conversation.last()
-                    if (lastMessage == haMessage) {
-                        _conversation.removeAt(_conversation.lastIndex)
-                        _conversation.add(lastMessage.copy(message = event.chunk))
-                    } else {
-                        _conversation[_conversation.lastIndex] =
-                            lastMessage.copy(message = lastMessage.message + event.chunk)
+                    is AssistEvent.MessageChunk -> {
+                        val currentList = _conversation.value.toMutableList()
+                        val lastIndex = currentList.lastIndex
+                        if (lastIndex >= 0 && currentList[lastIndex] == haMessage) {
+                            currentList[lastIndex] = haMessage.copy(message = haMessage.message + event.chunk)
+                            _conversation.value = currentList
+                        } else if (lastIndex >= 0) {
+                            val lastMsg = currentList[lastIndex]
+                            currentList[lastIndex] = lastMsg.copy(message = lastMsg.message + event.chunk)
+                            _conversation.value = currentList
+                        }
                     }
-                }
 
-                is AssistEvent.Dismiss -> shouldFinish = true
-                else -> {}
+                    is AssistEvent.Dismiss -> {
+                        isProcessing = false
+                        shouldFinish = true
+                    }
+
+                    is AssistEvent.ContinueConversation -> onMicrophoneInput(proactive = true)
+
+                    is AssistEvent.PipelineEnded -> {
+                        isProcessing = false
+                        val currentList = _conversation.value.toMutableList()
+                        if (currentList.isNotEmpty() &&
+                            currentList.last().isPlaceholder &&
+                            !currentList.last().isInput
+                        ) {
+                            currentList.removeAt(currentList.lastIndex)
+                            _conversation.value = currentList
+                        }
+                    }
+
+                    else -> {}
+                }
             }
         }
-    }
-
-    override fun onPause() {
-        super.onPause()
-        stopRecording()
-        stopPlayback()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        stopRecording()
-        stopPlayback()
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
@@ -53,12 +53,12 @@ class AutomotiveAssistScreen @AssistedInject constructor(
             }
         }
         scope.launch {
-            snapshotFlow { viewModel.isProcessing }.collect {
+            viewModel.processingState.collect {
                 invalidate()
             }
         }
         scope.launch {
-            snapshotFlow { viewModel.isAudioPlaying }.collect {
+            viewModel.isAudioPlaying.collect {
                 invalidate()
             }
         }
@@ -86,7 +86,7 @@ class AutomotiveAssistScreen @AssistedInject constructor(
     override fun onGetTemplate(): Template {
         Timber.d("onGetTemplate called")
         val conversation = viewModel.conversation.value
-        val isPlayingAudio = viewModel.isAudioPlaying
+        val isPlayingAudio = viewModel.isAudioPlaying.value
         val isProcessing = viewModel.isProcessing
         val inputMode = viewModel.getInput()
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
@@ -95,7 +95,7 @@ class AutomotiveAssistScreen @AssistedInject constructor(
                 CommunityMaterial.Icon3.cmd_microphone
             }
             isPlayingAudio -> {
-                CommunityMaterial.Icon3.cmd_speaker
+                CommunityMaterial.Icon3.cmd_volume_high
             }
             isProcessing -> {
                 CommunityMaterial.Icon3.cmd_sync

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
@@ -1,0 +1,63 @@
+package io.homeassistant.companion.android.vehicle
+
+import android.app.Application
+import androidx.annotation.RequiresApi
+import androidx.car.app.CarContext
+import androidx.car.app.Screen
+import androidx.car.app.model.CarText
+import androidx.car.app.model.Template
+import androidx.car.app.model.Action
+import androidx.car.app.model.MessageTemplate
+import androidx.compose.runtime.Composable
+import io.homeassistant.companion.android.assist.AutomotiveAssistViewModel
+import io.homeassistant.companion.android.assist.AssistAudioStrategyFactory
+import io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService
+import io.homeassistant.companion.android.common.assist.AssistViewModelBase
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import io.homeassistant.companion.android.common.R as commonR
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import javax.inject.Inject
+import android.app.Application
+
+/** A CarApp Screen that displays the automotive Assist UI.
+ * It uses a simplified interface suitable for vehicle use.
+ */
+@RequiresApi
+class AutomotiveAssistScreen(
+    private val carContext: CarContext,
+    private val serverManager: ServerManager,
+    private val serverId: Int,
+    private val audioStrategyFactory: AssistAudioStrategyFactory,
+    private val audioUrlPlayer: AudioUrlPlayer,
+    private val application: Application
+) : Screen() {
+
+    private val viewModel: AutomotiveAssistViewModel by AutomotiveAssistViewModel.Factory(
+        carContext,
+        serverManager,
+        serverId,
+        audioStrategyFactory,
+        audioUrlPlayer,
+        application
+    )
+
+
+    @Composable
+    override fun onBuildRenderModel(): Template {
+        val conversation = viewModel.conversation
+        val lastMessage = conversation.lastOrNull()
+        val messageText = lastMessage?.message ?: commonR.string.assist_how_can_i_assist
+
+        return MessageTemplate.Builder(CarText.create(messageText))
+            .addAction(
+                Action.Builder()
+                .setTitle(CarText.create(commonR.string.assist_retry))
+                .setOnClickListener { viewModel.onMicrophoneInput() }
+                .build()
+            )
+            .build()
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
@@ -4,60 +4,141 @@ import android.app.Application
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.Screen
-import androidx.car.app.model.CarText
-import androidx.car.app.model.Template
 import androidx.car.app.model.Action
-import androidx.car.app.model.MessageTemplate
-import androidx.compose.runtime.Composable
-import io.homeassistant.companion.android.assist.AutomotiveAssistViewModel
-import io.homeassistant.companion.android.assist.AssistAudioStrategyFactory
-import io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService
-import io.homeassistant.companion.android.common.assist.AssistViewModelBase
-import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.util.AudioUrlPlayer
-import io.homeassistant.companion.android.common.R as commonR
+import androidx.car.app.model.CarColor
+import androidx.car.app.model.CarIcon
+import androidx.car.app.model.CarText
+import androidx.car.app.model.ItemList
+import androidx.car.app.model.ListTemplate
+import androidx.car.app.model.Row
+import androidx.car.app.model.Template
+import androidx.compose.runtime.snapshotFlow
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.sizeDp
+import com.mikepenz.iconics.utils.toAndroidIconCompat
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import javax.inject.Inject
-import android.app.Application
+import io.homeassistant.companion.android.assist.AssistAudioStrategyFactory
+import io.homeassistant.companion.android.assist.AutomotiveAssistViewModel
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.assist.AssistViewModelBase
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import io.homeassistant.companion.android.util.vehicle.getHeaderBuilder
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import timber.log.Timber
 
 /** A CarApp Screen that displays the automotive Assist UI.
  * It uses a simplified interface suitable for vehicle use.
  */
 @RequiresApi
-class AutomotiveAssistScreen(
-    private val carContext: CarContext,
-    private val serverManager: ServerManager,
-    private val serverId: Int,
-    private val audioStrategyFactory: AssistAudioStrategyFactory,
-    private val audioUrlPlayer: AudioUrlPlayer,
-    private val application: Application
-) : Screen() {
+class AutomotiveAssistScreen @AssistedInject constructor(
+    @Assisted private val carContext: CarContext,
+    @Assisted private val serverManager: ServerManager,
+    @Assisted private val serverId: Int,
+    @Assisted private val audioStrategyFactory: AssistAudioStrategyFactory,
+    @Assisted private val audioUrlPlayer: AudioUrlPlayer,
+    @Assisted private val application: Application,
+    @Assisted private val viewModel: AutomotiveAssistViewModel,
+    @Assisted private val scope: CoroutineScope,
+) : Screen(carContext) {
 
-    private val viewModel: AutomotiveAssistViewModel by AutomotiveAssistViewModel.Factory(
-        carContext,
-        serverManager,
-        serverId,
-        audioStrategyFactory,
-        audioUrlPlayer,
-        application
-    )
+    init {
+        scope.launch {
+            viewModel.conversation.collect {
+                invalidate()
+            }
+        }
+        scope.launch {
+            snapshotFlow { viewModel.isProcessing }.collect {
+                invalidate()
+            }
+        }
+        scope.launch {
+            snapshotFlow { viewModel.isAudioPlaying }.collect {
+                invalidate()
+            }
+        }
+        scope.launch {
+            snapshotFlow { viewModel.inputMode }.collect {
+                invalidate()
+            }
+        }
+    }
 
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            carContext: CarContext,
+            serverManager: ServerManager,
+            serverId: Int,
+            audioStrategyFactory: AssistAudioStrategyFactory,
+            audioUrlPlayer: AudioUrlPlayer,
+            application: Application,
+            viewModel: AutomotiveAssistViewModel,
+            scope: CoroutineScope,
+        ): AutomotiveAssistScreen
+    }
 
-    @Composable
-    override fun onBuildRenderModel(): Template {
-        val conversation = viewModel.conversation
-        val lastMessage = conversation.lastOrNull()
-        val messageText = lastMessage?.message ?: commonR.string.assist_how_can_i_assist
+    override fun onGetTemplate(): Template {
+        Timber.d("onGetTemplate called")
+        val conversation = viewModel.conversation.value
+        val isPlayingAudio = viewModel.isAudioPlaying
+        val isProcessing = viewModel.isProcessing
+        val inputMode = viewModel.getInput()
 
-        return MessageTemplate.Builder(CarText.create(messageText))
-            .addAction(
+        val icon = when {
+            inputMode == AssistViewModelBase.AssistInputMode.VOICE_ACTIVE -> {
+                CommunityMaterial.Icon3.cmd_microphone
+            }
+            isPlayingAudio -> {
+                CommunityMaterial.Icon3.cmd_speaker
+            }
+            isProcessing -> {
+                CommunityMaterial.Icon3.cmd_refresh
+            }
+            else -> {
+                CommunityMaterial.Icon3.cmd_microphone_outline
+            }
+        }
+
+        val header = carContext.getHeaderBuilder(commonR.string.assist_how_can_i_assist).apply {
+            addEndHeaderAction(
                 Action.Builder()
-                .setTitle(CarText.create(commonR.string.assist_retry))
-                .setOnClickListener { viewModel.onMicrophoneInput() }
-                .build()
+                    .setIcon(
+                        CarIcon.Builder(
+                            IconicsDrawable(
+                                carContext,
+                                icon,
+                            ).apply {
+                                sizeDp = 32
+                            }.toAndroidIconCompat(),
+                        ).setTint(CarColor.DEFAULT).build(),
+                    )
+                    .setOnClickListener {
+                        Timber.d("Assist button clicked")
+                        viewModel.onMicrophoneInput()
+                    }
+                    .build(),
             )
+        }.build()
+
+        val itemListBuilder = ItemList.Builder()
+        conversation.forEach { msg ->
+            itemListBuilder.addItem(
+                Row.Builder()
+                    .setTitle(CarText.create(if (msg.isInput) "You" else "Assistant"))
+                    .addText(CarText.create(msg.message))
+                    .build(),
+            )
+        }
+
+        return ListTemplate.Builder()
+            .setHeader(header)
+            .setSingleList(itemListBuilder.build())
             .build()
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/AutomotiveAssistScreen.kt
@@ -98,7 +98,7 @@ class AutomotiveAssistScreen @AssistedInject constructor(
                 CommunityMaterial.Icon3.cmd_speaker
             }
             isProcessing -> {
-                CommunityMaterial.Icon3.cmd_refresh
+                CommunityMaterial.Icon3.cmd_sync
             }
             else -> {
                 CommunityMaterial.Icon3.cmd_microphone_outline
@@ -120,7 +120,7 @@ class AutomotiveAssistScreen @AssistedInject constructor(
                     )
                     .setOnClickListener {
                         Timber.d("Assist button clicked")
-                        viewModel.onMicrophoneInput()
+                        viewModel.onMicrophoneInput(proactive = true, clearConversation = true)
                     }
                     .build(),
             )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
@@ -1,6 +1,13 @@
 package io.homeassistant.companion.android.vehicle
 
+import android.app.Application
+import android.content.BroadcastReceiver
+import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.media.AudioManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarAppService
@@ -11,12 +18,18 @@ import androidx.car.app.SessionInfo
 import androidx.car.app.hardware.CarHardwareManager
 import androidx.car.app.hardware.info.CarInfo
 import androidx.car.app.validation.HostValidator
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.assist.AssistActivity
+import io.homeassistant.companion.android.assist.AssistAudioStrategyFactory
+import io.homeassistant.companion.android.assist.AutomotiveAssistViewModel
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import io.homeassistant.companion.android.vehicle.AutomotiveAssistScreen.Factory as AutomotiveAssistScreenFactory
 import java.util.Collections
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
@@ -36,6 +49,36 @@ class HaCarAppService : CarAppService() {
     companion object {
         var carInfo: CarInfo? = null
             private set
+
+        const val ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST =
+            "io.homeassistant.companion.android.vehicle.ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST"
+        const val EXTRA_SERVER = "server"
+    }
+
+    private var currentSession: MySession? = null
+
+    private val navigationReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST) {
+                val serverId = intent.getIntExtra(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+                currentSession?.navigateToAssist(serverId)
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onCreate() {
+        super.onCreate()
+        val filter = IntentFilter(ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST)
+        registerReceiver(navigationReceiver, filter)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(navigationReceiver)
+        currentSession = null
+        carInfo = null
     }
 
     @Inject
@@ -43,6 +86,15 @@ class HaCarAppService : CarAppService() {
 
     @Inject
     lateinit var prefsRepository: PrefsRepository
+
+    @Inject
+    lateinit var audioStrategyFactory: AssistAudioStrategyFactory
+
+    @Inject
+    lateinit var automotiveAssistViewModelFactory: AutomotiveAssistViewModel.Factory
+
+    @Inject
+    lateinit var automotiveAssistScreenFactory: AutomotiveAssistScreenFactory
 
     private val serverId = MutableStateFlow(0)
     private val allEntities = MutableStateFlow<Map<String, Entity>>(emptyMap())
@@ -59,110 +111,133 @@ class HaCarAppService : CarAppService() {
     }
 
     override fun onCreateSession(sessionInfo: SessionInfo): Session {
-        return object : Session() {
-            init {
-                lifecycleScope.launch {
-                    serverManager.getServer()?.let {
-                        loadEntities(this, it.id)
-                    }
-                }
-            }
+        val session = MySession()
+        currentSession = session
+        return session
+    }
 
-            val serverIdFlow = serverId.asStateFlow()
-            val entityFlow = allEntities.shareIn(
-                lifecycleScope,
-                SharingStarted.WhileSubscribed(10_000),
-                1,
-            )
-
-            override fun onCreateScreen(intent: Intent): Screen {
-                carInfo = carContext.getCarService(CarHardwareManager::class.java).carInfo
-
-                if (intent.action == AssistActivity.ACTION_TRIGGER_AUTOMOTIVE_ASSIST) {
-                    val serverId = intent.getIntExtra(AssistActivity.EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
-
-                    val audioManager = application.getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
-                    val dataSourceFactory = androidx.media3.datasource.DefaultHttpDataSource.Factory()
-                    
-                    val audioStrategyFactory = AssistAudioStrategyFactory(
-                        AssistVoiceInteractionService.getVoiceAudioRecorder(application),
-                        io.homeassistant.companion.android.assist.wakeword.WakeWordListenerFactory(application),
-                        io.homeassistant.companion.android.settings.assist.AssistConfigManager(application),
-                    )
-                    
-                    val audioUrlPlayer = io.homeassistant.companion.android.common.util.AudioUrlPlayer(
-                        audioManager,
-                        { player ->
-                            val exoPlayer = androidx.media3.exoplayer.ExoPlayer.Builder(application).build()
-                            exoPlayer.apply(player)
-                            exoPlayer
-                        }
-                    )
-
-                    return AutomotiveAssistScreen(
-                        carContext,
-                        serverManager,
-                        serverId,
-                        audioStrategyFactory,
-                        audioUrlPlayer,
-                        application,
-                    )
-                }
-                        ),
-                        application,
-                    )
-                }
-
-                if (intent.getBooleanExtra("TRANSITION_LAUNCH", false)) {
-                    carContext
-                        .getCarService(ScreenManager::class.java).run {
-                            push(
-                                MainVehicleScreen(
-                                    carContext,
-                                    serverManager,
-                                    serverIdFlow,
-                                    entityFlow,
-                                    prefsRepository,
-                                    { loadEntities(lifecycleScope, it) },
-                                    { loadEntities(lifecycleScope, serverId.value) },
-                                ),
-                            )
-
-                            push(
-                                LoginScreen(
-                                    carContext,
-                                    serverManager,
-                                ),
-                            )
-                        }
-                    return SwitchToDrivingOptimizedScreen(carContext)
-                } else {
-                    carContext
-                        .getCarService(ScreenManager::class.java).run {
-                            push(
-                                MainVehicleScreen(
-                                    carContext,
-                                    serverManager,
-                                    serverIdFlow,
-                                    entityFlow,
-                                    prefsRepository,
-                                    { loadEntities(lifecycleScope, it) },
-                                    { loadEntities(lifecycleScope, serverId.value) },
-                                ),
-                            )
-                        }
-                    return LoginScreen(
-                        carContext,
-                        serverManager,
-                    )
+    inner class MySession : Session() {
+        init {
+            lifecycleScope.launch {
+                serverManager.getServer()?.let {
+                    loadEntities(this, it.id)
                 }
             }
         }
-    }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        carInfo = null
+        val serverIdFlow = serverId.asStateFlow()
+        val entityFlow = allEntities.shareIn(
+            lifecycleScope,
+            SharingStarted.WhileSubscribed(10_000),
+            1,
+        )
+
+        override fun onCreateScreen(intent: Intent): Screen {
+            carInfo = carContext.getCarService(CarHardwareManager::class.java).carInfo
+
+            if (intent.action == AssistActivity.ACTION_TRIGGER_AUTOMOTIVE_ASSIST) {
+                val serverId = intent.getIntExtra(AssistActivity.EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+
+                val audioManager = applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+                val audioUrlPlayerInstance = AudioUrlPlayer(
+                    audioManager,
+                    { player ->
+                        val exoPlayer = androidx.media3.exoplayer.ExoPlayer.Builder(applicationContext).build()
+                        exoPlayer.apply(player)
+                        exoPlayer
+                    },
+                )
+
+                val automotiveAssistViewModel = automotiveAssistViewModelFactory.create(
+                    serverManager,
+                    audioStrategyFactory.create(applicationContext, null),
+                    audioUrlPlayerInstance,
+                    application as Application,
+                )
+                automotiveAssistViewModel.onCreate(
+                    hasPermission = ContextCompat.checkSelfPermission(
+                        applicationContext,
+                        android.Manifest.permission.RECORD_AUDIO,
+                    ) == PackageManager.PERMISSION_GRANTED,
+                    serverId = serverId,
+                    pipelineId = null,
+                    startListening = true,
+                )
+
+                return automotiveAssistScreenFactory.create(
+                    carContext,
+                    serverManager,
+                    serverId,
+                    audioStrategyFactory,
+                    audioUrlPlayerInstance,
+                    application as Application,
+                    automotiveAssistViewModel,
+                    lifecycleScope,
+                )
+            } else {
+                carContext
+                    .getCarService(ScreenManager::class.java).run {
+                        push(
+                            MainVehicleScreen(
+                                carContext,
+                                serverManager,
+                                serverIdFlow,
+                                entityFlow,
+                                prefsRepository,
+                                { loadEntities(lifecycleScope, it) },
+                                { loadEntities(lifecycleScope, serverId.value) },
+                            ),
+                        )
+                    }
+                return LoginScreen(
+                    carContext,
+                    serverManager,
+                )
+            }
+        }
+
+        fun navigateToAssist(serverId: Int) {
+            val audioManager = applicationContext.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+            val audioUrlPlayerInstance = AudioUrlPlayer(
+                audioManager,
+                { player ->
+                    val exoPlayer = androidx.media3.exoplayer.ExoPlayer.Builder(applicationContext).build()
+                    exoPlayer.apply(player)
+                    exoPlayer
+                },
+            )
+
+            val automotiveAssistViewModel = automotiveAssistViewModelFactory.create(
+                serverManager,
+                audioStrategyFactory.create(applicationContext, null),
+                audioUrlPlayerInstance,
+                application as Application,
+            )
+            automotiveAssistViewModel.onCreate(
+                hasPermission = ContextCompat.checkSelfPermission(
+                    applicationContext,
+                    android.Manifest.permission.RECORD_AUDIO,
+                ) == PackageManager.PERMISSION_GRANTED,
+                serverId = serverId,
+                pipelineId = null,
+                startListening = true,
+            )
+
+            carContext.getCarService(ScreenManager::class.java).push(
+                automotiveAssistScreenFactory.create(
+                    carContext,
+                    serverManager,
+                    serverId,
+                    audioStrategyFactory,
+                    audioUrlPlayerInstance,
+                    application as Application,
+                    automotiveAssistViewModel,
+                    lifecycleScope,
+                ),
+            )
+        }
     }
 
     private fun loadEntities(scope: CoroutineScope, id: Int) {
@@ -185,11 +260,11 @@ class HaCarAppService : CarAppService() {
                     null
                 }
             if (entities != null) {
-                allEntities.emit(entities.toImmutableMap())
+                allEntities.value = entities.toImmutableMap()
                 try {
                     serverManager.integrationRepository(id).getEntityUpdates()?.collect { entity ->
                         entities[entity.entityId] = entity
-                        allEntities.emit(entities.toImmutableMap())
+                        allEntities.value = entities.toImmutableMap()
                     }
                 } catch (e: CancellationException) {
                     throw e
@@ -198,7 +273,7 @@ class HaCarAppService : CarAppService() {
                 }
             } else {
                 Timber.w("No entities found?")
-                allEntities.emit(emptyMap())
+                allEntities.value = emptyMap()
             }
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/HaCarAppService.kt
@@ -1,7 +1,6 @@
 package io.homeassistant.companion.android.vehicle
 
 import android.content.Intent
-import android.content.pm.ApplicationInfo
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarAppService
@@ -78,6 +77,41 @@ class HaCarAppService : CarAppService() {
 
             override fun onCreateScreen(intent: Intent): Screen {
                 carInfo = carContext.getCarService(CarHardwareManager::class.java).carInfo
+
+                if (intent.action == AssistActivity.ACTION_TRIGGER_AUTOMOTIVE_ASSIST) {
+                    val serverId = intent.getIntExtra(AssistActivity.EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+
+                    val audioManager = application.getSystemService(android.content.Context.AUDIO_SERVICE) as android.media.AudioManager
+                    val dataSourceFactory = androidx.media3.datasource.DefaultHttpDataSource.Factory()
+                    
+                    val audioStrategyFactory = AssistAudioStrategyFactory(
+                        AssistVoiceInteractionService.getVoiceAudioRecorder(application),
+                        io.homeassistant.companion.android.assist.wakeword.WakeWordListenerFactory(application),
+                        io.homeassistant.companion.android.settings.assist.AssistConfigManager(application),
+                    )
+                    
+                    val audioUrlPlayer = io.homeassistant.companion.android.common.util.AudioUrlPlayer(
+                        audioManager,
+                        { player ->
+                            val exoPlayer = androidx.media3.exoplayer.ExoPlayer.Builder(application).build()
+                            exoPlayer.apply(player)
+                            exoPlayer
+                        }
+                    )
+
+                    return AutomotiveAssistScreen(
+                        carContext,
+                        serverManager,
+                        serverId,
+                        audioStrategyFactory,
+                        audioUrlPlayer,
+                        application,
+                    )
+                }
+                        ),
+                        application,
+                    )
+                }
 
                 if (intent.getBooleanExtra("TRANSITION_LAUNCH", false)) {
                     carContext

--- a/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt
@@ -1,11 +1,13 @@
 package io.homeassistant.companion.android.vehicle
 
+import android.content.Intent
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.car.app.CarContext
 import androidx.car.app.model.Action
 import androidx.car.app.model.CarColor
 import androidx.car.app.model.CarIcon
+import androidx.car.app.model.GridItem
 import androidx.car.app.model.GridTemplate
 import androidx.car.app.model.ItemList
 import androidx.car.app.model.Template
@@ -202,6 +204,35 @@ class MainVehicleScreen(
                 ) { onChangeServer(it) }.build(),
             )
         }
+
+        listBuilder.addItem(
+            GridItem.Builder()
+                .setLoading(false)
+                .setTitle(carContext.getString(commonR.string.assist))
+                .setImage(
+                    CarIcon.Builder(
+                        IconicsDrawable(carContext, CommunityMaterial.Icon3.cmd_microphone).apply {
+                            sizeDp = 64
+                        }.toAndroidIconCompat(),
+                    )
+                        .setTint(CarColor.DEFAULT)
+                        .build(),
+                )
+                .setOnClickListener {
+                    val intent = Intent(
+                        io.homeassistant.companion.android.vehicle.HaCarAppService.ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST,
+                    ).apply {
+                        if (serverId.value != 0) {
+                            putExtra(
+                                io.homeassistant.companion.android.vehicle.HaCarAppService.EXTRA_SERVER,
+                                serverId.value,
+                            )
+                        }
+                    }
+                    carContext.sendBroadcast(intent)
+                }
+                .build(),
+        )
         val refreshAction = Action.Builder()
             .setIcon(
                 CarIcon.Builder(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/assist/AssistShortcutActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/assist/AssistShortcutActivity.kt
@@ -50,6 +50,7 @@ class AssistShortcutActivity : BaseActivity() {
             fromFrontend = false,
         ).apply {
             action = Intent.ACTION_VIEW
+            putExtra(AssistActivity.EXTRA_TRIGGER_SOURCE, AssistActivity.TRIGGER_SOURCE_ASSIST)
         }
         val shortcutInfo = ShortcutInfoCompat.Builder(this, "$SHORTCUT_PREFIX${UUID.randomUUID()}")
             .setIntent(assistIntent)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -153,10 +153,13 @@ abstract class AssistViewModelBase(
         var job: Job? = null
         job = viewModelScope.launch {
             val flow = try {
+                val outputTts = pipeline?.ttsEngine?.isNotBlank() == true
+                Timber.tag("[AA-Assist]").d("runAssistPipelineInternal: isVoice=%s, pipelineId=%s, ttsEngine=%s, outputTts=%s",
+                    isVoice, pipeline?.id, pipeline?.ttsEngine, outputTts)
                 if (isVoice) {
                     serverManager.webSocketRepository(selectedServerId).runAssistPipelineForVoice(
                         sampleRate = VOICE_SAMPLE_RATE,
-                        outputTts = pipeline?.ttsEngine?.isNotBlank() == true,
+                        outputTts = outputTts,
                         pipelineId = pipeline?.id,
                         conversationId = conversationId,
                         wakeWordPhrase = wakeWordPhrase,
@@ -225,17 +228,22 @@ abstract class AssistViewModelBase(
     }
 
     private fun handleRunStart(data: AssistPipelineRunStart?, isVoice: Boolean, onEvent: (AssistEvent) -> Unit) {
+        Timber.tag("[AA-Assist]").d("handleRunStart: isVoice=%s, hasTtsOutput=%s", isVoice, data?.ttsOutput != null)
         if (!isVoice) return
 
         data?.ttsOutput?.let { ttsOutput ->
             val audioPath = ttsOutput.url
+            Timber.tag("[AA-Assist]").d("handleRunStart: audioPath=%s, currentPath=%s", audioPath, currentPathBeingPlayed)
             val shouldPlay = currentPathBeingPlayed != audioPath || currentPlayAudioJob?.isActive != true
+            Timber.tag("[AA-Assist]").d("handleRunStart: shouldPlay=%s, audioPathNotBlank=%s", shouldPlay, audioPath.isNotBlank())
             if (audioPath.isNotBlank() && shouldPlay) {
                 currentPathBeingPlayed = audioPath
                 stopPlayback()
                 currentPlayAudioJob = viewModelScope.launch {
                     try {
+                        Timber.tag("[AA-Assist]").d("handleRunStart: starting audio playback for %s", audioPath)
                         playAudio(audioPath).collect { state ->
+                            Timber.tag("[AA-Assist]").d("handleRunStart: playback state=%s", state)
                             when (state) {
                                 PlaybackState.PLAYING -> isPlayingAudio = true
                                 PlaybackState.STOP_PLAYING -> {
@@ -246,7 +254,9 @@ abstract class AssistViewModelBase(
                                 PlaybackState.READY -> { /* No op */ }
                             }
                         }
+                        Timber.tag("[AA-Assist]").d("handleRunStart: audio playback flow completed")
                     } finally {
+                        Timber.tag("[AA-Assist]").d("handleRunStart: finally block - setting isPlayingAudio=false")
                         isPlayingAudio = false
                     }
                 }
@@ -276,9 +286,12 @@ abstract class AssistViewModelBase(
     }
 
     private fun handleIntentEnd(data: AssistPipelineIntentEnd?, onEvent: (AssistEvent) -> Unit) {
+        Timber.tag("[AA-Assist]").d("handleIntentEnd: intentOutput=%s", data?.intentOutput != null)
         val intentOutput = data?.intentOutput ?: return
         conversationId = intentOutput.conversationId
         continueConversation.set(intentOutput.continueConversation)
+        Timber.tag("[AA-Assist]").d("handleIntentEnd: continueConversation=%s, speech=%s",
+            intentOutput.continueConversation, intentOutput.response.speech?.plain?.get("speech"))
         intentOutput.response.speech?.plain?.get("speech")?.let { speech ->
             onEvent(AssistEvent.Message.Output(speech))
         }
@@ -377,15 +390,24 @@ abstract class AssistViewModelBase(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun playAudio(path: String): Flow<PlaybackState> {
+        Timber.tag("[AA-Assist]").d("playAudio: resolving path=%s", path)
         return serverManager.connectionStateProvider(selectedServerId).urlFlow().flatMapLatest { urlState ->
             val baseUrl = if (urlState is UrlState.HasUrl) {
+                Timber.tag("[AA-Assist]").d("playAudio: urlState=HasUrl, baseUrl=%s", urlState.url)
                 urlState.url
             } else {
+                Timber.tag("[AA-Assist]").d("playAudio: urlState not HasUrl, baseUrl=null, stateType=%s", urlState::class.simpleName)
                 null
             }
-            UrlUtil.handle(baseUrl, path)?.let {
+            val resolvedUrl = UrlUtil.handle(baseUrl, path)
+            Timber.tag("[AA-Assist]").d("playAudio: resolvedUrl=%s", resolvedUrl)
+            resolvedUrl?.let {
+                Timber.tag("[AA-Assist]").d("playAudio: calling audioUrlPlayer.playAudio(%s)", it)
                 audioUrlPlayer.playAudio(it.toString())
-            } ?: emptyFlow()
+            } ?: run {
+                Timber.tag("[AA-Assist]").e("playAudio: URL resolution failed, returning emptyFlow")
+                emptyFlow()
+            }
         }
     }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -30,6 +30,8 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -136,6 +138,15 @@ abstract class AssistViewModelBase(
 
     /** Whether TTS audio is currently being played back. Updated by playback handlers. */
     protected var isPlayingAudio = false
+        private set
+
+    private val _isPlayingAudioFlow = MutableStateFlow(false)
+    val isPlayingAudioState: StateFlow<Boolean> = _isPlayingAudioFlow
+
+    protected fun setIsPlayingAudio(value: Boolean) {
+        isPlayingAudio = value
+        _isPlayingAudioFlow.value = value
+    }
 
     /**
      * @param text input to run an intent pipeline with, or `null` to run a STT pipeline (check if
@@ -245,9 +256,9 @@ abstract class AssistViewModelBase(
                         playAudio(audioPath).collect { state ->
                             Timber.tag("[AA-Assist]").d("handleRunStart: playback state=%s", state)
                             when (state) {
-                                PlaybackState.PLAYING -> isPlayingAudio = true
+                                PlaybackState.PLAYING -> setIsPlayingAudio(true)
                                 PlaybackState.STOP_PLAYING -> {
-                                    isPlayingAudio = false
+                                    setIsPlayingAudio(false)
                                     onEvent(AssistEvent.PlaybackFinished)
                                     notifyContinueConversationIfNeeded(onEvent)
                                 }
@@ -257,7 +268,7 @@ abstract class AssistViewModelBase(
                         Timber.tag("[AA-Assist]").d("handleRunStart: audio playback flow completed")
                     } finally {
                         Timber.tag("[AA-Assist]").d("handleRunStart: finally block - setting isPlayingAudio=false")
-                        isPlayingAudio = false
+                        setIsPlayingAudio(false)
                     }
                 }
             }
@@ -307,12 +318,12 @@ abstract class AssistViewModelBase(
 
         currentPlayAudioJob = viewModelScope.launch {
             val audioPath = data?.ttsOutput?.url
-            if (!audioPath.isNullOrBlank()) {
-                isPlayingAudio = true
-                try {
+             if (!audioPath.isNullOrBlank()) {
+                setIsPlayingAudio(true)
+               try {
                     playAudio(audioPath).first { state -> state == PlaybackState.STOP_PLAYING }
                 } finally {
-                    isPlayingAudio = false
+                    setIsPlayingAudio(false)
                 }
                 onEvent(AssistEvent.PlaybackFinished)
             }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -59,11 +59,19 @@ sealed interface AssistEvent {
 }
 
 abstract class AssistViewModelBase(
-    protected val serverManager: ServerManager,
-    protected val audioStrategy: AssistAudioStrategy,
+    protected open val serverManager: ServerManager,
+    protected open val audioStrategy: AssistAudioStrategy,
     private val audioUrlPlayer: AudioUrlPlayer,
     application: Application,
 ) : AndroidViewModel(application) {
+
+    open fun onPause() {}
+    open fun onDestroy() {}
+
+    override fun onCleared() {
+        super.onCleared()
+        onDestroy()
+    }
 
     companion object {
         const val PIPELINE_PREFERRED = "preferred"

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/AudioUrlPlayer.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/AudioUrlPlayer.kt
@@ -71,10 +71,13 @@ class AudioUrlPlayer @VisibleForTesting constructor(
      */
     @OptIn(UnstableApi::class)
     fun playAudio(url: String, isAssistant: Boolean = true): Flow<PlaybackState> = callbackFlow {
+        Timber.tag("[AA-Assist]").d("AudioUrlPlayer.playAudio: url=%s, isAssistant=%s", url, isAssistant)
         if (!canPlayMusic()) {
+            Timber.tag("[AA-Assist]").d("AudioUrlPlayer.playAudio: canPlayMusic=false, closing flow")
             close()
             return@callbackFlow
         }
+        Timber.tag("[AA-Assist]").d("AudioUrlPlayer.playAudio: canPlayMusic=true, creating player")
         var request: AudioFocusRequestCompat? = null
 
         val player = playerCreator {
@@ -88,10 +91,14 @@ class AudioUrlPlayer @VisibleForTesting constructor(
             addListener(
                 object : Player.Listener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
+                        Timber.tag("[AA-Assist]").d("AudioUrlPlayer: onPlaybackStateChanged=%s, hasStartedPlayback=%s",
+                            playbackState, hasStartedPlayback)
                         when (playbackState) {
                             Player.STATE_READY -> {
+                                Timber.tag("[AA-Assist]").d("AudioUrlPlayer: STATE_READY reached")
                                 if (!hasStartedPlayback) {
                                     hasStartedPlayback = true
+                                    Timber.tag("[AA-Assist]").d("AudioUrlPlayer: requesting focus and playing")
                                     trySend(PlaybackState.READY)
                                     request = requestFocus(isAssistant)
                                     play()
@@ -142,7 +149,10 @@ class AudioUrlPlayer @VisibleForTesting constructor(
 
     private fun canPlayMusic(): Boolean {
         return try {
-            audioManager != null && audioManager.getStreamVolume(STREAM_MUSIC) != 0
+            val canPlay = audioManager != null && audioManager.getStreamVolume(STREAM_MUSIC) != 0
+            Timber.tag("[AA-Assist]").d("AudioUrlPlayer.canPlayMusic: audioManager=%s, volume=%s, canPlay=%s",
+                audioManager != null, audioManager?.getStreamVolume(STREAM_MUSIC), canPlay)
+            canPlay
         } catch (e: RuntimeException) {
             Timber.e(e, "Couldn't get stream volume")
             true


### PR DESCRIPTION
## Summary

Enables the Assist widget to trigger voice recording functionality within the Android Auto interface using a broadcast-based "Signal/Observe" pattern. The implementation ensures that the intent remains functional for mobile users by correctly routing to the main web view Activity when Android Auto is not present.

## High-Level Overview

### The Problem
Users want to trigger the "Assist" feature (voice interaction with Home Assistant) directly from a Home Assistant widget on their Android device. Currently, when a user interacts with the widget, the app needs to decide where to show the Assist interface: on the phone's main screen (the web view) or on the car's display (Android Auto). Without a way to distinguish between these two contexts, the app might try to open a mobile popup while the user is driving, which is not only useless but potentially distracting.

### The Solution
We implemented a "smart trigger" system. When the widget is pressed, it sets a `trigger_source` extra flag (`TRIGGER_SOURCE_ASSIST`) on the Intent. The `AssistActivity` then checks: "Is the user currently connected to Android Auto?"

- **If YES (Android Auto):** It sends a broadcast with `ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST` to `HaCarAppService`, which pushes the `AutomotiveAssistScreen` onto its session's screen stack.
- **If NO (Mobile):** It launches the standard Assist interface directly within `AssistActivity` on the phone.

## Architectural Overview

We moved from a "one-size-fits-all" intent to a Signal/Observe pattern. Instead of the widget telling the app exactly what to do, it now signals the intent via an Intent extra, and `AssistActivity` observes that signal and decides how to react based on the current context.

### Workflow

1. **Widget Interaction:** User taps the widget → `AssistShortcutActivity` sets `EXTRA_TRIGGER_SOURCE = TRIGGER_SOURCE_ASSIST` on the launch Intent.
2. **Context Check:** `AssistActivity` reads `triggerSource` from the Intent.
3. **Path A (Mobile):** If no Android Auto connection (`carInfo == null`), `AssistActivity` proceeds to render the standard `AssistViewModel` UI.
4. **Path B (Android Auto):** If `carInfo != null`, `AssistActivity` sends a broadcast (`ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST`) to `HaCarAppService` and finishes itself.

## Technical Implementation Details

### 1. Intent Routing (AssistActivity)

`AssistActivity` now checks the `triggerSource` extra on launch. If it matches `TRIGGER_SOURCE_ASSIST` and an Android Auto connection exists, it broadcasts `ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST` (with `EXTRA_SERVER`) and calls `finish()`.

### 2. Car App Service (HaCarAppService)

`HaCarAppService` now registers a `BroadcastReceiver` for `ACTION_NAVIGATE_TO_AUTOMOTIVE_ASSIST` during `onCreate()`. When received, it calls `currentSession.navigateToAssist(serverId)`, which:

- Creates an `AutomotiveAssistViewModel` with the appropriate audio strategy and ExoPlayer.
- Creates an `AutomotiveAssistScreen` and pushes it onto the `ScreenManager`.

Additionally, the microphone icon on `MainVehicleScreen` now triggers the same broadcast, providing an in-app entry point to the Assist screen.

### 3. State-Driven UI (AutomotiveAssistScreen)

A new Car App `Screen` tailored for vehicle use. It listens to:

- `viewModel.conversation` — message list
- `viewModel.processingState` — loading indicator
- `viewModel.isAudioPlaying` — playback icon
- `viewModel.inputMode` — voice/text mode

Uses a Car `ListTemplate` with `Header` and `Row` items for messages, mapping state to `CommunityMaterial` icons (microphone, volume, sync).

### 4. AutomotiveAssistViewModel

A new `AssistViewModelBase` subclass providing a simplified state model for Android Auto. It maps the full `AssistEvent` pipeline to a reduced `conversation`, `processingState`, and `isAudioPlaying` flows. Uses `@AssistedInject` for DI with assisted factories.

### 5. Base Refactoring (AssistViewModelBase)

- `onPause()` and `onDestroy()` moved from public methods to overridable hooks.
- `isPlayingAudio` exposed via `StateFlow<Boolean>` (`isPlayingAudioState`) for observe-in-UI patterns.
- All state changes now use `setIsPlayingAudio()` to update the internal var and flow atomically.
- Heavy Timber logging added with `"[AA-Assist]"` tag for debugging the pipeline across voice recognition, TTS playback, and intent handling stages.

### 6. Data Flow & Synchronization

**Single Source of Truth:** Both the mobile UI (`AssistViewModel`) and Android Auto UI (`AutomotiveAssistViewModel`) extend from `AssistViewModelBase`, sharing the core assist pipeline logic (recorder setup, WebSocket pipeline execution, TTS playback).

**Thread Safety:** All state mutations go through base class methods (`setIsPlayingAudio()`) to prevent race conditions during rapid state changes in the pipeline.

**Lifecycle Management:** `AutomotiveAssistScreen` collects from `viewModel` flows in `init {}` blocks, calling `invalidate()` to trigger Car App template recomposition on each emission.