### PR TITLE
fix(WebView): properly recover when the renderer process is gone (refs #5823)

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -581,12 +581,32 @@ class WebViewActivity :
                 }
 
                 override fun onRenderProcessGone(view: WebView?, handler: RenderProcessGoneDetail?): Boolean {
-                    Timber.e("onRenderProcessGone: webView crashed")
-                    view?.let {
-                        reload()
-                        lifecycleScope.launch {
-                            webViewAddJavascriptInterface()
+                    val didCrash = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        handler?.didCrash() == true
+                    } else {
+                        // On API < 26 didCrash() is unavailable; treat as a crash so we still recover.
+                        true
+                    }
+                    Timber.e(
+                        "onRenderProcessGone: WebView renderer is gone (didCrash=$didCrash). " +
+                            "This is commonly triggered by a GPU context loss or out-of-memory in the " +
+                            "renderer process (see #5823 — Mali GPU + EXT_robustness on Android 10), " +
+                            "which can leave dashboard cards rendering as blank/greyed-out surfaces. " +
+                            "Recreating the activity to recover with a fresh WebView.",
+                    )
+                    // Per the android.webkit.WebView contract, once the render process is gone the
+                    // WebView instance is unusable and must not be touched again — calling reload()
+                    // on the dead WebView is a no-op and leaves the user looking at greyed-out
+                    // cards forever. Detach and destroy the dead WebView so its native resources
+                    // are released, then recreate the activity to rebuild a fresh WebView and
+                    // reload the last URL through the normal onCreate path. Returning `true` tells
+                    // the system we have handled the crash so the hosting app process is not killed.
+                    if (!isFinishing && !isRelaunching) {
+                        view?.let { dead ->
+                            (dead.parent as? android.view.ViewGroup)?.removeView(dead)
+                            dead.destroy()
                         }
+                        recreate()
                     }
 
                     return true


### PR DESCRIPTION
## Recover the WebView when the renderer process is gone (refs #5823)

### Problem

Issue [#5823](https://github.com/home-assistant/android/issues/5823) reports that line-style dashboard cards (`graph card`, `apex-charts-card`, `mini-graph-card`) render as permanently greyed-out blank surfaces on a Samsung Note Pro 12.2 (Mali-T628 GPU) running LineageOS 17.1 / Android 10 with WebView Dev 142.0.7418.5. Cards become functional again only when the user enters dashboard edit mode (which forces a re-layout) and revert to greyed-out afterwards.

The chromium log excerpt the reporter attached shows the smoking gun:

```
SharedContextState context lost via EXT_robustness
RasterDecoderImpl: Context lost during MakeCurrent
GLES-MALI <pid> [tgid] : OoM error
```

i.e. the Mali GPU driver dropped the renderer's GL context (the `EXT_robustness` GPU robustness extension is the standard way Chromium learns its GL context died) and the renderer subsequently OOM'd. On API ≥ 26 Android then signals this to the embedder via `WebViewClient.onRenderProcessGone(view, detail)` with `detail.didCrash() == false` (renderer killed by the system, not crashed by the page).

### Why the current code does not recover

`WebViewActivity` already overrides `onRenderProcessGone`, but the body is:

```kotlin
Timber.e("onRenderProcessGone: webView crashed")
view?.let {
    reload()
    lifecycleScope.launch {
        webViewAddJavascriptInterface()
    }
}
return true
```

Per the `android.webkit.WebView` Javadoc, once the WebView's render process is gone the WebView instance is permanently unusable and any subsequent method call on it is a no-op:

> The given WebView can't be used after this method is called. Any further calls on the > WebView will result in undefined behavior.

So the existing `reload()` (which calls reload on the activity's same WebView field) silently does nothing, and the JS bridge re-registration also does nothing. The user is left looking at the greyed-out dashboard until they manually kill and relaunch the app — exactly the symptom #5823 describes.

### Fix

Implement the recovery pattern the framework documentation recommends:

1. Read `RenderProcessGoneDetail.didCrash()` (API ≥ 26) so the log line tells us whether the renderer crashed (e.g. JS heap OOM) or was killed by the system (e.g. GPU context loss + low memory) — useful triage information for future reports.
2. Detach the dead WebView from its parent and call `destroy()` on it so its native resources are released.
3. Call `Activity.recreate()` so `onCreate` runs again with a brand-new WebView, the presenter re-loads the last URL through the normal path, and the JS bridge is re-registered.
4. Skip steps 2-3 if the activity is already finishing or relaunching, to avoid racing with `relaunchApp()` / a back-press tear-down.
5. Continue to return `true` so the hosting app process is not killed by the system when the renderer dies.

### Scope

* Single file change: `app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt`.
* No new dependencies, no new strings, no preference / settings UI surface.
* Behaviour is unchanged on healthy devices  `onRenderProcessGone` simply does not fire there.
* On affected devices the user sees a brief activity recreation (~ the same as a screen rotation) instead of staying stuck on greyed-out cards.
