### PR TITLE
Remove unnecessary permissions for actions

### DIFF
--- a/.github/workflows/renovate-lockfiles.yml
+++ b/.github/workflows/renovate-lockfiles.yml
@@ -12,7 +12,6 @@ jobs:
   update-lockfiles:
     runs-on: ubuntu-latest
     permissions:
-      actions: write # Start workflows pr.yml
       contents: write # To push to the current branch
     steps:
       # Avoid re-running when this workflow just pushed a lockfile update


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We don't need the `action: write` permission anymore in the renovate lockfile workflow since we don't start any workflow anymore.