### PR TITLE
Enable fullscreen support at the LaunchActivity level

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
@@ -14,9 +15,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.IntentCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
@@ -130,7 +134,10 @@ class LaunchActivity : AppCompatActivity() {
             HATheme {
                 val navController = rememberNavController()
                 val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+                val isFullScreen by viewModel.isFullScreen.collectAsStateWithLifecycle()
                 val snackbarHostState = remember { SnackbarHostState() }
+
+                FullscreenEffect(isFullScreen = isFullScreen)
 
                 MissingPlayServicesNotice(
                     isMissingRequiredPlayServices = playServicesAvailability.isMissingRequiredPlayServices(),
@@ -168,6 +175,22 @@ class LaunchActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         if (!isFinishing && WIPFeature.USE_FRONTEND_V2) SensorReceiver.updateAllSensors(this)
+    }
+}
+
+@Composable
+private fun FullscreenEffect(isFullScreen: Boolean) {
+    val view = LocalView.current
+    val window = LocalActivity.current?.window ?: return
+    LaunchedEffect(isFullScreen) {
+        val controller = WindowInsetsControllerCompat(window, view)
+        if (isFullScreen) {
+            controller.systemBarsBehavior =
+                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            controller.hide(systemBars())
+        } else {
+            controller.show(systemBars())
+        }
     }
 }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
@@ -13,6 +13,7 @@ import io.homeassistant.companion.android.automotive.navigation.AutomotiveRoute
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.network.NetworkState
 import io.homeassistant.companion.android.common.data.network.NetworkStatusMonitor
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.ResyncRegistrationWorker.Companion.enqueueResyncRegistration
 import io.homeassistant.companion.android.database.server.Server
@@ -22,8 +23,13 @@ import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
 import io.homeassistant.companion.android.onboarding.OnboardingRoute
 import io.homeassistant.companion.android.onboarding.WearOnboardingRoute
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -67,6 +73,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
     private val workManager: WorkManager,
     private val serverManager: ServerManager,
     private val networkStatusMonitor: NetworkStatusMonitor,
+    private val prefsRepository: PrefsRepository,
     private val hasLocationTrackingSupport: Boolean,
     isAutomotive: Boolean,
     isFullFlavor: Boolean,
@@ -78,6 +85,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
         workManager: WorkManager,
         serverManager: ServerManager,
         networkStatusMonitor: NetworkStatusMonitor,
+        prefsRepository: PrefsRepository,
         @LocationTrackingSupport hasLocationTrackingSupport: Boolean,
         @IsAutomotive isAutomotive: Boolean,
     ) : this(
@@ -85,6 +93,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
         workManager,
         serverManager,
         networkStatusMonitor,
+        prefsRepository,
         hasLocationTrackingSupport,
         isAutomotive = isAutomotive,
         isFullFlavor = BuildConfig.FLAVOR == "full",
@@ -101,6 +110,11 @@ internal class LaunchViewModel @VisibleForTesting constructor(
 
     private val _uiState = MutableStateFlow<LaunchUiState>(LaunchUiState.Loading)
     val uiState = _uiState.asStateFlow()
+
+    /** Emits the current fullscreen preference, reacting to changes in real-time. */
+    val isFullScreen: StateFlow<Boolean> = flow {
+        emitAll(prefsRepository.fullScreenEnabledFlow())
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
 
     init {
         viewModelScope.launch {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.automotive.navigation.AutomotiveRoute
 import io.homeassistant.companion.android.common.data.authentication.SessionState
 import io.homeassistant.companion.android.common.data.network.NetworkState
 import io.homeassistant.companion.android.common.data.network.NetworkStatusMonitor
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
@@ -39,6 +40,10 @@ import org.junit.jupiter.params.provider.EnumSource
 class LaunchViewModelTest {
     private val serverManager: ServerManager = mockk(relaxed = true)
     private val networkStatusMonitor: NetworkStatusMonitor = mockk(relaxed = true)
+    private val fullScreenEnabledFlow = MutableStateFlow(false)
+    private val prefsRepository: PrefsRepository = mockk(relaxed = true) {
+        coEvery { this@mockk.fullScreenEnabledFlow() } returns this@LaunchViewModelTest.fullScreenEnabledFlow
+    }
 
     private val workManager: WorkManager = mockk()
 
@@ -55,6 +60,7 @@ class LaunchViewModelTest {
             workManager,
             serverManager,
             networkStatusMonitor,
+            prefsRepository,
             hasLocationTrackingSupport,
             isAutomotive,
             isFullFlavor,
@@ -543,5 +549,37 @@ class LaunchViewModelTest {
             LaunchUiState.Ready(WearOnboardingRoute(wearName = "Pixel Watch", urlToOnboard = null)),
             viewModel.uiState.value,
         )
+    }
+
+    @Test
+    fun `Given fullscreen enabled when observed then isFullScreen is true`() = runTest {
+        fullScreenEnabledFlow.value = true
+        createViewModel()
+        advanceUntilIdle()
+
+        assertTrue(viewModel.isFullScreen.value)
+    }
+
+    @Test
+    fun `Given fullscreen disabled when observed then isFullScreen is false`() = runTest {
+        fullScreenEnabledFlow.value = false
+        createViewModel()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.isFullScreen.value)
+    }
+
+    @Test
+    fun `Given fullscreen preference changes then isFullScreen updates reactively`() = runTest {
+        fullScreenEnabledFlow.value = false
+        createViewModel()
+        advanceUntilIdle()
+
+        assertFalse(viewModel.isFullScreen.value)
+
+        fullScreenEnabledFlow.value = true
+        advanceUntilIdle()
+
+        assertTrue(viewModel.isFullScreen.value)
     }
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -75,6 +75,9 @@ interface PrefsRepository {
 
     suspend fun setFullScreenEnabled(enabled: Boolean)
 
+    /** Emits the current fullscreen preference immediately on collection, then on every change. */
+    suspend fun fullScreenEnabledFlow(): Flow<Boolean>
+
     suspend fun isKeepScreenOnEnabled(): Boolean
 
     suspend fun setKeepScreenOnEnabled(enabled: Boolean)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -207,6 +207,17 @@ internal class PrefsRepositoryImpl @Inject constructor(
         localStorage().putBoolean(PREF_FULLSCREEN_ENABLED, enabled)
     }
 
+    override suspend fun fullScreenEnabledFlow(): Flow<Boolean> {
+        val localStorage = localStorage()
+        return merge(
+            localStorage.observeChanges(PREF_FULLSCREEN_ENABLED),
+            // Seed an initial emission so collectors read the current value immediately
+            flowOf(""),
+        ).map {
+            isFullScreenEnabled()
+        }
+    }
+
     override suspend fun isKeepScreenOnEnabled(): Boolean {
         return localStorage().getBoolean(PREF_KEEP_SCREEN_ON_ENABLED)
     }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -183,4 +183,33 @@ class PrefsRepositoryImplTest {
             }
         }
     }
+
+    @Nested
+    inner class FullScreenEnabledFlow {
+
+        @Test
+        fun `Given collecting flow when subscribing then current full screen enabled is emitted immediately`() = runTest {
+            coEvery { localStorage.getBoolean("fullscreen_enabled") } returns true
+
+            repository.fullScreenEnabledFlow().test {
+                assertTrue(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given collecting flow when full screen changes then updated full screen enabled is emitted`() = runTest {
+            coEvery { localStorage.getBoolean("fullscreen_enabled") } returns true
+
+            repository.fullScreenEnabledFlow().test {
+                awaitItem() // consume initial emission
+
+                coEvery { localStorage.getBoolean("fullscreen_enabled") } returns false
+                keyChangesFlow.emit("fullscreen_enabled")
+
+                assertFalse(awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+    }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This Pr does bring the fullscreen feature to the `LaunchActivity` directly. It is observing any changes on the fullscreen settings to know when to hide/show the systemUI. Compare to the approach of the `WebViewActivity` this set the fullscreen mode to all the screen under the `LaunchActivity` so the `FrontendScreen` and the whole onboarding for now now support the fullscreen mode.

My objective is now that the `FrontendScreen` can make request to the activity, and the `LaunchViewModel` is going to handle the logic for it. For instance if opening a video in full screen it is going to go in fullscreen and when leaving the video then the `LaunchViewModel` is going to be the one deciding to leave or not the fullscreen mode (since it might be set in the settings to be in full screen).

This PR is based on #6739 and will need a rebase.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

https://github.com/user-attachments/assets/08c05113-1a7a-485e-824a-0b6d89f067a0

