### PR TITLE
Move the debug flag for WebView into the Application and Settings

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -100,12 +100,12 @@ open class HomeAssistantApplication :
         registerActivityLifecycleCallbacks(LifecycleHandler)
 
         ioScope.launch {
-            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled())
             initCrashReporting(
                 applicationContext,
                 prefsRepository.isCrashReporting(),
             )
             initCrashSaving(applicationContext)
+            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled())
             languagesManager.applyCurrentLang()
             nightModeManager.applyCurrentNightMode()
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -11,6 +11,7 @@ import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.PowerManager
 import android.telephony.TelephonyManager
+import android.webkit.WebView
 import androidx.core.content.ContextCompat
 import coil3.ImageLoader
 import coil3.PlatformContext
@@ -99,6 +100,7 @@ open class HomeAssistantApplication :
         registerActivityLifecycleCallbacks(LifecycleHandler)
 
         ioScope.launch {
+            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled())
             initCrashReporting(
                 applicationContext,
                 prefsRepository.isCrashReporting(),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -2,10 +2,12 @@ package io.homeassistant.companion.android.settings.developer
 
 import android.content.Context
 import android.webkit.WebStorage
+import android.webkit.WebView
 import androidx.activity.result.ActivityResult
 import androidx.preference.PreferenceDataStore
 import androidx.webkit.WebStorageCompat
 import androidx.webkit.WebViewFeature
+import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
@@ -51,7 +53,10 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
     override fun putBoolean(key: String?, value: Boolean) {
         mainScope.launch {
             when (key) {
-                "webview_debug" -> prefsRepository.setWebViewDebugEnabled(value)
+                "webview_debug" -> {
+                    prefsRepository.setWebViewDebugEnabled(value)
+                    WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || value)
+                }
                 else -> throw IllegalArgumentException("No boolean found by this key: $key")
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -85,7 +85,6 @@ import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
-import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.assist.AssistActivity
 import io.homeassistant.companion.android.authenticator.Authenticator
@@ -1354,8 +1353,6 @@ class WebViewActivity :
         lifecycleScope.launch {
             SensorWorker.start(this@WebViewActivity)
             WebsocketManager.start(this@WebViewActivity)
-
-            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || presenter.isWebViewDebugEnabled())
 
             requestedOrientation = when (presenter.getScreenOrientation()) {
                 getString(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenter.kt
@@ -41,8 +41,6 @@ interface WebViewPresenter {
 
     suspend fun getPageZoomLevel(): Int
     suspend fun isPinchToZoomEnabled(): Boolean
-    suspend fun isWebViewDebugEnabled(): Boolean
-
     suspend fun isAppLocked(): Boolean
     suspend fun setAppActive(active: Boolean)
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewPresenterImpl.kt
@@ -396,10 +396,6 @@ class WebViewPresenterImpl @Inject constructor(
         return prefsRepository.isPinchToZoomEnabled()
     }
 
-    override suspend fun isWebViewDebugEnabled(): Boolean {
-        return prefsRepository.isWebViewDebugEnabled()
-    }
-
     override suspend fun isAppLocked(): Boolean = if (serverManager.isRegistered()) {
         try {
             serverManager.integrationRepository(serverId).isAppLocked()


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Move the set of the debug capability of the WebView at the Application level and also in the settings level. The idea is to enable/disable it globally so that it apply right away when changing and also when the app starts.

There is a risk where maybe the debug flag is set after the webview load since it uses the ioScope in the Application but I'm not sure.