### PR TITLE
Configure Composer diagnostic stacktrace

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -11,8 +11,6 @@ import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import android.telephony.TelephonyManager
-import androidx.compose.runtime.Composer
-import androidx.compose.runtime.ExperimentalComposeRuntimeApi
 import androidx.core.content.ContextCompat
 import coil3.ImageLoader
 import coil3.PlatformContext
@@ -25,6 +23,7 @@ import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.sensors.AudioSensorManager
 import io.homeassistant.companion.android.common.sensors.LastUpdateManager
 import io.homeassistant.companion.android.common.util.HAStrictMode
+import io.homeassistant.companion.android.common.util.configureComposeDiagnosticStackTrace
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.database.settings.SensorUpdateFrequencySetting
@@ -80,7 +79,6 @@ open class HomeAssistantApplication :
     @Inject
     lateinit var settingsDao: SettingsDao
 
-    @OptIn(ExperimentalComposeRuntimeApi::class)
     override fun onCreate() {
         // We should initialize the logger as early as possible in the lifecycle of the application
         Timber.plant(Timber.DebugTree())
@@ -110,8 +108,7 @@ open class HomeAssistantApplication :
             nightModeManager.applyCurrentNightMode()
         }
 
-        // Enable only for debug flavor to avoid perf regressions in release
-        Composer.setDiagnosticStackTraceEnabled(BuildConfig.DEBUG)
+        configureComposeDiagnosticStackTrace(isDebug = BuildConfig.DEBUG)
 
         // This will make sure we start/stop when we actually need too.
         ContextCompat.registerReceiver(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ComposeDiagnostics.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ComposeDiagnostics.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.common.util
+
+import androidx.compose.runtime.Composer
+import androidx.compose.runtime.tooling.ComposeStackTraceMode
+
+/**
+ * Configures the global Compose diagnostic stack trace mode so that crashes occurring during
+ * composition carry a composition stack trace as a suppressed exception.
+ *
+ * In debug builds, [ComposeStackTraceMode.SourceInformation] is used to produce precise file
+ * and line numbers. It records Compose source information at runtime, which adds some
+ * performance overhead and should not be used in release builds.
+ *
+ * In release builds, [ComposeStackTraceMode.GroupKeys] is used. It has no runtime overhead
+ * and still emits a composition stack trace on crashes.
+ *
+ * @param isDebug whether the current build is a debug build (typically `BuildConfig.DEBUG`).
+ */
+fun configureComposeDiagnosticStackTrace(isDebug: Boolean) {
+    Composer.setDiagnosticStackTraceMode(
+        if (isDebug) {
+            ComposeStackTraceMode.SourceInformation
+        } else {
+            ComposeStackTraceMode.GroupKeys
+        },
+    )
+}

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -10,8 +10,6 @@ import android.net.wifi.WifiManager
 import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
-import androidx.compose.runtime.Composer
-import androidx.compose.runtime.ExperimentalComposeRuntimeApi
 import androidx.core.content.ContextCompat
 import dagger.hilt.android.HiltAndroidApp
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
@@ -19,6 +17,7 @@ import io.homeassistant.companion.android.common.data.keychain.KeyStoreRepositor
 import io.homeassistant.companion.android.common.data.keychain.NamedKeyStore
 import io.homeassistant.companion.android.common.sensors.AudioSensorManager
 import io.homeassistant.companion.android.common.util.HAStrictMode
+import io.homeassistant.companion.android.common.util.configureComposeDiagnosticStackTrace
 import io.homeassistant.companion.android.complications.ComplicationReceiver
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import javax.inject.Inject
@@ -36,7 +35,6 @@ open class HomeAssistantApplication : Application() {
     @NamedKeyStore
     lateinit var keyStore: KeyChainRepository
 
-    @OptIn(ExperimentalComposeRuntimeApi::class)
     override fun onCreate() {
         // We should initialize the logger as early as possible in the lifecycle of the application
         Timber.plant(Timber.DebugTree())
@@ -51,8 +49,7 @@ open class HomeAssistantApplication : Application() {
 
         Timber.i("Running ${BuildConfig.VERSION_NAME} on SDK ${Build.VERSION.SDK_INT}")
 
-        // Enable only for debug flavor to avoid perf regressions in release
-        Composer.setDiagnosticStackTraceEnabled(BuildConfig.DEBUG)
+        configureComposeDiagnosticStackTrace(isDebug = BuildConfig.DEBUG)
 
         ioScope.launch {
             keyStore.load(applicationContext, KeyStoreRepository.ALIAS)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We were already enabling the compose stacktrace in debug but the recent version of Compose introduced a new way of setting it up that also allow getting more information without performance impacts on release (less precise).
Also `setDiagnosticStackTraceEnabled` has been deprecated

<img width="834" height="536" alt="image" src="https://github.com/user-attachments/assets/341d5ecb-2771-441d-b816-57fdc75b10f4" />

I decided to enable it in Release too with the `Groupkeys` mode and make common function for both app and wear.

<img width="891" height="1265" alt="image" src="https://github.com/user-attachments/assets/0ed4dc21-2510-4c6c-b120-0bdbb69a3b1c" />