### PR TITLE
Remove Trigger workflow step from Renovate lockfile worflow

### DIFF
--- a/.github/workflows/renovate-lockfiles.yml
+++ b/.github/workflows/renovate-lockfiles.yml
@@ -52,15 +52,3 @@ jobs:
             git commit -m "Update dependency lockfiles"
             git push
           fi
-
-      - name: Trigger Workflow
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        if: steps.check-skip.outputs.skip != 'true'
-        with:
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'pr.yml',
-              ref: context.ref,
-            })


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We don't need anymore to manually trigger a a workflow when the lockfile is updated, since we can manually approve it to run from Github. It is better even if it adds a bit of delay, because before only an admin was able to merge the PR by by-passing the checks.