### PR TITLE
Disable microwakeword test on wearOS

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -358,7 +358,7 @@ jobs:
             arch: x86_64
             profile: "wearos_small_round"
             target: "android-wear"
-            gradle_target: ":wear:connectedDebugAndroidTest :common:connectedDebugAndroidTest :microwakeword:connectedDebugAndroidTest"
+            gradle_target: ":wear:connectedDebugAndroidTest :common:connectedDebugAndroidTest"
     steps:
       - name: Delete unnecessary tools 🔧
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
For now we don't have any reason to run the microwakeword instrumentation test on the wear and it seems that is it causing the CI to be flaky. Probably because it is just too much for the host to run the emulator and build the C++ at the same time (just a guess).