### PR TITLE
Add ExoPlayer support for FrontendScreen from frontend request

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -21,9 +21,11 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -35,6 +37,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -65,6 +68,7 @@ import io.homeassistant.companion.android.onboarding.locationforsecureconnection
 import io.homeassistant.companion.android.onboarding.locationforsecureconnection.LocationForSecureConnectionViewModelFactory
 import io.homeassistant.companion.android.util.OnSwipeListener
 import io.homeassistant.companion.android.util.compose.HAPreviews
+import io.homeassistant.companion.android.util.compose.media.player.HAMediaPlayer
 import io.homeassistant.companion.android.util.compose.webview.HAWebView
 import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.webview.insecure.BlockInsecureScreen
@@ -145,6 +149,7 @@ internal fun FrontendScreen(
         onDownloadRequested = viewModel::onDownloadRequested,
         webViewActions = viewModel.webViewActions,
         onGesture = viewModel::onGesture,
+        onExoPlayerFullscreenChanged = viewModel::onExoPlayerFullscreenChanged,
         modifier = modifier,
     )
 }
@@ -176,6 +181,7 @@ internal fun FrontendScreenContent(
     onDownloadRequested: (url: String, contentDisposition: String, mimetype: String) -> Unit = { _, _, _ -> },
     webViewActions: Flow<WebViewAction> = emptyFlow(),
     onGesture: (GestureDirection, Int) -> Unit = { _, _ -> },
+    onExoPlayerFullscreenChanged: (Boolean) -> Unit = {},
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 
@@ -209,6 +215,11 @@ internal fun FrontendScreenContent(
             onWebViewCreationFailed = onWebViewCreationFailed,
             onDownloadRequested = onDownloadRequested,
             onGesture = onGesture,
+        )
+
+        ExoPlayerOverlay(
+            contentState = viewState as? FrontendViewState.Content,
+            onFullscreenChanged = onExoPlayerFullscreenChanged,
         )
 
         StateOverlay(
@@ -583,6 +594,23 @@ private fun WebViewEffects(
             }
         }
     }
+}
+
+@Composable
+private fun ExoPlayerOverlay(contentState: FrontendViewState.Content?, onFullscreenChanged: (Boolean) -> Unit) {
+    val exoState = contentState?.exoPlayerState ?: return
+    val size = exoState.size ?: return
+    HAMediaPlayer(
+        player = exoState.player,
+        contentScale = ContentScale.Inside,
+        modifier = Modifier
+            .offset(exoState.left, exoState.top)
+            .size(size),
+        fullscreenModifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black),
+        onFullscreenClicked = onFullscreenChanged,
+    )
 }
 
 @HAPreviews

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -253,22 +253,11 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private var zoomObserverJob: Job? = null
 
     init {
-        // Timeout watcher - cancels automatically when state changes from Loading
         viewModelScope.launch {
             _viewState.collectLatest { state ->
-                if (state is FrontendViewState.Loading) {
-                    delay(CONNECTION_TIMEOUT)
-                    // Only trigger timeout if still in Loading state
-                    if (_viewState.value is FrontendViewState.Loading) {
-                        onError(
-                            FrontendConnectionError.UnreachableError(
-                                message = commonR.string.webview_error_TIMEOUT,
-                                errorDetails = "",
-                                rawErrorType = "ConnectionTimeout",
-                            ),
-                        )
-                    }
-                }
+                releaseExoPlayerIfLeavingContent(state)
+                // Timeout watcher - cancels automatically when state changes from Loading
+                watchLoadingTimeout(state)
             }
         }
 
@@ -279,7 +268,12 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
 
         viewModelScope.launch {
+            var wasFullScreen = false
             exoPlayerManager.state.collect { exoState ->
+                if (wasFullScreen && exoState == null) {
+                    _events.tryEmit(FrontendEvent.RequestFullscreen(fullscreen = false))
+                }
+                wasFullScreen = exoState?.isFullScreen == true
                 _viewState.update { currentState ->
                     if (currentState is FrontendViewState.Content) {
                         currentState.copy(exoPlayerState = exoState)
@@ -446,6 +440,38 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             is GestureResult.Forwarded, is GestureResult.Ignored -> { /* no-op */ }
         }
     }
+
+    /**
+     * Releases the ExoPlayer whenever the view state is anything other than [FrontendViewState.Content].
+     *
+     * The overlay only makes sense while the frontend WebView is interactive, so leaving
+     * Content (server switch, error, retry) must tear the player down to avoid stale audio
+     * or network usage.
+     */
+    private fun releaseExoPlayerIfLeavingContent(state: FrontendViewState) {
+        if (state !is FrontendViewState.Content) {
+            exoPlayerManager.close()
+        }
+    }
+
+    /**
+     * Waits the [CONNECTION_TIMEOUT] in [FrontendViewState.Loading] and emits an
+     * [FrontendConnectionError.UnreachableError] if the WebView has not finished loading by then.
+     */
+    private suspend fun watchLoadingTimeout(state: FrontendViewState) {
+        if (state !is FrontendViewState.Loading) return
+        delay(CONNECTION_TIMEOUT)
+        if (_viewState.value is FrontendViewState.Loading) {
+            onError(
+                FrontendConnectionError.UnreachableError(
+                    message = commonR.string.webview_error_TIMEOUT,
+                    errorDetails = "",
+                    rawErrorType = "ConnectionTimeout",
+                ),
+            )
+        }
+    }
+
     private fun loadServer() {
         urlFlowJob?.cancel()
         urlFlowJob = viewModelScope.launch {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -18,6 +18,7 @@ import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionErrorStateProvider
+import io.homeassistant.companion.android.frontend.exoplayer.FrontendExoPlayerManager
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
@@ -88,6 +89,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val dialogManager: FrontendDialogManager,
     private val fileChooserManager: FileChooserManager,
     private val httpAuthManager: HttpAuthManager,
+    private val exoPlayerManager: FrontendExoPlayerManager,
 ) : ViewModel(),
     FrontendConnectionErrorStateProvider {
 
@@ -107,6 +109,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         dialogManager: FrontendDialogManager,
         fileChooserManager: FileChooserManager,
         httpAuthManager: HttpAuthManager,
+        exoPlayerManager: FrontendExoPlayerManager,
     ) : this(
         initialServerId = savedStateHandle.toRoute<FrontendRoute>().serverId,
         initialPath = savedStateHandle.toRoute<FrontendRoute>().path,
@@ -123,6 +126,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         dialogManager = dialogManager,
         fileChooserManager = fileChooserManager,
         httpAuthManager = httpAuthManager,
+        exoPlayerManager = exoPlayerManager,
     )
 
     /**
@@ -274,7 +278,24 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             }
         }
 
+        viewModelScope.launch {
+            exoPlayerManager.state.collect { exoState ->
+                _viewState.update { currentState ->
+                    if (currentState is FrontendViewState.Content) {
+                        currentState.copy(exoPlayerState = exoState)
+                    } else {
+                        currentState
+                    }
+                }
+            }
+        }
+
         loadServer()
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        exoPlayerManager.close()
     }
 
     /**
@@ -401,6 +422,17 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
     }
 
+    /**
+     * Called when the ExoPlayer fullscreen state changes.
+     *
+     * Updates the player UI state and emits a [FrontendEvent.RequestFullscreen] so the
+     * host activity can decide the actual system bar visibility.
+     */
+    fun onExoPlayerFullscreenChanged(isFullScreen: Boolean) {
+        exoPlayerManager.onFullscreenChanged(isFullScreen)
+        _events.tryEmit(FrontendEvent.RequestFullscreen(isFullScreen))
+    }
+
     private suspend fun handleGestureResult(result: GestureResult) {
         when (result) {
             is GestureResult.Navigate -> _events.emit(result.event)
@@ -488,6 +520,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
             is FrontendHandlerEvent.WriteNfcTag -> {
                 _events.tryEmit(FrontendEvent.NavigateToNfcWrite(messageId = result.messageId, tagId = result.tagId))
+            }
+
+            is FrontendHandlerEvent.ExoPlayerAction -> {
+                exoPlayerManager.handle(result)
             }
 
             is FrontendHandlerEvent.ConfigSent,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.frontend
 import androidx.compose.ui.graphics.Color
 import io.homeassistant.companion.android.common.data.prefs.NightModeTheme
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
+import io.homeassistant.companion.android.frontend.exoplayer.ExoPlayerUiState
 import io.homeassistant.companion.android.util.compose.webview.BLANK_URL
 
 /**
@@ -54,6 +55,7 @@ sealed interface FrontendViewState {
         val nightModeTheme: NightModeTheme? = null,
         val statusBarColor: Color? = null,
         val backgroundColor: Color? = null,
+        val exoPlayerState: ExoPlayerUiState? = null,
     ) : FrontendViewState
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/ExoPlayerUiState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/ExoPlayerUiState.kt
@@ -22,5 +22,5 @@ data class ExoPlayerUiState(
     val top: Dp = 0.dp,
     val left: Dp = 0.dp,
     val isFullScreen: Boolean = false,
-    val videoAspectRatio: Float? = null,
+    val videoAspectRatio: Double? = null,
 )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/ExoPlayerUiState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/ExoPlayerUiState.kt
@@ -1,0 +1,26 @@
+package io.homeassistant.companion.android.frontend.exoplayer
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.Player
+
+/**
+ * UI state for the ExoPlayer overlay rendered on top of the WebView.
+ *
+ * @param player The active player instance
+ * @param size The size of the player overlay, or null while waiting for resize
+ * @param top Top offset of the overlay
+ * @param left Left offset of the overlay
+ * @param isFullScreen Whether the player is in fullscreen mode
+ * @param videoAspectRatio Native video aspect ratio (height / width) once known, used to compute
+ *   a sensible height when the frontend sends a zero-height DOMRect
+ */
+data class ExoPlayerUiState(
+    val player: Player,
+    val size: DpSize? = null,
+    val top: Dp = 0.dp,
+    val left: Dp = 0.dp,
+    val isFullScreen: Boolean = false,
+    val videoAspectRatio: Float? = null,
+)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
@@ -28,8 +28,7 @@ import timber.log.Timber
  * which are forwarded here as [FrontendHandlerEvent.ExoPlayerAction] instances. This manager
  * owns the [Player] instance and exposes a [state] flow.
  *
- * The player is lazily created on the first `play_hls` and reused across streams. It is only
- * released when the manager is [close]d (typically in ViewModel's `onCleared`).
+ * The player need to be released by calling [close]d (typically in ViewModel's `onCleared`).
  */
 class FrontendExoPlayerManager @VisibleForTesting constructor(
     private val playerCreator: suspend (ExoPlayer.() -> Unit) -> ExoPlayer,
@@ -56,7 +55,7 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
                 playHls(url = message.url, muted = message.muted)
             }
 
-            is FrontendHandlerEvent.ExoPlayerAction.Stop -> stop()
+            is FrontendHandlerEvent.ExoPlayerAction.Stop -> close()
             is FrontendHandlerEvent.ExoPlayerAction.Resize -> {
                 resize(left = message.left, top = message.top, right = message.right, bottom = message.bottom)
             }
@@ -71,11 +70,6 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
         exoPlayer.volume = if (muted) 0f else 1f
         exoPlayer.prepare()
         _state.value = ExoPlayerUiState(player = exoPlayer)
-    }
-
-    private fun stop() {
-        player?.stop()
-        _state.value = null
     }
 
     private suspend fun getOrCreatePlayer(): ExoPlayer {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
@@ -1,0 +1,146 @@
+package io.homeassistant.companion.android.frontend.exoplayer
+
+import android.content.Context
+import android.net.Uri
+import androidx.annotation.VisibleForTesting
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.ExoPlayer
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.common.util.initializePlayer
+import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent
+import java.io.Closeable
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+/**
+ * Manages the ExoPlayer lifecycle for streams requested by the Home Assistant frontend.
+ *
+ * The frontend sends `exoplayer/play_hls`, `exoplayer/resize`, and `exoplayer/stop` messages
+ * which are forwarded here as [FrontendHandlerEvent.ExoPlayerAction] instances. This manager
+ * owns the [Player] instance and exposes a [state] flow.
+ *
+ * The player is lazily created on the first `play_hls` and reused across streams. It is only
+ * released when the manager is [close]d (typically in ViewModel's `onCleared`).
+ */
+class FrontendExoPlayerManager @VisibleForTesting constructor(
+    private val playerCreator: suspend (ExoPlayer.() -> Unit) -> ExoPlayer,
+) : Closeable {
+
+    @Inject
+    constructor(@ApplicationContext context: Context, dataSourceFactory: DataSource.Factory) : this(
+        { configure ->
+            initializePlayer(context, dataSourceFactory).apply(configure)
+        },
+    )
+
+    private var player: ExoPlayer? = null
+
+    private val _state = MutableStateFlow<ExoPlayerUiState?>(null)
+    val state: StateFlow<ExoPlayerUiState?> = _state.asStateFlow()
+
+    /**
+     * Handles a [FrontendHandlerEvent.ExoPlayerAction] from the external bus.
+     */
+    suspend fun handle(message: FrontendHandlerEvent.ExoPlayerAction) {
+        when (message) {
+            is FrontendHandlerEvent.ExoPlayerAction.PlayHls -> {
+                playHls(url = message.url, muted = message.muted)
+            }
+
+            is FrontendHandlerEvent.ExoPlayerAction.Stop -> stop()
+            is FrontendHandlerEvent.ExoPlayerAction.Resize -> {
+                resize(left = message.left, top = message.top, right = message.right, bottom = message.bottom)
+            }
+        }
+    }
+
+    private suspend fun playHls(url: Uri, muted: Boolean) {
+        val exoPlayer = getOrCreatePlayer()
+        exoPlayer.stop()
+        exoPlayer.setMediaItem(MediaItem.fromUri(url))
+        exoPlayer.playWhenReady = true
+        exoPlayer.volume = if (muted) 0f else 1f
+        exoPlayer.prepare()
+        _state.value = ExoPlayerUiState(player = exoPlayer)
+    }
+
+    private fun stop() {
+        player?.stop()
+        _state.value = null
+    }
+
+    private suspend fun getOrCreatePlayer(): ExoPlayer {
+        player?.let { return it }
+        return playerCreator {
+            addListener(VideoSizeListener())
+        }.also { player = it }
+    }
+
+    private fun resize(left: Float, top: Float, right: Float, bottom: Float) {
+        Timber.d("resize left=$left top=$top right=$right bottom=$bottom")
+        _state.update { currentState ->
+            if (currentState == null) return@update null
+
+            val width = right - left
+            // If the frontend didn't impose a real height (bottom equals or precedes top),
+            // compute one from the video's aspect ratio if we know it.
+            val height = if (bottom > top) {
+                bottom - top
+            } else {
+                currentState.videoAspectRatio?.let { ratio -> width * ratio } ?: 0f
+            }
+
+            currentState.copy(
+                left = left.dp,
+                top = top.dp,
+                size = DpSize(width.dp, height.coerceAtLeast(0f).dp),
+            )
+        }
+    }
+
+    /**
+     * Toggles fullscreen state for the player.
+     */
+    fun onFullscreenChanged(isFullScreen: Boolean) {
+        _state.update { it?.copy(isFullScreen = isFullScreen) }
+    }
+
+    /**
+     * Releases the player and clears state. Safe to call multiple times.
+     */
+    override fun close() {
+        player?.release()
+        player = null
+        _state.value = null
+    }
+
+    /**
+     * Listener that caches the video's native aspect ratio on the UI state and auto-calculates
+     * the player height when the frontend has not imposed a real height (e.g. zero-height DOMRect).
+     */
+    private inner class VideoSizeListener : Player.Listener {
+        override fun onVideoSizeChanged(videoSize: VideoSize) {
+            if (videoSize.height == 0 || videoSize.width == 0) return
+            val ratio = videoSize.height.toFloat() / videoSize.width
+            Timber.d("onVideoSizeChanged ${videoSize.width}x${videoSize.height} (ratio=$ratio)")
+            _state.update { currentState ->
+                if (currentState == null) return@update null
+                // Store the ratio for later zero-height resizes.
+                val withRatio = currentState.copy(videoAspectRatio = ratio)
+                // Also auto-size now if the current height was not imposed by the frontend.
+                val size = withRatio.size ?: return@update withRatio
+                if (size.height > 0.dp) return@update withRatio
+                withRatio.copy(size = DpSize(size.width, size.width * ratio))
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
@@ -28,7 +28,7 @@ import timber.log.Timber
  * which are forwarded here as [FrontendHandlerEvent.ExoPlayerAction] instances. This manager
  * owns the [Player] instance and exposes a [state] flow.
  *
- * The player need to be released by calling [close]d (typically in ViewModel's `onCleared`).
+ * The player need to be released by calling [close] (typically in ViewModel's `onCleared`).
  */
 class FrontendExoPlayerManager @VisibleForTesting constructor(
     private val playerCreator: suspend (ExoPlayer.() -> Unit) -> ExoPlayer,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManager.kt
@@ -85,7 +85,7 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
         }.also { player = it }
     }
 
-    private fun resize(left: Float, top: Float, right: Float, bottom: Float) {
+    private fun resize(left: Double, top: Double, right: Double, bottom: Double) {
         Timber.d("resize left=$left top=$top right=$right bottom=$bottom")
         _state.update { currentState ->
             if (currentState == null) return@update null
@@ -96,13 +96,13 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
             val height = if (bottom > top) {
                 bottom - top
             } else {
-                currentState.videoAspectRatio?.let { ratio -> width * ratio } ?: 0f
+                currentState.videoAspectRatio?.let { ratio -> width * ratio } ?: 0.0
             }
 
             currentState.copy(
                 left = left.dp,
                 top = top.dp,
-                size = DpSize(width.dp, height.coerceAtLeast(0f).dp),
+                size = DpSize(width.dp, height.coerceAtLeast(0.0).dp),
             )
         }
     }
@@ -130,7 +130,7 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
     private inner class VideoSizeListener : Player.Listener {
         override fun onVideoSizeChanged(videoSize: VideoSize) {
             if (videoSize.height == 0 || videoSize.width == 0) return
-            val ratio = videoSize.height.toFloat() / videoSize.width
+            val ratio = videoSize.height.toDouble() / videoSize.width
             Timber.d("onVideoSizeChanged ${videoSize.width}x${videoSize.height} (ratio=$ratio)")
             _state.update { currentState ->
                 if (currentState == null) return@update null
@@ -139,7 +139,7 @@ class FrontendExoPlayerManager @VisibleForTesting constructor(
                 // Also auto-size now if the current height was not imposed by the frontend.
                 val size = withRatio.size ?: return@update withRatio
                 if (size.height > 0.dp) return@update withRatio
-                withRatio.copy(size = DpSize(size.width, size.width * ratio))
+                withRatio.copy(size = DpSize(size.width, size.width * ratio.toFloat()))
             }
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
@@ -170,3 +170,49 @@ data class TagWritePayload(val tag: String? = null)
 @SerialName("handleBlob")
 data class HandleBlobMessage(override val id: Int? = null, val data: String, val filename: String) :
     IncomingExternalBusMessage
+
+/**
+ * Message requesting to start playing an HLS stream via ExoPlayer.
+ *
+ * The frontend provides the stream URL and an optional muted flag.
+ * The app should respond with a result message on success.
+ */
+@Serializable
+@SerialName("exoplayer/play_hls")
+data class ExoPlayerPlayHlsMessage(
+    override val id: Int? = null,
+    val payload: ExoPlayerPlayHlsPayload = ExoPlayerPlayHlsPayload(),
+) : IncomingExternalBusMessage
+
+@Serializable
+data class ExoPlayerPlayHlsPayload(val url: String? = null, val muted: Boolean = false)
+
+/**
+ * Message requesting to stop ExoPlayer playback and release the player.
+ *
+ * This is a fire-and-forget message.
+ */
+@Serializable
+@SerialName("exoplayer/stop")
+data class ExoPlayerStopMessage(override val id: Int? = null) : IncomingExternalBusMessage
+
+/**
+ * Message requesting to resize and reposition the ExoPlayer overlay.
+ *
+ * Payload values come from `Element.getBoundingClientRect()` and are already scaled
+ * to screen coordinates.
+ */
+@Serializable
+@SerialName("exoplayer/resize")
+data class ExoPlayerResizeMessage(
+    override val id: Int? = null,
+    val payload: ExoPlayerResizePayload = ExoPlayerResizePayload(),
+) : IncomingExternalBusMessage
+
+@Serializable
+data class ExoPlayerResizePayload(
+    val left: Float = 0f,
+    val top: Float = 0f,
+    val right: Float = 0f,
+    val bottom: Float = 0f,
+)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
@@ -211,8 +211,8 @@ data class ExoPlayerResizeMessage(
 
 @Serializable
 data class ExoPlayerResizePayload(
-    val left: Float = 0f,
-    val top: Float = 0f,
-    val right: Float = 0f,
-    val bottom: Float = 0f,
+    val left: Double = 0.0,
+    val top: Double = 0.0,
+    val right: Double = 0.0,
+    val bottom: Double = 0.0,
 )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
@@ -106,6 +106,6 @@ sealed interface FrontendHandlerEvent {
          * @param right Right edge in dp
          * @param bottom Bottom edge in dp, or 0 if the frontend does not impose a height constraint
          */
-        data class Resize(val left: Float, val top: Float, val right: Float, val bottom: Float) : ExoPlayerAction
+        data class Resize(val left: Double, val top: Double, val right: Double, val bottom: Double) : ExoPlayerAction
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.frontend.handler
 
+import android.net.Uri
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
@@ -79,4 +80,32 @@ sealed interface FrontendHandlerEvent {
      * @param tagId Optional pre-filled tag identifier. When null, the user is prompted to enter one.
      */
     data class WriteNfcTag(val messageId: Int, val tagId: String?) : FrontendHandlerEvent
+
+    sealed interface ExoPlayerAction : FrontendHandlerEvent {
+
+        /**
+         * Start playing an HLS stream.
+         *
+         * @param messageId The external bus message ID for the result callback
+         * @param url The HLS stream URL
+         * @param muted Whether playback should start muted
+         */
+        data class PlayHls(val messageId: Int?, val url: Uri, val muted: Boolean) : ExoPlayerAction
+
+        /** Stop playback and release the player. */
+        data object Stop : ExoPlayerAction
+
+        /**
+         * Resize and reposition the player overlay.
+         *
+         * Values come from the frontend's `Element.getBoundingClientRect()` and are already
+         * scaled to screen pixels (expressed as dp for Compose).
+         *
+         * @param left Left offset in dp
+         * @param top Top offset in dp
+         * @param right Right edge in dp
+         * @param bottom Bottom edge in dp, or 0 if the frontend does not impose a height constraint
+         */
+        data class Resize(val left: Float, val top: Float, val right: Float, val bottom: Float) : ExoPlayerAction
+    }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.frontend.handler
 
 import android.content.pm.PackageManager
+import androidx.core.net.toUri
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.di.qualifiers.IsAutomotive
@@ -196,7 +197,7 @@ class FrontendMessageHandler @Inject constructor(
                     externalBusRepository.send(ResultMessage(id = message.id, success = true))
                     FrontendHandlerEvent.ExoPlayerAction.PlayHls(
                         messageId = message.id,
-                        url = android.net.Uri.parse(url),
+                        url = url.toUri(),
                         muted = message.payload.muted,
                     )
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
@@ -10,6 +10,9 @@ import io.homeassistant.companion.android.frontend.download.FrontendDownloadMana
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConfigGetMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerPlayHlsMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerResizeMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerStopMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HandleBlobMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.IncomingExternalBusMessage
@@ -180,6 +183,37 @@ class FrontendMessageHandler @Inject constructor(
                 FrontendHandlerEvent.WriteNfcTag(
                     messageId = message.id ?: -1,
                     tagId = message.payload.tag,
+                )
+            }
+
+            is ExoPlayerPlayHlsMessage -> {
+                val url = message.payload.url
+                if (url == null) {
+                    Timber.w("exoplayer/play_hls received without URL")
+                    FrontendHandlerEvent.UnknownMessage
+                } else {
+                    Timber.d("exoplayer/play_hls url=${sensitive(url)} muted=${message.payload.muted}")
+                    externalBusRepository.send(ResultMessage(id = message.id, success = true))
+                    FrontendHandlerEvent.ExoPlayerAction.PlayHls(
+                        messageId = message.id,
+                        url = android.net.Uri.parse(url),
+                        muted = message.payload.muted,
+                    )
+                }
+            }
+
+            is ExoPlayerStopMessage -> {
+                Timber.d("exoplayer/stop received")
+                FrontendHandlerEvent.ExoPlayerAction.Stop
+            }
+
+            is ExoPlayerResizeMessage -> {
+                Timber.d("exoplayer/resize received")
+                FrontendHandlerEvent.ExoPlayerAction.Resize(
+                    left = message.payload.left,
+                    top = message.payload.top,
+                    right = message.payload.right,
+                    bottom = message.payload.bottom,
                 )
             }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEvent.kt
@@ -55,4 +55,13 @@ sealed interface FrontendEvent {
      * @param tagId Optional pre-filled tag identifier.
      */
     data class NavigateToNfcWrite(val messageId: Int, val tagId: String?) : FrontendEvent
+
+    /**
+     * Request the host activity to enter or leave fullscreen (hide/show system bars).
+     *
+     * This is a request, not a command: the LaunchViewModel decides the actual system bar
+     * visibility by combining this with the user's fullscreen preference. For instance, if
+     * the preference already enables fullscreen, a `false` request won't leave fullscreen.
+     */
+    data class RequestFullscreen(val fullscreen: Boolean) : FrontendEvent
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
@@ -71,6 +71,7 @@ internal fun NavGraphBuilder.frontendScreen(
     onConfigureHomeNetwork: (serverId: Int) -> Unit,
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
     onShowServerSwitcher: (onServerSelected: (Int) -> Unit) -> Unit,
+    onRequestFullscreen: (Boolean) -> Unit = {},
 ) {
     if (WIPFeature.USE_FRONTEND_V2) {
         composable<FrontendRoute> {
@@ -99,6 +100,7 @@ internal fun NavGraphBuilder.frontendScreen(
                 onNavigateToNfcWrite = { messageId, tagId ->
                     nfcWriteLauncher.launch(WriteNfcTag.Input(tagId = tagId, messageId = messageId))
                 },
+                onRequestFullscreen = onRequestFullscreen,
             )
 
             FrontendScreen(
@@ -141,6 +143,7 @@ internal fun FrontendEventHandler(
     onOpenExternalLink: suspend (Uri) -> Unit,
     onShowServerSwitcher: () -> Unit,
     onNavigateToNfcWrite: (messageId: Int, tagId: String?) -> Unit,
+    onRequestFullscreen: (Boolean) -> Unit,
 ) {
     val resources = LocalResources.current
     LaunchedEffect(Unit) {
@@ -176,6 +179,10 @@ internal fun FrontendEventHandler(
 
                 is FrontendEvent.NavigateToNfcWrite -> {
                     onNavigateToNfcWrite(event.messageId, event.tagId)
+                }
+
+                is FrontendEvent.RequestFullscreen -> {
+                    onRequestFullscreen(event.fullscreen)
                 }
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -158,6 +158,7 @@ class LaunchActivity : AppCompatActivity() {
                     navController = navController,
                     startDestination = (uiState as? LaunchUiState.Ready)?.startDestination,
                     snackbarHostState = snackbarHostState,
+                    onRequestFullscreen = viewModel::onFullscreenRequested,
                     modifier = Modifier.hazeSource(hazeState),
                 )
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
@@ -115,10 +116,20 @@ internal class LaunchViewModel @VisibleForTesting constructor(
     private val _uiState = MutableStateFlow<LaunchUiState>(LaunchUiState.Loading)
     val uiState = _uiState.asStateFlow()
 
-    /** Emits the current fullscreen preference, reacting to changes in real-time. */
-    val isFullScreen: StateFlow<Boolean> = flow {
-        emitAll(prefsRepository.fullScreenEnabledFlow())
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
+    private val fullscreenRequested = MutableStateFlow(false)
+
+    /**
+     * Emits whether the app should currently be in fullscreen mode.
+     *
+     * Combines the user's fullscreen preference with temporary fullscreen requests from the
+     * frontend (e.g. ExoPlayer entering fullscreen) via a logical OR. The preference therefore
+     * takes priority: while it is enabled, a `false` request cannot leave fullscreen.
+     */
+    val isFullScreen: StateFlow<Boolean> = combine(
+        flow { emitAll(prefsRepository.fullScreenEnabledFlow()) },
+        fullscreenRequested,
+    ) { preference, requested -> preference || requested }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = false)
 
     private val _isAppLocked = MutableStateFlow(false)
     val isAppLocked: StateFlow<Boolean> = _isAppLocked.asStateFlow()
@@ -162,6 +173,16 @@ internal class LaunchViewModel @VisibleForTesting constructor(
             appLockStateManager.setAppActive(active = true)
             _isAppLocked.value = false
         }
+    }
+
+    /**
+     * Request a temporary fullscreen state from the frontend.
+     *
+     * A `true` request makes the app enter fullscreen regardless of the user preference.
+     * A `false` request only leaves fullscreen when the user preference is also disabled.
+     */
+    fun onFullscreenRequested(fullscreen: Boolean) {
+        fullscreenRequested.value = fullscreen
     }
 
     private suspend fun handleInitialState(initialDeepLink: LaunchActivity.DeepLink?) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HAApp.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HAApp.kt
@@ -42,6 +42,7 @@ internal fun HAApp(
     startDestination: HAStartDestinationRoute?,
     snackbarHostState: SnackbarHostState,
     modifier: Modifier = Modifier,
+    onRequestFullscreen: (Boolean) -> Unit = {},
 ) {
     Scaffold(
         modifier = modifier,
@@ -69,6 +70,7 @@ internal fun HAApp(
             HANavHost(
                 navController = navController,
                 startDestination = startDestination,
+                onRequestFullscreen = onRequestFullscreen,
                 onShowSnackbar = { message, action ->
                     snackbarHostState.showSnackbar(
                         message,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HANavHost.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HANavHost.kt
@@ -50,6 +50,7 @@ internal fun HANavHost(
     navController: NavHostController,
     startDestination: HAStartDestinationRoute?,
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
+    onRequestFullscreen: (Boolean) -> Unit = {},
 ) {
     val activity = LocalActivity.current
     val isAutomotive = activity?.isAutomotive() == true
@@ -121,6 +122,7 @@ internal fun HANavHost(
                 },
                 onShowSnackbar = onShowSnackbar,
                 onShowServerSwitcher = { onServerSelected -> showServerSwitcher(activity, onServerSelected) },
+                onRequestFullscreen = onRequestFullscreen,
             )
             setHomeNetworkScreen(
                 onGotoNextScreen = {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -5,6 +5,7 @@ import android.webkit.HttpAuthHandler
 import android.webkit.JsResult
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
+import androidx.lifecycle.ViewModel
 import app.cash.turbine.test
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckRepository
@@ -21,6 +22,7 @@ import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
+import io.homeassistant.companion.android.frontend.exoplayer.FrontendExoPlayerManager
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage
@@ -101,6 +103,10 @@ class FrontendViewModelTest {
         coEvery { permissionManager.checkStoragePermissionForDownload() } returns true
     }
 
+    private val exoPlayerManager: FrontendExoPlayerManager = mockk(relaxed = true) {
+        every { state } returns MutableStateFlow(null)
+    }
+
     private fun createViewModel(
         serverId: Int = this.serverId,
         path: String? = null,
@@ -128,6 +134,7 @@ class FrontendViewModelTest {
             dialogManager = dialogManager,
             fileChooserManager = fileChooserManager,
             httpAuthManager = httpAuthManager,
+            exoPlayerManager = exoPlayerManager,
         )
     }
 
@@ -1478,6 +1485,73 @@ class FrontendViewModelTest {
                     serverId = serverId,
                 )
             }
+        }
+    }
+
+    @Nested
+    inner class ExoPlayer {
+
+        @Test
+        fun `Given fullscreen true when onExoPlayerFullscreenChanged then manager is notified and RequestFullscreen true emitted`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            val viewModel = createViewModel()
+
+            viewModel.events.test {
+                viewModel.onExoPlayerFullscreenChanged(isFullScreen = true)
+                assertEquals(FrontendEvent.RequestFullscreen(fullscreen = true), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            verify { exoPlayerManager.onFullscreenChanged(isFullScreen = true) }
+        }
+
+        @Test
+        fun `Given fullscreen false when onExoPlayerFullscreenChanged then manager is notified and RequestFullscreen false emitted`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            val viewModel = createViewModel()
+
+            viewModel.events.test {
+                viewModel.onExoPlayerFullscreenChanged(isFullScreen = false)
+                assertEquals(FrontendEvent.RequestFullscreen(fullscreen = false), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            verify { exoPlayerManager.onFullscreenChanged(isFullScreen = false) }
+        }
+
+        @Test
+        fun `Given ExoPlayerAction message when handled then manager handle is called`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            createViewModel()
+
+            val action = FrontendHandlerEvent.ExoPlayerAction.Stop
+            messageFlow.emit(action)
+            advanceUntilIdle()
+
+            coVerify { exoPlayerManager.handle(action) }
+        }
+
+        @Test
+        fun `Given ViewModel is cleared when onCleared then manager is closed`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            // onCleared is protected on ViewModel; invoke it via reflection to simulate
+            // ViewModel lifecycle teardown without pulling in the full ViewModelStore machinery.
+            val onCleared = ViewModel::class.java.getDeclaredMethod("onCleared")
+            onCleared.isAccessible = true
+            onCleared.invoke(viewModel)
+
+            verify { exoPlayerManager.close() }
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -6,6 +6,7 @@ import android.webkit.JsResult
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import androidx.lifecycle.ViewModel
+import androidx.media3.common.Player
 import app.cash.turbine.test
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckRepository
@@ -22,6 +23,7 @@ import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
+import io.homeassistant.companion.android.frontend.exoplayer.ExoPlayerUiState
 import io.homeassistant.companion.android.frontend.exoplayer.FrontendExoPlayerManager
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
@@ -40,6 +42,7 @@ import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.homeassistant.companion.android.testing.unit.FakeClock
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
+import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -1535,6 +1538,75 @@ class FrontendViewModelTest {
             advanceUntilIdle()
 
             coVerify { exoPlayerManager.handle(action) }
+        }
+
+        @Test
+        fun `Given player is in fullscreen when player state becomes null then RequestFullscreen false is emitted`() = runTest {
+            val playerState = MutableStateFlow<ExoPlayerUiState?>(null)
+            every { exoPlayerManager.state } returns playerState
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.events.test {
+                // Simulate the player entering fullscreen, then being torn down (e.g. via
+                // ExoPlayerAction.Stop or a server switch closing the manager).
+                playerState.value = ExoPlayerUiState(player = mockk(relaxed = true), isFullScreen = true)
+                playerState.value = null
+
+                assertEquals(FrontendEvent.RequestFullscreen(fullscreen = false), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given player never entered fullscreen when player state becomes null then no RequestFullscreen is emitted`() = runTest {
+            val playerState = MutableStateFlow<ExoPlayerUiState?>(null)
+            every { exoPlayerManager.state } returns playerState
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+
+            viewModel.events.test {
+                playerState.value = ExoPlayerUiState(player = mockk<Player>(relaxed = true), isFullScreen = false)
+                playerState.value = null
+                advanceUntilIdle()
+
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given Content state when state transitions out of Content then player is closed`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            every { urlManager.serverUrlFlow(2, any()) } returns flowOf(
+                UrlLoadResult.Success(url = "https://example.com/2?external_auth=1", serverId = 2),
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+            assertTrue(viewModel.viewState.value is FrontendViewState.Content)
+
+            // Reset the recorded calls (without clearing the `state` stub) so we only verify
+            // the close() invoked by the transition out of Content.
+            clearMocks(exoPlayerManager, answers = false, childMocks = false)
+
+            viewModel.switchServer(serverId = 2)
+            advanceUntilIdle()
+
+            verify(atLeast = 1) { exoPlayerManager.close() }
         }
 
         @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
@@ -1,0 +1,217 @@
+package io.homeassistant.companion.android.frontend.exoplayer
+
+import android.net.Uri
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.media3.exoplayer.ExoPlayer
+import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent.ExoPlayerAction
+import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ConsoleLogExtension::class)
+class FrontendExoPlayerManagerTest {
+
+    private val mockPlayer: ExoPlayer = mockk(relaxed = true)
+    private val playerCreator: suspend (ExoPlayer.() -> Unit) -> ExoPlayer = { configure ->
+        mockPlayer.apply(configure)
+    }
+
+    private lateinit var manager: FrontendExoPlayerManager
+
+    @BeforeEach
+    fun setUp() {
+        manager = FrontendExoPlayerManager(playerCreator = playerCreator)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        manager.close()
+    }
+
+    @Nested
+    inner class PlayHls {
+
+        @Test
+        fun `Given play_hls when handled then state contains the player`() = runTest {
+            val uri = TEST_URI
+
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            val state = manager.state.value
+            assertNotNull(state)
+            assertSame(mockPlayer, state!!.player)
+        }
+
+        @Test
+        fun `Given play_hls with muted when handled then player volume is 0`() = runTest {
+            val uri = TEST_URI
+
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = true))
+
+            verify { mockPlayer.volume = 0f }
+        }
+
+        @Test
+        fun `Given play_hls without muted when handled then player volume is 1`() = runTest {
+            val uri = TEST_URI
+
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            verify { mockPlayer.volume = 1f }
+        }
+
+        @Test
+        fun `Given play_hls when handled then player prepares with media item`() = runTest {
+            val uri = TEST_URI
+
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            verify { mockPlayer.setMediaItem(any()) }
+            verify { mockPlayer.playWhenReady = true }
+            verify { mockPlayer.prepare() }
+        }
+
+        @Test
+        fun `Given two play_hls when handled then player is reused`() = runTest {
+            var createCount = 0
+            val reusingManager = FrontendExoPlayerManager(
+                playerCreator = { configure ->
+                    createCount++
+                    mockPlayer.apply(configure)
+                },
+            )
+
+            val uri = TEST_URI
+            reusingManager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+            reusingManager.handle(ExoPlayerAction.PlayHls(messageId = 2, url = uri, muted = true))
+
+            assertEquals(1, createCount)
+            reusingManager.close()
+        }
+    }
+
+    @Nested
+    inner class Stop {
+
+        @Test
+        fun `Given playing when stop then state is null`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.handle(ExoPlayerAction.Stop)
+
+            assertNull(manager.state.value)
+        }
+
+        @Test
+        fun `Given playing when stop then player stop is called`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.handle(ExoPlayerAction.Stop)
+
+            verify { mockPlayer.stop() }
+        }
+
+        @Test
+        fun `Given not playing when stop then no crash`() = runTest {
+            manager.handle(ExoPlayerAction.Stop)
+
+            assertNull(manager.state.value)
+        }
+    }
+
+    @Nested
+    inner class Resize {
+
+        @Test
+        fun `Given playing when resize then state has correct position and size`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.handle(ExoPlayerAction.Resize(left = 10f, top = 20f, right = 310f, bottom = 220f))
+
+            val state = manager.state.value
+            assertNotNull(state)
+            assertEquals(10.dp, state!!.left)
+            assertEquals(20.dp, state.top)
+            assertEquals(DpSize(300.dp, 200.dp), state.size)
+        }
+
+        @Test
+        fun `Given not playing when resize then state stays null`() = runTest {
+            manager.handle(ExoPlayerAction.Resize(left = 10f, top = 20f, right = 310f, bottom = 220f))
+
+            assertNull(manager.state.value)
+        }
+    }
+
+    @Nested
+    inner class Fullscreen {
+
+        @Test
+        fun `Given playing when fullscreen changed then state reflects it`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.onFullscreenChanged(isFullScreen = true)
+
+            assertEquals(true, manager.state.value?.isFullScreen)
+        }
+
+        @Test
+        fun `Given not playing when fullscreen changed then state stays null`() {
+            manager.onFullscreenChanged(isFullScreen = true)
+
+            assertNull(manager.state.value)
+        }
+    }
+
+    @Nested
+    inner class Close {
+
+        @Test
+        fun `Given playing when closed then player is released`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.close()
+
+            verify { mockPlayer.release() }
+            assertNull(manager.state.value)
+        }
+
+        @Test
+        fun `Given not playing when closed then no crash`() {
+            manager.close()
+
+            assertNull(manager.state.value)
+        }
+
+        @Test
+        fun `Given already closed when closed again then safe`() = runTest {
+            val uri = TEST_URI
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
+
+            manager.close()
+            manager.close()
+
+            verify(exactly = 1) { mockPlayer.release() }
+        }
+    }
+
+    companion object {
+        private val TEST_URI: Uri = mockk(relaxed = true)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
@@ -3,10 +3,14 @@ package io.homeassistant.companion.android.frontend.exoplayer
 import android.net.Uri
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.media3.common.Player
+import androidx.media3.common.VideoSize
 import androidx.media3.exoplayer.ExoPlayer
 import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent.ExoPlayerAction
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
@@ -154,6 +158,49 @@ class FrontendExoPlayerManagerTest {
             manager.handle(ExoPlayerAction.Resize(left = 10.0, top = 20.0, right = 310.0, bottom = 220.0))
 
             assertNull(manager.state.value)
+        }
+
+        @Test
+        fun `Given zero-height resize without known aspect ratio when handled then state size has zero height`() = runTest {
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = TEST_URI, muted = false))
+
+            manager.handle(ExoPlayerAction.Resize(left = 0.0, top = 126.5, right = 486.25, bottom = 126.5))
+
+            val state = manager.state.value
+            assertNotNull(state)
+            assertEquals(0.dp, state!!.left)
+            assertEquals(126.5.dp, state.top)
+            assertEquals(DpSize(486.25.dp, 0.dp), state.size)
+        }
+
+        @Test
+        fun `Given aspect ratio known when zero-height resize then height computed from aspect ratio`() = runTest {
+            val listenerSlot = slot<Player.Listener>()
+            every { mockPlayer.addListener(capture(listenerSlot)) } answers { }
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = TEST_URI, muted = false))
+            // 1000x500 video → ratio 0.5
+            listenerSlot.captured.onVideoSizeChanged(VideoSize(1000, 500))
+
+            manager.handle(ExoPlayerAction.Resize(left = 0.0, top = 100.0, right = 400.0, bottom = 100.0))
+
+            val state = manager.state.value
+            assertNotNull(state)
+            assertEquals(DpSize(400.dp, 200.dp), state!!.size)
+        }
+
+        @Test
+        fun `Given prior zero-height resize when video size changed then size is auto-computed from ratio`() = runTest {
+            val listenerSlot = slot<Player.Listener>()
+            every { mockPlayer.addListener(capture(listenerSlot)) } answers { }
+            manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = TEST_URI, muted = false))
+            manager.handle(ExoPlayerAction.Resize(left = 0.0, top = 100.0, right = 400.0, bottom = 100.0))
+
+            // 1000x500 video → ratio 0.5
+            listenerSlot.captured.onVideoSizeChanged(VideoSize(1000, 500))
+
+            val state = manager.state.value
+            assertNotNull(state)
+            assertEquals(DpSize(400.dp, 200.dp), state!!.size)
         }
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/exoplayer/FrontendExoPlayerManagerTest.kt
@@ -140,7 +140,7 @@ class FrontendExoPlayerManagerTest {
             val uri = TEST_URI
             manager.handle(ExoPlayerAction.PlayHls(messageId = 1, url = uri, muted = false))
 
-            manager.handle(ExoPlayerAction.Resize(left = 10f, top = 20f, right = 310f, bottom = 220f))
+            manager.handle(ExoPlayerAction.Resize(left = 10.0, top = 20.0, right = 310.0, bottom = 220.0))
 
             val state = manager.state.value
             assertNotNull(state)
@@ -151,7 +151,7 @@ class FrontendExoPlayerManagerTest {
 
         @Test
         fun `Given not playing when resize then state stays null`() = runTest {
-            manager.handle(ExoPlayerAction.Resize(left = 10f, top = 20f, right = 310f, bottom = 220f))
+            manager.handle(ExoPlayerAction.Resize(left = 10.0, top = 20.0, right = 310.0, bottom = 220.0))
 
             assertNull(manager.state.value)
         }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
@@ -197,10 +197,10 @@ class IncomingExternalBusMessageTest {
         assertInstanceOf(ExoPlayerResizeMessage::class.java, message)
         val resize = message as ExoPlayerResizeMessage
         assertEquals(24, resize.id)
-        assertEquals(0f, resize.payload.left)
-        assertEquals(10.5f, resize.payload.top)
-        assertEquals(486.25f, resize.payload.right)
-        assertEquals(200.5f, resize.payload.bottom)
+        assertEquals(0.0, resize.payload.left)
+        assertEquals(10.5, resize.payload.top)
+        assertEquals(486.25, resize.payload.right)
+        assertEquals(200.5, resize.payload.bottom)
     }
 
     @Test
@@ -224,9 +224,9 @@ class IncomingExternalBusMessageTest {
 
         assertInstanceOf(ExoPlayerResizeMessage::class.java, message)
         val resize = message as ExoPlayerResizeMessage
-        assertEquals(0f, resize.payload.left)
-        assertEquals(0f, resize.payload.top)
-        assertEquals(0f, resize.payload.right)
-        assertEquals(0f, resize.payload.bottom)
+        assertEquals(0, resize.payload.left)
+        assertEquals(0, resize.payload.top)
+        assertEquals(0, resize.payload.right)
+        assertEquals(0, resize.payload.bottom)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
@@ -224,9 +224,9 @@ class IncomingExternalBusMessageTest {
 
         assertInstanceOf(ExoPlayerResizeMessage::class.java, message)
         val resize = message as ExoPlayerResizeMessage
-        assertEquals(0, resize.payload.left)
-        assertEquals(0, resize.payload.top)
-        assertEquals(0, resize.payload.right)
-        assertEquals(0, resize.payload.bottom)
+        assertEquals(0.0, resize.payload.left)
+        assertEquals(0.0, resize.payload.top)
+        assertEquals(0.0, resize.payload.right)
+        assertEquals(0.0, resize.payload.bottom)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
@@ -136,4 +136,97 @@ class IncomingExternalBusMessageTest {
         val unknownMessage = message as UnknownIncomingMessage
         assertTrue(unknownMessage.content.toString().contains("future-feature"))
     }
+
+    @Test
+    fun `Given exoplayer play_hls JSON with full payload then parses to ExoPlayerPlayHlsMessage`() {
+        val json =
+            """{"type":"exoplayer/play_hls","id":20,"payload":{"url":"https://example.com/stream.m3u8","muted":true}}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerPlayHlsMessage::class.java, message)
+        val playHls = message as ExoPlayerPlayHlsMessage
+        assertEquals(20, playHls.id)
+        assertEquals("https://example.com/stream.m3u8", playHls.payload.url)
+        assertTrue(playHls.payload.muted)
+    }
+
+    @Test
+    fun `Given exoplayer play_hls JSON without muted then parses with muted defaulting to false`() {
+        val json =
+            """{"type":"exoplayer/play_hls","id":21,"payload":{"url":"https://example.com/stream.m3u8"}}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerPlayHlsMessage::class.java, message)
+        val playHls = message as ExoPlayerPlayHlsMessage
+        assertEquals("https://example.com/stream.m3u8", playHls.payload.url)
+        assertFalse(playHls.payload.muted)
+    }
+
+    @Test
+    fun `Given exoplayer play_hls JSON without payload then parses with default payload`() {
+        val json = """{"type":"exoplayer/play_hls","id":22}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerPlayHlsMessage::class.java, message)
+        val playHls = message as ExoPlayerPlayHlsMessage
+        assertEquals(22, playHls.id)
+        assertNull(playHls.payload.url)
+        assertFalse(playHls.payload.muted)
+    }
+
+    @Test
+    fun `Given exoplayer stop JSON then parses to ExoPlayerStopMessage`() {
+        val json = """{"type":"exoplayer/stop","id":23}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerStopMessage::class.java, message)
+        assertEquals(23, (message as ExoPlayerStopMessage).id)
+    }
+
+    @Test
+    fun `Given exoplayer resize JSON with fractional pixels then parses payload as floats`() {
+        val json = """{"type":"exoplayer/resize","id":24,""" +
+            """"payload":{"left":0,"top":10.5,"right":486.25,"bottom":200.5}}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerResizeMessage::class.java, message)
+        val resize = message as ExoPlayerResizeMessage
+        assertEquals(24, resize.id)
+        assertEquals(0f, resize.payload.left)
+        assertEquals(10.5f, resize.payload.top)
+        assertEquals(486.25f, resize.payload.right)
+        assertEquals(200.5f, resize.payload.bottom)
+    }
+
+    @Test
+    fun `Given exoplayer resize JSON with zero-height DOMRect then parses payload with top equal to bottom`() {
+        // Mirrors the real-world case where the frontend sends resize before the video element
+        // is laid out: top == bottom, so the manager must fall back to the video aspect ratio.
+        val json = """{"type":"exoplayer/resize","id":26,""" +
+            """"payload":{"left":0,"top":126.5,"right":486.25,"bottom":126.5}}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        val resize = message as ExoPlayerResizeMessage
+        assertEquals(resize.payload.top, resize.payload.bottom)
+    }
+
+    @Test
+    fun `Given exoplayer resize JSON without payload then parses with zero defaults`() {
+        val json = """{"type":"exoplayer/resize","id":25}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ExoPlayerResizeMessage::class.java, message)
+        val resize = message as ExoPlayerResizeMessage
+        assertEquals(0f, resize.payload.left)
+        assertEquals(0f, resize.payload.top)
+        assertEquals(0f, resize.payload.right)
+        assertEquals(0f, resize.payload.bottom)
+    }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
@@ -204,19 +204,6 @@ class IncomingExternalBusMessageTest {
     }
 
     @Test
-    fun `Given exoplayer resize JSON with zero-height DOMRect then parses payload with top equal to bottom`() {
-        // Mirrors the real-world case where the frontend sends resize before the video element
-        // is laid out: top == bottom, so the manager must fall back to the video aspect ratio.
-        val json = """{"type":"exoplayer/resize","id":26,""" +
-            """"payload":{"left":0,"top":126.5,"right":486.25,"bottom":126.5}}"""
-
-        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
-
-        val resize = message as ExoPlayerResizeMessage
-        assertEquals(resize.payload.top, resize.payload.bottom)
-    }
-
-    @Test
     fun `Given exoplayer resize JSON without payload then parses with zero defaults`() {
         val json = """{"type":"exoplayer/resize","id":25}"""
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -610,7 +610,7 @@ class FrontendMessageHandlerTest {
     @Test
     fun `Given exoplayer resize message when messageResults then emits Resize with payload values`() = runTest {
         val message = ExoPlayerResizeMessage(
-            payload = ExoPlayerResizePayload(left = 1.5f, top = 2.5f, right = 100.5f, bottom = 50.5f),
+            payload = ExoPlayerResizePayload(left = 1.5, top = 2.5, right = 100.5, bottom = 50.5),
         )
         every { externalBusRepository.incomingMessages() } returns flowOf(message)
 
@@ -618,10 +618,10 @@ class FrontendMessageHandlerTest {
             val event = awaitItem()
             assertTrue(event is FrontendHandlerEvent.ExoPlayerAction.Resize)
             val resize = event as FrontendHandlerEvent.ExoPlayerAction.Resize
-            assertEquals(1.5f, resize.left)
-            assertEquals(2.5f, resize.top)
-            assertEquals(100.5f, resize.right)
-            assertEquals(50.5f, resize.bottom)
+            assertEquals(1.5, resize.left)
+            assertEquals(2.5, resize.top)
+            assertEquals(100.5, resize.right)
+            assertEquals(50.5, resize.bottom)
             expectNoEvents()
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.frontend.handler
 
 import android.content.pm.PackageManager
+import android.net.Uri
 import app.cash.turbine.test
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.util.AppVersion
@@ -14,6 +15,11 @@ import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalB
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConfigGetMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ConnectionStatusPayload
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerPlayHlsMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerPlayHlsPayload
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerResizeMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerResizePayload
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ExoPlayerStopMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HandleBlobMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
@@ -38,6 +44,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
@@ -542,5 +549,80 @@ class FrontendMessageHandlerTest {
         }
 
         coVerify { downloadManager.handleBlob(data = testData, filename = testFilename) }
+    }
+
+    @Test
+    fun `Given exoplayer play_hls message with URL when messageResults then emits PlayHls and sends success result`() = runTest {
+        mockkStatic(Uri::class)
+        val mockUri = mockk<Uri>(relaxed = true)
+        every { Uri.parse("https://example.com/stream.m3u8") } returns mockUri
+
+        val message = ExoPlayerPlayHlsMessage(
+            id = 9,
+            payload = ExoPlayerPlayHlsPayload(url = "https://example.com/stream.m3u8", muted = true),
+        )
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        val responseSlot = slot<OutgoingExternalBusMessage>()
+        coEvery { externalBusRepository.send(capture(responseSlot)) } returns Unit
+
+        handler.messageResults().test {
+            val event = awaitItem()
+            assertTrue(event is FrontendHandlerEvent.ExoPlayerAction.PlayHls)
+            val playHls = event as FrontendHandlerEvent.ExoPlayerAction.PlayHls
+            assertEquals(9, playHls.messageId)
+            assertEquals(mockUri, playHls.url)
+            assertEquals(true, playHls.muted)
+            expectNoEvents()
+        }
+
+        coVerify { externalBusRepository.send(any()) }
+        val result = responseSlot.captured as ResultMessage
+        assertEquals(9, result.id)
+        assertEquals(true, result.success)
+    }
+
+    @Test
+    fun `Given exoplayer play_hls message without URL when messageResults then emits UnknownMessage and sends nothing`() = runTest {
+        val message = ExoPlayerPlayHlsMessage(id = 9, payload = ExoPlayerPlayHlsPayload(url = null, muted = false))
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val event = awaitItem()
+            assertTrue(event is FrontendHandlerEvent.UnknownMessage)
+            expectNoEvents()
+        }
+
+        coVerify(exactly = 0) { externalBusRepository.send(any()) }
+    }
+
+    @Test
+    fun `Given exoplayer stop message when messageResults then emits Stop`() = runTest {
+        every { externalBusRepository.incomingMessages() } returns flowOf(ExoPlayerStopMessage())
+
+        handler.messageResults().test {
+            val event = awaitItem()
+            assertEquals(FrontendHandlerEvent.ExoPlayerAction.Stop, event)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given exoplayer resize message when messageResults then emits Resize with payload values`() = runTest {
+        val message = ExoPlayerResizeMessage(
+            payload = ExoPlayerResizePayload(left = 1.5f, top = 2.5f, right = 100.5f, bottom = 50.5f),
+        )
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val event = awaitItem()
+            assertTrue(event is FrontendHandlerEvent.ExoPlayerAction.Resize)
+            val resize = event as FrontendHandlerEvent.ExoPlayerAction.Resize
+            assertEquals(1.5f, resize.left)
+            assertEquals(2.5f, resize.top)
+            assertEquals(100.5f, resize.right)
+            assertEquals(50.5f, resize.bottom)
+            expectNoEvents()
+        }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -46,6 +46,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkAll
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
@@ -56,6 +57,7 @@ import kotlinx.serialization.json.int
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -96,6 +98,11 @@ class FrontendMessageHandlerTest {
             downloadManager = downloadManager,
             isAutomotive = false,
         )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
@@ -49,6 +49,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -78,6 +79,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -109,6 +111,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -146,6 +149,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -171,6 +175,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = { uri -> capturedUri = uri },
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -196,6 +201,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = { serverSwitcherShown = true },
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -224,6 +230,7 @@ class FrontendEventHandlerTest {
                 onOpenExternalLink = {},
                 onShowServerSwitcher = {},
                 onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
             )
         }
 
@@ -253,6 +260,7 @@ class FrontendEventHandlerTest {
                     capturedMessageId = messageId
                     capturedTagId = tagId
                 },
+                onRequestFullscreen = {},
             )
         }
 
@@ -282,6 +290,7 @@ class FrontendEventHandlerTest {
                     capturedMessageId = messageId
                     capturedTagId = tagId
                 },
+                onRequestFullscreen = {},
             )
         }
 
@@ -291,5 +300,39 @@ class FrontendEventHandlerTest {
 
         assertEquals(7, capturedMessageId)
         assertEquals(null, capturedTagId)
+    }
+
+    @Test
+    fun `Given RequestFullscreen true event then onRequestFullscreen is called with true`() = runTest {
+        assertEquals(true, runRequestFullscreenTest(fullscreen = true))
+    }
+
+    @Test
+    fun `Given RequestFullscreen false event then onRequestFullscreen is called with false`() = runTest {
+        assertEquals(false, runRequestFullscreenTest(fullscreen = false))
+    }
+
+    private suspend fun runRequestFullscreenTest(fullscreen: Boolean): Boolean? {
+        var captured: Boolean? = null
+        val events = MutableSharedFlow<FrontendEvent>()
+
+        composeTestRule.setContent {
+            FrontendEventHandler(
+                events = events,
+                onShowSnackbar = { _, _ -> false },
+                onNavigateToSettings = {},
+                onNavigateToAssist = { _, _, _ -> },
+                onOpenExternalLink = {},
+                onShowServerSwitcher = {},
+                onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = { captured = it },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        events.emit(FrontendEvent.RequestFullscreen(fullscreen = fullscreen))
+        composeTestRule.waitForIdle()
+
+        return captured
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
@@ -303,18 +303,18 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given RequestFullscreen true event then onRequestFullscreen is called with true`() = runTest {
+    fun `Given RequestFullscreen true event then onRequestFullscreen is called with true`() {
         assertEquals(true, runRequestFullscreenTest(fullscreen = true))
     }
 
     @Test
-    fun `Given RequestFullscreen false event then onRequestFullscreen is called with false`() = runTest {
+    fun `Given RequestFullscreen false event then onRequestFullscreen is called with false`() {
         assertEquals(false, runRequestFullscreenTest(fullscreen = false))
     }
 
-    private suspend fun runRequestFullscreenTest(fullscreen: Boolean): Boolean? {
+    private fun runRequestFullscreenTest(fullscreen: Boolean): Boolean? {
         var captured: Boolean? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
@@ -665,7 +665,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun `Given fullscreen requested when preference is disabled then isFullScreen stays true`() = runTest {
+    fun `Given fullscreen request is active when preference turns off then isFullScreen stays true`() = runTest {
         fullScreenEnabledFlow.value = true
         createViewModel()
         viewModel.onFullscreenRequested(fullscreen = true)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
@@ -627,7 +627,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun `Given preference off when fullscreen is requested then isFullScreen is true`() = runTest {
+    fun `Given fullscreen preference off when fullscreen is requested then isFullScreen is true`() = runTest {
         fullScreenEnabledFlow.value = false
         createViewModel()
         advanceUntilIdle()
@@ -639,7 +639,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun `Given preference off when fullscreen request is cleared then isFullScreen is false`() = runTest {
+    fun `Given fullscreen preference off when fullscreen request is cleared then isFullScreen is false`() = runTest {
         fullScreenEnabledFlow.value = false
         createViewModel()
         viewModel.onFullscreenRequested(fullscreen = true)
@@ -652,7 +652,7 @@ class LaunchViewModelTest {
     }
 
     @Test
-    fun `Given preference on when fullscreen request is cleared then isFullScreen stays true`() = runTest {
+    fun `Given fullscreen preference on when fullscreen request is cleared then isFullScreen stays true`() = runTest {
         fullScreenEnabledFlow.value = true
         createViewModel()
         viewModel.onFullscreenRequested(fullscreen = true)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
@@ -625,4 +625,55 @@ class LaunchViewModelTest {
         coVerify { appLockStateManager.setAppActive(active = true) }
         assertFalse(viewModel.isAppLocked.value)
     }
+
+    @Test
+    fun `Given preference off when fullscreen is requested then isFullScreen is true`() = runTest {
+        fullScreenEnabledFlow.value = false
+        createViewModel()
+        advanceUntilIdle()
+
+        viewModel.onFullscreenRequested(fullscreen = true)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.isFullScreen.value)
+    }
+
+    @Test
+    fun `Given preference off when fullscreen request is cleared then isFullScreen is false`() = runTest {
+        fullScreenEnabledFlow.value = false
+        createViewModel()
+        viewModel.onFullscreenRequested(fullscreen = true)
+        advanceUntilIdle()
+
+        viewModel.onFullscreenRequested(fullscreen = false)
+        advanceUntilIdle()
+
+        assertFalse(viewModel.isFullScreen.value)
+    }
+
+    @Test
+    fun `Given preference on when fullscreen request is cleared then isFullScreen stays true`() = runTest {
+        fullScreenEnabledFlow.value = true
+        createViewModel()
+        viewModel.onFullscreenRequested(fullscreen = true)
+        advanceUntilIdle()
+
+        viewModel.onFullscreenRequested(fullscreen = false)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.isFullScreen.value)
+    }
+
+    @Test
+    fun `Given fullscreen requested when preference is disabled then isFullScreen stays true`() = runTest {
+        fullScreenEnabledFlow.value = true
+        createViewModel()
+        viewModel.onFullscreenRequested(fullscreen = true)
+        advanceUntilIdle()
+
+        fullScreenEnabledFlow.value = false
+        advanceUntilIdle()
+
+        assertTrue(viewModel.isFullScreen.value)
+    }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR adds support for showing exoPlayer from a frontend command on the `FrontendScreen`. 
I've introduced a `ExoPlayerOverlay` to manage the player, once the player is initialized for the session we keep it so it can be reuse. I've also introduced a way to request full screen to the activity, it is also use to request leaving full screen but if the settings is already set to full screen then it stays on full screen.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

https://github.com/user-attachments/assets/c48a6fb6-6c48-4074-a13b-f318ff6b89a0