### PR TITLE
Verify device's preferred Thread dataset after import

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -78,7 +78,7 @@ class ThreadManagerImpl @Inject constructor(
         return if (getDeviceDataset == null) {
             ThreadManager.SyncResult.NoneHaveCredentials
         } else {
-            val appIsDevicePreferred = appAddedIsPreferredCredentials(context)
+            val appIsDevicePreferred = appAddedPreferredCredential(context) != null
             Timber.d("Thread: device ${if (appIsDevicePreferred) "prefers" else "doesn't prefer" } dataset from app")
 
             return if (appIsDevicePreferred) {
@@ -128,7 +128,8 @@ class ThreadManagerImpl @Inject constructor(
                 Timber.d(
                     "Thread: device ${if (coreIsDevicePreferred) "prefers" else "doesn't prefer" } core preferred dataset",
                 )
-                val appIsDevicePreferred = coreIsDevicePreferred || appAddedIsPreferredCredentials(context)
+                val appPreferredCredential = if (coreIsDevicePreferred) null else appAddedPreferredCredential(context)
+                val appIsDevicePreferred = coreIsDevicePreferred || appPreferredCredential != null
                 Timber.d(
                     "Thread: device ${if (appIsDevicePreferred) "prefers" else "doesn't prefer" } dataset from app",
                 )
@@ -136,6 +137,7 @@ class ThreadManagerImpl @Inject constructor(
                 var exportFromDevice = false
                 var updated: Boolean? = null
                 var deviceNowPrefersCore: Boolean? = null
+                var devicePreferredNetworkName: String? = null
                 if (!coreIsDevicePreferred) {
                     if (appIsDevicePreferred) {
                         // Update or remove the device preferred credential to match core state.
@@ -188,6 +190,9 @@ class ThreadManagerImpl @Inject constructor(
                                         }
                                     } core preferred dataset",
                                 )
+                                if (deviceNowPrefersCore == false) {
+                                    devicePreferredNetworkName = appAddedPreferredCredential(context)?.networkName
+                                }
                                 true
                             } else { // Core prefers imported from other app, this shouldn't be managed by HA
                                 localIds.forEach { baId ->
@@ -217,6 +222,7 @@ class ThreadManagerImpl @Inject constructor(
                     fromApp = appIsDevicePreferred,
                     updated = updated,
                     deviceNowPrefersCore = deviceNowPrefersCore,
+                    devicePreferredNetworkName = devicePreferredNetworkName,
                     exportIntent = if (exportFromDevice) deviceThreadIntent else null,
                 )
             } catch (e: Exception) {
@@ -226,6 +232,7 @@ class ThreadManagerImpl @Inject constructor(
                     fromApp = null,
                     updated = null,
                     deviceNowPrefersCore = null,
+                    devicePreferredNetworkName = null,
                     exportIntent = null,
                 )
             }
@@ -284,7 +291,7 @@ class ThreadManagerImpl @Inject constructor(
     }
 
     @OptIn(ExperimentalStdlibApi::class)
-    private suspend fun appAddedIsPreferredCredentials(context: Context): Boolean {
+    private suspend fun appAddedPreferredCredential(context: Context): ThreadNetworkCredentials? {
         val appCredentials = suspendCoroutine { cont ->
             ThreadNetwork.getNetworkClient(context)
                 .allCredentials
@@ -292,21 +299,17 @@ class ThreadManagerImpl @Inject constructor(
                 .addOnFailureListener { cont.resume(null) }
         }
         return try {
-            appCredentials?.any {
-                val isPreferred = isPreferredCredentials(context, it)
-                if (isPreferred) {
-                    Timber.d(
-                        "Thread device prefers app added dataset: %s (PAN %s, EXTPAN %s)",
-                        it.networkName,
-                        it.panId,
-                        it.extendedPanId.toHexString(HexFormat.UpperCase),
-                    )
-                }
-                isPreferred
-            } ?: false
+            appCredentials?.firstOrNull { isPreferredCredentials(context, it) }?.also {
+                Timber.d(
+                    "Thread device prefers app added dataset: %s (PAN %s, EXTPAN %s)",
+                    it.networkName,
+                    it.panId,
+                    it.extendedPanId.toHexString(HexFormat.UpperCase),
+                )
+            }
         } catch (e: Exception) {
             Timber.e(e, "Thread app added credentials preferred check failed")
-            false
+            null
         }
     }
 

--- a/app/src/full/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImpl.kt
@@ -135,6 +135,7 @@ class ThreadManagerImpl @Inject constructor(
 
                 var exportFromDevice = false
                 var updated: Boolean? = null
+                var deviceNowPrefersCore: Boolean? = null
                 if (!coreIsDevicePreferred) {
                     if (appIsDevicePreferred) {
                         // Update or remove the device preferred credential to match core state.
@@ -169,6 +170,24 @@ class ThreadManagerImpl @Inject constructor(
                                     )
                                 }
                                 Timber.d("Thread update device completed: deleted ${localIds.size} datasets, updated 1")
+                                // ThreadNetworkClient.addCredentials does not promote the new
+                                // credential to preferred. Verify what Play Services chose so the
+                                // caller can report honestly instead of assuming success.
+                                deviceNowPrefersCore = try {
+                                    isPreferredDatasetByDevice(context, coreThreadDataset.datasetId, serverId)
+                                } catch (e: Exception) {
+                                    Timber.w(e, "Unable to verify preferred dataset after import")
+                                    null
+                                }
+                                Timber.d(
+                                    "Thread: after import device ${
+                                        when (deviceNowPrefersCore) {
+                                            true -> "now prefers"
+                                            false -> "still doesn't prefer"
+                                            null -> "preference state unknown for"
+                                        }
+                                    } core preferred dataset",
+                                )
                                 true
                             } else { // Core prefers imported from other app, this shouldn't be managed by HA
                                 localIds.forEach { baId ->
@@ -197,6 +216,7 @@ class ThreadManagerImpl @Inject constructor(
                     matches = coreIsDevicePreferred,
                     fromApp = appIsDevicePreferred,
                     updated = updated,
+                    deviceNowPrefersCore = deviceNowPrefersCore,
                     exportIntent = if (exportFromDevice) deviceThreadIntent else null,
                 )
             } catch (e: Exception) {
@@ -205,6 +225,7 @@ class ThreadManagerImpl @Inject constructor(
                     matches = null,
                     fromApp = null,
                     updated = null,
+                    deviceNowPrefersCore = null,
                     exportIntent = null,
                 )
             }
@@ -262,6 +283,7 @@ class ThreadManagerImpl @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalStdlibApi::class)
     private suspend fun appAddedIsPreferredCredentials(context: Context): Boolean {
         val appCredentials = suspendCoroutine { cont ->
             ThreadNetwork.getNetworkClient(context)
@@ -274,9 +296,10 @@ class ThreadManagerImpl @Inject constructor(
                 val isPreferred = isPreferredCredentials(context, it)
                 if (isPreferred) {
                     Timber.d(
-                        "Thread device prefers app added dataset: ${it.networkName} (PAN ${it.panId}, EXTPAN ${String(
-                            it.extendedPanId,
-                        )})",
+                        "Thread device prefers app added dataset: %s (PAN %s, EXTPAN %s)",
+                        it.networkName,
+                        it.panId,
+                        it.extendedPanId.toHexString(HexFormat.UpperCase),
                     )
                 }
                 isPreferred

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -101,7 +101,16 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
                             view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_match), true)
                         } else if (syncResult.fromApp == true && syncResult.updated == true) {
                             val message = if (syncResult.deviceNowPrefersCore == false) {
-                                context.getString(commonR.string.thread_debug_result_updated_not_preferred)
+                                val base = context.getString(commonR.string.thread_debug_result_updated_not_preferred)
+                                val name = syncResult.devicePreferredNetworkName
+                                if (name != null) {
+                                    "$base ${context.getString(
+                                        commonR.string.thread_debug_result_mismatch_detail,
+                                        name,
+                                    )}"
+                                } else {
+                                    base
+                                }
                             } else {
                                 context.getString(commonR.string.thread_debug_result_updated)
                             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/developer/DeveloperSettingsPresenterImpl.kt
@@ -100,10 +100,12 @@ class DeveloperSettingsPresenterImpl @Inject constructor(
                         } else if (syncResult.matches == true) {
                             view.onThreadDebugResult(context.getString(commonR.string.thread_debug_result_match), true)
                         } else if (syncResult.fromApp == true && syncResult.updated == true) {
-                            view.onThreadDebugResult(
-                                context.getString(commonR.string.thread_debug_result_updated),
-                                true,
-                            )
+                            val message = if (syncResult.deviceNowPrefersCore == false) {
+                                context.getString(commonR.string.thread_debug_result_updated_not_preferred)
+                            } else {
+                                context.getString(commonR.string.thread_debug_result_updated)
+                            }
+                            view.onThreadDebugResult(message, syncResult.deviceNowPrefersCore != false)
                         } else if (syncResult.fromApp == true && syncResult.updated == false) {
                             view.onThreadDebugResult(
                                 context.getString(commonR.string.thread_debug_result_removed),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -19,6 +19,7 @@ interface ThreadManager {
             val fromApp: Boolean?,
             val updated: Boolean?,
             val deviceNowPrefersCore: Boolean?,
+            val devicePreferredNetworkName: String?,
             val exportIntent: IntentSender?,
         ) : SyncResult()
         object NoneHaveCredentials : SyncResult()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/thread/ThreadManager.kt
@@ -18,6 +18,7 @@ interface ThreadManager {
             val matches: Boolean?,
             val fromApp: Boolean?,
             val updated: Boolean?,
+            val deviceNowPrefersCore: Boolean?,
             val exportIntent: IntentSender?,
         ) : SyncResult()
         object NoneHaveCredentials : SyncResult()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1178,6 +1178,7 @@
     <string name="thread_debug_result_removed">Removed old network from Home Assistant on this device</string>
     <string name="thread_debug_result_unsupported_server">The Home Assistant server does not support Thread</string>
     <string name="thread_debug_result_updated">Updated network from Home Assistant on this device</string>
+    <string name="thread_debug_result_updated_not_preferred">Updated network from Home Assistant on this device, but the device still prefers a different network</string>
     <string name="thread_debug_summary">Manually update device and server Thread credentials and verify results</string>
     <string name="thread_export_success">Imported credential</string>
     <string name="thread_export_none">You don\'t have any credentials to import.</string>


### PR DESCRIPTION
## Summary

After a Thread sync with `coreIsDevicePreferred == false && appIsDevicePreferred == true` (i.e. the device prefers an app-added credential that doesn't match HA's preferred dataset), `fullSyncPreferredDataset` deletes mismatched border-agent IDs and re-imports HA's preferred TLV via `ThreadNetworkClient.addCredentials`. The path then unconditionally returned `updated = true` and the developer settings screen reported "Updated network from Home Assistant on this device".

`ThreadNetworkClient.addCredentials` only stores a credential under the supplied border agent — the Google Play Services Thread API does not expose any way to set the preferred dataset, and Play Services often keeps preferring the older app-added credential. As a result the device's preferred dataset was unchanged, the next sync re-detected the same mismatch, ran the same delete-and-import again, and reported success again. The user-visible outcome was an apparently successful sync that looped indefinitely without actually changing what Play Services preferred.

This PR makes the report honest:

- After `importDatasetFromServer` succeeds, `isPreferredCredentials` is queried for the just-imported TLV.
- The result is exposed via a new `deviceNowPrefersCore: Boolean?` field on `SyncResult.AllHaveCredentials`.
- The developer settings screen shows a dedicated message (`thread_debug_result_updated_not_preferred`) when the device still prefers a different network, with a non-success indicator, so the user knows that another sync won't resolve the state.

It also fixes a cosmetic log issue surfaced while debugging this: the "device prefers app added dataset" line was printing the extended PAN ID via `String(ByteArray)`, which produces control characters. It now formats the EXTPAN as upper-case hex.

This is a companion to #6818, which addresses the symmetric problem on the server side (`thread/add_dataset_tlv` does not promote a dataset to preferred either). Both stem from the same underlying issue: neither the server-side WS command (since [home-assistant/core#108278](https://github.com/home-assistant/core/pull/108278)) nor the Play Services `addCredentials` call promote the just-added dataset, so the app must verify and report rather than assume.

A deeper follow-up is still needed on the device side: `getThreadBorderAgentIds()` is replaced (not appended) on every successful import, so border-agent IDs HA used in earlier sessions are no longer tracked and the cleanup loop won't remove them. Iterating `ThreadNetworkClient.allCredentials` and removing every owned credential whose BA doesn't match the current core preferred would address that, but it's a more invasive change and is intentionally not part of this PR.

## Checklist

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots

## Link to pull request in documentation repositories

## Any other notes

`ThreadManager.SyncResult.AllHaveCredentials` gains a new `deviceNowPrefersCore` constructor parameter. All in-tree callers are updated; the change is contained in the app module.