### PR TITLE
Handle missing client certificate chooser activity

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.util
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.ContextWrapper
 import android.security.KeyChain
@@ -81,25 +82,33 @@ open class TLSWebViewClient(private var keyChainRepository: KeyChainRepository) 
 
     private fun selectClientCert(activity: Activity, request: ClientCertRequest) {
         // prompt the user for a key
-        KeyChain.choosePrivateKeyAlias(
-            activity,
-            SafeKeyChainAliasCallback(keyChainRepository, activity.applicationContext) { key, chain ->
-                if (key == null || chain == null) {
-                    hasUserDeniedAccess = true
-                    request.ignore()
-                } else {
-                    checkChainValidity()
-                    this.key = key
-                    this.chain = chain
-                    request.proceed(key, chain)
-                }
-            },
-            request.keyTypes,
-            request.principals,
-            request.host,
-            request.port,
-            null,
-        )
+        try {
+            KeyChain.choosePrivateKeyAlias(
+                activity,
+                SafeKeyChainAliasCallback(keyChainRepository, activity.applicationContext) { key, chain ->
+                    if (key == null || chain == null) {
+                        hasUserDeniedAccess = true
+                        request.ignore()
+                    } else {
+                        checkChainValidity()
+                        this.key = key
+                        this.chain = chain
+                        request.proceed(key, chain)
+                    }
+                },
+                request.keyTypes,
+                request.principals,
+                request.host,
+                request.port,
+                null,
+            )
+        } catch (e: ActivityNotFoundException) {
+            // some cut-down ROMs don't have a client TLS certificate chooser activity (com.android.keychain.CHOOSER)
+            // cancel the request so the WebView proceeds without presenting a cert
+            Timber.w(e, "Client certificate chooser activity not available, proceeding without cert")
+            hasUserDeniedAccess = true
+            request.ignore()
+        }
     }
 
     private fun checkChainValidity() {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary

On certain Android devices with cut-down ROMs (e.g. [Movistar Home RG3205W](https://github.com/zry98/movistar-home-hacks/blob/main/RG3205W/README.en.md)), there is no system activity (`com.android.keychain.CHOOSER`) to handle the client-side certificate chooser invoked by `KeyChain.choosePrivateKeyAlias`. When a web server requests a client certificate, this caused an `ActivityNotFoundException`, which is not handled by the app so it crashes on start.

<details>
<summary>Crash logs</summary>

```
Timestamp: 2026-04-16 02:22:40.207
Thread: main
Exception: org.chromium.base.JniAndroid$UncaughtExceptionException: Native stack trace:
#00 pc 0x0287c549 /system/app/WebView/WebView.apk (offset 0xcb0000)
#01 pc 0x0287508f /system/app/WebView/WebView.apk (offset 0xcb0000)
#02 pc 0x010e1e05 /system/app/WebView/WebView.apk (offset 0xcb0000)
#03 pc 0x010f41a1 /system/app/WebView/WebView.apk (offset 0xcb0000)
#04 pc 0x010eb405 /system/app/WebView/WebView.apk (offset 0xcb0000)
#05 pc 0x01df3e7f /system/app/WebView/WebView.apk (offset 0xcb0000)
#06 pc 0x01df3f59 /system/app/WebView/WebView.apk (offset 0xcb0000)
#07 pc 0x028413ed /system/app/WebView/WebView.apk (offset 0xcb0000)
#08 pc 0x0284f4a9 /system/app/WebView/WebView.apk (offset 0xcb0000)
#09 pc 0x02871743 /system/app/WebView/WebView.apk (offset 0xcb0000)
#10 pc 0x02871711 /system/app/WebView/WebView.apk (offset 0xcb0000)
#11 pc 0x02871505 /system/app/WebView/WebView.apk (offset 0xcb0000)
#12 pc 0x0000ff5d /system/lib/libutils.so
#13 pc 0x0000fc83 /system/lib/libutils.so
#14 pc 0x000a29eb /system/lib/libandroid_runtime.so

	at org.chromium.base.JniAndroid.handleException(chromium-SystemWebView.apk-default-720406300:21)
	at android.os.MessageQueue.nativePollOnce(Native Method)
	at android.os.MessageQueue.next(MessageQueue.java:325)
	at android.os.Looper.loop(Looper.java:142)
	at android.app.ActivityThread.main(ActivityThread.java:6518)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
Caused by: android.content.ActivityNotFoundException: No Activity found to handle Intent { act=com.android.keychain.CHOOSER pkg=com.android.keychain (has extras) }
	at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1944)
	at android.app.Instrumentation.execStartActivity(Instrumentation.java:1618)
	at android.app.Activity.startActivityForResult(Activity.java:4501)
	at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.kt:694)
	at android.app.Activity.startActivityForResult(Activity.java:4459)
	at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.kt:679)
	at android.app.Activity.startActivity(Activity.java:4820)
	at android.app.Activity.startActivity(Activity.java:4788)
	at android.security.KeyChain.choosePrivateKeyAlias(KeyChain.java:390)
	at android.security.KeyChain.choosePrivateKeyAlias(KeyChain.java:319)
	at io.homeassistant.companion.android.util.TLSWebViewClient.selectClientCert(TLSWebViewClient.kt:84)
	at io.homeassistant.companion.android.util.TLSWebViewClient.onReceivedClientCertRequest(TLSWebViewClient.kt:74)
	at org.chromium.android_webview.AwContentsClientBridge.selectClientCertificate(chromium-SystemWebView.apk-default-720406300:157)
```

</details>

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes

On Chrome for Android, this exception is handled by showing a dismiss-able alert "Client side certificate selection is not supported by the operating system".