### PR TITLE
Fix WebViewActivity leak via Handler.postDelayed in waitForConnection (#5453)

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1996,11 +1996,6 @@ class WebViewActivity :
             Timber.i("Fragments ${supportFragmentManager.fragments} displayed, skipping connection wait")
         } else {
             Timber.d("Waiting for loadedUrl ${sensitive(loadedUrl.toString())}")
-            // Use lifecycleScope so the delayed check is automatically cancelled when the
-            // activity is destroyed. Previously this used Handler(Looper.getMainLooper())
-            // .postDelayed { ... } with a lambda capturing `this`, which kept the destroyed
-            // WebViewActivity retained in the main MessageQueue for up to CONNECTION_DELAY ms
-            // (e.g. when the activity was recreated due to a theme change). See issue #5453.
             lifecycleScope.launch {
                 delay(CONNECTION_DELAY)
                 val firstSegment = loadedUrl?.pathSegments?.firstOrNull().orEmpty()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -14,8 +14,6 @@ import android.net.http.SslError
 import android.os.Build
 import android.os.Bundle
 import android.os.Environment
-import android.os.Handler
-import android.os.Looper
 import android.text.method.HideReturnsTransformationMethod
 import android.text.method.PasswordTransformationMethod
 import android.util.DisplayMetrics
@@ -1998,19 +1996,22 @@ class WebViewActivity :
             Timber.i("Fragments ${supportFragmentManager.fragments} displayed, skipping connection wait")
         } else {
             Timber.d("Waiting for loadedUrl ${sensitive(loadedUrl.toString())}")
-            Handler(Looper.getMainLooper()).postDelayed(
-                {
-                    val firstSegment = loadedUrl?.pathSegments?.firstOrNull().orEmpty()
-                    if (
-                        !isConnected &&
-                        !firstSegment.contains("api") &&
-                        !firstSegment.contains("local")
-                    ) {
-                        showError(errorType = ErrorType.TIMEOUT_EXTERNAL_BUS)
-                    }
-                },
-                CONNECTION_DELAY,
-            )
+            // Use lifecycleScope so the delayed check is automatically cancelled when the
+            // activity is destroyed. Previously this used Handler(Looper.getMainLooper())
+            // .postDelayed { ... } with a lambda capturing `this`, which kept the destroyed
+            // WebViewActivity retained in the main MessageQueue for up to CONNECTION_DELAY ms
+            // (e.g. when the activity was recreated due to a theme change). See issue #5453.
+            lifecycleScope.launch {
+                delay(CONNECTION_DELAY)
+                val firstSegment = loadedUrl?.pathSegments?.firstOrNull().orEmpty()
+                if (
+                    !isConnected &&
+                    !firstSegment.contains("api") &&
+                    !firstSegment.contains("local")
+                ) {
+                    showError(errorType = ErrorType.TIMEOUT_EXTERNAL_BUS)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #5453 — `WebViewActivity` was being retained in the main thread `MessageQueue` after `onDestroy`, matching the LeakCanary trace in the issue.

## Root cause

`WebViewActivity.waitForConnection()` posted a 10-second delayed `Runnable` directly on the main thread `Handler`:

```kotlin
Handler(Looper.getMainLooper()).postDelayed(
    {
        val firstSegment = loadedUrl?.pathSegments?.firstOrNull().orEmpty()
        if (
            !isConnected &&
            !firstSegment.contains("api") &&
            !firstSegment.contains("local")
        ) {
            showError(errorType = ErrorType.TIMEOUT_EXTERNAL_BUS)
        }
    },
    CONNECTION_DELAY,
)
```

The lambda captures `this` (the `WebViewActivity`). If the activity is destroyed before `CONNECTION_DELAY` (10 s) elapses — e.g. on the configuration change that motivated the report (theme switch recreates the activity) — the queued `Message` keeps a strong reference to the destroyed activity until the delay fires. This matches the leak trace exactly:

```
android.os.MessageQueue
  ↓ MessageQueue[0]
android.os.Message
  Message.callback = instance @… of WebViewActivity$$ExternalSyntheticLambda23
  ↓ Message.callback
WebViewActivity$$ExternalSyntheticLambda23
  f$0 instance of WebViewActivity (with mDestroyed = true)
  ↓ ExternalSyntheticLambda23.f$0
WebViewActivity (Leaking: YES)
```

`waitForConnection()` is called from `onResume`, `onDismissListener`s of error dialogs, and the timeout-external-bus "wait" button — all paths that can fire shortly before a recreation.

## Fix

Replace the raw `Handler.postDelayed` with `lifecycleScope.launch { delay(CONNECTION_DELAY); … }`. The activity-scoped coroutine is automatically cancelled when the `Lifecycle` reaches `DESTROYED`, so the captured `WebViewActivity` is released immediately on `onDestroy` instead of lingering in the main `MessageQueue`. Behaviour is otherwise unchanged: the timeout still runs on the main dispatcher and still calls `showError(ErrorType.TIMEOUT_EXTERNAL_BUS)` after the same 10 s delay when the connection has not been established.

The now-unused `android.os.Handler` and `android.os.Looper` imports are removed.

## Testing

- Verified that the only `Handler` / `Looper` references in `WebViewActivity` were the ones removed by this change (`HttpAuthHandler`, `SslErrorHandler`, `RenderProcessGoneDetail` `handler` parameters are unrelated identifiers).
- Manual reproduction (recreating the activity via a theme switch within the 10 s window) no longer reports the leak in LeakCanary.

## Notes for reviewers

This is a minimal, behaviour-preserving fix targeting only the leak in #5453. There are other `webView.post { … }` and `runOnUiThread { … }` call sites in this file, but those are dispatched immediately and don't sit in the queue across `onDestroy`, so they are out of scope here.
