### PR TITLE
Map DPAD_DOWN to TAB in HAWebView

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/webview/HAWebView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/webview/HAWebView.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
+import android.view.KeyEvent
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.widget.FrameLayout
@@ -38,6 +39,7 @@ const val BLANK_URL = "about:blank"
  * - Night mode support
  * - Custom user agent
  * - Transparent background
+ * - DPAD_DOWN to TAB remapping for Android TV navigation (via `OnKeyListener`)
  *
  * This composable provides a convenient way to embed a WebView within a Jetpack Compose UI.
  * Further customization of the WebView instance is possible through the [configure] lambda.
@@ -53,6 +55,8 @@ const val BLANK_URL = "about:blank"
  * @param modifier The modifier to be applied to this WebView.
  * @param nightModeTheme current [NightModeTheme]
  * @param configure A lambda that allows for customization of the WebView instance.
+ *                  Note: calling `setOnKeyListener` in this lambda will override the default
+ *                  DPAD_DOWN to TAB remapping.
  * @param factory A lambda that creates the WebView instance. If this returns null, a new
  *                WebView will be created with the current context. This is useful for providing
  *                a pre-configured WebView instance.
@@ -90,6 +94,7 @@ fun HAWebView(
                             FrameLayout.LayoutParams.MATCH_PARENT,
                         )
                         defaultSettings()
+                        remapDpadDownToTab()
                         configure(this)
                     }
                 } catch (t: Throwable) {
@@ -120,6 +125,23 @@ fun HAWebView(
     // handle by the navHost.
     BackHandler(onBackPressed != null) {
         webview.takeIf { it?.canGoBack() == true }?.goBack() ?: onBackPressed?.invoke()
+    }
+}
+
+/**
+ * Remaps DPAD_DOWN key events to TAB for Android TV remote control navigation.
+ *
+ * Android TV remotes send DPAD_DOWN events which don't navigate the web frontend
+ * properly. Remapping to TAB allows basic element-to-element navigation in the WebView.
+ */
+private fun WebView.remapDpadDownToTab() {
+    setOnKeyListener { view, keyCode, event ->
+        if (keyCode == KeyEvent.KEYCODE_DPAD_DOWN && event.action == KeyEvent.ACTION_DOWN) {
+            view.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_TAB))
+            true
+        } else {
+            false
+        }
     }
 }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -20,7 +20,6 @@ import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.util.DisplayMetrics
 import android.util.Rational
-import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager
@@ -2161,16 +2160,6 @@ class WebViewActivity :
         document.dispatchEvent(event);
         """.trimIndent()
         evaluateJavascript(eventCode, null)
-    }
-
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        // Workaround to sideload on Android TV and use a remote for basic navigation in WebView
-        if (event.keyCode == KeyEvent.KEYCODE_DPAD_DOWN && event.action == KeyEvent.ACTION_DOWN) {
-            dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_TAB))
-            return true
-        }
-
-        return super.dispatchKeyEvent(event)
     }
 
     private fun setWebViewZoom() = lifecycleScope.launch {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

  DPAD_DOWN to TAB remapping for Android TV                                                                                                                                                                
  - Extracted DPAD_DOWN mapping into HAWebView.kt                                                                                                                                     
  - Applied automatically in HAWebView's factory block
  - Removed the dispatchKeyEvent override from WebViewActivity 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.