### PR TITLE
fix(sensors): catch per-server zone fetch errors in geofence registration

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -49,6 +49,7 @@ import io.homeassistant.companion.android.location.HighAccuracyLocationService
 import io.homeassistant.companion.android.notifications.MessagingManager
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -1096,30 +1097,38 @@ class LocationSensorManager :
         val highAccuracyZones = getHighAccuracyModeZones(false)
 
         var geofenceCount = 0
-        getEnabledServers(latestContext, zoneLocation).map { serverId ->
+        val serverZones = getEnabledServers(latestContext, zoneLocation).map { serverId ->
             ioScope.async {
                 try {
-                    val configuredZones = getZones(serverId, forceRefresh = true)
-                    configuredZones.forEach {
-                        addGeofenceToBuilder(geofencingRequestBuilder, serverId, it)
-                        geofenceCount++
-                        if (geofenceCount >= 100) {
-                            return@async
-                        }
-                        if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains("${serverId}_${it.entityId}")) {
-                            addGeofenceToBuilder(geofencingRequestBuilder, serverId, it, highAccuracyTriggerRange)
-                            geofenceCount++
-                            if (geofenceCount >= 100) {
-                                return@async
-                            }
-                        }
-                    }
-                    geofenceRegistered.add(serverId)
+                    serverId to getZones(serverId, forceRefresh = true)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     Timber.w(e, "Failed to fetch zones for server $serverId, skipping")
+                    null
                 }
             }
         }.awaitAll()
+
+        serverZones.forEach { result ->
+            if (result == null || geofenceCount >= 100) return@forEach
+
+            val (serverId, configuredZones) = result
+            configuredZones.forEach {
+                if (geofenceCount >= 100) return@forEach
+
+                addGeofenceToBuilder(geofencingRequestBuilder, serverId, it)
+                geofenceCount++
+                if (geofenceCount >= 100) return@forEach
+
+                if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains("${serverId}_${it.entityId}")) {
+                    addGeofenceToBuilder(geofencingRequestBuilder, serverId, it, highAccuracyTriggerRange)
+                    geofenceCount++
+                }
+            }
+            geofenceRegistered.add(serverId)
+        }
+
         return if (geofenceCount > 0) geofencingRequestBuilder.build() else null
     }
 

--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -1098,22 +1098,26 @@ class LocationSensorManager :
         var geofenceCount = 0
         getEnabledServers(latestContext, zoneLocation).map { serverId ->
             ioScope.async {
-                val configuredZones = getZones(serverId, forceRefresh = true)
-                configuredZones.forEach {
-                    addGeofenceToBuilder(geofencingRequestBuilder, serverId, it)
-                    geofenceCount++
-                    if (geofenceCount >= 100) {
-                        return@async
-                    }
-                    if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains("${serverId}_${it.entityId}")) {
-                        addGeofenceToBuilder(geofencingRequestBuilder, serverId, it, highAccuracyTriggerRange)
+                try {
+                    val configuredZones = getZones(serverId, forceRefresh = true)
+                    configuredZones.forEach {
+                        addGeofenceToBuilder(geofencingRequestBuilder, serverId, it)
                         geofenceCount++
                         if (geofenceCount >= 100) {
                             return@async
                         }
+                        if (highAccuracyTriggerRange > 0 && highAccuracyZones.contains("${serverId}_${it.entityId}")) {
+                            addGeofenceToBuilder(geofencingRequestBuilder, serverId, it, highAccuracyTriggerRange)
+                            geofenceCount++
+                            if (geofenceCount >= 100) {
+                                return@async
+                            }
+                        }
                     }
+                    geofenceRegistered.add(serverId)
+                } catch (e: Exception) {
+                    Timber.w(e, "Failed to fetch zones for server $serverId, skipping")
                 }
-                geofenceRegistered.add(serverId)
             }
         }.awaitAll()
         return if (geofenceCount > 0) geofencingRequestBuilder.build() else null


### PR DESCRIPTION
## Bug

When multiple servers are configured and one is unreachable, `createGeofencingRequest()` calls `getZones()` inside `ioScope.async` blocks collected with `awaitAll()`. If any server's zone fetch throws (e.g. `NoUrlAvailableException` or HTTP 410), the exception propagates and crashes the entire function — breaking geofence registration for **all** servers, including healthy ones.

## Fix

Wrap each server's async block in a try/catch. Zone fetch failures are logged via Timber and the server is skipped, allowing other servers to register their geofences normally.

Closes #6721