### PR TITLE
Enable cookie in FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.net.Uri
 import android.view.MotionEvent
 import android.view.View
+import android.webkit.CookieManager
 import android.webkit.WebChromeClient
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -412,29 +413,12 @@ private fun SafeHAWebView(
                     .weight(1f)
                     .background(Color.Transparent),
                 configure = {
-                    onWebViewCreated(this)
-                    this.webViewClient = webViewClient
-                    webChromeClient?.let { this.webChromeClient = it }
-                    setDownloadListener { url, _, contentDisposition, mimetype, _ ->
-                        onDownloadRequested(url, contentDisposition, mimetype)
-                    }
-                    setOnTouchListener(
-                        object : OnSwipeListener(context) {
-                            override fun onSwipe(
-                                e1: MotionEvent,
-                                e2: MotionEvent,
-                                velocity: Float,
-                                direction: GestureDirection,
-                                pointerCount: Int,
-                            ): Boolean {
-                                if (pointerCount > 1 && velocity >= MINIMUM_GESTURE_VELOCITY) {
-                                    onGesture(direction, pointerCount)
-                                }
-                                return false
-                            }
-
-                            override fun onMotionEventHandled(v: View?, event: MotionEvent?): Boolean = false
-                        },
+                    configureForFrontend(
+                        webViewClient = webViewClient,
+                        webChromeClient = webChromeClient,
+                        onWebViewCreated = onWebViewCreated,
+                        onDownloadRequested = onDownloadRequested,
+                        onGesture = onGesture,
                     )
                 },
                 onBackPressed = onBackClick,
@@ -466,6 +450,59 @@ private fun SafeHAWebView(
 @Composable
 private fun Color.Overlay(modifier: Modifier = Modifier) {
     Spacer(modifier = modifier.background(this))
+}
+
+/**
+ * Applies the WebView configuration required to host the Home Assistant frontend
+ *
+ * The `ClickableViewAccessibility` lint is suppressed because the touch listener only observes
+ * multi-pointer swipe gestures (returning `false` for every event) — clicks still flow through
+ * the WebView's built-in handling, so overriding `performClick` would add no accessibility value.
+ */
+@SuppressLint("ClickableViewAccessibility")
+private fun WebView.configureForFrontend(
+    webViewClient: WebViewClient,
+    webChromeClient: WebChromeClient?,
+    onWebViewCreated: (WebView) -> Unit,
+    onDownloadRequested: (url: String, contentDisposition: String, mimetype: String) -> Unit,
+    onGesture: (GestureDirection, Int) -> Unit,
+) {
+    onWebViewCreated(this)
+
+    this.webViewClient = webViewClient
+
+    webChromeClient?.let { this.webChromeClient = it }
+
+    // Enable first-party cookies globally and third-party cookies for this WebView.
+    // The Home Assistant frontend relies on third-party cookies for some integrations
+    // (e.g. embedded content served from a different origin).
+    CookieManager.getInstance().apply {
+        setAcceptCookie(true)
+        setAcceptThirdPartyCookies(this@configureForFrontend, true)
+    }
+
+    setDownloadListener { url, _, contentDisposition, mimetype, _ ->
+        onDownloadRequested(url, contentDisposition, mimetype)
+    }
+
+    setOnTouchListener(
+        object : OnSwipeListener(context) {
+            override fun onSwipe(
+                e1: MotionEvent,
+                e2: MotionEvent,
+                velocity: Float,
+                direction: GestureDirection,
+                pointerCount: Int,
+            ): Boolean {
+                if (pointerCount > 1 && velocity >= MINIMUM_GESTURE_VELOCITY) {
+                    onGesture(direction, pointerCount)
+                }
+                return false
+            }
+
+            override fun onMotionEventHandled(v: View?, event: MotionEvent?): Boolean = false
+        },
+    )
 }
 
 /**


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Based on #6714 it adds the missing setup for the cookie in `FrontendScreen`and move the Webview configure block into a dedicated function to keep everything readable.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.