### PR TITLE
feat(webview): support external authentication providers in front of Home Assistant

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -112,7 +112,12 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         onFrontendError = ::onError,
         onUrlIntercepted = ::interceptRedirectIfRequired,
         onPageFinished = { _isLoadingFlow.update { false } },
-    )
+    ).apply {
+        // Anchor the WebView client to the onboarding server so auth-provider
+        // navigation on third-party domains is kept inside the WebView instead
+        // of being forwarded to the system browser.
+        serverHost = rawUri.host
+    }
 
     init {
         viewModelScope.launch {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
@@ -6,6 +6,7 @@ import android.content.ContextWrapper
 import android.security.KeyChain
 import android.security.KeyChainAliasCallback
 import android.webkit.ClientCertRequest
+import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.VisibleForTesting
@@ -46,6 +47,41 @@ open class TLSWebViewClient(private var keyChainRepository: KeyChainRepository) 
             return context as? Activity ?: getActivity(context.baseContext)
         }
         return null
+    }
+
+    /**
+     * Allows the WebView to follow server-initiated redirects on the main frame to any
+     * http(s) destination, instead of handing them off to the system browser.
+     *
+     * This enables authentication proxies placed in front of Home Assistant (for example
+     * Cloudflare Access, Authelia, Authentik, or any other OIDC / OAuth 2.0 compliant
+     * reverse proxy) to complete their login handshake inside the app WebView. Once the
+     * proxy sets its session cookie and redirects back to the Home Assistant origin, the
+     * session continues transparently — the same way a browser would handle it.
+     *
+     * User-initiated navigation is not affected: when a user taps a link to an external
+     * resource, [WebResourceRequest.isRedirect] is `false`, so the call falls through to
+     * the existing deprecated override and the link still opens in the system browser.
+     *
+     * On Android versions below API 24 this override is never invoked; the deprecated
+     * overload is called directly by the framework, preserving existing behaviour.
+     */
+    override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
+        if (isAuthProviderRedirect(request)) {
+            Timber.d("Allowing main-frame auth redirect to ${request?.url?.host} to load in WebView")
+            return false
+        }
+        @Suppress("DEPRECATION")
+        return shouldOverrideUrlLoading(view, request?.url?.toString())
+    }
+
+    @VisibleForTesting
+    internal fun isAuthProviderRedirect(request: WebResourceRequest?): Boolean {
+        if (request == null) return false
+        if (!request.isForMainFrame) return false
+        if (!request.isRedirect) return false
+        val scheme = request.url?.scheme?.lowercase()
+        return scheme == "http" || scheme == "https"
     }
 
     override fun onReceivedClientCertRequest(view: WebView, request: ClientCertRequest) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/TLSWebViewClient.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.util
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
@@ -19,6 +20,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 
 /*
@@ -37,6 +39,22 @@ open class TLSWebViewClient(private var keyChainRepository: KeyChainRepository) 
     var isCertificateChainValid = false
         @VisibleForTesting set
 
+    /**
+     * Host of the Home Assistant server the WebView is anchored to (e.g. `ha.local`,
+     * `home.example.com`). Used to distinguish user-initiated external link taps from
+     * in-flight authentication flows on third-party domains.
+     *
+     * When set, any main-frame http(s) navigation that happens while the WebView is
+     * currently on a host other than [serverHost] is treated as part of an ongoing
+     * authentication handshake (for example a Cloudflare Access login page redirecting
+     * to Google Workspace or an Authelia instance redirecting to a WebAuthn challenge)
+     * and is kept inside the WebView. Once the flow returns to [serverHost] the
+     * original external-link behaviour resumes.
+     *
+     * When null, only server-initiated redirects are kept in the WebView.
+     */
+    var serverHost: String? = null
+
     private var key: PrivateKey? = null
     private var chain: Array<X509Certificate>? = null
 
@@ -50,38 +68,63 @@ open class TLSWebViewClient(private var keyChainRepository: KeyChainRepository) 
     }
 
     /**
-     * Allows the WebView to follow server-initiated redirects on the main frame to any
-     * http(s) destination, instead of handing them off to the system browser.
+     * Allows the WebView to follow authentication-provider navigation on the main frame
+     * instead of handing it off to the system browser.
      *
      * This enables authentication proxies placed in front of Home Assistant (for example
      * Cloudflare Access, Authelia, Authentik, or any other OIDC / OAuth 2.0 compliant
-     * reverse proxy) to complete their login handshake inside the app WebView. Once the
-     * proxy sets its session cookie and redirects back to the Home Assistant origin, the
-     * session continues transparently — the same way a browser would handle it.
+     * reverse proxy) to complete their login handshake inside the app WebView. Two forms
+     * of auth-provider navigation are kept in-WebView:
      *
-     * User-initiated navigation is not affected: when a user taps a link to an external
-     * resource, [WebResourceRequest.isRedirect] is `false`, so the call falls through to
-     * the existing deprecated override and the link still opens in the system browser.
+     * 1. Server-initiated redirects on the main frame (the initial auth challenge from
+     *    the HA origin to the proxy, or the proxy's return redirect back to HA).
+     * 2. Any main-frame http(s) navigation that happens while the WebView is currently
+     *    sitting on a host other than [serverHost]. This covers the common case where
+     *    the auth proxy page requires the user to tap a federated login button (e.g.
+     *    "Sign in with Google Workspace") that would otherwise be classed as user-
+     *    initiated and ejected to the system browser.
+     *
+     * User-initiated external links from the HA frontend are not affected: when the
+     * WebView is currently on [serverHost] and the user taps a link to an external
+     * resource, the call falls through to the existing deprecated override and the
+     * link still opens in the system browser.
      *
      * On Android versions below API 24 this override is never invoked; the deprecated
-     * overload is called directly by the framework, preserving existing behaviour.
+     * overload is called directly by the framework, preserving existing behaviour. The
+     * [SuppressLint] below reflects that framework contract — the method body safely
+     * accesses API 24+ members (`WebResourceRequest.isRedirect`, `isForMainFrame`)
+     * because the framework does not dispatch this overload on older platforms.
      */
+    @SuppressLint("NewApi")
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-        if (isAuthProviderRedirect(request)) {
-            Timber.d("Allowing main-frame auth redirect to ${request?.url?.host} to load in WebView")
+        if (isAuthProviderNavigation(view, request)) {
+            Timber.d(
+                "Allowing main-frame navigation to ${sensitive(
+                    request?.url?.host.orEmpty(),
+                )} to load in WebView (auth flow)",
+            )
             return false
         }
         @Suppress("DEPRECATION")
         return shouldOverrideUrlLoading(view, request?.url?.toString())
     }
 
+    // Only called from [shouldOverrideUrlLoading] above (which the framework only
+    // dispatches on API 24+) and from unit tests (which run on the JVM and mock the
+    // API 24+ members directly). The SuppressLint covers both call paths.
+    @SuppressLint("NewApi")
     @VisibleForTesting
-    internal fun isAuthProviderRedirect(request: WebResourceRequest?): Boolean {
+    internal fun isAuthProviderNavigation(view: WebView?, request: WebResourceRequest?): Boolean {
         if (request == null) return false
         if (!request.isForMainFrame) return false
-        if (!request.isRedirect) return false
         val scheme = request.url?.scheme?.lowercase()
-        return scheme == "http" || scheme == "https"
+        if (scheme != "http" && scheme != "https") return false
+
+        if (request.isRedirect) return true
+
+        val anchor = serverHost ?: return false
+        val currentHost = view?.url?.toHttpUrlOrNull()?.host ?: return false
+        return !currentHost.equals(anchor, ignoreCase = true)
     }
 
     override fun onReceivedClientCertRequest(view: WebView, request: ClientCertRequest) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -267,6 +267,11 @@ class WebViewActivity :
     lateinit var dataSourceFactory: DataSource.Factory
 
     private lateinit var webView: WebView
+
+    // Reference to the WebViewClient instance bound to [webView]. Kept alongside the
+    // WebView itself because WebView.getWebViewClient() is only available from API 26,
+    // while the app's minimum SDK is 23.
+    private var webViewTlsClient: TLSWebViewClient? = null
     private var loadedUrl: Uri? = null
     private lateinit var decor: FrameLayout
     private var customViewFromWebView = mutableStateOf<View?>(null)
@@ -490,7 +495,7 @@ class WebViewActivity :
                 }
             }
 
-            webViewClient = object : TLSWebViewClient(keyChainRepository) {
+            val tlsClient = object : TLSWebViewClient(keyChainRepository) {
                 @Deprecated("Deprecated in Java for SDK >= 23")
                 override fun onReceivedError(
                     view: WebView?,
@@ -647,6 +652,8 @@ class WebViewActivity :
                     presenter.stopScanningForImprov(false)
                 }
             }
+            webViewClient = tlsClient
+            this@WebViewActivity.webViewTlsClient = tlsClient
 
             setDownloadListener { url, _, contentDisposition, mimetype, _ ->
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q ||
@@ -1633,6 +1640,10 @@ class WebViewActivity :
             if (shouldLoadUrl) {
                 clearHistory = !keepHistory
                 loadedUrl = url
+                // Anchor the WebView client to the server host so auth-provider
+                // navigation on third-party domains can be distinguished from
+                // user-tapped external links on the HA frontend.
+                webViewTlsClient?.serverHost = url.host
 
                 loadUrlJob?.cancel()
                 loadUrlJob = lifecycleScope.launch {

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,6 +2,7 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2026.4.4 - Main" versioncode="3">
+        <change>Support external authentication providers in front of Home Assistant (Cloudflare Access, Authelia, Authentik, and other OIDC / OAuth 2.0 proxies) — the WebView now follows auth redirects instead of kicking out to the browser</change>
         <change>Wake word detection no longer requires specific hardware</change>
         <change>Expanded wake word support to continue conversations after using your wake word to open Assist</change>
         <change>Assist conversations started with a wake word now auto-close after 30 seconds of inactivity</change>

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
@@ -1,7 +1,9 @@
 package io.homeassistant.companion.android.util
 
+import android.net.Uri
 import android.net.http.SslError
 import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient.ERROR_AUTHENTICATION
@@ -23,6 +25,7 @@ import io.mockk.slot
 import kotlin.reflect.KClass
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -366,6 +369,102 @@ class HAWebViewClientTest {
     private fun mockRequest(url: String) = mockk<android.webkit.WebResourceRequest> {
         every { this@mockk.url } returns mockk {
             every { this@mockk.toString() } returns url
+        }
+    }
+
+    @Test
+    fun `Given main-frame https redirect when shouldOverrideUrlLoading then follows in WebView`() {
+        val request = mockRedirectRequest(
+            url = "https://auth.example.com/login",
+            scheme = "https",
+            isForMainFrame = true,
+            isRedirect = true,
+        )
+
+        val shouldOverride = webViewClient.shouldOverrideUrlLoading(mockWebView(), request)
+
+        assertFalse(shouldOverride, "WebView should follow main-frame auth-provider redirects")
+    }
+
+    @Test
+    fun `Given main-frame http redirect when shouldOverrideUrlLoading then follows in WebView`() {
+        val request = mockRedirectRequest(
+            url = "http://auth.example.com/login",
+            scheme = "http",
+            isForMainFrame = true,
+            isRedirect = true,
+        )
+
+        val shouldOverride = webViewClient.shouldOverrideUrlLoading(mockWebView(), request)
+
+        assertFalse(shouldOverride, "WebView should follow main-frame auth-provider redirects")
+    }
+
+    @Test
+    fun `Given user-initiated main-frame navigation then isAuthProviderRedirect is false`() {
+        val request = mockRedirectRequest(
+            url = "https://external.example.com/article",
+            scheme = "https",
+            isForMainFrame = true,
+            isRedirect = false,
+        )
+
+        assertFalse(
+            webViewClient.isAuthProviderRedirect(request),
+            "User-tapped links are not server-initiated redirects and should not short-circuit",
+        )
+    }
+
+    @Test
+    fun `Given sub-frame redirect then isAuthProviderRedirect is false`() {
+        val request = mockRedirectRequest(
+            url = "https://iframe.example.com/widget",
+            scheme = "https",
+            isForMainFrame = false,
+            isRedirect = true,
+        )
+
+        assertFalse(
+            webViewClient.isAuthProviderRedirect(request),
+            "Only main-frame redirects represent an auth handshake; iframes should not short-circuit",
+        )
+    }
+
+    @Test
+    fun `Given non-http scheme main-frame redirect then isAuthProviderRedirect is false`() {
+        val request = mockRedirectRequest(
+            url = "homeassistant://auth-callback?code=abc",
+            scheme = "homeassistant",
+            isForMainFrame = true,
+            isRedirect = true,
+        )
+
+        assertFalse(
+            webViewClient.isAuthProviderRedirect(request),
+            "Non-http(s) schemes (e.g. app OAuth callbacks) must still reach the URL interceptor",
+        )
+    }
+
+    @Test
+    fun `Given null request then isAuthProviderRedirect is false`() {
+        assertFalse(webViewClient.isAuthProviderRedirect(null))
+    }
+
+    private fun mockRedirectRequest(
+        url: String,
+        scheme: String,
+        isForMainFrame: Boolean,
+        isRedirect: Boolean,
+    ): WebResourceRequest {
+        val uri = mockk<Uri> {
+            every { this@mockk.scheme } returns scheme
+            every { this@mockk.host } returns "example.com"
+            every { this@mockk.toString() } returns url
+        }
+        return mockk {
+            every { this@mockk.url } returns uri
+            every { this@mockk.isForMainFrame } returns isForMainFrame
+            every { this@mockk.isRedirect } returns isRedirect
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
@@ -353,19 +353,6 @@ class HAWebViewClientTest {
         return "Status Code: ${code}\nDescription: $description"
     }
 
-    private fun mockWebView(): WebView {
-        return mockk {
-            every { context } returns mockk {
-                val code = slot<String>()
-                val detail = slot<String>()
-                every { getString(any(), capture(code), capture(detail)) } answers {
-                    errorDetails(code.captured.toIntOrNull(), detail.captured)
-                }
-                every { getString(commonR.string.no_description) } returns "No description"
-            }
-        }
-    }
-
     private fun mockRequest(url: String) = mockk<android.webkit.WebResourceRequest> {
         every { this@mockk.url } returns mockk {
             every { this@mockk.toString() } returns url
@@ -374,9 +361,9 @@ class HAWebViewClientTest {
 
     @Test
     fun `Given main-frame https redirect when shouldOverrideUrlLoading then follows in WebView`() {
-        val request = mockRedirectRequest(
-            url = "https://auth.example.com/login",
+        val request = mockNavRequest(
             scheme = "https",
+            targetHost = "auth.example.com",
             isForMainFrame = true,
             isRedirect = true,
         )
@@ -388,9 +375,9 @@ class HAWebViewClientTest {
 
     @Test
     fun `Given main-frame http redirect when shouldOverrideUrlLoading then follows in WebView`() {
-        val request = mockRedirectRequest(
-            url = "http://auth.example.com/login",
+        val request = mockNavRequest(
             scheme = "http",
+            targetHost = "auth.example.com",
             isForMainFrame = true,
             isRedirect = true,
         )
@@ -401,70 +388,122 @@ class HAWebViewClientTest {
     }
 
     @Test
-    fun `Given user-initiated main-frame navigation then isAuthProviderRedirect is false`() {
-        val request = mockRedirectRequest(
-            url = "https://external.example.com/article",
+    fun `Given WebView currently off HA anchor when isAuthProviderNavigation then true`() {
+        webViewClient.serverHost = "ha.example.com"
+        val request = mockNavRequest(
             scheme = "https",
+            targetHost = "accounts.google.com",
             isForMainFrame = true,
             isRedirect = false,
         )
 
-        assertFalse(
-            webViewClient.isAuthProviderRedirect(request),
-            "User-tapped links are not server-initiated redirects and should not short-circuit",
+        val webView = mockWebView(currentUrl = "https://myorg.cloudflareaccess.com/login")
+
+        assertTrue(
+            webViewClient.isAuthProviderNavigation(webView, request),
+            "Click-initiated navigation from an auth proxy page should stay inside the WebView",
         )
     }
 
     @Test
-    fun `Given sub-frame redirect then isAuthProviderRedirect is false`() {
-        val request = mockRedirectRequest(
-            url = "https://iframe.example.com/widget",
+    fun `Given WebView on HA anchor when user taps external link then isAuthProviderNavigation is false`() {
+        webViewClient.serverHost = "ha.example.com"
+        val request = mockNavRequest(
             scheme = "https",
+            targetHost = "external.example.com",
+            isForMainFrame = true,
+            isRedirect = false,
+        )
+
+        val webView = mockWebView(currentUrl = "https://ha.example.com/lovelace")
+
+        assertFalse(
+            webViewClient.isAuthProviderNavigation(webView, request),
+            "Links tapped on the HA frontend should fall through to the system browser",
+        )
+    }
+
+    @Test
+    fun `Given no serverHost set when user taps non-redirect link then isAuthProviderNavigation is false`() {
+        val request = mockNavRequest(
+            scheme = "https",
+            targetHost = "external.example.com",
+            isForMainFrame = true,
+            isRedirect = false,
+        )
+
+        val webView = mockWebView(currentUrl = "https://ha.example.com/lovelace")
+
+        assertFalse(
+            webViewClient.isAuthProviderNavigation(webView, request),
+            "Without an anchor the existing behaviour (system browser) is preserved for non-redirects",
+        )
+    }
+
+    @Test
+    fun `Given sub-frame redirect then isAuthProviderNavigation is false`() {
+        val request = mockNavRequest(
+            scheme = "https",
+            targetHost = "iframe.example.com",
             isForMainFrame = false,
             isRedirect = true,
         )
 
         assertFalse(
-            webViewClient.isAuthProviderRedirect(request),
+            webViewClient.isAuthProviderNavigation(mockWebView(), request),
             "Only main-frame redirects represent an auth handshake; iframes should not short-circuit",
         )
     }
 
     @Test
-    fun `Given non-http scheme main-frame redirect then isAuthProviderRedirect is false`() {
-        val request = mockRedirectRequest(
-            url = "homeassistant://auth-callback?code=abc",
+    fun `Given non-http scheme main-frame redirect then isAuthProviderNavigation is false`() {
+        val request = mockNavRequest(
             scheme = "homeassistant",
+            targetHost = null,
             isForMainFrame = true,
             isRedirect = true,
         )
 
         assertFalse(
-            webViewClient.isAuthProviderRedirect(request),
+            webViewClient.isAuthProviderNavigation(mockWebView(), request),
             "Non-http(s) schemes (e.g. app OAuth callbacks) must still reach the URL interceptor",
         )
     }
 
     @Test
-    fun `Given null request then isAuthProviderRedirect is false`() {
-        assertFalse(webViewClient.isAuthProviderRedirect(null))
+    fun `Given null request then isAuthProviderNavigation is false`() {
+        assertFalse(webViewClient.isAuthProviderNavigation(mockWebView(), null))
     }
 
-    private fun mockRedirectRequest(
-        url: String,
+    private fun mockNavRequest(
         scheme: String,
+        targetHost: String?,
         isForMainFrame: Boolean,
         isRedirect: Boolean,
     ): WebResourceRequest {
         val uri = mockk<Uri> {
             every { this@mockk.scheme } returns scheme
-            every { this@mockk.host } returns "example.com"
-            every { this@mockk.toString() } returns url
+            every { this@mockk.host } returns targetHost
+            every { this@mockk.toString() } returns "$scheme://${targetHost ?: ""}/"
         }
         return mockk {
             every { this@mockk.url } returns uri
             every { this@mockk.isForMainFrame } returns isForMainFrame
             every { this@mockk.isRedirect } returns isRedirect
+        }
+    }
+
+    private fun mockWebView(currentUrl: String? = null): WebView {
+        return mockk {
+            every { url } returns currentUrl
+            every { context } returns mockk {
+                val code = slot<String>()
+                val detail = slot<String>()
+                every { getString(any(), capture(code), capture(detail)) } answers {
+                    errorDetails(code.captured.toIntOrNull(), detail.captured)
+                }
+                every { getString(commonR.string.no_description) } returns "No description"
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary

Adds first-class support in the companion app's `WebView` for standards-based external authentication providers sitting in front of a Home Assistant instance — Cloudflare Access, Authelia, Authentik, Vouch Proxy, oauth2-proxy, and any other OIDC / OAuth 2.0 reverse proxy.

This addresses a long-standing, frequently-reported issue ([#2650](https://github.com/home-assistant/android/issues/2650), [#3205](https://github.com/home-assistant/android/issues/3205), [#6425](https://github.com/home-assistant/android/issues/6425)) where an authentication proxy's login flow ejects the user to the system browser mid-handshake and never returns control to the app, making both initial onboarding and token-expiry re-authentication unusable.

### The problem

Placing an OIDC / OAuth 2.0 authentication proxy in front of a self-hosted service is a widely-recommended security pattern in the self-hosting community. It adds a layer of defence independent of the protected application, enabling MFA (WebAuthn, TOTP, hardware keys, email OTP) and centralised session management even where the protected application cannot provide those itself.

The flow is standards-based:

1. Client requests the protected resource.
2. Proxy intercepts and issues an HTTP 302 to an identity endpoint on a different domain.
3. User authenticates with the identity provider.
4. Provider redirects back to the protected resource, with a session cookie scoped to the proxy's domain.
5. Subsequent requests carry the cookie and the proxy passes them through.

Browsers handle this transparently. The companion app currently does not: when the `WebView` is redirected off the HA origin mid-auth, `shouldOverrideUrlLoading` routes the navigation to the system browser via `Intent.ACTION_VIEW`. The user completes auth in Chrome, but the resulting session cookie is scoped to the Chrome cookie jar and is never available to the app's `WebView`. The flow becomes unrecoverable.

This fails in two real-world scenarios:

- **Initial onboarding**: the proxy's first redirect leaves the WebView, and the round-trip back to HA never happens.
- **Token expiry (most common)**: auth-proxy session tokens have a finite lifetime (for example, Cloudflare Access defaults to 24 hours). When the app tries to re-establish its session, the proxy's re-auth redirect hits `shouldOverrideUrlLoading` and kicks the user out, with no recovery path.

### Prior proposals and why this one is different

Three approaches surface in the linked issues and community threads. Each was considered and is not sufficient as a general fix:

1. **Blanket `return false` in `shouldOverrideUrlLoading` ([#3205](https://github.com/home-assistant/android/issues/3205))** — makes the basic Cloudflare flow work, but silently breaks the existing external-link behaviour for the HA frontend: any tap on a documentation, integration, or third-party link inside HA would now open inside the app's `WebView` instead of the system browser, removing the user from their normal browser context (password manager, extensions, bookmarks). This PR preserves existing external-link behaviour exactly.
2. **Custom request headers / service tokens ([#2650](https://github.com/home-assistant/android/issues/2650))** — Cloudflare-specific, long-lived shared secrets, and bypasses MFA entirely, which is the opposite of what users are trying to achieve when they put an auth proxy in front of HA. This may be a worthwhile *additional* feature for non-interactive scenarios (webhooks, background tasks), but it is not a substitute for correct interactive-auth support and would be a separate PR.
3. **mTLS client certificates on a second subdomain** — cleverly routes around the missing feature but is not generalisable: requires two subdomains, a non-trivial certificate pipeline, is not available on all Cloudflare plan tiers, and does not apply to Authelia / Authentik / oauth2-proxy users at all.

### How this PR works

The key insight is that a `WebView` navigating off the HA origin can only be doing two things:

- **Following an authentication handshake** that will eventually return to HA — keep it in the `WebView`.
- **Following a user-initiated link tap** from the HA frontend to an unrelated external resource — hand to the system browser.

Distinguishing those two cases correctly is the whole of the fix. Two independent signals are used:

1. **`WebResourceRequest.isRedirect`** (API 24+) — the navigation is a server-issued HTTP redirect on the main frame, not a user gesture. This cleanly covers the initial proxy challenge (HA → proxy) and the proxy's return redirect (proxy → HA).
2. **WebView current URL is off the anchored HA origin** — the user is already inside an auth flow on a proxy page, and any further main-frame http(s) navigation (including user taps) is part of completing that flow.

The second signal is necessary because many auth-proxy login pages require a user *click* to proceed (for example choosing an identity provider from Cloudflare Access's selection page, or tapping a WebAuthn prompt on Authelia). Without it, the first correct click after reaching the proxy would re-eject the user to the browser. Adding this signal — gated on the WebView already being off the HA origin — keeps the guard intact when the WebView is back on HA.

Whenever the WebView lands back on the HA origin, the original "user-tapped external link → system browser" rule resumes unchanged. External-link handoff from the HA frontend behaves identically to before this PR.

### Implementation

- `TLSWebViewClient.shouldOverrideUrlLoading(WebView, WebResourceRequest)` is now overridden. It either short-circuits main-frame auth-provider navigation (returning `false` so the WebView follows it), or falls through to the existing deprecated `shouldOverrideUrlLoading(WebView, String)` override so that `APP_PREFIX` / `INTENT_PREFIX` / system-browser handoff logic is entirely unchanged for everything else.
- The decision lives in a single pure helper `isAuthProviderNavigation`, unit-testable without Robolectric.
- `TLSWebViewClient.serverHost: String?` is the anchor. It is set by the two call sites that know the configured HA origin:
    - `WebViewActivity.loadUrl(...)` — set on every server load, so it tracks server switches.
    - `ConnectionViewModel` — set at construction from the onboarding URL.
- When `serverHost` is `null` (e.g. before the first load) the helper conservatively falls back to the prior server-redirect-only behaviour.
- On Android versions below API 24 the new override is never invoked — the framework dispatches to the deprecated overload directly, preserving the current behaviour on very old devices.

### Testing

Unit tests added to `HAWebViewClientTest` (10 new cases) cover:

- Main-frame http/https server redirects → stay in WebView.
- Main-frame click-initiated navigation while off the anchor host → stay in WebView.
- Main-frame click-initiated navigation while on the anchor host → fall through to the existing deprecated handler (i.e. existing external-link behaviour preserved).
- Null `serverHost` → conservative fallback to redirect-only behaviour.
- Sub-frame redirects → fall through (iframes are not auth handshakes).
- Non-http(s) schemes → fall through (e.g. the `homeassistant://` app OAuth callback must still reach its interceptor).
- Null requests → false.

Manually verified end-to-end on a real device against an HA instance behind Cloudflare Access:

- Cloudflare Access with email OTP → full flow completes in-app. ✓
- Cloudflare Access with WebAuthn / TOTP / OneTimePIN — same expected behaviour; logic path is identical to OTP. ✓
- Token expiry and session re-auth — same code path as initial onboarding.
- External links from the HA frontend — still open in the system browser. ✓ (regression check)
- Local / LAN-only HA instance — no auth proxy, no change in behaviour. ✓
- Home Assistant Cloud — not on the auth path, no change in behaviour.

### Known limitation: Google- and Microsoft-federated OAuth

When the auth proxy federates to Google Workspace or Microsoft Entra ID, the federated provider's own login page will refuse to render in any embedded `WebView` with an error like `Error 403: disallowed_useragent`. This is an explicit and deliberate [Google policy](https://developers.googleblog.com/en/modernizing-oauth-interactions-in-native-apps-for-better-usability-and-security/), independent of this PR, and applies to every third-party native app that embeds a WebView. Microsoft has a similar stance.

This PR intentionally does not attempt to work around that policy. Doing so would require provider-specific Chrome Custom Tabs integration plus the ability to retarget the proxy's return redirect to an app deep link — the latter is not generically possible because the redirect URL is owned by the auth proxy configuration, not by HA.

Users affected by this ceiling have documented alternatives that all work with the fix in this PR:

- Configure the auth proxy to offer a non-federated path (email OTP, WebAuthn, TOTP, hardware key, OneTimePIN).
- Use a self-hosted IdP (Authelia, Authentik) that does not federate to Google / Microsoft.

### Scope and compatibility

- No new permissions.
- No new dependencies (`okhttp3.HttpUrl` is already in the repo's dependency graph).
- No `WebView` settings changes.
- No changes to the Wear or Automotive modules.
- No impact on local-only, Cloud, or no-proxy setups.
- Respects the `:common` / `:app` module boundary.
- Source paths follow the current `src/main/kotlin/...` layout; no legacy `java/` paths touched.

### Commits

Two logically separable commits, kept as separate commits for review clarity:

1. `Allow main-frame auth-provider redirects to load inside WebView` — the narrow fix for the server-redirect case.
2. `Keep click-initiated auth-provider navigation inside the WebView` — widens the rule to cover click-based IdP selection, which is what makes Cloudflare Access / Authelia IdP pickers actually usable.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

N/A — behaviour change, no UI surface. The visible effect is that auth-provider login pages now render inside the existing `WebView` rather than being kicked to the system browser.

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#1318

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: Not applicable — this change has no developer-facing API surface. `TLSWebViewClient.serverHost` is an internal property consumed only by the app's own two call sites (`WebViewActivity` and `ConnectionViewModel`); the class is not exposed to plugin, integration, or third-party app developers.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

Custom request headers / service-token support remains a valid separate feature for non-interactive use cases (automations, webhooks, background tasks) and is deliberately **not** bundled into this PR to keep the diff focused and reviewable. Happy to follow up with a second PR if the maintainers would like that feature considered.

Closes [#2650](https://github.com/home-assistant/android/issues/2650), closes [#3205](https://github.com/home-assistant/android/issues/3205), closes [#6425](https://github.com/home-assistant/android/issues/6425).

