### PR TITLE
fix(webview): tie legacy externalApp bridge lifecycle to the configured server origin

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
 import android.graphics.Rect
 import android.net.Uri
 import android.net.http.SslError
@@ -501,6 +502,35 @@ class WebViewActivity :
                     Timber.e("onReceivedError: errorCode: $errorCode url:$failingUrl")
                     if (failingUrl == loadedUrl.toString()) {
                         showError()
+                    }
+                }
+
+                override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                    super.onPageStarted(view, url, favicon)
+                    // Align the lifecycle of the legacy `externalApp` JavaScript bridge with
+                    // the configured Home Assistant origin. The V1 bridge is registered via
+                    // [WebView.addJavascriptInterface] and has no per-call origin check, so any
+                    // page loaded in the WebView can reach it and call methods such as
+                    // `getExternalAuth`. The V2 bridge uses [WebViewCompat.addWebMessageListener]
+                    // and already rejects messages whose `sourceOrigin` does not match the
+                    // configured server, so it does not need to be torn down here.
+                    //
+                    // Stripping the V1 interface whenever the WebView navigates off-origin is
+                    // defence-in-depth against scenarios where the WebView could otherwise be
+                    // pointed at untrusted content that attempts to exfiltrate the user's
+                    // Home Assistant auth token through the bridge.
+                    val target = url?.toUri()
+                    if (target != null && !target.hasSameOrigin(loadedUrl)) {
+                        Timber.d("WebView navigated off the configured server origin, removing legacy external bridge")
+                        view?.removeJavascriptInterface(EXTERNAL_APP_V1)
+                    } else if (target != null) {
+                        // Returning to (or still on) the Home Assistant origin — reinstate the
+                        // bridge chosen for this server and WebView pair (V1 or V2). The helper
+                        // is idempotent: it removes whichever interface is not in use before
+                        // registering the one that is.
+                        lifecycleScope.launch {
+                            webViewAddJavascriptInterface()
+                        }
                     }
                 }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary

Aligns the legacy `externalApp` JavaScript bridge with the origin-isolation posture the newer `externalAppV2` bridge already has.

### Background

The app exposes two JavaScript bridges to the Home Assistant frontend:

- **`externalAppV2`** — registered via `WebViewCompat.addWebMessageListener`. Every message is rejected if its `sourceOrigin` does not match the currently-loaded server URL (see [`WebViewActivity.registerExternalAppV2`](https://github.com/home-assistant/android/blob/main/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt#L920-L945)). Safe regardless of where the WebView navigates.
- **`externalApp`** — registered via `WebView.addJavascriptInterface`. Has **no origin check**. Any page currently loaded in the `WebView` can invoke `externalApp.getExternalAuth(...)` and receive the user's Home Assistant authentication token, or `externalApp.externalBus(...)` to speak on the frontend message bus. This is the legacy bridge used as a fallback when the server doesn't yet support V2 or when the device's WebView implementation doesn't provide `WEB_MESSAGE_LISTENER`.

In the common path the WebView only loads content from the configured server origin, so this gap is latent rather than active. But it's a real attack surface for edge cases:

- Redirect races where the `WebView` briefly starts loading an off-origin URL before `shouldOverrideUrlLoading` can eject the navigation to the system browser.
- Compromise of the HA frontend origin itself (cache poisoning, a misbehaving integration surfacing untrusted content, supply-chain issues on a frontend asset) — all of which would already reach the V1 bridge today.
- Future changes that relax off-origin handling for any reason.

This was raised by a maintainer in the review of [#6725](https://github.com/home-assistant/android/pull/6725) and separately noted as worth tightening:

> _"The app injects a JavaScript interface used to retrieve the current authentication token, and we must ensure that only the Home Assistant frontend can access it."_

That PR has been closed as out of scope. This PR is the standalone hardening commitment from that thread and does **not** depend on anything from #6725 — it is pure defence-in-depth for the existing bridge and has no user-facing behaviour change.

### Change

Override `onPageStarted` in the main `WebView`'s client and tie the V1 bridge lifecycle to the configured server origin:

- When the `WebView` navigates to a URL whose origin does not match `loadedUrl` (the configured Home Assistant URL), `webView.removeJavascriptInterface(EXTERNAL_APP_V1)` is invoked before the new page's JavaScript can execute.
- When the `WebView` returns to (or stays on) the configured server origin, the existing `webViewAddJavascriptInterface()` helper is invoked. That helper already picks V1 or V2 correctly based on server capabilities and WebView feature support, and its internals are idempotent — so calling it again is safe.
- V2 is untouched; its existing `sourceOrigin.hasSameOrigin(loadedUrl)` check remains the source of truth for V2 message filtering.

Origin comparison uses the existing `Uri.hasSameOrigin(Uri?)` helper in `:common`, which is the same helper the V2 path uses and is already unit-tested in [`UriExtensionsTest`](https://github.com/home-assistant/android/blob/main/common/src/test/kotlin/io/homeassistant/companion/android/util/UriExtensionsTest.kt).

### Scope

- One file changed: `app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt`.
- 30 insertions, 0 deletions.
- No new APIs, no new dependencies, no new permissions, no string changes, no manifest changes.
- No changelog entry — there is no user-visible behaviour change.
- Wear and Automotive unaffected (Automotive reuses `:app` sources and inherits the fix).

### Verification

- `:app:testFullDebugUnitTest` — passing.
- `:common:test` — passing (covers the `Uri.hasSameOrigin` helper the change relies on).
- `:app:lintFullDebug` — _Lint found no new issues (and 161 errors and 4 hints filtered by baseline lint-baseline.xml)_.
- `:app:assembleMinimalDebug`, `:automotive:assembleMinimalDebug`, `:wear:assembleDebug` — all build green.
- `./gradlew :app:ktlintFormat` — clean.

### Test coverage note

The core decision is a single `Uri.hasSameOrigin(loadedUrl)` call, which is already covered by parameterised tests in `UriExtensionsTest`. The wiring (override `onPageStarted`, call `removeJavascriptInterface` on off-origin) lives inside the anonymous `TLSWebViewClient` in `WebViewActivity`, matching the rest of that class — `onPageFinished`, `onReceivedError`, `onReceivedHttpError`, etc. also live there and are not directly unit-tested. Happy to add a Robolectric test targeting the anonymous client if a reviewer would prefer.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

N/A — defence-in-depth hardening, no user-visible surface.

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: Not applicable — no user-visible behaviour change.

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: Not applicable — no developer-facing API surface changes; this is an internal lifecycle tweak inside `WebViewActivity`.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

This PR was committed to in the review of #6725 as an unconditional hardening independent of that PR's outcome. It stands on its own and is not an attempt to re-open the decision made there — it's the security hardening piece only.
