### PR TITLE
Add support for Zoom in FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -9,6 +9,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckRepository
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckState
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.util.GestureDirection
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
@@ -75,6 +76,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val frontendJsBridgeFactory: FrontendJsBridgeFactory,
     private val downloadManager: FrontendDownloadManager,
     private val gestureHandler: FrontendGestureHandler,
+    private val prefsRepository: PrefsRepository,
 ) : ViewModel(),
     FrontendConnectionErrorStateProvider {
 
@@ -89,6 +91,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         frontendJsBridgeFactory: FrontendJsBridgeFactory,
         downloadManager: FrontendDownloadManager,
         gestureHandler: FrontendGestureHandler,
+        prefsRepository: PrefsRepository,
     ) : this(
         initialServerId = savedStateHandle.toRoute<FrontendRoute>().serverId,
         initialPath = savedStateHandle.toRoute<FrontendRoute>().path,
@@ -100,6 +103,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         frontendJsBridgeFactory = frontendJsBridgeFactory,
         downloadManager = downloadManager,
         gestureHandler = gestureHandler,
+        prefsRepository = prefsRepository,
     )
 
     /**
@@ -176,6 +180,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         currentUrlFlow = urlFlow,
         onFrontendError = ::onError,
         onCrash = ::onRetry,
+        onPageFinished = ::onPageFinished,
     )
 
     val webChromeClient: HAWebChromeClient = HAWebChromeClient(
@@ -193,6 +198,9 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
     /** Job tracking the urlFlow collection - cancelled when switching servers. */
     private var urlFlowJob: Job? = null
+
+    /** Job tracking the zoom settings flow collection - restarted on each page load. */
+    private var zoomObserverJob: Job? = null
 
     init {
         // Timeout watcher - cancels automatically when state changes from Loading
@@ -524,5 +532,28 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
         // Automatically run connectivity checks when an error occurs
         runConnectivityChecks()
+    }
+
+    /**
+     * Called when a page finishes loading in the WebView.
+     *
+     * Cancels any previous zoom observer and starts a fresh collection of
+     * [PrefsRepository.zoomSettingsFlow]. Because the flow emits the current values
+     * on start, this immediately applies zoom against the loaded DOM (needed because
+     * navigations can reset the viewport meta tag). The collection then stays active
+     * to react to settings changes until the next page load restarts it.
+     */
+    private fun onPageFinished() {
+        zoomObserverJob?.cancel()
+        zoomObserverJob = viewModelScope.launch {
+            prefsRepository.zoomSettingsFlow.collect { settings ->
+                _webViewActions.emit(
+                    WebViewAction.ApplyZoom(
+                        zoomLevel = settings.zoomLevel,
+                        pinchToZoomEnabled = settings.pinchToZoomEnabled,
+                    ),
+                )
+            }
+        }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -546,7 +546,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private fun onPageFinished() {
         zoomObserverJob?.cancel()
         zoomObserverJob = viewModelScope.launch {
-            prefsRepository.zoomSettingsFlow.collect { settings ->
+            prefsRepository.zoomSettingsFlow().collect { settings ->
                 _webViewActions.emit(
                     WebViewAction.ApplyZoom(
                         zoomLevel = settings.zoomLevel,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.frontend
 import android.webkit.WebView
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
+import io.homeassistant.companion.android.util.compose.webview.settings
 import io.homeassistant.companion.android.util.sensitive
 import kotlinx.coroutines.CompletableDeferred
 import timber.log.Timber
@@ -85,6 +86,58 @@ sealed interface WebViewAction {
             webView.evaluateJavascript(script) { scriptResult ->
                 result.complete(scriptResult)
             }
+        }
+    }
+
+    /**
+     * Applies zoom settings to the WebView.
+     *
+     * Sets the base zoom level via [WebView.setInitialScale] (scaled by device density),
+     * enables or disables pinch-to-zoom via [android.webkit.WebSettings.setBuiltInZoomControls],
+     * and injects JavaScript to modify the viewport meta tag.
+     *
+     * @param zoomLevel Zoom level percentage (e.g. 100 for no zoom, 150 for 150%).
+     * @param pinchToZoomEnabled Whether the user has enabled pinch-to-zoom.
+     */
+    data class ApplyZoom(val zoomLevel: Int, val pinchToZoomEnabled: Boolean) : WebViewAction {
+        /**
+         * JavaScript that adjusts the viewport meta tag for pinch-to-zoom support.
+         *
+         * When [pinchToZoom] is true, removes `user-scalable`, `minimum-scale`, and `maximum-scale`
+         * restrictions and adds `user-scalable=yes`.
+         * When false, restores the original viewport content.
+         *
+         * Idea from https://github.com/home-assistant/iOS/pull/1472
+         */
+        private fun viewportZoomScript(pinchToZoom: Boolean): String {
+            val enabled = if (pinchToZoom) "true" else "false"
+            return """
+        if (typeof viewport === 'undefined') {
+            var viewport = document.querySelector('meta[name="viewport"]');
+            if (viewport != null && typeof original_elements === 'undefined') {
+                var original_elements = viewport['content'];
+            }
+        }
+        if (viewport != null) {
+            if ($enabled) {
+                const ignoredBits = ['user-scalable', 'minimum-scale', 'maximum-scale'];
+                let elements = viewport['content'].split(',').filter(contentItem => {
+                    return ignoredBits.every(ignoredBit => !contentItem.includes(ignoredBit));
+                });
+                elements.push('user-scalable=yes');
+                viewport['content'] = elements.join(',');
+            } else {
+                viewport['content'] = original_elements;
+            }
+        }
+            """.trimIndent()
+        }
+
+        override fun run(webView: WebView) {
+            val density = webView.resources.displayMetrics.density
+            webView.setInitialScale((density * zoomLevel).toInt())
+            webView.settings { builtInZoomControls = pinchToZoomEnabled }
+            webView.evaluateJavascript(viewportZoomScript(pinchToZoomEnabled)) {}
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -68,7 +68,7 @@ class FrontendViewModelTest {
     private val gestureHandler: FrontendGestureHandler = mockk(relaxed = true)
     private val zoomSettingsFlow = MutableStateFlow(ZoomSettings())
     private val prefsRepository: PrefsRepository = mockk(relaxed = true) {
-        every { this@mockk.zoomSettingsFlow } returns this@FrontendViewModelTest.zoomSettingsFlow
+        coEvery { this@mockk.zoomSettingsFlow() } returns this@FrontendViewModelTest.zoomSettingsFlow
     }
 
     private val serverId = 1

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -6,6 +6,8 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckRepository
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckResult
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckState
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
+import io.homeassistant.companion.android.common.data.prefs.ZoomSettings
 import io.homeassistant.companion.android.common.util.GestureDirection
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
@@ -64,6 +66,10 @@ class FrontendViewModelTest {
     private val frontendJsBridgeFactory: FrontendJsBridgeFactory = mockk(relaxed = true)
     private val downloadManager: FrontendDownloadManager = mockk(relaxed = true)
     private val gestureHandler: FrontendGestureHandler = mockk(relaxed = true)
+    private val zoomSettingsFlow = MutableStateFlow(ZoomSettings())
+    private val prefsRepository: PrefsRepository = mockk(relaxed = true) {
+        every { this@mockk.zoomSettingsFlow } returns this@FrontendViewModelTest.zoomSettingsFlow
+    }
 
     private val serverId = 1
     private val testUrlWithAuth = "https://example.com?external_auth=1"
@@ -90,6 +96,7 @@ class FrontendViewModelTest {
             frontendJsBridgeFactory = frontendJsBridgeFactory,
             downloadManager = downloadManager,
             gestureHandler = gestureHandler,
+            prefsRepository = prefsRepository,
         )
     }
 
@@ -827,6 +834,94 @@ class FrontendViewModelTest {
             advanceUntilIdle()
 
             assertEquals(permissionManager.pendingPermissionRequest, viewModel.pendingPermissionRequest)
+        }
+    }
+
+    @Nested
+    inner class Zoom {
+
+        private fun createViewModelWithPageFinishedCapture(): Pair<FrontendViewModel, () -> Unit> {
+            var capturedPageFinished: (() -> Unit)? = null
+            every {
+                webViewClientFactory.create(
+                    currentUrlFlow = any(),
+                    onFrontendError = any(),
+                    onCrash = any(),
+                    onPageFinished = any(),
+                )
+            } answers {
+                capturedPageFinished = lastArg()
+                mockk(relaxed = true)
+            }
+
+            val viewModel = createViewModel()
+            return viewModel to { capturedPageFinished!!.invoke() }
+        }
+
+        @Test
+        fun `Given page finishes then ApplyZoom action is emitted with current settings`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            zoomSettingsFlow.value = ZoomSettings(zoomLevel = 150, pinchToZoomEnabled = true)
+
+            val (viewModel, triggerPageFinished) = createViewModelWithPageFinishedCapture()
+
+            viewModel.webViewActions.test {
+                triggerPageFinished()
+
+                val action = awaitItem() as WebViewAction.ApplyZoom
+                assertEquals(150, action.zoomLevel)
+                assertEquals(true, action.pinchToZoomEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given page loaded when settings change then ApplyZoom action is emitted without page finish`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val (viewModel, triggerPageFinished) = createViewModelWithPageFinishedCapture()
+
+            viewModel.webViewActions.test {
+                triggerPageFinished()
+                awaitItem() // consume initial emission
+
+                zoomSettingsFlow.value = ZoomSettings(zoomLevel = 150, pinchToZoomEnabled = true)
+
+                val action = awaitItem() as WebViewAction.ApplyZoom
+                assertEquals(150, action.zoomLevel)
+                assertEquals(true, action.pinchToZoomEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given page finishes again then observer restarts with fresh values`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            zoomSettingsFlow.value = ZoomSettings(zoomLevel = 100, pinchToZoomEnabled = false)
+
+            val (viewModel, triggerPageFinished) = createViewModelWithPageFinishedCapture()
+
+            viewModel.webViewActions.test {
+                triggerPageFinished()
+                val first = awaitItem() as WebViewAction.ApplyZoom
+                assertEquals(100, first.zoomLevel)
+
+                // Settings changed between page loads
+                zoomSettingsFlow.value = ZoomSettings(zoomLevel = 200, pinchToZoomEnabled = true)
+
+                triggerPageFinished()
+                val second = awaitItem() as WebViewAction.ApplyZoom
+                assertEquals(200, second.zoomLevel)
+                assertEquals(true, second.pinchToZoomEnabled)
+
+                cancelAndIgnoreRemainingEvents()
+            }
         }
     }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
@@ -5,6 +5,10 @@ import androidx.core.content.edit
 import io.homeassistant.companion.android.common.data.LocalStorage
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -104,5 +108,18 @@ class LocalStorageImpl(sharedPreferences: suspend () -> SharedPreferences) : Loc
 
     override suspend fun remove(key: String) {
         withContext(Dispatchers.IO) { sharedPreferences().edit { remove(key) } }
+    }
+
+    override fun observeChanges(key: String): Flow<String> = callbackFlow {
+        val prefs = sharedPreferences()
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+            if (changedKey == key) {
+                launch { send(key) }
+            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose {
+            prefs.unregisterOnSharedPreferenceChangeListener(listener)
+        }
     }
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/LocalStorage.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/LocalStorage.kt
@@ -29,10 +29,8 @@ interface LocalStorage {
     suspend fun remove(key: String)
 
     /**
-     * Returns a [Flow] that emits the [key] each time the value associated with it changes.
-     *
-     * The flow uses [android.content.SharedPreferences.OnSharedPreferenceChangeListener]
-     * under the hood and only emits for the specified key.
+     * Returns a [Flow] that emits the [key] each time the value associated with it changes
+     * and only emits for the specified [key].
      */
     fun observeChanges(key: String): Flow<String>
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/LocalStorage.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/LocalStorage.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.common.data
 
+import kotlinx.coroutines.flow.Flow
+
 interface LocalStorage {
 
     suspend fun putString(key: String, value: String?)
@@ -25,4 +27,12 @@ interface LocalStorage {
     suspend fun getStringSet(key: String): Set<String>?
 
     suspend fun remove(key: String)
+
+    /**
+     * Returns a [Flow] that emits the [key] each time the value associated with it changes.
+     *
+     * The flow uses [android.content.SharedPreferences.OnSharedPreferenceChangeListener]
+     * under the hood and only emits for the specified key.
+     */
+    fun observeChanges(key: String): Flow<String>
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.HAGesture
+import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
 enum class NightModeTheme(val storageValue: String) {
@@ -22,6 +23,16 @@ enum class NightModeTheme(val storageValue: String) {
 
 @Parcelize
 data class AutoFavorite(val serverId: Int, val entityId: String) : Parcelable
+
+/**
+ * Holds the current zoom configuration for the WebView.
+ *
+ * @param zoomLevel Zoom level percentage (e.g. 100 for no zoom, 150 for 150%).
+ * @param pinchToZoomEnabled Whether the user has enabled pinch-to-zoom.
+ */
+data class ZoomSettings(val zoomLevel: Int = DEFAULT_ZOOM_LEVEL, val pinchToZoomEnabled: Boolean = false)
+
+private const val DEFAULT_ZOOM_LEVEL = 100
 
 interface PrefsRepository {
     suspend fun getAppVersion(): String?
@@ -79,6 +90,9 @@ interface PrefsRepository {
     suspend fun isPinchToZoomEnabled(): Boolean
 
     suspend fun setPinchToZoomEnabled(enabled: Boolean)
+
+    /** Emits the current [ZoomSettings] immediately on collection, then on every change. */
+    val zoomSettingsFlow: Flow<ZoomSettings>
 
     suspend fun isAutoPlayVideoEnabled(): Boolean
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -92,7 +92,7 @@ interface PrefsRepository {
     suspend fun setPinchToZoomEnabled(enabled: Boolean)
 
     /** Emits the current [ZoomSettings] immediately on collection, then on every change. */
-    val zoomSettingsFlow: Flow<ZoomSettings>
+    suspend fun zoomSettingsFlow(): Flow<ZoomSettings>
 
     suspend fun isAutoPlayVideoEnabled(): Boolean
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -9,6 +9,10 @@ import io.homeassistant.companion.android.di.qualifiers.NamedIntegrationStorage
 import io.homeassistant.companion.android.di.qualifiers.NamedThemesStorage
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -226,6 +230,19 @@ internal class PrefsRepositoryImpl @Inject constructor(
     override suspend fun setPinchToZoomEnabled(enabled: Boolean) {
         localStorage().putBoolean(PREF_PINCH_TO_ZOOM_ENABLED, enabled)
     }
+
+    override val zoomSettingsFlow: Flow<ZoomSettings> =
+        merge(
+            localStorage.observeChanges(PREF_PAGE_ZOOM_LEVEL),
+            localStorage.observeChanges(PREF_PINCH_TO_ZOOM_ENABLED),
+            // Seed an initial emission so collectors read the current values immediately
+            flowOf(""),
+        ).map {
+            ZoomSettings(
+                zoomLevel = getPageZoomLevel(),
+                pinchToZoomEnabled = isPinchToZoomEnabled(),
+            )
+        }
 
     override suspend fun isAutoPlayVideoEnabled(): Boolean {
         return localStorage().getBoolean(PREF_AUTOPLAY_VIDEO)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -231,8 +231,9 @@ internal class PrefsRepositoryImpl @Inject constructor(
         localStorage().putBoolean(PREF_PINCH_TO_ZOOM_ENABLED, enabled)
     }
 
-    override val zoomSettingsFlow: Flow<ZoomSettings> =
-        merge(
+    override suspend fun zoomSettingsFlow(): Flow<ZoomSettings> {
+        val localStorage = localStorage()
+        return merge(
             localStorage.observeChanges(PREF_PAGE_ZOOM_LEVEL),
             localStorage.observeChanges(PREF_PINCH_TO_ZOOM_ENABLED),
             // Seed an initial emission so collectors read the current values immediately
@@ -243,6 +244,7 @@ internal class PrefsRepositoryImpl @Inject constructor(
                 pinchToZoomEnabled = isPinchToZoomEnabled(),
             )
         }
+    }
 
     override suspend fun isAutoPlayVideoEnabled(): Boolean {
         return localStorage().getBoolean(PREF_AUTOPLAY_VIDEO)

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/LocalStorageImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/LocalStorageImplTest.kt
@@ -1,0 +1,50 @@
+package io.homeassistant.companion.android.common
+
+import android.content.SharedPreferences
+import app.cash.turbine.test
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(ConsoleLogExtension::class)
+class LocalStorageImplTest {
+    private val listenerSlot = slot<SharedPreferences.OnSharedPreferenceChangeListener>()
+    private val sharedPreferences: SharedPreferences = mockk(relaxed = true) {
+        every { registerOnSharedPreferenceChangeListener(capture(listenerSlot)) } returns Unit
+    }
+    private val localStorage = LocalStorageImpl { sharedPreferences }
+
+    @Test
+    fun `Given observing key when matching key changes then key is emitted`() = runTest {
+        localStorage.observeChanges("my_key").test {
+            listenerSlot.captured.onSharedPreferenceChanged(sharedPreferences, "my_key")
+            assertEquals("my_key", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Given observing key when different key changes then nothing is emitted`() = runTest {
+        localStorage.observeChanges("my_key").test {
+            listenerSlot.captured.onSharedPreferenceChanged(sharedPreferences, "other_key")
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `Given observing key when cancelled then listener is unregistered`() = runTest {
+        localStorage.observeChanges("my_key").test {
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify { sharedPreferences.unregisterOnSharedPreferenceChangeListener(any()) }
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -1,21 +1,31 @@
 package io.homeassistant.companion.android.common.data.prefs
 
+import app.cash.turbine.test
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.HAGesture
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
+@ExtendWith(ConsoleLogExtension::class)
 class PrefsRepositoryImplTest {
-    private val localStorage = mockk<LocalStorage>()
+    private val keyChangesFlow = MutableSharedFlow<String>()
+    private val localStorage = mockk<LocalStorage> {
+        every { observeChanges(any()) } returns keyChangesFlow
+    }
     private val integrationStorage = mockk<LocalStorage>()
 
     private lateinit var repository: PrefsRepositoryImpl
@@ -117,5 +127,58 @@ class PrefsRepositoryImplTest {
 
         // Verify no integration storage was accessed since no migration was needed
         coVerify(exactly = 0) { integrationStorage.getString(any()) }
+    }
+
+    @Nested
+    inner class ZoomSettingsFlow {
+
+        @Test
+        fun `Given collecting flow then current zoom settings are emitted immediately`() = runTest {
+            coEvery { localStorage.getInt("page_zoom_level") } returns 150
+            coEvery { localStorage.getBoolean("pinch_to_zoom_enabled") } returns true
+
+            repository.zoomSettingsFlow().test {
+                val settings = awaitItem()
+                assertEquals(150, settings.zoomLevel)
+                assertEquals(true, settings.pinchToZoomEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given collecting flow when zoom key changes then updated settings are emitted`() = runTest {
+            coEvery { localStorage.getInt("page_zoom_level") } returns 100
+            coEvery { localStorage.getBoolean("pinch_to_zoom_enabled") } returns false
+
+            repository.zoomSettingsFlow().test {
+                awaitItem() // consume initial emission
+
+                coEvery { localStorage.getInt("page_zoom_level") } returns 200
+                keyChangesFlow.emit("page_zoom_level")
+
+                val updated = awaitItem()
+                assertEquals(200, updated.zoomLevel)
+                assertEquals(false, updated.pinchToZoomEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given collecting flow when pinch to zoom key changes then updated settings are emitted`() = runTest {
+            coEvery { localStorage.getInt("page_zoom_level") } returns 100
+            coEvery { localStorage.getBoolean("pinch_to_zoom_enabled") } returns false
+
+            repository.zoomSettingsFlow().test {
+                awaitItem() // consume initial emission
+
+                coEvery { localStorage.getBoolean("pinch_to_zoom_enabled") } returns true
+                keyChangesFlow.emit("pinch_to_zoom_enabled")
+
+                val updated = awaitItem()
+                assertEquals(100, updated.zoomLevel)
+                assertEquals(true, updated.pinchToZoomEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
     }
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -12,6 +12,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -81,7 +83,7 @@ class PrefsRepositoryImplTest {
 
         val result = repository.isChangeLogPopupEnabled()
 
-        assertEquals(true, result)
+        assertTrue(result)
     }
 
     @Test
@@ -92,7 +94,7 @@ class PrefsRepositoryImplTest {
 
         val result = repository.isChangeLogPopupEnabled()
 
-        assertEquals(true, result)
+        assertTrue(result)
     }
 
     @Test
@@ -103,7 +105,7 @@ class PrefsRepositoryImplTest {
 
         val result = repository.isChangeLogPopupEnabled()
 
-        assertEquals(false, result)
+        assertFalse(result)
     }
 
     @Test
@@ -140,7 +142,7 @@ class PrefsRepositoryImplTest {
             repository.zoomSettingsFlow().test {
                 val settings = awaitItem()
                 assertEquals(150, settings.zoomLevel)
-                assertEquals(true, settings.pinchToZoomEnabled)
+                assertTrue(settings.pinchToZoomEnabled)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -158,7 +160,7 @@ class PrefsRepositoryImplTest {
 
                 val updated = awaitItem()
                 assertEquals(200, updated.zoomLevel)
-                assertEquals(false, updated.pinchToZoomEnabled)
+                assertFalse(updated.pinchToZoomEnabled)
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -176,7 +178,7 @@ class PrefsRepositoryImplTest {
 
                 val updated = awaitItem()
                 assertEquals(100, updated.zoomLevel)
-                assertEquals(true, updated.pinchToZoomEnabled)
+                assertTrue(updated.pinchToZoomEnabled)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR adds support the Zoom feature from WebViewActivity to the FrontendScreen. I also introduced a generic way to observe changes on the LocalStorage.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.