### PR TITLE
Use OIDC to authenticate on Emulator.wtf

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -322,10 +322,10 @@ jobs:
   instrumentation_test_app:
     name: "Instrumentation Test app"
     needs: [lint, lockfiles, ktlint]
-    environment: ui-test
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      id-token: write # Needed for OIDC authentication
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -352,10 +352,13 @@ jobs:
             echo 'DEVICES_EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - uses: emulator-wtf/configure-credentials@d0d840f8d9e2920e284788fcfa32f0a1eed95bf0 # v1.0.0
+        with:
+          oidc-configuration-id: 3196ed49-5442-4377-9e34-f4b2d7040b4e # This is retrieved from the emulator.wtf console
+
       - name: Run tests full
         uses: emulator-wtf/run-tests@01944281be70008e1b97d9f8458039c18cd3d779 # v0.9.11
         with:
-          api-token: ${{ secrets.EMULATOR_WTF_TOKEN }}
           devices: ${{ steps.devices.outputs.list }}
           app: app/build/outputs/apk/full/debug/app-full-debug.apk
           test: app/build/outputs/apk/androidTest/full/debug/app-full-debug-androidTest.apk
@@ -364,7 +367,6 @@ jobs:
       - name: Run tests minimal
         uses: emulator-wtf/run-tests@01944281be70008e1b97d9f8458039c18cd3d779 # v0.9.11
         with:
-          api-token: ${{ secrets.EMULATOR_WTF_TOKEN }}
           devices: ${{ steps.devices.outputs.list }}
           app: app/build/outputs/apk/minimal/debug/app-minimal-debug.apk
           test: app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -321,7 +321,7 @@ jobs:
 
   instrumentation_test_app:
     name: "Instrumentation Test app"
-    # needs: [lint, lockfiles, ktlint]
+    needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
     environment: ui-test
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -321,7 +321,7 @@ jobs:
 
   instrumentation_test_app:
     name: "Instrumentation Test app"
-    # needs: [lint, lockfiles, ktlint]
+    needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -323,8 +323,8 @@ jobs:
     name: "Instrumentation Test app"
     needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
+    environment: ui-test
     permissions:
-      pull-requests: write
       id-token: write # Needed for OIDC authentication
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -354,7 +354,7 @@ jobs:
 
       - uses: emulator-wtf/configure-credentials@d0d840f8d9e2920e284788fcfa32f0a1eed95bf0 # v1.0.0
         with:
-          oidc-configuration-id: 3196ed49-5442-4377-9e34-f4b2d7040b4e # This is retrieved from the emulator.wtf console
+          oidc-configuration-id: ${{ vars.EMULATOR_WTF_OIDC_CONFIGURATION_ID }} # This is retrieved from the emulator.wtf console
 
       - name: Run tests full
         uses: emulator-wtf/run-tests@01944281be70008e1b97d9f8458039c18cd3d779 # v0.9.11

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -321,7 +321,7 @@ jobs:
 
   instrumentation_test_app:
     name: "Instrumentation Test app"
-    needs: [lint, lockfiles, ktlint]
+    # needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
     environment: ui-test
     permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -321,7 +321,7 @@ jobs:
 
   instrumentation_test_app:
     name: "Instrumentation Test app"
-    needs: [lint, lockfiles, ktlint]
+    # needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We can't use secrets in forks, because of that we are not able to run instrumentation tests on Emulator.wtf. They offer a way to use Github to authenticate in their system, this way we only use a temporary token https://docs.emulator.wtf/oidc/github/.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.