### PR TITLE
Allow artifacts update for Ruby with renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -36,6 +36,10 @@
     ],
     packageRules: [
         {
+            matchManagers: ['bundler'],
+            skipArtifactsUpdate: false,
+        },
+        {
             matchDatasources: [
                 'maven',
             ],


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
#6737 highlighted an issue in renovate, where all the ruby packages were not updated anymore. The issue was introduced when we added `skipArtifactsUpdate` in #6420 so that we don't update the lockfile for gradle because it was missing NDK setup. This PR is disabling the skip for when the manager is `bundler` which should allow the renovate to execute `bundle install` to update the lockfile.

I need this merged on main to see if renovate works properly now. I've validated the config file with the renovate validator `npx --yes --package renovate@latest -- renovate-config-validator` and no issue were spotted.