### PR TITLE
Remove the use of Dispachers.Default in AppLockViewModel

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/AppLockViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/AppLockViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import javax.inject.Inject
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -18,7 +17,7 @@ class AppLockViewModel @Inject constructor(private val serverManager: ServerMana
      * which is critical for the app lock feature.
      */
     fun setAppActive(serverId: Int?, active: Boolean) {
-        viewModelScope.launch(Dispatchers.Default) {
+        viewModelScope.launch {
             val resolvedId = serverId ?: ServerManager.SERVER_ID_ACTIVE
             serverManager.getServer(resolvedId)?.let {
                 try {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We were using the default dispatcher in the `AppLockViewModel` but it is not needed since the method called are Main safe already. 
Because of the usage of the default dispatcher the unit test of `setAppActive` is flaky https://github.com/home-assistant/android/actions/runs/24982874143/job/73151266819?pr=6776

```
[9](https://github.com/home-assistant/android/actions/runs/24982817100/job/73149459136?pr=6777#step:4:590)
> Task :app:testFullDebugUnitTest

AppLockViewModelTest > SetAppActive > Given a null server ID when setting app active then uses SERVER_ID_ACTIVE() FAILED
    java.lang.AssertionError at AppLockViewModelTest.kt:58

858 tests completed, 1 failed
```
