### PR TITLE
Ignore JobService leak in InstrumentationTest for API23

### DIFF
--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -5,9 +5,9 @@ import leakcanary.DetectLeaksAfterTestSuccess
 import leakcanary.LeakCanary
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExternalResource
 import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
-import org.junit.runners.model.Statement
 import shark.AndroidReferenceMatchers
 
 class LaunchActivityTest {
@@ -15,26 +15,25 @@ class LaunchActivityTest {
 
     private val detectLeaksRule = DetectLeaksAfterTestSuccess()
 
-    private val jobServiceLibraryLeakRule: TestRule = TestRule { base, _ ->
-        object : Statement() {
-            override fun evaluate() {
-                val previousConfig = LeakCanary.config
-                LeakCanary.config = previousConfig.copy(
-                    // WorkManager on API 23 can retain the JobService binder stub after onDestroy(),
-                    // which is external to LaunchActivity and should be treated as a library leak here.
-                    referenceMatchers = previousConfig.referenceMatchers +
-                        AndroidReferenceMatchers.nativeGlobalVariableLeak(
-                            className = "android.app.job.JobService\$1",
-                            description = "API 23 can retain JobService binder stubs after Service.onDestroy().",
-                            patternApplies = { sdkInt < 24 },
-                        ),
-                )
-                try {
-                    base.evaluate()
-                } finally {
-                    LeakCanary.config = previousConfig
-                }
-            }
+    private val jobServiceLibraryLeakRule = object : ExternalResource() {
+        private lateinit var previousConfig: LeakCanary.Config
+
+        override fun before() {
+            previousConfig = LeakCanary.config
+            // WorkManager on API 23 can retain the JobService binder stub after onDestroy(),
+            // which is external to LaunchActivity and should be treated as a library leak here.
+            LeakCanary.config = previousConfig.copy(
+                referenceMatchers = previousConfig.referenceMatchers +
+                    AndroidReferenceMatchers.nativeGlobalVariableLeak(
+                        className = "android.app.job.JobService\$1",
+                        description = "API 23 can retain JobService binder stubs after Service.onDestroy().",
+                        patternApplies = { sdkInt < 24 },
+                    ),
+            )
+        }
+
+        override fun after() {
+            LeakCanary.config = previousConfig
         }
     }
 

--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -21,8 +21,9 @@ class LaunchActivityTest {
 
         override fun before() {
             previousConfig = LeakCanary.config
-            // WorkManager on API 23 can retain the JobService binder stub after onDestroy(),
-            // which is external to LaunchActivity and should be treated as a library leak here.
+            // WorkManager on lower APIs can retain the JobService binder stub after onDestroy(),
+            // which is external to LaunchActivity and should be treated as a library leak here for
+            // observed and confirmed leaks (API 23 only).
             LeakCanary.config = previousConfig.copy(
                 referenceMatchers = previousConfig.referenceMatchers +
                     AndroidReferenceMatchers.nativeGlobalVariableLeak(

--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -1,26 +1,48 @@
 package io.homeassistant.companion.android.launch
 
-import android.os.Build
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import leakcanary.DetectLeaksAfterTestSuccess
+import leakcanary.LeakCanary
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.rules.TestRule
+import org.junit.runners.model.Statement
+import shark.AndroidReferenceMatchers
 
 class LaunchActivityTest {
-    @get:Rule
-    val composeTestRule = createAndroidComposeRule<LaunchActivity>()
+    private val composeTestRule = createAndroidComposeRule<LaunchActivity>()
 
-    @get:Rule
-    val detectLeaksRule: TestRule = TestRule { base, description ->
-        // API 23 can retain WorkManager's SystemJobService after LaunchActivity schedules background work,
-        // which trips LeakCanary on a library-managed reference path rather than an activity leak.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            DetectLeaksAfterTestSuccess().apply(base, description)
-        } else {
-            base
+    private val detectLeaksRule = DetectLeaksAfterTestSuccess()
+
+    private val jobServiceLibraryLeakRule: TestRule = TestRule { base, _ ->
+        object : Statement() {
+            override fun evaluate() {
+                val previousConfig = LeakCanary.config
+                LeakCanary.config = previousConfig.copy(
+                    // WorkManager on API 23 can retain the JobService binder stub after onDestroy(),
+                    // which is external to LaunchActivity and should be treated as a library leak here.
+                    referenceMatchers = previousConfig.referenceMatchers +
+                        AndroidReferenceMatchers.nativeGlobalVariableLeak(
+                            className = "android.app.job.JobService\$1",
+                            description = "API 23 can retain JobService binder stubs after Service.onDestroy().",
+                            patternApplies = { sdkInt < 24 },
+                        ),
+                )
+                try {
+                    base.evaluate()
+                } finally {
+                    LeakCanary.config = previousConfig
+                }
+            }
         }
     }
+
+    @get:Rule
+    val ruleChain: TestRule = RuleChain
+        .outerRule(jobServiceLibraryLeakRule)
+        .around(detectLeaksRule)
+        .around(composeTestRule)
 
     @Test
     fun launchActivity() {

--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.launch
 
+import android.os.Build
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import leakcanary.LeakCanary
@@ -27,7 +28,7 @@ class LaunchActivityTest {
                     AndroidReferenceMatchers.nativeGlobalVariableLeak(
                         className = "android.app.job.JobService\$1",
                         description = "API 23 can retain JobService binder stubs after Service.onDestroy().",
-                        patternApplies = { sdkInt < 24 },
+                        patternApplies = { sdkInt < Build.VERSION_CODES.N },
                     ),
             )
         }

--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -1,16 +1,26 @@
 package io.homeassistant.companion.android.launch
 
+import android.os.Build
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestRule
 
 class LaunchActivityTest {
     @get:Rule
     val composeTestRule = createAndroidComposeRule<LaunchActivity>()
 
     @get:Rule
-    val ruleChain = DetectLeaksAfterTestSuccess()
+    val detectLeaksRule: TestRule = TestRule { base, description ->
+        // API 23 can retain WorkManager's SystemJobService after LaunchActivity schedules background work,
+        // which trips LeakCanary on a library-managed reference path rather than an activity leak.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            DetectLeaksAfterTestSuccess().apply(base, description)
+        } else {
+            base
+        }
+    }
 
     @Test
     fun launchActivity() {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After https://github.com/home-assistant/android/pull/6720 we started to see failure on the CI while running the dumb InstrumentationTest on `LaunchActivity` on API23 

```
Starting 4 tests on emulator-5554 - 6.0
emulator-5554 - 6.0 Tests 3/4 completed. (0 skipped) (0 failed)

io.homeassistant.companion.android.launch.LaunchActivityTest > launchActivity[emulator-5554 - 6.0] FAILED 
	leakcanary.NoLeakAssertionFailedError: Application memory leaks were detected:
	====================================
Tests on emulator-5554 - 6.0 failed: There was 1 failure(s).
Finished 4 tests on emulator-5554 - 6.0
Execute io.homeassistant.companion.android.launch.LaunchActivityTest.launchActivity: FAILED
leakcanary.NoLeakAssertionFailedError: leakcanary.NoLeakAssertionFailedError: Application memory leaks were detected:
====================================
HEAP ANALYSIS RESULT
====================================
1 APPLICATION LEAKS

References underlined with "~~~" are likely causes.
Learn more at https://squ.re/leaks.

895 bytes retained by leaking objects
Signature: 6491376cfe66b1cac0d47b3ae180fd9027019aa5
┬───
│ GC Root: Global variable in native code
│
├─ android.app.job.JobService$1 instance
│    Leaking: UNKNOWN
│    Retaining 923 B in 20 objects
│    Anonymous subclass of android.app.job.IJobService$Stub
│    this$0 instance of androidx.work.impl.background.systemjob.SystemJobService
│    ↓ JobService$1.this$0
│                   ~~~~~~
╰→ androidx.work.impl.background.systemjob.SystemJobService instance
​     Leaking: YES (ObjectWatcher was watching this because androidx.work.impl.background.systemjob.SystemJobService received Service#onDestroy() callback and Service not held by ActivityThread)
​     Retaining 895 B in 19 objects
​     key = 34356ee8-4bed-48c5-9557-20b4007d973c
​     watchDurationMillis = 5147
​     retainedDurationMillis = 142
​     mApplication instance of io.homeassistant.companion.android.HomeAssistantApplication
​     mBase instance of android.app.ContextImpl

```

I don't think we can do much about it so I decided to ignore it when running on API 23.