### PR TITLE
Initialize Timber before Application.onCreate

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -82,6 +82,8 @@ open class HomeAssistantApplication :
 
     @OptIn(ExperimentalComposeRuntimeApi::class)
     override fun onCreate() {
+        // We should initialize the logger as early as possible in the lifecycle of the application
+        Timber.plant(Timber.DebugTree())
         super.onCreate()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
@@ -94,8 +96,6 @@ open class HomeAssistantApplication :
             )
         }
 
-        // We should initialize the logger as early as possible in the lifecycle of the application
-        Timber.plant(Timber.DebugTree())
         Timber.i("Running ${BuildConfig.VERSION_NAME} on SDK ${Build.VERSION.SDK_INT}")
 
         registerActivityLifecycleCallbacks(LifecycleHandler)

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -38,6 +38,8 @@ open class HomeAssistantApplication : Application() {
 
     @OptIn(ExperimentalComposeRuntimeApi::class)
     override fun onCreate() {
+        // We should initialize the logger as early as possible in the lifecycle of the application
+        Timber.plant(Timber.DebugTree())
         super.onCreate()
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
@@ -47,8 +49,6 @@ open class HomeAssistantApplication : Application() {
             HAStrictMode.enable()
         }
 
-        // We should initialize the logger as early as possible in the lifecycle of the application
-        Timber.plant(Timber.DebugTree())
         Timber.i("Running ${BuildConfig.VERSION_NAME} on SDK ${Build.VERSION.SDK_INT}")
 
         // Enable only for debug flavor to avoid perf regressions in release


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While looking at https://github.com/home-assistant/android/pull/6753 I found out that we were missing the logs that we might have during Hilt initialization happening in `super.onCreate` because we are planting the Tree after it. We should plant the Tree before anything else.