### PR TITLE
Introduce WebViewAction and enforce EvaluateScriptUsage

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -45,9 +45,6 @@ import io.homeassistant.companion.android.common.compose.theme.LocalHAColorSchem
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionErrorScreen
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionErrorStateProvider
-import io.homeassistant.companion.android.frontend.externalbus.WebViewScript
-import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
-import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge
 import io.homeassistant.companion.android.frontend.js.FrontendJsCallback
 import io.homeassistant.companion.android.frontend.permissions.MultiplePermissionsEffect
@@ -117,8 +114,6 @@ internal fun FrontendScreen(
         webViewClient = viewModel.webViewClient,
         webChromeClient = viewModel.webChromeClient,
         frontendJsCallback = viewModel.frontendJsCallback,
-        scriptsToEvaluate = viewModel.scriptsToEvaluate,
-        hapticEvents = viewModel.hapticEvents,
         pendingPermissionRequest = pendingPermissionRequest,
         onClearPendingPermissionRequest = viewModel::clearPendingPermissionRequest,
         onBlockInsecureRetry = viewModel::onRetry,
@@ -134,6 +129,7 @@ internal fun FrontendScreen(
         onShowSnackbar = onShowSnackbar,
         onWebViewCreationFailed = viewModel::onWebViewCreationFailed,
         onDownloadRequested = viewModel::onDownloadRequested,
+        webViewActions = viewModel.webViewActions,
         modifier = modifier,
     )
 }
@@ -145,7 +141,6 @@ internal fun FrontendScreenContent(
     webViewClient: WebViewClient,
     webChromeClient: WebChromeClient,
     frontendJsCallback: FrontendJsCallback,
-    scriptsToEvaluate: Flow<WebViewScript>,
     onBlockInsecureRetry: () -> Unit,
     onOpenExternalLink: suspend (Uri) -> Unit,
     onBlockInsecureHelpClick: suspend () -> Unit,
@@ -157,13 +152,13 @@ internal fun FrontendScreenContent(
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
     onWebViewCreationFailed: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
-    hapticEvents: Flow<HapticType> = emptyFlow(),
     pendingPermissionRequest: PermissionRequest<*>? = null,
     onClearPendingPermissionRequest: () -> Unit = {},
     errorStateProvider: FrontendConnectionErrorStateProvider = FrontendConnectionErrorStateProvider.noOp,
     securityLevelViewModel: LocationForSecureConnectionViewModel? = null,
     onSecurityLevelDone: () -> Unit = {},
     onDownloadRequested: (url: String, contentDisposition: String, mimetype: String) -> Unit = { _, _, _ -> },
+    webViewActions: Flow<WebViewAction> = emptyFlow(),
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 
@@ -171,8 +166,7 @@ internal fun FrontendScreenContent(
         webView = webView,
         url = viewState.url,
         frontendJsCallback = frontendJsCallback,
-        scriptsToEvaluate = scriptsToEvaluate,
-        hapticEvents = hapticEvents,
+        webViewActions = webViewActions,
     )
 
     PendingPermissionHandler(
@@ -503,15 +497,15 @@ private fun PendingPermissionHandler(
 }
 
 /**
- * Handles WebView side effects: URL loading, script evaluation, haptics.
+ * Handles WebView side effects: URL loading and [WebViewAction] dispatch.
  */
+@OptIn(EvaluateScriptUsage::class)
 @Composable
 private fun WebViewEffects(
     webView: WebView?,
     url: String,
     frontendJsCallback: FrontendJsCallback,
-    scriptsToEvaluate: Flow<WebViewScript>,
-    hapticEvents: Flow<HapticType>,
+    webViewActions: Flow<WebViewAction>,
 ) {
     if (webView != null) {
         LaunchedEffect(webView, url) {
@@ -520,16 +514,8 @@ private fun WebViewEffects(
             webView.loadUrl(url)
         }
         LaunchedEffect(webView) {
-            scriptsToEvaluate.collect { webViewScript ->
-                Timber.d("Evaluating script: ${sensitive(webViewScript.script)}")
-                webView.evaluateJavascript(webViewScript.script) { result ->
-                    webViewScript.result.complete(result)
-                }
-            }
-        }
-        LaunchedEffect(webView) {
-            hapticEvents.collect { hapticType ->
-                HapticFeedbackPerformer.perform(webView, hapticType)
+            webViewActions.collect { action ->
+                action.run(webView)
             }
         }
     }
@@ -548,7 +534,6 @@ private fun FrontendScreenLoadingPreview() {
             webViewClient = WebViewClient(),
             webChromeClient = WebChromeClient(),
             frontendJsCallback = FrontendJsBridge.noOp,
-            scriptsToEvaluate = emptyFlow(),
             onBlockInsecureRetry = {},
             onOpenExternalLink = {},
             onBlockInsecureHelpClick = {},
@@ -581,7 +566,6 @@ private fun FrontendScreenErrorPreview() {
             webViewClient = WebViewClient(),
             webChromeClient = WebChromeClient(),
             frontendJsCallback = FrontendJsBridge.noOp,
-            scriptsToEvaluate = emptyFlow(),
             onBlockInsecureRetry = {},
             onOpenExternalLink = {},
             onBlockInsecureHelpClick = {},
@@ -610,7 +594,6 @@ private fun FrontendScreenInsecurePreview() {
             webViewClient = WebViewClient(),
             webChromeClient = WebChromeClient(),
             frontendJsCallback = FrontendJsBridge.noOp,
-            scriptsToEvaluate = emptyFlow(),
             onBlockInsecureRetry = {},
             onOpenExternalLink = {},
             onBlockInsecureHelpClick = {},
@@ -637,7 +620,6 @@ private fun FrontendScreenSecurityLevelRequiredPreview() {
             webViewClient = WebViewClient(),
             webChromeClient = WebChromeClient(),
             frontendJsCallback = FrontendJsBridge.noOp,
-            scriptsToEvaluate = emptyFlow(),
             onBlockInsecureRetry = {},
             onOpenExternalLink = {},
             onBlockInsecureHelpClick = {},

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -499,7 +499,6 @@ private fun PendingPermissionHandler(
 /**
  * Handles WebView side effects: URL loading and [WebViewAction] dispatch.
  */
-@OptIn(EvaluateScriptUsage::class)
 @Composable
 private fun WebViewEffects(
     webView: WebView?,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -13,8 +13,6 @@ import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionErrorStateProvider
-import io.homeassistant.companion.android.frontend.externalbus.WebViewScript
-import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.handler.FrontendBusObserver
 import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent
 import io.homeassistant.companion.android.frontend.js.BridgeState
@@ -44,6 +42,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -144,8 +143,8 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val _events = MutableSharedFlow<FrontendEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<FrontendEvent> = _events.asSharedFlow()
 
-    private val _hapticEvents = MutableSharedFlow<HapticType>(extraBufferCapacity = 16)
-    val hapticEvents: SharedFlow<HapticType> = _hapticEvents.asSharedFlow()
+    private val _webViewActions = MutableSharedFlow<WebViewAction>(extraBufferCapacity = 1)
+    val webViewActions: Flow<WebViewAction> = merge(_webViewActions, frontendBusObserver.webViewActions())
 
     override val urlFlow: StateFlow<String?> =
         _viewState.map { it.url }
@@ -156,9 +155,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         _viewState.map { state -> (state as? FrontendViewState.Error)?.error }
             .distinctUntilChanged()
             .stateIn(viewModelScope, SharingStarted.Eagerly, (_viewState.value as? FrontendViewState.Error)?.error)
-
-    /** Flow of scripts to be evaluated in the WebView. */
-    val scriptsToEvaluate: Flow<WebViewScript> = frontendBusObserver.scriptsToEvaluate()
 
     /**
      * JavaScript bridge for communication between the WebView and native code.
@@ -385,7 +381,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             }
 
             is FrontendHandlerEvent.PerformHaptic -> {
-                _hapticEvents.tryEmit(result.hapticType)
+                _webViewActions.tryEmit(WebViewAction.Haptic(result.hapticType))
             }
 
             is FrontendHandlerEvent.AuthError -> {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -1,0 +1,101 @@
+package io.homeassistant.companion.android.frontend
+
+import android.webkit.WebView
+import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
+import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
+import io.homeassistant.companion.android.util.sensitive
+import kotlinx.coroutines.CompletableDeferred
+import timber.log.Timber
+
+/**
+ * Actions that require direct interaction with the WebView.
+ *
+ * These actions are emitted by the ViewModel and consumed by the Screen layer,
+ * which holds the WebView reference. This decouples WebView operations from
+ * business logic while keeping them type-safe.
+ *
+ * Any feature that needs to trigger a WebView operation from the ViewModel
+ * (e.g., gestures, script evaluation, haptic feedback) should use this sealed
+ * interface rather than passing the WebView reference to non-UI layers.
+ *
+ * The Screen collects these via [FrontendViewModel.webViewActions] and executes
+ * the corresponding WebView method.
+ */
+sealed interface WebViewAction {
+
+    sealed interface AwaitableAction<T> : WebViewAction {
+        /**
+         * Marker for actions that signal completion via [CompletableDeferred].
+         *
+         * The Screen must call [result].complete() after executing the action.
+         * Callers can await [result] to suspend until the action is fully processed.
+         */
+        val result: CompletableDeferred<T>
+    }
+
+    fun run(webView: WebView)
+
+    /** Navigate forward in WebView history if possible. */
+    data class Forward(override val result: CompletableDeferred<Unit> = CompletableDeferred()) : AwaitableAction<Unit> {
+        override fun run(webView: WebView) {
+            if (webView.canGoForward()) webView.goForward()
+            result.complete(Unit)
+        }
+    }
+
+    /** Reload the current page. */
+    data class Reload(override val result: CompletableDeferred<Unit> = CompletableDeferred()) : AwaitableAction<Unit> {
+        override fun run(webView: WebView) {
+            webView.reload()
+            result.complete(Unit)
+        }
+    }
+
+    /** Perform haptic feedback on the WebView. */
+    data class Haptic(val type: HapticType, override val result: CompletableDeferred<Unit> = CompletableDeferred()) :
+        AwaitableAction<Unit> {
+        override fun run(webView: WebView) {
+            HapticFeedbackPerformer.perform(webView, type)
+            result.complete(Unit)
+        }
+    }
+
+    /** Clear the WebView navigation history. */
+    data class ClearHistory(override val result: CompletableDeferred<Unit> = CompletableDeferred()) :
+        AwaitableAction<Unit> {
+        override fun run(webView: WebView) {
+            webView.clearHistory()
+            result.complete(Unit)
+        }
+    }
+
+    /**
+     * Evaluate a JavaScript script in the WebView, the result of the execution is
+     * emitted through [result].
+     */
+    @EvaluateScriptUsage
+    data class EvaluateScript(
+        val script: String,
+        override val result: CompletableDeferred<String?> = CompletableDeferred(),
+    ) : AwaitableAction<String?> {
+        override fun run(webView: WebView) {
+            Timber.d("Evaluating script: ${sensitive(script)}")
+            webView.evaluateJavascript(script) { scriptResult ->
+                result.complete(scriptResult)
+            }
+        }
+    }
+}
+
+/**
+ * Gates direct JavaScript evaluation in the WebView behind an explicit opt-in.
+ */
+@RequiresOptIn(
+    message =
+    "Evaluating raw JavaScript tightly couples the app to frontend internals and is fragile across frontend changes. " +
+        "Prefer collaborating with the frontend team to add a dedicated externalBus message. " +
+        "Only opt in as a last resort, and document on the opt-in site why the externalBus is not a viable option so reviewers can challenge the usage.",
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class EvaluateScriptUsage

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -89,9 +89,7 @@ sealed interface WebViewAction {
     }
 }
 
-/**
- * Gates direct JavaScript evaluation in the WebView behind an explicit opt-in.
- */
+/** Gates direct JavaScript evaluation in the WebView behind an explicit opt-in. */
 @RequiresOptIn(
     message =
     "Evaluating raw JavaScript tightly couples the app to frontend internals and is fragile across frontend changes. " +

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -27,8 +27,10 @@ sealed interface WebViewAction {
         /**
          * Marker for actions that signal completion via [CompletableDeferred].
          *
-         * The Screen must call [result].complete() after executing the action.
-         * Callers can await [result] to suspend until the action is fully processed.
+         * The Screen executes the action by calling [run], and the action
+         * implementation is responsible for completing [result] when processing has
+         * finished. Completion may happen directly inside [run] or asynchronously
+         * from a callback started by [run].
          */
         val result: CompletableDeferred<T>
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/download/FrontendDownloadManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/download/FrontendDownloadManager.kt
@@ -7,6 +7,7 @@ import android.webkit.URLUtil
 import androidx.core.net.toUri
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge.Companion.externalBusCallback
 import io.homeassistant.companion.android.frontend.session.ServerSessionManager
@@ -144,7 +145,16 @@ class FrontendDownloadManager @Inject constructor(
      * Triggers a blob download by fetching the blob data via the Fetch API and sending it back
      * through the external bus as a data URI for [handleBlob] to process.
      * Requires the blob URL to still be valid (not yet revoked by the frontend).
+     *
+     * Opts into [EvaluateScriptUsage] because we inject a small async function into the
+     * frontend and, once it has read the blob as a data URL, we make it call back into
+     * the external bus (via `window.externalBus(...)`) so the result is delivered through
+     * the normal typed message path (see [handleBlob]). A dedicated externalBus event
+     * could have been introduced for this, but the integration predates the
+     * [EvaluateScriptUsage] policy and we also need it to work against older frontend
+     * versions that do not expose such a message type.
      */
+    @OptIn(EvaluateScriptUsage::class)
     private suspend fun triggerBlobDownload(url: String, contentDisposition: String, mimetype: String): DownloadResult {
         Timber.d("Triggering blob download for ${sensitive(url)}")
         val fallbackFilename = withContext(Dispatchers.IO) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepository.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepository.kt
@@ -1,19 +1,11 @@
 package io.homeassistant.companion.android.frontend.externalbus
 
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
+import io.homeassistant.companion.android.frontend.WebViewAction
 import io.homeassistant.companion.android.frontend.externalbus.incoming.IncomingExternalBusMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.OutgoingExternalBusMessage
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.json.JsonElement
-
-/**
- * Represents a JavaScript script to be evaluated in the WebView.
- *
- * @property script The JavaScript code to evaluate
- * @property result Deferred that will be completed with the evaluation result.
- *                  The WebView consumer should call [result.complete] with the result.
- */
-data class WebViewScript(val script: String, val result: CompletableDeferred<String?> = CompletableDeferred())
 
 /**
  * Repository for typed communication with the Home Assistant frontend via the external bus.
@@ -28,15 +20,18 @@ interface FrontendExternalBusRepository {
 
     /**
      * Sends a typed message to the frontend via the external bus.
+     *
+     * The message is serialized to JSON and emitted as a [WebViewAction.EvaluateScript].
+     * This is fire-and-forget — the evaluation result is not awaited.
      */
     suspend fun send(message: OutgoingExternalBusMessage)
 
     /**
-     * Returns a flow of scripts to evaluate in the WebView.
+     * Returns a flow of [WebViewAction] to be executed by the WebView.
      *
-     * The WebView should collect this flow and call `evaluateJavascript` for each script.
+     * The WebView should collect this flow and execute each action accordingly.
      */
-    fun scriptsToEvaluate(): Flow<WebViewScript>
+    fun webViewActions(): Flow<WebViewAction>
 
     /**
      * Evaluates a raw JavaScript script in the WebView and returns the result.
@@ -45,6 +40,7 @@ interface FrontendExternalBusRepository {
      *
      * @return The evaluation result from the WebView, or null if the script returns no value
      */
+    @EvaluateScriptUsage
     suspend fun evaluateScript(script: String): String?
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package io.homeassistant.companion.android.frontend.externalbus
 
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
+import io.homeassistant.companion.android.frontend.WebViewAction
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.externalbus.incoming.IncomingExternalBusMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.OutgoingExternalBusMessage
@@ -41,7 +43,7 @@ val frontendExternalBusJson = Json(kotlinJsonMapper) {
  */
 class FrontendExternalBusRepositoryImpl @Inject constructor() : FrontendExternalBusRepository {
 
-    private val scriptsFlow = MutableSharedFlow<WebViewScript>(
+    private val actionsFlow = MutableSharedFlow<WebViewAction>(
         // Don't suspend if the WebView is temporarily unavailable
         extraBufferCapacity = BUFFER_CAPACITY,
     )
@@ -50,19 +52,34 @@ class FrontendExternalBusRepositoryImpl @Inject constructor() : FrontendExternal
         extraBufferCapacity = BUFFER_CAPACITY,
     )
 
+    /**
+     * Opts into [EvaluateScriptUsage] because this is the internal mechanism that
+     * implements the external bus itself. The frontend installs `window.externalBus`
+     * as the entry point for messages from the native app (see `ExternalMessaging.attach`
+     * in the frontend), so delivering a bus message means invoking that function via
+     * `evaluateJavascript`. There is no higher-level alternative — this call is what
+     * other callers rely on when they use [send].
+     *
+     * [send] enforces strong typing by accepting an [OutgoingExternalBusMessage] parameter,
+     * hiding the JSON serialization and script wrapping from callers. This keeps the raw
+     * `evaluateScript` usage confined to this single site so callers doesn't have to construct
+     * arbitrary scripts and use the typed message API.
+     */
+    @OptIn(EvaluateScriptUsage::class)
     override suspend fun send(message: OutgoingExternalBusMessage) {
         val json = frontendExternalBusJson.encodeToString(message)
         val script = "externalBus($json);"
         Timber.d("Queuing external bus message: ${sensitive(script)}")
-        scriptsFlow.emit(WebViewScript(script))
+        actionsFlow.emit(WebViewAction.EvaluateScript(script))
     }
 
-    override fun scriptsToEvaluate(): Flow<WebViewScript> = scriptsFlow.asSharedFlow()
+    override fun webViewActions(): Flow<WebViewAction> = actionsFlow.asSharedFlow()
 
+    @EvaluateScriptUsage
     override suspend fun evaluateScript(script: String): String? {
-        val webViewScript = WebViewScript(script)
-        scriptsFlow.emit(webViewScript)
-        return webViewScript.result.await()
+        val action = WebViewAction.EvaluateScript(script)
+        actionsFlow.emit(action)
+        return action.result.await()
     }
 
     override fun incomingMessages(): Flow<IncomingExternalBusMessage> = incomingFlow.asSharedFlow()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImpl.kt
@@ -62,7 +62,7 @@ class FrontendExternalBusRepositoryImpl @Inject constructor() : FrontendExternal
      *
      * [send] enforces strong typing by accepting an [OutgoingExternalBusMessage] parameter,
      * hiding the JSON serialization and script wrapping from callers. This keeps the raw
-     * `evaluateScript` usage confined to this single site so callers doesn't have to construct
+     * `evaluateScript` usage confined to this single site so callers do not have to construct
      * arbitrary scripts and use the typed message API.
      */
     @OptIn(EvaluateScriptUsage::class)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendBusObserver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendBusObserver.kt
@@ -1,10 +1,10 @@
 package io.homeassistant.companion.android.frontend.handler
 
-import io.homeassistant.companion.android.frontend.externalbus.WebViewScript
+import io.homeassistant.companion.android.frontend.WebViewAction
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Observes the frontend external bus for incoming events and scripts to evaluate.
+ * Observes the frontend external bus for incoming events and WebView actions.
  *
  * This interface exposes the ViewModel-facing API of [FrontendMessageHandler],
  * separating it from the bridge-facing [io.homeassistant.companion.android.frontend.js.FrontendJsHandler].
@@ -17,10 +17,9 @@ interface FrontendBusObserver {
     fun messageResults(): Flow<FrontendHandlerEvent>
 
     /**
-     * Returns a flow of scripts to evaluate in the WebView.
+     * Returns a flow of [WebViewAction] to be executed by the WebView.
      *
-     * The WebView should collect this flow and call `evaluateJavascript` for each script,
-     * then complete the deferred result with the evaluation output.
+     * The WebView should collect this flow and execute each action accordingly.
      */
-    fun scriptsToEvaluate(): Flow<WebViewScript>
+    fun webViewActions(): Flow<WebViewAction>
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
@@ -4,9 +4,10 @@ import android.content.pm.PackageManager
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.di.qualifiers.IsAutomotive
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
+import io.homeassistant.companion.android.frontend.WebViewAction
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
-import io.homeassistant.companion.android.frontend.externalbus.WebViewScript
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConfigGetMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HandleBlobMessage
@@ -68,30 +69,44 @@ class FrontendMessageHandler @Inject constructor(
      * Called when the frontend requests authentication.
      *
      * The bridge has already parsed and validated the callback name before calling this.
+     *
+     * Opts into [EvaluateScriptUsage] because the auth protocol runs on its own channel,
+     * not the external bus: the frontend installs a callback on `window` (e.g.
+     * `window.externalAuthSetToken`) and waits for the native app to invoke it directly
+     * with the auth response.
      */
+    @OptIn(EvaluateScriptUsage::class)
     override suspend fun getExternalAuth(authPayload: AuthPayload, serverId: Int) {
         Timber.d("getExternalAuth called")
         when (val result = sessionManager.getExternalAuth(serverId, authPayload)) {
             is ExternalAuthResult.Success -> {
-                evaluateScript(result.callbackScript)
+                externalBusRepository.evaluateScript(result.callbackScript)
             }
 
             is ExternalAuthResult.Failed -> {
-                evaluateScript(result.callbackScript)
+                externalBusRepository.evaluateScript(result.callbackScript)
                 result.error?.let { jsCallbackEvents.tryEmit(FrontendHandlerEvent.AuthError(it)) }
             }
         }
     }
 
+    /**
+     * Called when the frontend requests to revoke the current authentication.
+     *
+     * Opts into [EvaluateScriptUsage] for the same reason as [getExternalAuth]: the frontend
+     * installs a `window.externalAuthRevokeToken` callback and waits for the native app to
+     * invoke it directly.
+     */
+    @OptIn(EvaluateScriptUsage::class)
     override suspend fun revokeExternalAuth(authPayload: AuthPayload, serverId: Int) {
         Timber.d("revokeExternalAuth called")
         when (val result = sessionManager.revokeExternalAuth(serverId, authPayload)) {
             is RevokeAuthResult.Success -> {
-                evaluateScript(result.callbackScript)
+                externalBusRepository.evaluateScript(result.callbackScript)
             }
 
             is RevokeAuthResult.Failed -> {
-                evaluateScript(result.callbackScript)
+                externalBusRepository.evaluateScript(result.callbackScript)
             }
         }
     }
@@ -114,11 +129,7 @@ class FrontendMessageHandler @Inject constructor(
         return merge(incomingResults, jsCallbackEvents)
     }
 
-    override fun scriptsToEvaluate(): Flow<WebViewScript> = externalBusRepository.scriptsToEvaluate()
-
-    private suspend fun evaluateScript(script: String): String? {
-        return externalBusRepository.evaluateScript(script)
-    }
+    override fun webViewActions(): Flow<WebViewAction> = externalBusRepository.webViewActions()
 
     private suspend fun handleMessage(message: IncomingExternalBusMessage): FrontendHandlerEvent {
         return when (message) {

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
@@ -11,7 +11,6 @@ import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge
 import io.homeassistant.companion.android.frontend.permissions.PermissionRequest
 import io.homeassistant.companion.android.util.compose.HAPreviews
-import kotlinx.coroutines.flow.emptyFlow
 
 class FrontendScreenScreenshotTest {
 
@@ -26,7 +25,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -55,7 +53,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -81,7 +78,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -111,7 +107,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -140,7 +135,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -170,7 +164,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},
@@ -205,7 +198,6 @@ class FrontendScreenScreenshotTest {
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
                 frontendJsCallback = FrontendJsBridge.noOp,
-                scriptsToEvaluate = emptyFlow(),
                 onBlockInsecureRetry = {},
                 onOpenExternalLink = {},
                 onBlockInsecureHelpClick = {},

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
@@ -41,7 +41,6 @@ import io.mockk.verify
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -392,7 +391,6 @@ class FrontendScreenTest {
                     webViewClient = WebViewClient(),
                     webChromeClient = WebChromeClient(),
                     frontendJsCallback = FrontendJsBridge.noOp,
-                    scriptsToEvaluate = emptyFlow(),
                     errorStateProvider = errorStateProvider,
                     pendingPermissionRequest = pendingPermissionRequest,
                     onBlockInsecureRetry = onBlockInsecureRetry,
@@ -447,7 +445,6 @@ class FrontendScreenTest {
                     webViewClient = WebViewClient(),
                     webChromeClient = WebChromeClient(),
                     frontendJsCallback = FrontendJsBridge.noOp,
-                    scriptsToEvaluate = emptyFlow(),
                     onBlockInsecureRetry = {},
                     onOpenExternalLink = {},
                     onBlockInsecureHelpClick = {},

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -66,7 +66,7 @@ class FrontendViewModelTest {
     @BeforeEach
     fun setUp() {
         every { frontendBusObserver.messageResults() } returns emptyFlow()
-        every { frontendBusObserver.scriptsToEvaluate() } returns emptyFlow()
+        every { frontendBusObserver.webViewActions() } returns emptyFlow()
         every { connectivityCheckRepository.runChecks(any()) } returns flowOf(ConnectivityCheckState())
     }
 
@@ -520,7 +520,7 @@ class FrontendViewModelTest {
         }
 
         @Test
-        fun `Given haptic message when collected then hapticEvents emits the type`() = runTest {
+        fun `Given haptic message when collected then webViewActions emits Haptic action`() = runTest {
             val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
             every { frontendBusObserver.messageResults() } returns messageFlow
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
@@ -529,21 +529,16 @@ class FrontendViewModelTest {
 
             val viewModel = createViewModel()
 
-            val hapticEvents = mutableListOf<HapticType>()
-            val job = backgroundScope.launch { viewModel.hapticEvents.collect { hapticEvents.add(it) } }
+            viewModel.webViewActions.test {
+                messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Success))
+                messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Light))
+                messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Heavy))
 
-            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
-
-            messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Success))
-            messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Light))
-            messageFlow.emit(FrontendHandlerEvent.PerformHaptic(HapticType.Heavy))
-            advanceUntilIdle()
-
-            assertEquals(3, hapticEvents.size)
-            assertEquals(HapticType.Success, hapticEvents[0])
-            assertEquals(HapticType.Light, hapticEvents[1])
-            assertEquals(HapticType.Heavy, hapticEvents[2])
-            job.cancel()
+                assertEquals(HapticType.Success, (awaitItem() as WebViewAction.Haptic).type)
+                assertEquals(HapticType.Light, (awaitItem() as WebViewAction.Haptic).type)
+                assertEquals(HapticType.Heavy, (awaitItem() as WebViewAction.Haptic).type)
+                cancelAndIgnoreRemainingEvents()
+            }
         }
 
         @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
@@ -1,0 +1,116 @@
+package io.homeassistant.companion.android.frontend
+
+import android.webkit.ValueCallback
+import android.webkit.WebView
+import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
+import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.slot
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(EvaluateScriptUsage::class)
+class WebViewActionTest {
+
+    private val webView: WebView = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setup() {
+        mockkObject(HapticFeedbackPerformer)
+        every { HapticFeedbackPerformer.perform(any(), any()) } just Runs
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkObject(HapticFeedbackPerformer)
+    }
+
+    @Test
+    fun `Given Forward when run and canGoForward is true then goForward is called and result completes`() = runTest {
+        every { webView.canGoForward() } returns true
+        val action = WebViewAction.Forward()
+
+        action.run(webView)
+
+        verify { webView.goForward() }
+        assertTrue(action.result.isCompleted)
+    }
+
+    @Test
+    fun `Given Forward when run and canGoForward is false then goForward is not called but result completes`() = runTest {
+        every { webView.canGoForward() } returns false
+        val action = WebViewAction.Forward()
+
+        action.run(webView)
+
+        verify(exactly = 0) { webView.goForward() }
+        assertTrue(action.result.isCompleted)
+    }
+
+    @Test
+    fun `Given Reload when run then reload is called and result completes`() = runTest {
+        val action = WebViewAction.Reload()
+
+        action.run(webView)
+
+        verify { webView.reload() }
+        assertTrue(action.result.isCompleted)
+    }
+
+    @Test
+    fun `Given Haptic when run then HapticFeedbackPerformer is invoked with the type and result completes`() = runTest {
+        val action = WebViewAction.Haptic(HapticType.Success)
+
+        action.run(webView)
+
+        verify { HapticFeedbackPerformer.perform(webView, HapticType.Success) }
+        assertTrue(action.result.isCompleted)
+    }
+
+    @Test
+    fun `Given ClearHistory when run then clearHistory is called and result completes`() = runTest {
+        val action = WebViewAction.ClearHistory()
+
+        action.run(webView)
+
+        verify { webView.clearHistory() }
+        assertTrue(action.result.isCompleted)
+    }
+
+    @Test
+    fun `Given EvaluateScript when run then evaluateJavascript is called and result completes with callback value`() = runTest {
+        val callbackSlot = slot<ValueCallback<String>>()
+        every { webView.evaluateJavascript(any(), capture(callbackSlot)) } just Runs
+        val action = WebViewAction.EvaluateScript(script = "doThing()")
+
+        action.run(webView)
+
+        verify { webView.evaluateJavascript("doThing()", any()) }
+        // Simulate the WebView invoking the callback with a result
+        callbackSlot.captured.onReceiveValue("\"ok\"")
+        assertTrue(action.result.isCompleted)
+        assertEquals("\"ok\"", action.result.await())
+    }
+
+    @Test
+    fun `Given EvaluateScript when run and callback returns null then result completes with null`() = runTest {
+        val callbackSlot = slot<ValueCallback<String>>()
+        every { webView.evaluateJavascript(any(), capture(callbackSlot)) } just Runs
+        val action = WebViewAction.EvaluateScript(script = "void(0)")
+
+        action.run(webView)
+
+        callbackSlot.captured.onReceiveValue(null)
+        assertEquals(null, action.result.await())
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/download/FrontendDownloadManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/download/FrontendDownloadManagerTest.kt
@@ -4,6 +4,7 @@ import android.app.DownloadManager
 import android.net.Uri
 import android.webkit.URLUtil
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.session.ServerSessionManager
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
@@ -28,7 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ConsoleLogExtension::class)
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, EvaluateScriptUsage::class)
 class FrontendDownloadManagerTest {
     private val systemDownloadManager: DownloadManager = mockk(relaxed = true)
     private val dataUriDownloadManager: DataUriDownloadManager = mockk(relaxed = true)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/FrontendExternalBusRepositoryImplTest.kt
@@ -1,6 +1,8 @@
 package io.homeassistant.companion.android.frontend.externalbus
 
 import app.cash.turbine.test
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
+import io.homeassistant.companion.android.frontend.WebViewAction
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConfigGetMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.UnknownIncomingMessage
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(EvaluateScriptUsage::class)
 class FrontendExternalBusRepositoryImplTest {
 
     private lateinit var repository: FrontendExternalBusRepositoryImpl
@@ -105,7 +108,7 @@ class FrontendExternalBusRepositoryImplTest {
     }
 
     @Test
-    fun `Given outgoing message when sent then emit as script on scriptsToEvaluate flow`() = runTest {
+    fun `Given outgoing message when sent then emit as EvaluateScript on webViewActions flow`() = runTest {
         val configResponse = ResultMessage.config(
             id = 1,
             config = ConfigResult(
@@ -117,12 +120,13 @@ class FrontendExternalBusRepositoryImplTest {
             ),
         )
 
-        repository.scriptsToEvaluate().test {
+        repository.webViewActions().test {
             repository.send(configResponse)
 
-            val script = awaitItem()
-            assertEquals("externalBus(${frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(configResponse)});", script.script)
-            assertFalse(script.result.isCompleted)
+            val action = awaitItem()
+            assertInstanceOf(WebViewAction.EvaluateScript::class.java, action)
+            val evaluateScript = action as WebViewAction.EvaluateScript
+            assertEquals("externalBus(${frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(configResponse)});", evaluateScript.script)
         }
     }
 
@@ -131,17 +135,19 @@ class FrontendExternalBusRepositoryImplTest {
         val testScript = "testCallback(true)"
         val expectedResult = "success"
 
-        repository.scriptsToEvaluate().test {
+        repository.webViewActions().test {
             // Start evaluateScript in background - it will suspend
             val resultDeferred = async { repository.evaluateScript(testScript) }
 
-            // Collect the emitted script
-            val webViewScript = awaitItem()
-            assertEquals(testScript, webViewScript.script)
-            assertFalse(webViewScript.result.isCompleted)
+            // Collect the emitted action
+            val action = awaitItem()
+            assertInstanceOf(WebViewAction.EvaluateScript::class.java, action)
+            val evaluateScript = action as WebViewAction.EvaluateScript
+            assertEquals(testScript, evaluateScript.script)
+            assertFalse(evaluateScript.result.isCompleted)
 
             // Simulate WebView completing the result
-            webViewScript.result.complete(expectedResult)
+            evaluateScript.result.complete(expectedResult)
 
             // Now evaluateScript should return
             val result = resultDeferred.await()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -5,11 +5,12 @@ import app.cash.turbine.test
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.util.AppVersion
 import io.homeassistant.companion.android.common.util.AppVersionProvider
+import io.homeassistant.companion.android.frontend.EvaluateScriptUsage
+import io.homeassistant.companion.android.frontend.WebViewAction
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
-import io.homeassistant.companion.android.frontend.externalbus.WebViewScript
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConfigGetMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusPayload
@@ -47,6 +48,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -54,7 +56,7 @@ import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ConsoleLogExtension::class)
-@OptIn(ExperimentalCoroutinesApi::class)
+@OptIn(ExperimentalCoroutinesApi::class, EvaluateScriptUsage::class)
 class FrontendMessageHandlerTest {
 
     private val externalBusRepository: FrontendExternalBusRepository = mockk(relaxed = true)
@@ -73,7 +75,7 @@ class FrontendMessageHandlerTest {
         every { matterManager.appSupportsCommissioning() } returns false
         every { threadManager.appSupportsThread() } returns false
         every { appVersionProvider() } returns AppVersion.from("1.0.0", 1)
-        every { externalBusRepository.scriptsToEvaluate() } returns emptyFlow()
+        every { externalBusRepository.webViewActions() } returns emptyFlow()
 
         handler = FrontendMessageHandler(
             externalBusRepository = externalBusRepository,
@@ -280,13 +282,14 @@ class FrontendMessageHandlerTest {
     }
 
     @Test
-    fun `Given scripts flow when scriptsToEvaluate then returns repository flow`() = runTest {
-        val script = WebViewScript(script = "test()")
-        every { externalBusRepository.scriptsToEvaluate() } returns flowOf(script)
+    fun `Given webViewActions flow when webViewActions then returns repository flow`() = runTest {
+        val action = WebViewAction.EvaluateScript(script = "test()")
+        every { externalBusRepository.webViewActions() } returns flowOf(action)
 
-        handler.scriptsToEvaluate().test {
+        handler.webViewActions().test {
             val result = awaitItem()
-            assertEquals(script.script, result.script)
+            assertInstanceOf(WebViewAction.EvaluateScript::class.java, result)
+            assertEquals("test()", (result as WebViewAction.EvaluateScript).script)
             awaitComplete()
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR is based on #6640 and replace the actions we can do on the WebView like evaluate script or others into a action flow using `WebViewAction`. The `WebViewAction` is a sealed class that contains actions it is tight to the Webkit framework by exposing a `run(webView)` method that we don't need to add the implementation of the action within a `when` on the screen. I've also introduce a `result` field used to notified when the action is done, it is important for some actions we run like getting the result of a script evaluation, or knowing when the clear action is done.

To raise awareness that we should not privileged injecting JS script I've introduce the opt in annotation `EvaluateScriptUsage`, that should be easy to spot during review. This should address part of https://github.com/home-assistant/android/pull/6708#discussion_r3081617806.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->