### PR TITLE
Fix leak of  WebMessageListener by properly removing it in onDestroy

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -570,6 +571,11 @@ private fun WebViewEffects(
             frontendJsCallback.attachToWebView(webView)
             Timber.v("Load url ${sensitive(url)}")
             webView.loadUrl(url)
+        }
+        DisposableEffect(webView) {
+            onDispose {
+                frontendJsCallback.detachFromWebView(webView)
+            }
         }
         LaunchedEffect(webView) {
             webViewActions.collect { action ->

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridge.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridge.kt
@@ -145,9 +145,6 @@ class FrontendJsBridge @AssistedInject constructor(
 
     /**
      * Removes both V1 and V2 native bridges from [webView].
-     *
-     * Removes both V1 and V2 unconditionally regardless of which one was registered:
-     * the underlying calls are no-ops if nothing is registered.
      */
     @SuppressLint("RequiresFeature")
     override fun detachFromWebView(webView: WebView) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridge.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridge.kt
@@ -144,6 +144,21 @@ class FrontendJsBridge @AssistedInject constructor(
     }
 
     /**
+     * Removes both V1 and V2 native bridges from [webView].
+     *
+     * Removes both V1 and V2 unconditionally regardless of which one was registered:
+     * the underlying calls are no-ops if nothing is registered.
+     */
+    @SuppressLint("RequiresFeature")
+    override fun detachFromWebView(webView: WebView) {
+        val webMessageListenerSupported = WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+        webView.removeJavascriptInterface(EXTERNAL_APP_V1)
+        if (webMessageListenerSupported) {
+            WebViewCompat.removeWebMessageListener(webView, EXTERNAL_APP_V2_LISTENER)
+        }
+    }
+
+    /**
      * Dispatches a parsed [BridgeMessage] to the [handler].
      *
      * Validates auth callback names at this layer before forwarding to the handler.
@@ -341,6 +356,7 @@ class FrontendJsBridge @AssistedInject constructor(
         /** A no-op implementation for use in tests and previews. */
         val noOp = object : FrontendJsCallback {
             override suspend fun attachToWebView(webView: WebView) {}
+            override fun detachFromWebView(webView: WebView) {}
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsCallback.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsCallback.kt
@@ -20,4 +20,14 @@ interface FrontendJsCallback {
      * @param webView The WebView to register callbacks into
      */
     suspend fun attachToWebView(webView: WebView)
+
+    /**
+     * Unregisters the JavaScript callbacks from the given [webView].
+     *
+     * Must be called when the [webView] is no longer in use to release resources
+     * retained by the bridge.
+     *
+     * @param webView The WebView to unregister callbacks from
+     */
+    fun detachFromWebView(webView: WebView)
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -1755,7 +1755,14 @@ class WebViewActivity :
         }
     }
 
+    @SuppressLint("RequiresFeature")
     override fun onDestroy() {
+        val webMessageListenerSupported = WebViewFeature.isFeatureSupported(WebViewFeature.WEB_MESSAGE_LISTENER)
+        webView.removeJavascriptInterface(EXTERNAL_APP_V1)
+        if (webMessageListenerSupported) {
+            WebViewCompat.removeWebMessageListener(webView, EXTERNAL_APP_V2_LISTENER)
+        }
+
         presenter.onFinish()
         super.onDestroy()
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridgeTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/js/FrontendJsBridgeTest.kt
@@ -206,6 +206,36 @@ class FrontendJsBridgeTest {
     }
 
     @Nested
+    inner class DetachFromWebView {
+
+        @Test
+        fun `Given WebMessageListener supported then removes both V1 interface and V2 listener`() = runTest {
+            mockWebViewFeatureSupported(supported = true)
+            mockWebViewCompat()
+            val webView: WebView = mockk(relaxed = true)
+            val bridge = createBridge(scope = this)
+
+            bridge.detachFromWebView(webView)
+
+            verify { webView.removeJavascriptInterface(FrontendJsBridge.EXTERNAL_APP_V1) }
+            verify { WebViewCompat.removeWebMessageListener(webView, FrontendJsBridge.EXTERNAL_APP_V2_LISTENER) }
+        }
+
+        @Test
+        fun `Given WebMessageListener not supported then removes only V1 interface`() = runTest {
+            mockWebViewFeatureSupported(supported = false)
+            mockWebViewCompat()
+            val webView: WebView = mockk(relaxed = true)
+            val bridge = createBridge(scope = this)
+
+            bridge.detachFromWebView(webView)
+
+            verify { webView.removeJavascriptInterface(FrontendJsBridge.EXTERNAL_APP_V1) }
+            verify(exactly = 0) { WebViewCompat.removeWebMessageListener(any(), any()) }
+        }
+    }
+
+    @Nested
     inner class Dispatching {
 
         @ParameterizedTest


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
```
                                                                                                      HEAP ANALYSIS RESULT                                                                                                                                                                                                
                                                                                                      ====================================                                                                                                                                                                                
                                                                                                      1 APPLICATION LEAKS                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
                                                                                                      References underlined with "~~~" are likely causes.                                                                                                                                                                 
                                                                                                      Learn more at https://squ.re/leaks.                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                          
                                                                                                      450489 bytes retained by leaking objects                                                                                                                                                                            
                                                                                                      Signature: 20d99f9429ce7825a15ec15b2fad9f71c54bb677                                                                                                                                                                 
                                                                                                      ┬───                                                                                                                                                                                                                
                                                                                                      │ GC Root: Global variable in native code                                                                                                                                                                           
                                                                                                      │                                                                                                                                                                                                                   
                                                                                                      ├─ org.chromium.android_webview.WebMessageListenerHolder instance                                                                                                                                                   
                                                                                                      │    Leaking: UNKNOWN                                                                                                                                                                                               
                                                                                                      │    Retaining 454.7 kB in 9893 objects                                                                                                                                                                             
                                                                                                      │    ↓ WebMessageListenerHolder.a                                                                                                                                                                                   
                                                                                                      │                               ~                                                                                                                                                                                   
                                                                                                      ├─ WV.yn2 instance                                                                                                                                                                                                  
                                                                                                      │    Leaking: UNKNOWN                                                                                                                                                                                               
  ──── (44 lines hidden) ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
                        Thread count: 80                                                                                                                                                                                                                                                                                  
                                                                                                      Heap total bytes: 34878252                                                                                                                                                                                          
                                                                                                      Bitmap count: 3                                                                                                                                                                                                     
                                                                                                      Bitmap total bytes: 22300                                                                                                                                                                                           
                                                                                                      Large bitmap count: 0                                                                                                                                                                                               
                                                                                                      Large bitmap total bytes: 0                                                                                                                                                                                         
                                                                                                      Db 1: open /data/user/0/io.homeassistant.companion.android.debug/no_backup/androidx.work.workdb                                                                                                                     
                                                                                                      Db 2: open /data/user/0/io.homeassistant.companion.android.debug/databases/HomeAssistantDB                                                                                                                          
                                                                                                      Count of retained yet cleared: 8 KeyedWeakReference instances                                                                                                                                                       
                                                                                                      Stats: LruCache[maxSize=3000,hits=138079,misses=267768,hitRate=34%]                                                                                                                                                 
                                                                                                      RandomAccess[bytes=13169600,reads=267768,travel=114893205909,range=40894780,size=52199287]                                                                                                                          
                                                                                                      Heap dump reason: 6 retained objects, app is not visible                                                                                                                                                            
                                                                                                      Analysis duration: 3973 ms                                                                                                                                                                                          
                                                                                                      Heap dump file path: /storage/emulated/0/Download/leakcanary-io.homeassistant.companion.android.                                                                                                                    
                                                                                                      debug/2026-05-04_11-53-40_946.hprof                                                                                                                                                                                 
                                                                                                      Heap dump timestamp: 1777888445865                                                                                                                                                                                  
                                                                                                      Heap dump duration: 20095 ms when I open the settings page from the FrontendScreen
```

The `addWebMessageListener` is keeping a strong reference to the WebView and needs to be removed when the Activity is destroyed. I've made the modification in the `WebViewActivity` and `FrontendScreen`. It is easier to reproduce if you turn on the settings to not keep the activity and open the settings (wait a bit for LeakCanary to analyze).


## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.