### PR TITLE
Fix compose unit test and kotlin configuration after update

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -7,6 +7,7 @@
     <option name="jvmTarget" value="11" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.3.20" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.3.21" />
   </component>
 </project>

--- a/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/androidTest/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.launch
 
 import android.os.Build
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import leakcanary.DetectLeaksAfterTestSuccess
 import leakcanary.LeakCanary
 import org.junit.Rule

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/error/FrontendConnectionErrorScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/error/FrontendConnectionErrorScreenTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.companion.android.frontend.error
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
@@ -1,16 +1,15 @@
 package io.homeassistant.companion.android.frontend.navigation
 
 import android.net.Uri
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.HiltComponentActivity
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import junit.framework.TestCase.assertEquals
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertNull
@@ -33,10 +32,10 @@ class FrontendEventHandlerTest {
     val composeTestRule = createAndroidComposeRule<HiltComponentActivity>()
 
     @Test
-    fun `Given NavigateToSettings event then onNavigateToSettings is called`() = runTest {
+    fun `Given NavigateToSettings event then onNavigateToSettings is called`() {
         var settingsNavigated = false
         var deepLink: SettingsActivity.Deeplink? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -62,10 +61,10 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given NavigateToAssistSettings event then onNavigateToSettings is called with deeplink`() = runTest {
+    fun `Given NavigateToAssistSettings event then onNavigateToSettings is called with deeplink`() {
         var settingsNavigated = false
         var deepLink: SettingsActivity.Deeplink? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -91,11 +90,11 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given NavigateToAssist event then onNavigateToAssist is called with correct params`() = runTest {
+    fun `Given NavigateToAssist event then onNavigateToAssist is called with correct params`() {
         var capturedServerId: Int? = null
         var capturedPipelineId: String? = null
         var capturedStartListening: Boolean? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -129,10 +128,10 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given ShowSnackbar event then onShowSnackbar is called with resolved message`() = runTest {
+    fun `Given ShowSnackbar event then onShowSnackbar is called with resolved message`() {
         var capturedMessage: String? = null
         var capturedAction: String? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -159,9 +158,9 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given OpenExternalLink event then onOpenExternalLink is called with the URI`() = runTest {
+    fun `Given OpenExternalLink event then onOpenExternalLink is called with the URI`() {
         var capturedUri: Uri? = null
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -184,9 +183,9 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given ShowServerSwitcher event then onShowServerSwitcher is called`() = runTest {
+    fun `Given ShowServerSwitcher event then onShowServerSwitcher is called`() {
         var serverSwitcherShown = false
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -208,10 +207,10 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given NavigateToDeveloperSettings event then onNavigateToSettings is called with Developer deeplink`() = runTest {
+    fun `Given NavigateToDeveloperSettings event then onNavigateToSettings is called with Developer deeplink`() {
         var settingsNavigated = false
         var deepLink: SettingsActivity.Deeplink? = null
-        val navigationEvents = MutableSharedFlow<FrontendEvent>()
+        val navigationEvents = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -237,10 +236,10 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given NavigateToNfcWrite event then onNavigateToNfcWrite is called with messageId and tagId`() = runTest {
+    fun `Given NavigateToNfcWrite event then onNavigateToNfcWrite is called with messageId and tagId`() {
         var capturedMessageId: Int? = null
         var capturedTagId: String? = "not-captured"
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(
@@ -266,10 +265,10 @@ class FrontendEventHandlerTest {
     }
 
     @Test
-    fun `Given NavigateToNfcWrite event without tagId then onNavigateToNfcWrite is called with null tagId`() = runTest {
+    fun `Given NavigateToNfcWrite event without tagId then onNavigateToNfcWrite is called with null tagId`() {
         var capturedMessageId: Int? = null
         var capturedTagId: String? = "not-captured"
-        val events = MutableSharedFlow<FrontendEvent>()
+        val events = TestSharedFlow<FrontendEvent>()
 
         composeTestRule.setContent {
             FrontendEventHandler(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/BaseOnboardingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/BaseOnboardingNavigationTest.kt
@@ -7,7 +7,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
 import androidx.navigation.compose.ComposeNavigator

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/WearOnboardingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/WearOnboardingNavigationTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -55,6 +55,7 @@ import io.homeassistant.companion.android.onboarding.wearmtls.navigation.WearMTL
 import io.homeassistant.companion.android.onboarding.wearmtls.navigation.navigateToWearMTLS
 import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.homeassistant.companion.android.testing.unit.stringResource
 import io.homeassistant.companion.android.util.FakePermissionResultRegistry
 import io.homeassistant.companion.android.util.compose.navigateToUri
@@ -71,7 +72,6 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.test.runTest
@@ -112,7 +112,7 @@ internal class WearOnboardingNavigationTest {
         }
     }
 
-    private val connectionNavigationEventFlow = MutableSharedFlow<ConnectionNavigationEvent>()
+    private val connectionNavigationEventFlow = TestSharedFlow<ConnectionNavigationEvent>()
 
     @BindValue
     @JvmField

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionNavigationTest.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.onboarding.connection
 
 import android.net.Uri
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
@@ -9,9 +9,9 @@ import io.homeassistant.companion.android.HiltComponentActivity
 import io.homeassistant.companion.android.onboarding.connection.navigation.HandleConnectionNavigationEvents
 import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -38,7 +38,7 @@ class ConnectionNavigationTest {
 
     @Test
     fun `Given HandleConnectionNavigationEvents when viewModel emits Authenticated then invoke onAuthenticated`() = runTest {
-        val sharedFlow = MutableSharedFlow<ConnectionNavigationEvent>()
+        val sharedFlow = TestSharedFlow<ConnectionNavigationEvent>()
 
         val viewModel = mockk<ConnectionViewModel> {
             every { navigationEventsFlow } returns sharedFlow
@@ -65,6 +65,8 @@ class ConnectionNavigationTest {
                 sharedFlow.emit(this)
             }
 
+        composeTestRule.awaitIdle()
+
         assertEquals(event.url, onAuthenticatedUrl)
         assertEquals(event.authCode, onAuthenticatedCode)
         assertEquals(event.requiredMTLS, onRequiredMTLS)
@@ -72,7 +74,7 @@ class ConnectionNavigationTest {
 
     @Test
     fun `Given HandleConnectionNavigationEvents when viewModel emits OpenExternalLink then invoke onOpenExternalLink`() = runTest {
-        val sharedFlow = MutableSharedFlow<ConnectionNavigationEvent>()
+        val sharedFlow = TestSharedFlow<ConnectionNavigationEvent>()
 
         val viewModel = mockk<ConnectionViewModel> {
             every { navigationEventsFlow } returns sharedFlow
@@ -96,6 +98,8 @@ class ConnectionNavigationTest {
             .apply {
                 sharedFlow.emit(this)
             }
+
+        composeTestRule.awaitIdle()
 
         assertEquals(event.url, onOpenExternalLink)
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenTest.kt
@@ -3,7 +3,7 @@ package io.homeassistant.companion.android.onboarding.connection
 import android.webkit.WebViewClient
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import dagger.hilt.android.testing.HiltAndroidRule

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/localfirst/LocalFirstScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/localfirst/LocalFirstScreenTest.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.onboarding.localfirst
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/localfirst/navigation/LocalFirstNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/localfirst/navigation/LocalFirstNavigationTest.kt
@@ -39,6 +39,8 @@ internal class LocalFirstNavigationTest : BaseOnboardingNavigationTest() {
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
 
+            waitForIdle()
+
             // In the test scenario since we never opened NameYourDevice the stack still contains Welcome
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<WelcomeRoute>() == true)
         }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationforsecureconnection/LocationForSecureConnectionScreenTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/LocationSharingScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/LocationSharingScreenTest.kt
@@ -10,7 +10,7 @@ import androidx.activity.result.ActivityResultRegistryOwner
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/navigation/LocationSharingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/navigation/LocationSharingNavigationTest.kt
@@ -40,6 +40,7 @@ internal class LocationSharingNavigationTest : BaseOnboardingNavigationTest() {
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<LocationForSecureConnectionRoute>() == true)
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+
             waitForIdle()
 
             // In the test scenario since we never opened NameYourDevice the stack still contains Welcome

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/navigation/LocationSharingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/locationsharing/navigation/LocationSharingNavigationTest.kt
@@ -40,6 +40,7 @@ internal class LocationSharingNavigationTest : BaseOnboardingNavigationTest() {
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<LocationForSecureConnectionRoute>() == true)
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+            waitForIdle()
 
             // In the test scenario since we never opened NameYourDevice the stack still contains Welcome
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<WelcomeRoute>() == true)
@@ -78,6 +79,8 @@ internal class LocationSharingNavigationTest : BaseOnboardingNavigationTest() {
             )
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+
+            waitForIdle()
 
             // In the test scenario since we never opened NameYourDevice the stack still contains Welcome
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<WelcomeRoute>() == true)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/manualserver/ManualServerScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/manualserver/navigation/ManualServerNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/manualserver/navigation/ManualServerNavigationTest.kt
@@ -64,6 +64,8 @@ internal class ManualServerNavigationTest : BaseOnboardingNavigationTest() {
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
 
+            waitForIdle()
+
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<ManualServerRoute>() == true)
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceNavigationTest.kt
@@ -1,6 +1,6 @@
 package io.homeassistant.companion.android.onboarding.nameyourdevice
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
@@ -9,9 +9,9 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.onboarding.nameyourdevice.navigation.HandleNameYourDeviceNavigationEvents
 import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -39,7 +39,7 @@ class NameYourDeviceNavigationTest {
 
     @Test
     fun `Given HandleNameYourDeviceNavigationEvents when viewModel emits DeviceNameSaved then invoke onDeviceNamed with serverId`() = runTest {
-        val sharedFlow = MutableSharedFlow<NameYourDeviceNavigationEvent>()
+        val sharedFlow = TestSharedFlow<NameYourDeviceNavigationEvent>()
         val viewModel = mockk<NameYourDeviceViewModel> {
             every { navigationEventsFlow } returns sharedFlow
         }
@@ -67,6 +67,8 @@ class NameYourDeviceNavigationTest {
             sharedFlow.emit(this)
         }
 
+        composeTestRule.awaitIdle()
+
         assertEquals(event.serverId, serverIdSet)
         assertEquals(event.hasPlainTextAccess, hasPlainTextAccessSet)
         assertEquals(event.isPubliclyAccessible, isPubliclyAccessibleSet)
@@ -74,7 +76,7 @@ class NameYourDeviceNavigationTest {
 
     @Test
     fun `Given HandleNameYourDeviceNavigationEvents when viewModel emits Error then invoke onShowSnackbar and onBackClick`() = runTest {
-        val sharedFlow = MutableSharedFlow<NameYourDeviceNavigationEvent>()
+        val sharedFlow = TestSharedFlow<NameYourDeviceNavigationEvent>()
         val viewModel = mockk<NameYourDeviceViewModel> {
             every { navigationEventsFlow } returns sharedFlow
         }
@@ -97,6 +99,8 @@ class NameYourDeviceNavigationTest {
         }
 
         sharedFlow.emit(NameYourDeviceNavigationEvent.Error(commonR.string.webview_error))
+
+        composeTestRule.awaitIdle()
 
         assertEquals(
             "There was an error loading Home Assistant, please review the connection settings and try again. We will attempt to try another provided URL when you select Refresh.",

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/NameYourDeviceScreenTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/navigation/NameYourDeviceNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/navigation/NameYourDeviceNavigationTest.kt
@@ -16,11 +16,11 @@ import io.homeassistant.companion.android.onboarding.locationforsecureconnection
 import io.homeassistant.companion.android.onboarding.locationsharing.navigation.LocationSharingRoute
 import io.homeassistant.companion.android.onboarding.nameyourdevice.NameYourDeviceNavigationEvent
 import io.homeassistant.companion.android.onboarding.nameyourdevice.NameYourDeviceViewModel
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.homeassistant.companion.android.testing.unit.stringResource
 import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertTrue
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,13 +34,13 @@ import org.robolectric.annotation.Config
 @Config(application = HiltTestApplication::class)
 @HiltAndroidTest
 internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
-    val nameYourDeviceNavigationFlow = MutableSharedFlow<NameYourDeviceNavigationEvent>()
+    val nameYourDeviceNavigationFlow = TestSharedFlow<NameYourDeviceNavigationEvent>()
 
     @BindValue
     @JvmField
     val nameYourDeviceViewModel: NameYourDeviceViewModel = mockk(relaxed = true) {
         every { navigationEventsFlow } returns nameYourDeviceNavigationFlow
-        every { onSaveClick() } coAnswers {
+        every { onSaveClick() } answers {
             nameYourDeviceNavigationFlow.emit(
                 NameYourDeviceNavigationEvent.DeviceNameSaved(
                     serverId = 42,
@@ -83,6 +83,7 @@ internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<LocalFirstRoute>() == true)
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+            waitForIdle()
 
             // The back stack is unchanged in this situation, but in reality the app is in background
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<LocalFirstRoute>() == true)
@@ -100,7 +101,7 @@ internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
     }
 
     private fun testDeviceNamedWithPublicUrl(hasPlainTextAccess: Boolean) {
-        every { nameYourDeviceViewModel.onSaveClick() } coAnswers {
+        every { nameYourDeviceViewModel.onSaveClick() } answers {
             nameYourDeviceNavigationFlow.emit(
                 NameYourDeviceNavigationEvent.DeviceNameSaved(
                     serverId = 42,
@@ -124,7 +125,7 @@ internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
 
     @Test
     fun `Given no location tracking with HTTPS public server when device named then onboarding completes`() {
-        every { nameYourDeviceViewModel.onSaveClick() } coAnswers {
+        every { nameYourDeviceViewModel.onSaveClick() } answers {
             nameYourDeviceNavigationFlow.emit(
                 NameYourDeviceNavigationEvent.DeviceNameSaved(
                     serverId = 42,
@@ -149,7 +150,7 @@ internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
 
     @Test
     fun `Given no location tracking with HTTP public server when device named then show LocationForSecureConnection`() {
-        every { nameYourDeviceViewModel.onSaveClick() } coAnswers {
+        every { nameYourDeviceViewModel.onSaveClick() } answers {
             nameYourDeviceNavigationFlow.emit(
                 NameYourDeviceNavigationEvent.DeviceNameSaved(
                     serverId = 42,

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/navigation/NameYourDeviceNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/nameyourdevice/navigation/NameYourDeviceNavigationTest.kt
@@ -83,6 +83,7 @@ internal class NameYourDeviceNavigationTest : BaseOnboardingNavigationTest() {
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<LocalFirstRoute>() == true)
 
             composeTestRule.activity.onBackPressedDispatcher.onBackPressed()
+
             waitForIdle()
 
             // The back stack is unchanged in this situation, but in reality the app is in background

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreenTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
@@ -36,6 +36,7 @@ import io.homeassistant.companion.android.onboarding.serverdiscovery.ONE_SERVER_
 import io.homeassistant.companion.android.onboarding.serverdiscovery.ServerDiscoveryModule
 import io.homeassistant.companion.android.onboarding.welcome.navigation.WelcomeRoute
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
+import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.homeassistant.companion.android.testing.unit.stringResource
 import io.homeassistant.companion.android.util.compose.navigateToUri
 import io.mockk.coVerify
@@ -46,7 +47,6 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.test.runTest
@@ -98,7 +98,7 @@ internal class ServerDiscoveryNavigationTest : BaseOnboardingNavigationTest() {
 
     val instanceChannel = Channel<HomeAssistantInstance>()
 
-    val connectionNavigationEventFlow = MutableSharedFlow<ConnectionNavigationEvent>()
+    val connectionNavigationEventFlow = TestSharedFlow<ConnectionNavigationEvent>()
 
     @BindValue
     @JvmField

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/sethomenetwork/SetHomeNetworkScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/sethomenetwork/SetHomeNetworkScreenTest.kt
@@ -3,7 +3,7 @@ package io.homeassistant.companion.android.onboarding.sethomenetwork
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/wearmtls/WearMTLSScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/wearmtls/WearMTLSScreenTest.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/welcome/WelcomeScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/welcome/WelcomeScreenTest.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.onboarding.welcome
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/HAAppTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/HAAppTest.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPickerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPickerTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.test.ForcedSize
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/io/homeassistant/companion/android/webview/insecure/BlockInsecureScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/webview/insecure/BlockInsecureScreenTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.junit4.AndroidComposeTestRule
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick

--- a/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
+++ b/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
@@ -1,10 +1,10 @@
 package io.homeassistant.companion.android.testing.unit
 
-import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * Test double for a [SharedFlow] that publishes values without ever suspending the caller.
@@ -37,6 +37,6 @@ class TestSharedFlow<T> private constructor(private val mutableFlow: MutableShar
     val subscriptionCount: StateFlow<Int> get() = mutableFlow.subscriptionCount
 
     fun emit(value: T) {
-        assertTrue("Failed to emit $value", mutableFlow.tryEmit(value))
+        assertTrue(mutableFlow.tryEmit(value), "Failed to emit $value")
     }
 }

--- a/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
+++ b/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
@@ -1,0 +1,34 @@
+package io.homeassistant.companion.android.testing.unit
+
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Test double for a [SharedFlow] that publishes values without ever suspending the caller.
+ *
+ * Suspending [MutableSharedFlow.emit] from a test scope deadlocks easily when the collector
+ * lives on a different scheduler (e.g. Compose's effect dispatcher) — the test thread parks
+ * inside `emit` waiting for the collector, but the collector cannot run until the test thread
+ * pumps its scheduler, which it cannot do while parked. This wrapper backs the flow with an
+ * `extraBufferCapacity = 1` slot and uses [MutableSharedFlow.tryEmit] so a single emission
+ * always succeeds without crossing schedulers; pumping the collector (e.g. via
+ * `composeTestRule.waitForIdle()` or `scheduler.advanceUntilIdle()`) then drains the value.
+ *
+ * The wrapper implements [SharedFlow] so it can be used wherever the production type is
+ * expected (Hilt `@BindValue` injection, etc.) while keeping the underlying mutable flow
+ * inaccessible to consumers.
+ *
+ * Failure to enqueue an emission (which would indicate the buffer is unexpectedly full)
+ * fails the test loudly rather than silently dropping the value.
+ */
+@OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+class TestSharedFlow<T> private constructor(private val mutableFlow: MutableSharedFlow<T>) :
+    SharedFlow<T> by mutableFlow {
+    constructor() : this(MutableSharedFlow(extraBufferCapacity = 1))
+
+    fun emit(value: T) {
+        assertTrue("Failed to emit $value", mutableFlow.tryEmit(value))
+    }
+}

--- a/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
+++ b/testing-unit/src/main/kotlin/io/homeassistant/companion/android/testing/unit/TestSharedFlow.kt
@@ -4,6 +4,7 @@ import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Test double for a [SharedFlow] that publishes values without ever suspending the caller.
@@ -27,6 +28,13 @@ import kotlinx.coroutines.flow.SharedFlow
 class TestSharedFlow<T> private constructor(private val mutableFlow: MutableSharedFlow<T>) :
     SharedFlow<T> by mutableFlow {
     constructor() : this(MutableSharedFlow(extraBufferCapacity = 1))
+
+    /**
+     * Mirrors [MutableSharedFlow.subscriptionCount] so tests can assert that a collector has
+     * subscribed before publishing. Not part of the [SharedFlow] interface, hence re-exposed
+     * explicitly.
+     */
+    val subscriptionCount: StateFlow<Int> get() = mutableFlow.subscriptionCount
 
     fun emit(value: T) {
         assertTrue("Failed to emit $value", mutableFlow.tryEmit(value))

--- a/wear/src/androidTest/kotlin/io/homeassistant/companion/android/splash/SplashActivityTest.kt
+++ b/wear/src/androidTest/kotlin/io/homeassistant/companion/android/splash/SplashActivityTest.kt
@@ -1,6 +1,6 @@
 package io.homeassistant.companion.android.splash
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import org.junit.Rule
 import org.junit.Test
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After updating compose we started to see unit test failure. It is because of the new API made that switch the execution from `UnconfinedTestDispatcher` to `StandardTestDispatcher` https://developer.android.com/develop/ui/compose/testing/migrate-v2.

I've made a small helper `TestSharedFlow` because we can't use a `MutableSharedFlow.emit` anymore it requires a small buffer otherwise it hangs forever since we can't advance the consumer while producing the event, instead we use `tryEmit` but we check that the emission succeed.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I've also update the Kotlin configuration that was missing after the bump of Kotlin.