### PR TITLE
Deprecated the old Material Design 2 theme to avoid using it

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/Theme.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/Theme.kt
@@ -50,6 +50,13 @@ private val haDarkColors = darkColors(
  * A Compose [MaterialTheme] version of the app's XML theme. This achieves the same goal as the
  * (now deprecated) [com.google.accompanist.themeadapter.material.MdcTheme].
  */
+@Deprecated(
+    "Uses Material Design 2. Use HATheme (Material Design 3) instead. Kept until remaining call sites are migrated.",
+    replaceWith = ReplaceWith(
+        "HATheme { content() }",
+        "io.homeassistant.companion.android.common.compose.theme.HATheme",
+    ),
+)
 @Composable
 fun HomeAssistantAppTheme(content: @Composable () -> Unit) {
     MaterialTheme(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/Theme.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/Theme.kt
@@ -52,10 +52,6 @@ private val haDarkColors = darkColors(
  */
 @Deprecated(
     "Uses Material Design 2. Use HATheme (Material Design 3) instead. Kept until remaining call sites are migrated.",
-    replaceWith = ReplaceWith(
-        "HATheme { content() }",
-        "io.homeassistant.companion.android.common.compose.theme.HATheme",
-    ),
 )
 @Composable
 fun HomeAssistantAppTheme(content: @Composable () -> Unit) {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We are in the middle of migrating to Material Design 3, we kept the `HomeAssistantAppTheme` for backward compatibility for screen that are not yet merged. This PR simply deprecates it so new contributors knows that we are migrating.