### PR TITLE
Adjust PermissionManager to use awaitResult

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -70,7 +69,6 @@ import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.webview.insecure.BlockInsecureScreen
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /** Minimum swipe velocity (pixels/second) to trigger a gesture action. */
@@ -130,7 +128,6 @@ internal fun FrontendScreen(
         frontendJsCallback = viewModel.frontendJsCallback,
         pendingPermissionRequest = pendingPermissionRequest,
         pendingDialog = pendingDialog,
-        onClearPendingPermissionRequest = viewModel::clearPendingPermissionRequest,
         pendingFileChooser = pendingFileChooser,
         onBlockInsecureRetry = viewModel::onRetry,
         onOpenExternalLink = onOpenExternalLink,
@@ -169,9 +166,8 @@ internal fun FrontendScreenContent(
     onShowSnackbar: suspend (message: String, action: String?) -> Boolean,
     onWebViewCreationFailed: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
-    pendingPermissionRequest: PermissionRequest<*>? = null,
+    pendingPermissionRequest: PermissionRequest? = null,
     pendingDialog: FrontendDialog? = null,
-    onClearPendingPermissionRequest: () -> Unit = {},
     pendingFileChooser: FileChooserRequest? = null,
     errorStateProvider: FrontendConnectionErrorStateProvider = FrontendConnectionErrorStateProvider.noOp,
     securityLevelViewModel: LocationForSecureConnectionViewModel? = null,
@@ -191,7 +187,6 @@ internal fun FrontendScreenContent(
 
     PendingPermissionHandler(
         pendingRequest = pendingPermissionRequest,
-        onClearPendingPermissionRequest = onClearPendingPermissionRequest,
     )
 
     PendingDialogHandler(
@@ -524,11 +519,9 @@ private fun WebView.configureForFrontend(
 }
 
 /**
- * Routes a [PermissionRequest] to the appropriate UI and delivers results directly.
- *
- * When the user responds, this composable:
- * 1. Clears the pending slot via [onClearPendingPermissionRequest] (unblocking queued requests)
- * 2. Calls [PermissionRequest.onResult] directly using a composable coroutine scope
+ * Routes a [PermissionRequest] to the appropriate UI and delivers the result back through the
+ * request's own callback. The slot is freed automatically by the manager once the callback is
+ * invoked, so this composable doesn't have to clear anything itself.
  *
  * Types with custom UI (e.g. [PermissionRequest.Notification] bottom sheet) are matched first.
  * Remaining types fall through to the system dialog based on their category:
@@ -537,43 +530,25 @@ private fun WebView.configureForFrontend(
  * Adding a new permission type that uses the system dialog requires no changes here.
  */
 @Composable
-private fun PendingPermissionHandler(
-    pendingRequest: PermissionRequest<*>?,
-    onClearPendingPermissionRequest: () -> Unit,
-) {
-    val coroutineScope = rememberCoroutineScope()
-
-    fun <T : PermissionRequest.Result> resolveResult(request: PermissionRequest<T>, result: T) {
-        onClearPendingPermissionRequest()
-        coroutineScope.launch { request.onResult(result) }
-    }
-
+private fun PendingPermissionHandler(pendingRequest: PermissionRequest?) {
     when (pendingRequest) {
-        // Types with custom UI
         is PermissionRequest.Notification -> {
             @SuppressLint("InlinedApi")
             NotificationPermissionPrompt(
-                onPermissionResult = { granted ->
-                    resolveResult(pendingRequest, PermissionRequest.Result.Single(granted = granted))
-                },
-                onDismiss = onClearPendingPermissionRequest,
+                onPermissionResult = pendingRequest.onResult,
+                onDismiss = pendingRequest.onDismiss,
             )
         }
-        // Default system dialogs by category
         is PermissionRequest.MultiplePermissions -> {
             MultiplePermissionsEffect(
                 pendingRequest = pendingRequest,
-                onPermissionResult = { permissions ->
-                    resolveResult(pendingRequest, PermissionRequest.Result.Multiple(permissions = permissions))
-                },
+                onPermissionResult = pendingRequest.onResult,
             )
         }
         is PermissionRequest.SinglePermission -> {
             SinglePermissionEffect(
                 pendingRequest = pendingRequest,
-                onPermissionResult = { granted ->
-                    resolveResult(pendingRequest, PermissionRequest.Result.Single(granted = granted))
-                },
+                onPermissionResult = pendingRequest.onResult,
             )
         }
         null -> { /* No pending permission */ }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -328,13 +328,11 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     /**
      * Handles a download request from the WebView.
      *
-     * On pre-Q devices, checks for [android.Manifest.permission.WRITE_EXTERNAL_STORAGE]
-     * before proceeding. If the permission is not granted, the request is deferred and the
-     * system permission dialog is triggered via [pendingPermissionRequest]. The download
-     * is retried automatically when permission is granted.
+     * On pre-Q devices, awaits the storage permission via [PermissionManager.checkStoragePermissionForDownload]
+     * before proceeding. If the user declines, the download is silently dropped.
      *
-     * Delegates to [FrontendDownloadManager] to dispatch the download based on URI scheme,
-     * then processes the [DownloadResult] to emit appropriate UI events.
+     * Delegates to [FrontendDownloadManager] to dispatch the download based on URI scheme, then
+     * processes the [DownloadResult] to emit appropriate UI events.
      *
      * @param url The URL of the file to download
      * @param contentDisposition The Content-Disposition header value
@@ -342,12 +340,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
      */
     fun onDownloadRequested(url: String, contentDisposition: String, mimetype: String) {
         viewModelScope.launch {
-            if (permissionManager.checkStoragePermissionForDownload {
-                    onDownloadRequested(url = url, contentDisposition = contentDisposition, mimetype = mimetype)
-                }
-            ) {
-                return@launch
-            }
+            if (!permissionManager.checkStoragePermissionForDownload()) return@launch
 
             val result = downloadManager.downloadFile(
                 url = url,
@@ -357,11 +350,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             )
             handleDownloadResult(result)
         }
-    }
-
-    /** Clears the current pending permission request from the slot. */
-    fun clearPendingPermissionRequest() {
-        permissionManager.clearPendingPermissionRequest()
     }
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionEffect.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionEffect.kt
@@ -19,7 +19,7 @@ import io.homeassistant.companion.android.common.util.FailFast
  */
 @Composable
 internal fun MultiplePermissionsEffect(
-    pendingRequest: PermissionRequest?,
+    pendingRequest: PermissionRequest.MultiplePermissions?,
     onPermissionResult: (Map<String, Boolean>) -> Unit,
 ) {
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -47,7 +47,10 @@ internal fun MultiplePermissionsEffect(
  * @param onPermissionResult Callback with whether the permission was granted
  */
 @Composable
-internal fun SinglePermissionEffect(pendingRequest: PermissionRequest?, onPermissionResult: (Boolean) -> Unit) {
+internal fun SinglePermissionEffect(
+    pendingRequest: PermissionRequest.SinglePermission?,
+    onPermissionResult: (Boolean) -> Unit,
+) {
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = onPermissionResult,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionEffect.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionEffect.kt
@@ -19,7 +19,7 @@ import io.homeassistant.companion.android.common.util.FailFast
  */
 @Composable
 internal fun MultiplePermissionsEffect(
-    pendingRequest: PermissionRequest<*>?,
+    pendingRequest: PermissionRequest?,
     onPermissionResult: (Map<String, Boolean>) -> Unit,
 ) {
     val permissionLauncher = rememberLauncherForActivityResult(
@@ -47,7 +47,7 @@ internal fun MultiplePermissionsEffect(
  * @param onPermissionResult Callback with whether the permission was granted
  */
 @Composable
-internal fun SinglePermissionEffect(pendingRequest: PermissionRequest<*>?, onPermissionResult: (Boolean) -> Unit) {
+internal fun SinglePermissionEffect(pendingRequest: PermissionRequest?, onPermissionResult: (Boolean) -> Unit) {
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = onPermissionResult,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
@@ -82,6 +82,8 @@ internal class PermissionManager @VisibleForTesting constructor(
      *   to configure websocket-based notification fallback.
      *
      * If the user dismisses the request without explicitly answering, no preference is persisted.
+     *
+     * @param serverId The server to check notification preferences for
      */
     @SuppressLint("NewApi")
     suspend fun checkNotificationPermission(serverId: Int) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
@@ -5,7 +5,6 @@ import android.os.Build
 import android.webkit.PermissionRequest as WebViewPermissionRequest
 import androidx.annotation.VisibleForTesting
 import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.common.util.NotificationStatusProvider
 import io.homeassistant.companion.android.common.util.PermissionChecker
 import io.homeassistant.companion.android.common.util.SingleSlotQueue
@@ -18,23 +17,26 @@ import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 
 /**
- * Centralizes all Android runtime permission request/result for the frontend screen.
+ * Snapshot of the WebView's requested resources: which can be auto-granted now, which still
+ * need user approval, and how to map back from each Android permission to the WebView resource
+ * string it originated from.
+ */
+private data class WebViewPermissionStatus(
+    val alreadyGranted: List<String>,
+    val toBeGranted: List<String>,
+    val resourcesByPermission: Map<String, String>,
+)
+
+/**
+ * Centralises all Android runtime permission request/result for the frontend screen.
  *
- * ## How it works
+ * Each `check*` / `on*` method runs the full request/response cycle: build a [PermissionRequest],
+ * suspend until the user responds via the request's callback, then react to the result inline.
+ * The slot is freed automatically including on coroutine cancellation by the underlying
+ * [SingleSlotQueue.awaitResult].
  *
- * All permission requests flow through a single [pendingPermissionRequest] state.
- * The UI observes this flow and decides what to do with it.
- *
- * Requests are queued: if a request is already in-flight, new requests suspend until the
- * current one is resolved or dismissed via [clearPendingPermissionRequest].
- *
- * ## Typical flow
- *
- * 1. A trigger (WebView callback, frontend connect, download) calls one of the `check*` / `on*` methods
- * 2. The method creates a [PermissionRequest] and emits it (suspending if one is already active)
- * 3. The observer reacts to the new request
- * 4. Once the user has responded, [clearPendingPermissionRequest] is called (freeing the slot
- *    for the next queued request) followed by [PermissionRequest.onResult] to let the request handle its result
+ * Concurrent triggers are waiting in FIFO order: a second method call suspends until the
+ * current request is resolved.
  */
 internal class PermissionManager @VisibleForTesting constructor(
     private val serverManager: ServerManager,
@@ -62,10 +64,10 @@ internal class PermissionManager @VisibleForTesting constructor(
         sdkInt = Build.VERSION.SDK_INT,
     )
 
-    private val _pendingPermissionRequest = SingleSlotQueue<PermissionRequest<*>>()
+    private val queue = SingleSlotQueue<PermissionRequest>()
 
     /** The current pending permission request that needs user approval, or null if none. */
-    val pendingPermissionRequest: StateFlow<PermissionRequest<*>?> = _pendingPermissionRequest
+    val pendingPermissionRequest: StateFlow<PermissionRequest?> = queue
 
     /**
      * Checks whether the notification permission request should be made and, if so,
@@ -73,70 +75,81 @@ internal class PermissionManager @VisibleForTesting constructor(
      *
      * Does nothing on pre-TIRAMISU devices (POST_NOTIFICATIONS does not exist).
      *
-     * Suspends if another permission request is already in-flight, and resumes once
-     * the slot is free.
-     *
-     * Whether to request depends on the flavor:
-     * - **Full** (FCM available): skips if notification permission is already granted system-wide,
-     *   since FCM handles push delivery without websocket configuration.
+     * Whether to ask depends on the flavor:
+     * - **Full** (FCM available): skips if notifications are already enabled system-wide, since
+     *   FCM handles push delivery without websocket configuration.
      * - **Minimal** (no FCM): always respects the per-server stored preference, allowing the user
      *   to configure websocket-based notification fallback.
      *
-     * @param serverId The server to check notification preferences for
+     * If the user dismisses the request without explicitly answering, no preference is persisted.
      */
     @SuppressLint("NewApi")
     suspend fun checkNotificationPermission(serverId: Int) {
         if (sdkInt < Build.VERSION_CODES.TIRAMISU) return
         if (!shouldAskNotificationPermission(serverId)) return
 
-        _pendingPermissionRequest.emit(
+        val granted: Boolean? = queue.awaitResult { resolve ->
             PermissionRequest.Notification(
                 serverId = serverId,
-                persistResult = { granted -> onNotificationPermissionResult(serverId = serverId, granted = granted) },
-            ),
-        )
+                onResult = { granted -> resolve(granted) },
+                onDismiss = { resolve(null) },
+            )
+        }
+        if (granted != null) {
+            onNotificationPermissionResult(serverId = serverId, granted = granted)
+        }
     }
 
     /**
-     * Checks whether the storage permission request should be made for a download and, if so,
-     * enqueues a [PermissionRequest.ExternalStorage].
+     * Ensures the app has permission to write to external storage for a download.
      *
-     * Does nothing on API 29+ (scoped storage) or when the permission is already granted.
+     * Returns `true` immediately on API 29+ (scoped storage no permission needed) and when the
+     * permission is already granted. Otherwise enqueues a [PermissionRequest.ExternalStorage],
+     * suspends until the user responds, and returns whether they granted it. The caller can then
+     * decide whether to proceed with the download.
      *
-     * Suspends if another permission request is already in-flight, and resumes once
-     * the slot is free.
-     *
-     * @param onGranted Callback invoked after the user grants the permission, typically
-     *        used to retry the download that was blocked
-     * @return `true` if the download must wait for permission; `false` if it can proceed now
+     * @return `true` if the download can proceed (permission available or not needed); `false` if
+     *         the user declined the permission
      */
-    suspend fun checkStoragePermissionForDownload(onGranted: () -> Unit): Boolean {
-        if (sdkInt >= Build.VERSION_CODES.Q) return false
-        if (permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) return false
+    suspend fun checkStoragePermissionForDownload(): Boolean {
+        if (sdkInt >= Build.VERSION_CODES.Q) return true
+        if (permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)) return true
 
-        Timber.d("Storage permission required for download, deferring until granted")
-        _pendingPermissionRequest.emit(
-            PermissionRequest.ExternalStorage(onGranted = onGranted),
-        )
-        return true
+        Timber.d("Storage permission required for download, awaiting user response")
+        return queue.awaitResult { onResult ->
+            PermissionRequest.ExternalStorage(onResult = onResult)
+        }
     }
 
     /**
      * Processes a WebView permission request (camera, microphone).
      *
-     * Resources for which the app already holds Android runtime permissions are collected
-     * and deferred so they can be granted together with any newly-approved resources in a
-     * single [WebViewPermissionRequest.grant] call.
+     * Resources whose Android permissions are already granted are deferred so they can be granted
+     * together with any newly-approved resources in a single [WebViewPermissionRequest.grant] call.
      *
-     * If permissions still need to be requested, a [PermissionRequest.WebView] is enqueued.
-     * Suspends if another permission request is already in-flight, and resumes once
-     * the slot is free.
-     *
-     * @param request The [WebViewPermissionRequest] from the WebView's `onPermissionRequest` callback
+     * If any permissions still need to be requested, suspends until the user responds and then
+     * grants/denies the original WebView request accordingly. Otherwise, auto-grants the
+     * already-granted resources without showing UI.
      */
     suspend fun onWebViewPermissionRequest(request: WebViewPermissionRequest?) {
         if (request == null) return
 
+        val status = assessWebViewPermissions(request)
+        if (status.toBeGranted.isEmpty()) {
+            autoGrantWebViewResources(request, status.alreadyGranted)
+            return
+        }
+        val grantedPermissions = queue.awaitResult { onResult ->
+            PermissionRequest.WebView(androidPermissions = status.toBeGranted, onResult = onResult)
+        }
+        resolveWebViewRequest(request, status, grantedPermissions)
+    }
+
+    /**
+     * Splits the WebView request's resources into those whose Android permissions are already
+     * granted (and can be auto-granted in one batch) and those that still need to be requested.
+     */
+    private fun assessWebViewPermissions(request: WebViewPermissionRequest): WebViewPermissionStatus {
         val alreadyGranted = mutableListOf<String>()
         val toBeGranted = mutableListOf<String>()
         val resourcesByPermission = mutableMapOf<String, String>()
@@ -151,38 +164,44 @@ internal class PermissionManager @VisibleForTesting constructor(
                 resourcesByPermission[androidPermission] = resource
             }
         }
-
-        if (toBeGranted.isNotEmpty()) {
-            Timber.d("Requesting Android permissions for WebView: $toBeGranted (already granted: $alreadyGranted)")
-            _pendingPermissionRequest.emit(
-                PermissionRequest.WebView(
-                    webViewRequest = request,
-                    androidPermissions = toBeGranted,
-                    webViewResourcesByPermission = resourcesByPermission,
-                    alreadyGrantedResources = alreadyGranted,
-                ),
-            )
-        } else if (alreadyGranted.isNotEmpty()) {
-            Timber.d("Auto-granting WebView resources: $alreadyGranted")
-            request.grant(alreadyGranted.toTypedArray())
-        }
+        return WebViewPermissionStatus(
+            alreadyGranted = alreadyGranted,
+            toBeGranted = toBeGranted,
+            resourcesByPermission = resourcesByPermission,
+        )
     }
 
     /**
-     * Clears the current pending permission request.
-     *
-     * Called by the observer in two scenarios:
-     * - Before delivering a result via [PermissionRequest.onResult] (freeing the slot for queued requests)
-     * - When the user dismisses the request without making an explicit choice, in which case
-     *   the request may reappear on the next trigger
-     *
-     * Must only be called when a request is in-flight; triggers [FailFast] otherwise.
+     * Grants [alreadyGranted] resources without showing UI, or returns silently when there is
+     * nothing to grant.
      */
-    fun clearPendingPermissionRequest() {
-        FailFast.failWhen(_pendingPermissionRequest.value == null) {
-            "Should have in-flight permission while calling clearPendingPermissionRequest"
+    private fun autoGrantWebViewResources(request: WebViewPermissionRequest, alreadyGranted: List<String>) {
+        if (alreadyGranted.isEmpty()) return
+        Timber.d("Auto-granting WebView resources: $alreadyGranted")
+        request.grant(alreadyGranted.toTypedArray())
+    }
+
+    /**
+     * Combines previously-granted resources from [status] with the resources the user has just
+     * approved and resolves the original [request] in a single grant/deny call.
+     */
+    private fun resolveWebViewRequest(
+        request: WebViewPermissionRequest,
+        status: WebViewPermissionStatus,
+        grantedPermissions: Map<String, Boolean>,
+    ) {
+        val newlyGrantedResources = grantedPermissions
+            .filter { (_, granted) -> granted }
+            .mapNotNull { (permission, _) -> status.resourcesByPermission[permission] }
+        val allGrantedResources = status.alreadyGranted + newlyGrantedResources
+
+        if (allGrantedResources.isNotEmpty()) {
+            Timber.d("Granting WebView resources: $allGrantedResources")
+            request.grant(allGrantedResources.toTypedArray())
+        } else {
+            Timber.d("User denied all requested permissions, denying WebView request")
+            request.deny()
         }
-        _pendingPermissionRequest.clear()
     }
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
@@ -2,141 +2,69 @@ package io.homeassistant.companion.android.frontend.permissions
 
 import android.Manifest
 import android.os.Build
-import android.webkit.PermissionRequest as WebViewPermissionRequest
 import androidx.annotation.RequiresApi
-import timber.log.Timber
 
 /**
- * An Android runtime permission request with its own result-handling logic.
+ * An Android runtime permission request enqueued in [PermissionManager].
  *
- * Organized into two categories based on how many permissions are requested:
- * - [SinglePermission] — requests a single Android permission (e.g. storage, notifications)
- * - [MultiplePermissions] — requests multiple Android permissions at once (e.g. camera + microphone)
+ * Subclasses fall into one of three categories the UI dispatches on:
+ * - [Notification] — the bottom-sheet prompt, allow/deny + dismiss-without-answering
+ * - [SinglePermission] — a single Android permission requested via the system dialog
+ * - [MultiplePermissions] — several Android permissions requested at once via the system dialog
  *
- * The composable layer uses this distinction to pick the right system dialog
- * ([SinglePermissionEffect] vs [MultiplePermissionsEffect]), so adding a new permission
- * type only requires extending the appropriate category, no handler changes needed
- * unless the new type requires custom UI.
- *
- * Results use two shapes matching the categories:
- * - [Result.Multiple] — maps each permission to its grant status
- * - [Result.Single] — a single granted/denied boolean
+ * Each category exposes the result-delivery callback the UI invokes once the user has responded;
+ * [PermissionManager] wires those callbacks into [io.homeassistant.companion.android.common.util.SingleSlotQueue.awaitResult]
+ * so the slot is freed automatically and the manager can react to the result inline.
  */
-internal sealed class PermissionRequest<T : PermissionRequest.Result> {
+internal sealed interface PermissionRequest {
 
     /** The Android runtime permissions to request. */
-    abstract val permissions: List<String>
-
-    /** Result of a permission request. */
-    sealed interface Result {
-        /** Result from a multi-permission system dialog. Maps each permission to its grant status. */
-        data class Multiple(val permissions: Map<String, Boolean>) : Result
-
-        /** Result from a single-permission dialog or a custom prompt. */
-        data class Single(val granted: Boolean) : Result
-    }
+    val permissions: List<String>
 
     /**
-     * Handles the user's response to this permission request.
-     *
-     * Called by the composable layer after clearing the pending slot. The generic parameter [T]
-     * ensures compile-time safety — each subclass receives its exact result type.
-     *
-     * @param result The typed result from the permission UI
+     * Base class for requests that involve a single Android permission resolved via the system
+     * dialog (i.e. the Boolean granted/denied path, no dismiss-without-answering).
      */
-    abstract suspend fun onResult(result: T)
-
-    /**
-     * Base class for permission requests that involve a single Android permission.
-     *
-     * Subclasses go through [SinglePermissionEffect] (system dialog) by default.
-     * Override with custom UI by adding a specific branch in the composable handler
-     * (e.g. [Notification] uses a bottom sheet).
-     */
-    sealed class SinglePermission(val permission: String) : PermissionRequest<Result.Single>() {
+    sealed class SinglePermission(val permission: String) : PermissionRequest {
         override val permissions: List<String> get() = listOf(permission)
+
+        /** Called by the UI once the user has answered the system dialog. */
+        abstract val onResult: (Boolean) -> Unit
+    }
+
+    /** Base class for requests that involve multiple Android permissions resolved at once. */
+    sealed class MultiplePermissions(override val permissions: List<String>) : PermissionRequest {
+
+        /** Called by the UI once the user has answered the multi-permission system dialog. */
+        abstract val onResult: (Map<String, Boolean>) -> Unit
     }
 
     /**
-     * Base class for permission requests that involve multiple Android permissions.
-     *
-     * Subclasses go through [MultiplePermissionsEffect] (system dialog).
+     * A WebView permission request (camera, microphone) that goes through the system multi-permission
+     * dialog. The grant/deny on the original WebView request is handled by [PermissionManager] after
+     * [onResult] is called.
      */
-    sealed class MultiplePermissions(override val permissions: List<String>) : PermissionRequest<Result.Multiple>()
+    class WebView(androidPermissions: List<String>, override val onResult: (Map<String, Boolean>) -> Unit) :
+        MultiplePermissions(permissions = androidPermissions)
+
+    /** A request for [Manifest.permission.WRITE_EXTERNAL_STORAGE]. */
+    class ExternalStorage(override val onResult: (Boolean) -> Unit) :
+        SinglePermission(permission = Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
     /**
-     * A WebView permission request (camera, microphone) that maps Android permissions
-     * back to WebView resource strings so the original [WebViewPermissionRequest] can be resolved.
+     * A notification permission request rendered as a bottom sheet (with an explicit allow/deny)
+     * before the system dialog, plus a separate dismiss path when the user closes the sheet without
+     * answering. Modelled as its own top-level category — not a [SinglePermission] — because
+     * dismiss-without-answering is a third outcome only this prompt has.
      *
-     * Combines resources that were already granted at request time with resources for which the
-     * user just approved the Android permission, then issues a single [WebViewPermissionRequest.grant]
-     * call. If nothing was granted at all, denies the entire request.
-     *
-     * @param webViewRequest The original [WebViewPermissionRequest] to grant/deny after the user responds
-     * @param webViewResourcesByPermission Maps each Android permission to its WebView resource string
-     * @param alreadyGrantedResources WebView resources already granted at request time, deferred so
-     *        all resources can be granted in a single [WebViewPermissionRequest.grant] call
-     */
-    class WebView(
-        val webViewRequest: WebViewPermissionRequest,
-        androidPermissions: List<String>,
-        val webViewResourcesByPermission: Map<String, String>,
-        val alreadyGrantedResources: List<String> = emptyList(),
-    ) : MultiplePermissions(permissions = androidPermissions) {
-
-        override suspend fun onResult(result: Result.Multiple) {
-            val newlyGrantedResources = result.permissions
-                .filter { (_, granted) -> granted }
-                .mapNotNull { (permission, _) -> webViewResourcesByPermission[permission] }
-
-            val allGrantedResources = alreadyGrantedResources + newlyGrantedResources
-
-            if (allGrantedResources.isNotEmpty()) {
-                Timber.d("Granting WebView resources: $allGrantedResources")
-                webViewRequest.grant(allGrantedResources.toTypedArray())
-            } else {
-                Timber.d("User denied all requested permissions, denying WebView request")
-                webViewRequest.deny()
-            }
-        }
-    }
-
-    /**
-     * A request for [Manifest.permission.WRITE_EXTERNAL_STORAGE].
-     *
-     * When the user grants the permission, [onGranted] is called to proceed with the
-     * operation that was blocked (e.g. retrying a file download).
-     *
-     * @param onGranted Callback invoked after the user grants the permission
-     */
-    class ExternalStorage(private val onGranted: () -> Unit) :
-        SinglePermission(permission = Manifest.permission.WRITE_EXTERNAL_STORAGE) {
-
-        override suspend fun onResult(result: Result.Single) {
-            if (result.granted) {
-                onGranted()
-            }
-        }
-    }
-
-    /**
-     * A notification permission request that shows a bottom sheet prompt before the system dialog.
-     *
-     * Unlike other [SinglePermission] types, this is rendered as visible UI (a bottom sheet
-     * with Allow/Deny buttons) rather than going straight to the system permission dialog.
-     * The composable handler checks for this type explicitly before falling through to the
-     * default [SinglePermissionEffect].
-     *
-     * @param serverId The server ID for persisting the user's choice
-     * @param persistResult Callback to persist the notification permission choice (websocket
-     *        settings on the minimal flavor, and "don't ask again" flag)
+     * @param serverId The server the prompt is being shown for
+     * @param onResult Called by the UI with `true` (allow) or `false` (deny)
+     * @param onDismiss Called by the UI when the user closes the sheet without answering. The
+     *        manager treats this as "ask again later" — no preference is persisted.
      */
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    class Notification(val serverId: Int, private val persistResult: suspend (granted: Boolean) -> Unit) :
-        SinglePermission(permission = Manifest.permission.POST_NOTIFICATIONS) {
-
-        override suspend fun onResult(result: Result.Single) {
-            persistResult(result.granted)
-        }
+    class Notification(val serverId: Int, val onResult: (Boolean) -> Unit, val onDismiss: () -> Unit) :
+        PermissionRequest {
+        override val permissions: List<String> get() = listOf(Manifest.permission.POST_NOTIFICATIONS)
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
@@ -21,10 +21,7 @@ internal sealed interface PermissionRequest {
     /** The Android runtime permissions to request. */
     val permissions: List<String>
 
-    /**
-     * Base class for requests that involve a single Android permission resolved via the system
-     * dialog (i.e. the Boolean granted/denied path, no dismiss-without-answering).
-     */
+    /** Base class for requests that involve a single Android permission resolved via the system dialog. */
     sealed class SinglePermission(val permission: String) : PermissionRequest {
         override val permissions: List<String> get() = listOf(permission)
 

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
@@ -175,7 +175,7 @@ class FrontendScreenScreenshotTest {
                 onSecurityLevelHelpClick = {},
                 onShowSnackbar = { _, _ -> true },
                 onWebViewCreationFailed = {},
-                pendingPermissionRequest = PermissionRequest.Notification(1) {},
+                pendingPermissionRequest = PermissionRequest.Notification(serverId = 1, onResult = {}, onDismiss = {}),
             )
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
@@ -41,6 +41,8 @@ import io.mockk.verify
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -298,7 +300,8 @@ class FrontendScreenTest {
                 viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                 pendingPermissionRequest = PermissionRequest.Notification(
                     serverId = 1,
-                    persistResult = { persistedResult = it },
+                    onResult = { granted -> persistedResult = granted },
+                    onDismiss = {},
                 ),
                 registry = registry,
             )
@@ -323,7 +326,10 @@ class FrontendScreenTest {
             every { resources } returns arrayOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)
         }
         val permissionManager = createPermissionManager()
-        permissionManager.onWebViewPermissionRequest(permissionRequest)
+        // onWebViewPermissionRequest now suspends until the user responds via pending.onResult,
+        // so we launch it; the registry below will resume it with the simulated grant result.
+        val managerJob = launch { permissionManager.onWebViewPermissionRequest(permissionRequest) }
+        advanceUntilIdle()
 
         composeTestRule.apply {
             setFrontendScreen(
@@ -334,8 +340,11 @@ class FrontendScreenTest {
             waitForIdle()
 
             registry.assertPermissionsRequested(Manifest.permission.CAMERA)
-            verify { permissionRequest.grant(arrayOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
         }
+        // Wait for the manager's post-result logic (grant/deny on the WebView request) to run
+        // before asserting on the mocked WebView request.
+        managerJob.join()
+        verify { permissionRequest.grant(arrayOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
     }
 
     @Test
@@ -345,7 +354,8 @@ class FrontendScreenTest {
             every { resources } returns arrayOf(WebViewPermissionRequest.RESOURCE_AUDIO_CAPTURE)
         }
         val permissionManager = createPermissionManager()
-        permissionManager.onWebViewPermissionRequest(permissionRequest)
+        val managerJob = launch { permissionManager.onWebViewPermissionRequest(permissionRequest) }
+        advanceUntilIdle()
 
         composeTestRule.apply {
             setFrontendScreen(
@@ -356,8 +366,9 @@ class FrontendScreenTest {
             waitForIdle()
 
             registry.assertPermissionsRequested(Manifest.permission.RECORD_AUDIO)
-            verify { permissionRequest.deny() }
         }
+        managerJob.join()
+        verify { permissionRequest.deny() }
     }
 
     private fun createPermissionManager(): PermissionManager = PermissionManager(
@@ -371,7 +382,7 @@ class FrontendScreenTest {
     private fun AndroidComposeTestRule<ActivityScenarioRule<HiltComponentActivity>, HiltComponentActivity>.setFrontendScreen(
         viewState: FrontendViewState,
         errorStateProvider: FrontendConnectionErrorStateProvider = FrontendConnectionErrorStateProvider.noOp,
-        pendingPermissionRequest: PermissionRequest<*>? = null,
+        pendingPermissionRequest: PermissionRequest? = null,
         onBlockInsecureRetry: () -> Unit = {},
         onBlockInsecureHelpClick: suspend () -> Unit = {},
         onOpenSettings: () -> Unit = {},
@@ -380,7 +391,6 @@ class FrontendScreenTest {
         onConfigureHomeNetwork: (serverId: Int) -> Unit = { _ -> },
         onSecurityLevelHelpClick: suspend () -> Unit = {},
         onSecurityLevelDone: () -> Unit = {},
-        onClearPendingPermissionRequest: () -> Unit = {},
         registry: ActivityResultRegistry? = null,
     ) {
         setContent {
@@ -402,7 +412,6 @@ class FrontendScreenTest {
                     onConfigureHomeNetwork = onConfigureHomeNetwork,
                     onSecurityLevelHelpClick = onSecurityLevelHelpClick,
                     onSecurityLevelDone = onSecurityLevelDone,
-                    onClearPendingPermissionRequest = onClearPendingPermissionRequest,
                     onShowSnackbar = { _, _ -> true },
                     onWebViewCreationFailed = {},
                 )

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -91,6 +91,9 @@ class FrontendViewModelTest {
         every { frontendBusObserver.messageResults() } returns emptyFlow()
         every { frontendBusObserver.webViewActions() } returns emptyFlow()
         every { connectivityCheckRepository.runChecks(any()) } returns flowOf(ConnectivityCheckState())
+        // Default: storage permission available so download tests don't bail out at the permission gate.
+        // Tests that exercise the deny path override this explicitly.
+        coEvery { permissionManager.checkStoragePermissionForDownload() } returns true
     }
 
     private fun createViewModel(
@@ -860,20 +863,6 @@ class FrontendViewModelTest {
 
             coVerify { permissionManager.checkNotificationPermission(serverId) }
         }
-
-        @Test
-        fun `Given permission dismissed then delegates to permission manager`() = runTest {
-            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
-                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
-            )
-
-            val viewModel = createViewModel()
-            advanceUntilIdle()
-
-            viewModel.clearPendingPermissionRequest()
-
-            verify { permissionManager.clearPendingPermissionRequest() }
-        }
     }
 
     @Nested
@@ -1324,13 +1313,11 @@ class FrontendViewModelTest {
         }
 
         @Test
-        fun `Given storage permission required when download requested then does not call downloadManager`() = runTest {
+        fun `Given storage permission denied when download requested then does not call downloadManager`() = runTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
             )
-            coEvery {
-                permissionManager.checkStoragePermissionForDownload(any())
-            } returns true
+            coEvery { permissionManager.checkStoragePermissionForDownload() } returns false
 
             val viewModel = createViewModel()
             advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
@@ -1346,17 +1333,12 @@ class FrontendViewModelTest {
         }
 
         @Test
-        fun `Given storage permission required when onGranted called then retries download`() = runTest {
+        fun `Given storage permission granted when download requested then proceeds with download`() = runTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
             )
-            val onGrantedSlot = mutableListOf<() -> Unit>()
-            coEvery {
-                permissionManager.checkStoragePermissionForDownload(capture(onGrantedSlot))
-            } returns true
-            coEvery {
-                downloadManager.downloadFile(any(), any(), any(), any())
-            } returns DownloadResult.Forwarded
+            coEvery { permissionManager.checkStoragePermissionForDownload() } returns true
+            coEvery { downloadManager.downloadFile(any(), any(), any(), any()) } returns DownloadResult.Forwarded
 
             val viewModel = createViewModel()
             advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
@@ -1366,14 +1348,6 @@ class FrontendViewModelTest {
                 contentDisposition = "attachment",
                 mimetype = "application/pdf",
             )
-
-            coVerify(exactly = 0) { downloadManager.downloadFile(any(), any(), any(), any()) }
-
-            // Simulate permission granted: onGranted retries the download
-            coEvery {
-                permissionManager.checkStoragePermissionForDownload(any())
-            } returns false
-            onGrantedSlot.last().invoke()
             advanceUntilIdle()
 
             coVerify {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
@@ -18,16 +18,15 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
-import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -253,7 +252,6 @@ class PermissionManagerTest {
             assertInstanceOf(PermissionRequest.WebView::class.java, pending)
             assertEquals(listOf(android.Manifest.permission.CAMERA), pending?.permissions)
 
-            // Tidy up
             (pending as PermissionRequest.WebView).onResult(emptyMap())
             advanceUntilIdle()
             job.join()
@@ -626,12 +624,14 @@ class PermissionManagerTest {
                 val storageJob = launch { manager.checkStoragePermissionForDownload() }
                 assertInstanceOf(PermissionRequest.ExternalStorage::class.java, turbine.awaitItem())
 
-                val firstWebViewJob = launch(Dispatchers.Default) {
+                val firstWebViewJob = launch {
                     manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE))
                 }
-                val secondWebViewJob = launch(Dispatchers.Default) {
+                val secondWebViewJob = launch {
                     manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_AUDIO_CAPTURE))
                 }
+                // Ensure both waiters are parked in queue.awaitResult before we resolve storage
+                runCurrent()
 
                 // Resolve storage — slot becomes null briefly, then first waiter takes it
                 (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(false)
@@ -647,8 +647,9 @@ class PermissionManagerTest {
                 val secondPending = turbine.awaitItem()
                 assertInstanceOf(PermissionRequest.WebView::class.java, secondPending)
 
-                // Both were served, and they are different permissions
-                assertNotEquals(firstPending.permissions, secondPending?.permissions)
+                // FIFO order: first waiter gets CAMERA (video), second gets RECORD_AUDIO (audio)
+                assertEquals(listOf(android.Manifest.permission.CAMERA), firstPending.permissions)
+                assertEquals(listOf(android.Manifest.permission.RECORD_AUDIO), secondPending?.permissions)
 
                 (secondPending as PermissionRequest.WebView).onResult(emptyMap())
                 firstWebViewJob.join()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
@@ -5,7 +5,6 @@ import android.webkit.PermissionRequest as WebViewPermissionRequest
 import app.cash.turbine.turbineScope
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
-import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.common.util.NotificationStatusProvider
 import io.homeassistant.companion.android.common.util.PermissionChecker
 import io.homeassistant.companion.android.database.settings.SensorUpdateFrequencySetting
@@ -21,6 +20,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -102,13 +101,18 @@ class PermissionManagerTest {
             coEvery { integrationRepository.shouldAskNotificationPermission() } returns storedPref?.toBooleanStrictOrNull()
 
             val manager = createManager(hasFcmPushSupport = hasFcm, sdkInt = Build.VERSION_CODES.TIRAMISU)
-            manager.checkNotificationPermission(serverId)
+            val job = launch { manager.checkNotificationPermission(serverId) }
+            advanceUntilIdle()
 
             if (expectedPending) {
                 assertInstanceOf(PermissionRequest.Notification::class.java, manager.pendingPermissionRequest.value)
+                // Dismiss to let the suspend return so the test scope can finish.
+                (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onDismiss()
             } else {
                 assertNull(manager.pendingPermissionRequest.value)
             }
+            advanceUntilIdle()
+            job.join()
         }
 
         @Test
@@ -132,26 +136,23 @@ class PermissionManagerTest {
     }
 
     @Nested
-    inner class OnPermissionResultNotification {
+    inner class NotificationPermissionResult {
 
         private fun mockShouldAsk() {
             every { notificationStatusProvider.areNotificationsEnabled() } returns false
             coEvery { integrationRepository.shouldAskNotificationPermission() } returns true
         }
 
-        private suspend fun resolveNotificationPermission(manager: PermissionManager, granted: Boolean) {
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.Notification
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Single(granted = granted))
-        }
-
         @Test
         fun `Given permission granted when doesn't have FcmPushSupport then inserts websocket settings`() = runTest {
             mockShouldAsk()
             val manager = createManager(hasFcmPushSupport = false, sdkInt = Build.VERSION_CODES.TIRAMISU)
-            manager.checkNotificationPermission(serverId)
 
-            resolveNotificationPermission(manager, granted = true)
+            val job = launch { manager.checkNotificationPermission(serverId) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onResult(true)
+            advanceUntilIdle()
+            job.join()
 
             coVerify {
                 settingsDao.insert(
@@ -177,23 +178,45 @@ class PermissionManagerTest {
         ) = runTest {
             mockShouldAsk()
             val manager = createManager(hasFcmPushSupport = hasFcm, sdkInt = Build.VERSION_CODES.TIRAMISU)
-            manager.checkNotificationPermission(serverId)
 
-            resolveNotificationPermission(manager, granted = granted)
+            val job = launch { manager.checkNotificationPermission(serverId) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onResult(granted)
+            advanceUntilIdle()
+            job.join()
 
             coVerify(exactly = 0) { settingsDao.insert(any()) }
         }
 
         @ParameterizedTest(name = "granted={0} -> persists do not ask again")
         @ValueSource(booleans = [true, false])
-        fun `Given any result then persists do not ask again`(granted: Boolean) = runTest {
+        fun `Given any explicit answer then persists do not ask again`(granted: Boolean) = runTest {
             mockShouldAsk()
             val manager = createManager(hasFcmPushSupport = false, sdkInt = Build.VERSION_CODES.TIRAMISU)
-            manager.checkNotificationPermission(serverId)
 
-            resolveNotificationPermission(manager, granted = granted)
+            val job = launch { manager.checkNotificationPermission(serverId) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onResult(granted)
+            advanceUntilIdle()
+            job.join()
 
             coVerify { integrationRepository.setAskNotificationPermission(false) }
+        }
+
+        @Test
+        fun `Given user dismisses without answering then does not persist preference`() = runTest {
+            mockShouldAsk()
+            val manager = createManager(hasFcmPushSupport = false, sdkInt = Build.VERSION_CODES.TIRAMISU)
+
+            val job = launch { manager.checkNotificationPermission(serverId) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onDismiss()
+            advanceUntilIdle()
+            job.join()
+
+            coVerify(exactly = 0) { integrationRepository.setAskNotificationPermission(any()) }
+            coVerify(exactly = 0) { settingsDao.insert(any()) }
+            assertNull(manager.pendingPermissionRequest.value)
         }
     }
 
@@ -222,12 +245,18 @@ class PermissionManagerTest {
             val request = mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
 
             verify(exactly = 0) { request.grant(any()) }
             val pending = manager.pendingPermissionRequest.value
             assertInstanceOf(PermissionRequest.WebView::class.java, pending)
             assertEquals(listOf(android.Manifest.permission.CAMERA), pending?.permissions)
+
+            // Tidy up
+            (pending as PermissionRequest.WebView).onResult(emptyMap())
+            advanceUntilIdle()
+            job.join()
         }
 
         @Test
@@ -236,15 +265,20 @@ class PermissionManagerTest {
             val request = mockPermissionRequest(WebViewPermissionRequest.RESOURCE_AUDIO_CAPTURE)
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
 
             val pending = manager.pendingPermissionRequest.value
             assertInstanceOf(PermissionRequest.WebView::class.java, pending)
             assertEquals(listOf(android.Manifest.permission.RECORD_AUDIO), pending?.permissions)
+
+            (pending as PermissionRequest.WebView).onResult(emptyMap())
+            advanceUntilIdle()
+            job.join()
         }
 
         @Test
-        fun `Given camera granted but mic not when both requested then defers grant and creates pending for mic`() = runTest {
+        fun `Given camera granted but mic not when both requested then creates pending request for mic only`() = runTest {
             every { permissionChecker.hasPermission(android.Manifest.permission.CAMERA) } returns true
             every { permissionChecker.hasPermission(android.Manifest.permission.RECORD_AUDIO) } returns false
             val request = mockPermissionRequest(
@@ -253,14 +287,17 @@ class PermissionManagerTest {
             )
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
 
             verify(exactly = 0) { request.grant(any()) }
             val pending = manager.pendingPermissionRequest.value
             assertInstanceOf(PermissionRequest.WebView::class.java, pending)
-            val webView = pending as PermissionRequest.WebView
-            assertEquals(listOf(android.Manifest.permission.RECORD_AUDIO), webView.permissions)
-            assertEquals(listOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE), webView.alreadyGrantedResources)
+            assertEquals(listOf(android.Manifest.permission.RECORD_AUDIO), pending?.permissions)
+
+            (pending as PermissionRequest.WebView).onResult(emptyMap())
+            advanceUntilIdle()
+            job.join()
         }
 
         @Test
@@ -304,7 +341,7 @@ class PermissionManagerTest {
     }
 
     @Nested
-    inner class OnPermissionResultWebView {
+    inner class WebViewPermissionResult {
 
         @Test
         fun `Given pending request when camera granted then grants WebView resource`() = runTest {
@@ -312,10 +349,12 @@ class PermissionManagerTest {
             val request = mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.CAMERA to true)))
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.CAMERA to true))
+            advanceUntilIdle()
+            job.join()
 
             verify { request.grant(arrayOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
             assertNull(manager.pendingPermissionRequest.value)
@@ -327,10 +366,12 @@ class PermissionManagerTest {
             val request = mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.CAMERA to false)))
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.CAMERA to false))
+            advanceUntilIdle()
+            job.join()
 
             verify { request.deny() }
             assertNull(manager.pendingPermissionRequest.value)
@@ -346,12 +387,12 @@ class PermissionManagerTest {
             )
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(
-                PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.RECORD_AUDIO to true)),
-            )
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.RECORD_AUDIO to true))
+            advanceUntilIdle()
+            job.join()
 
             verify {
                 request.grant(
@@ -371,12 +412,12 @@ class PermissionManagerTest {
             )
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(
-                PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.RECORD_AUDIO to false)),
-            )
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.RECORD_AUDIO to false))
+            advanceUntilIdle()
+            job.join()
 
             verify { request.grant(arrayOf(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
             assertNull(manager.pendingPermissionRequest.value)
@@ -392,17 +433,16 @@ class PermissionManagerTest {
             )
 
             val manager = createManager()
-            manager.onWebViewPermissionRequest(request)
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(
-                PermissionRequest.Result.Multiple(
-                    permissions = mapOf(
-                        android.Manifest.permission.CAMERA to false,
-                        android.Manifest.permission.RECORD_AUDIO to true,
-                    ),
+            val job = launch { manager.onWebViewPermissionRequest(request) }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView).onResult(
+                mapOf(
+                    android.Manifest.permission.CAMERA to false,
+                    android.Manifest.permission.RECORD_AUDIO to true,
                 ),
             )
+            advanceUntilIdle()
+            job.join()
 
             verify { request.grant(arrayOf(WebViewPermissionRequest.RESOURCE_AUDIO_CAPTURE)) }
             assertNull(manager.pendingPermissionRequest.value)
@@ -417,125 +457,78 @@ class PermissionManagerTest {
     inner class CheckStoragePermissionForDownload {
 
         @Test
-        fun `Given Q+ device then returns false without checking permission`() = runTest {
+        fun `Given Q+ device then returns true without checking permission`() = runTest {
             val manager = createManager(sdkInt = Build.VERSION_CODES.Q)
-            val result = manager.checkStoragePermissionForDownload {}
-
-            assertFalse(result)
+            assertTrue(manager.checkStoragePermissionForDownload())
             assertNull(manager.pendingPermissionRequest.value)
         }
 
         @Test
-        fun `Given pre-Q device when storage permission already granted then returns false`() = runTest {
+        fun `Given pre-Q device when storage permission already granted then returns true`() = runTest {
             every {
                 permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
             } returns true
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            val result = manager.checkStoragePermissionForDownload {}
-
-            assertFalse(result)
+            assertTrue(manager.checkStoragePermissionForDownload())
             assertNull(manager.pendingPermissionRequest.value)
         }
 
         @Test
-        fun `Given pre-Q device when storage permission not granted then returns true and emits pending request`() = runTest {
+        fun `Given pre-Q device when storage permission not granted then emits pending request`() = runTest {
             every {
                 permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
             } returns false
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            val result = manager.checkStoragePermissionForDownload {}
+            val result = async { manager.checkStoragePermissionForDownload() }
+            advanceUntilIdle()
 
-            assertTrue(result)
             val pending = manager.pendingPermissionRequest.value
             assertInstanceOf(PermissionRequest.ExternalStorage::class.java, pending)
             assertEquals(
                 listOf(android.Manifest.permission.WRITE_EXTERNAL_STORAGE),
                 pending?.permissions,
             )
+
+            (pending as PermissionRequest.ExternalStorage).onResult(false)
+            advanceUntilIdle()
+            assertFalse(result.await())
         }
     }
 
     @Nested
-    inner class OnPermissionResultStorage {
+    inner class StoragePermissionResult {
 
         @Test
-        fun `Given pending download when permission granted then calls onGranted`() = runTest {
+        fun `Given pending download when permission granted then returns true`() = runTest {
             every {
                 permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
             } returns false
 
-            var onGrantedCalled = false
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            manager.checkStoragePermissionForDownload { onGrantedCalled = true }
+            val result = async { manager.checkStoragePermissionForDownload() }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(true)
+            advanceUntilIdle()
 
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage
-            manager.clearPendingPermissionRequest()
-            pending.onResult(
-                PermissionRequest.Result.Single(granted = true),
-            )
-
-            assertTrue(onGrantedCalled)
+            assertTrue(result.await())
             assertNull(manager.pendingPermissionRequest.value)
         }
 
         @Test
-        fun `Given pending download when permission denied then does not call onGranted`() = runTest {
+        fun `Given pending download when permission denied then returns false`() = runTest {
             every {
                 permissionChecker.hasPermission(android.Manifest.permission.WRITE_EXTERNAL_STORAGE)
             } returns false
 
-            var onGrantedCalled = false
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            manager.checkStoragePermissionForDownload { onGrantedCalled = true }
+            val result = async { manager.checkStoragePermissionForDownload() }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(false)
+            advanceUntilIdle()
 
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage
-            manager.clearPendingPermissionRequest()
-            pending.onResult(
-                PermissionRequest.Result.Single(granted = false),
-            )
-
-            assertFalse(onGrantedCalled)
-            assertNull(manager.pendingPermissionRequest.value)
-        }
-    }
-
-    // endregion
-
-    // region Dismiss
-
-    @Nested
-    inner class DismissPendingPermission {
-
-        @Test
-        fun `Given no pending request when clearPendingPermissionRequest called then triggers FailFast`() = runTest {
-            var failFastTriggered = false
-            FailFast.setHandler { _, _ -> failFastTriggered = true }
-
-            val manager = createManager()
-            assertNull(manager.pendingPermissionRequest.value)
-
-            manager.clearPendingPermissionRequest()
-
-            assertTrue(failFastTriggered, "FailFast should trigger when clearing without a pending request")
-        }
-
-        @Test
-        fun `Given pending request when dismissed then clears without calling callbacks`() = runTest {
-            every {
-                permissionChecker.hasPermission(android.Manifest.permission.POST_NOTIFICATIONS)
-            } returns false
-            every { notificationStatusProvider.areNotificationsEnabled() } returns false
-            coEvery { integrationRepository.shouldAskNotificationPermission() } returns true
-
-            val manager = createManager(sdkInt = Build.VERSION_CODES.TIRAMISU)
-            manager.checkNotificationPermission(1)
-
-            assertNotNull(manager.pendingPermissionRequest.value)
-
-            manager.clearPendingPermissionRequest()
-
+            assertFalse(result.await())
             assertNull(manager.pendingPermissionRequest.value)
         }
     }
@@ -557,26 +550,29 @@ class PermissionManagerTest {
             } returns false
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            manager.checkStoragePermissionForDownload {}
+            val storageJob = launch { manager.checkStoragePermissionForDownload() }
+            advanceUntilIdle()
 
-            assertNotNull(manager.pendingPermissionRequest.value)
+            assertInstanceOf(PermissionRequest.ExternalStorage::class.java, manager.pendingPermissionRequest.value)
 
             val webViewRequest = mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)
-            val job = launch { manager.onWebViewPermissionRequest(webViewRequest) }
+            val webViewJob = launch { manager.onWebViewPermissionRequest(webViewRequest) }
             advanceUntilIdle()
 
             // Still waiting — storage request is pending
             assertInstanceOf(PermissionRequest.ExternalStorage::class.java, manager.pendingPermissionRequest.value)
 
             // Resolve storage
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Single(granted = true))
+            (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(true)
             advanceUntilIdle()
-            job.join()
+            storageJob.join()
 
             // Now WebView request is pending
             assertInstanceOf(PermissionRequest.WebView::class.java, manager.pendingPermissionRequest.value)
+
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView).onResult(emptyMap())
+            advanceUntilIdle()
+            webViewJob.join()
         }
 
         @Test
@@ -589,12 +585,14 @@ class PermissionManagerTest {
             } returns false
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
-            launch { manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
+            val webViewJob = launch {
+                manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE))
+            }
             advanceUntilIdle()
 
-            val job = launch {
-                val result = manager.checkStoragePermissionForDownload {}
-                assertTrue(result)
+            val storageJob = launch {
+                val result = manager.checkStoragePermissionForDownload()
+                assertFalse(result, "Storage permission was denied below")
             }
             advanceUntilIdle()
 
@@ -602,18 +600,21 @@ class PermissionManagerTest {
             assertInstanceOf(PermissionRequest.WebView::class.java, manager.pendingPermissionRequest.value)
 
             // Resolve WebView
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.CAMERA to true)))
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.CAMERA to true))
             advanceUntilIdle()
-            job.join()
+            webViewJob.join()
 
             // Now storage request is pending
             assertInstanceOf(PermissionRequest.ExternalStorage::class.java, manager.pendingPermissionRequest.value)
+
+            (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(false)
+            advanceUntilIdle()
+            storageJob.join()
         }
 
         @Test
-        fun `Given two concurrent requests waiting when each is cleared then both are served sequentially`() = runTest {
+        fun `Given two concurrent requests waiting when each is resolved then both are served sequentially`() = runTest {
             every { permissionChecker.hasPermission(any()) } returns false
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.P)
@@ -622,32 +623,36 @@ class PermissionManagerTest {
                 val turbine = manager.pendingPermissionRequest.testIn(backgroundScope)
                 assertNull(turbine.awaitItem())
 
-                manager.checkStoragePermissionForDownload {}
+                val storageJob = launch { manager.checkStoragePermissionForDownload() }
                 assertInstanceOf(PermissionRequest.ExternalStorage::class.java, turbine.awaitItem())
 
-                launch(Dispatchers.Default) {
+                val firstWebViewJob = launch(Dispatchers.Default) {
                     manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE))
                 }
-                launch(Dispatchers.Default) {
+                val secondWebViewJob = launch(Dispatchers.Default) {
                     manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_AUDIO_CAPTURE))
                 }
 
-                // Clear storage — first waiter fills the slot, second stays suspended
-                manager.clearPendingPermissionRequest()
+                // Resolve storage — slot becomes null briefly, then first waiter takes it
+                (manager.pendingPermissionRequest.value as PermissionRequest.ExternalStorage).onResult(false)
+                storageJob.join()
                 assertNull(turbine.awaitItem())
                 val firstPending = turbine.awaitItem()
                 assertInstanceOf(PermissionRequest.WebView::class.java, firstPending)
                 turbine.expectNoEvents()
 
-                // Clear first waiter — second waiter now fills the slot
-                manager.clearPendingPermissionRequest()
+                // Resolve first waiter — slot becomes null briefly, second waiter takes it
+                (firstPending as PermissionRequest.WebView).onResult(emptyMap())
                 assertNull(turbine.awaitItem())
                 val secondPending = turbine.awaitItem()
                 assertInstanceOf(PermissionRequest.WebView::class.java, secondPending)
 
                 // Both were served, and they are different permissions
-                assertNotEquals(firstPending?.permissions, secondPending?.permissions)
+                assertNotEquals(firstPending.permissions, secondPending?.permissions)
 
+                (secondPending as PermissionRequest.WebView).onResult(emptyMap())
+                firstWebViewJob.join()
+                secondWebViewJob.join()
                 turbine.cancelAndIgnoreRemainingEvents()
             }
         }
@@ -661,25 +666,30 @@ class PermissionManagerTest {
             coEvery { integrationRepository.shouldAskNotificationPermission() } returns true
 
             val manager = createManager(sdkInt = Build.VERSION_CODES.TIRAMISU)
-            launch { manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE)) }
+            val webViewJob = launch {
+                manager.onWebViewPermissionRequest(mockPermissionRequest(WebViewPermissionRequest.RESOURCE_VIDEO_CAPTURE))
+            }
             advanceUntilIdle()
 
             // checkNotificationPermission suspends until pending is null
-            val job = launch { manager.checkNotificationPermission(serverId) }
+            val notificationJob = launch { manager.checkNotificationPermission(serverId) }
             advanceUntilIdle()
 
             // Still waiting — WebView request is pending
             assertInstanceOf(PermissionRequest.WebView::class.java, manager.pendingPermissionRequest.value)
 
             // Resolve the WebView request
-            val pending = manager.pendingPermissionRequest.value as PermissionRequest.WebView
-            manager.clearPendingPermissionRequest()
-            pending.onResult(PermissionRequest.Result.Multiple(permissions = mapOf(android.Manifest.permission.CAMERA to true)))
+            (manager.pendingPermissionRequest.value as PermissionRequest.WebView)
+                .onResult(mapOf(android.Manifest.permission.CAMERA to true))
             advanceUntilIdle()
+            webViewJob.join()
 
             // Now the notification request should be set
-            job.join()
             assertInstanceOf(PermissionRequest.Notification::class.java, manager.pendingPermissionRequest.value)
+
+            (manager.pendingPermissionRequest.value as PermissionRequest.Notification).onDismiss()
+            advanceUntilIdle()
+            notificationJob.join()
         }
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I've introduce `awaitResult` in the queue recently and applying this pattern to the manager that use a queue where it needs to wait for a result. This allow us to not have to call clear on the viewModel to clear the queue, each team auto clear the queue once the result is retrieved from the UI. It is yet again another refactor of the `PermissionManager`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.