### PR TITLE
Introduce RequestAccurateLocationReceiver and restrict LocationSensorManager export

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -183,6 +183,17 @@ class LocationSensorManager :
             SINGLE_ACCURATE_LOCATION,
         }
 
+        /**
+         * Builds an explicit-component [Intent] addressed to this receiver that triggers a single
+         * accurate location update via [ACTION_REQUEST_ACCURATE_LOCATION_UPDATE].
+         */
+        fun createRequestAccurateLocationUpdateIntent(context: Context): Intent = Intent(
+            context,
+            LocationSensorManager::class.java,
+        ).apply {
+            action = ACTION_REQUEST_ACCURATE_LOCATION_UPDATE
+        }
+
         suspend fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {
             DatabaseEntryPoint.resolve(context).sensorDao().add(
                 SensorSetting(
@@ -1379,11 +1390,7 @@ class LocationSensorManager :
             sensorSetting.firstOrNull { it.name == SETTING_INCLUDE_SENSOR_UPDATE }?.value ?: "false"
         if (includeSensorUpdate == "true") {
             if (isEnabled(context, singleAccurateLocation)) {
-                context.sendBroadcast(
-                    Intent(context, this.javaClass).apply {
-                        action = ACTION_REQUEST_ACCURATE_LOCATION_UPDATE
-                    },
-                )
+                context.sendBroadcast(createRequestAccurateLocationUpdateIntent(context))
             }
         } else {
             sensorDao.add(

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -333,12 +333,18 @@
         <receiver
             android:name=".sensors.LocationSensorManager"
             android:enabled="true"
+            android:exported="false" />
+
+        <!--Exported proxy for the public REQUEST_ACCURATE_UPDATE action, used by external
+        automation tools such as Tasker (see https://github.com/home-assistant/android/pull/5509).
+        LocationSensorManager itself stays unexported. Exposing this receiver is safe: no data
+        leaves Home Assistant, and the action only triggers a sensor update with no other side
+        effects.-->
+        <receiver
+            android:name=".sensors.RequestAccurateLocationReceiver"
+            android:enabled="true"
             android:exported="true"
             tools:ignore="ExportedReceiver">
-            <!--As discussed in https://github.com/home-assistant/android/pull/5509 we are ok
-            about exposing this receiver since the data are not leaking outside of Home Assistant.
-            And Action would just force the update of the sensor nothing else.
-            -->
             <intent-filter>
                 <action android:name="io.homeassistant.companion.android.background.REQUEST_ACCURATE_UPDATE" />
             </intent-filter>

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -628,10 +628,7 @@ class MessagingManager @Inject constructor(
     }
 
     private fun requestAccurateLocationUpdate() {
-        val intent = Intent(context, LocationSensorManager::class.java)
-        intent.action = LocationSensorManager.ACTION_REQUEST_ACCURATE_LOCATION_UPDATE
-
-        context.sendBroadcast(intent)
+        context.sendBroadcast(LocationSensorManager.createRequestAccurateLocationUpdateIntent(context))
     }
 
     private fun removeNotificationChannel(channelName: String) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/RequestAccurateLocationReceiver.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/RequestAccurateLocationReceiver.kt
@@ -1,0 +1,26 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import timber.log.Timber
+
+/**
+ * Exported entry point for the public
+ * `io.homeassistant.companion.android.background.REQUEST_ACCURATE_UPDATE` action used by external
+ * automation tools (e.g. Tasker) to ask the app for a fresh accurate location reading.
+ *
+ * Acts as a thin, proxy in front of [LocationSensorManager], which itself stays
+ * unexported. We forward only the accurate-update action via an explicit-component broadcast and
+ * deliberately drop any extras supplied by the caller.
+ */
+class RequestAccurateLocationReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != LocationSensorManager.ACTION_REQUEST_ACCURATE_LOCATION_UPDATE) {
+            Timber.w("Ignoring unexpected action on RequestAccurateLocationReceiver: ${intent.action}")
+            return
+        }
+        context.sendBroadcast(LocationSensorManager.createRequestAccurateLocationUpdateIntent(context))
+    }
+}

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/sensors/LocationSensorManager.kt
@@ -51,6 +51,18 @@ class LocationSensorManager :
 
         fun setHighAccuracyModeSetting(context: Context, enabled: Boolean) {}
         fun setHighAccuracyModeIntervalSetting(context: Context, updateInterval: Int) {}
+
+        /**
+         * Builds an explicit-component [Intent] addressed to this receiver that triggers a single
+         * accurate location update via [ACTION_REQUEST_ACCURATE_LOCATION_UPDATE]. No-op in the
+         * minimal flavor since [LocationSensorManager.onReceive] does nothing.
+         */
+        fun createRequestAccurateLocationUpdateIntent(context: Context): Intent = Intent(
+            context,
+            LocationSensorManager::class.java,
+        ).apply {
+            action = ACTION_REQUEST_ACCURATE_LOCATION_UPDATE
+        }
     }
 
     override fun onReceive(context: Context, intent: Intent) {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/RequestAccurateLocationReceiverTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/RequestAccurateLocationReceiverTest.kt
@@ -1,0 +1,68 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.testing.unit.ConsoleLogRule
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class RequestAccurateLocationReceiverTest {
+
+    @get:Rule
+    val consoleLogRule = ConsoleLogRule()
+
+    @Test
+    fun `Given accurate update action when receiving then forward explicit broadcast to LocationSensorManager without extra`() {
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "io.homeassistant.companion.android"
+        val forwarded = slot<Intent>()
+        every { context.sendBroadcast(capture(forwarded)) } returns Unit
+
+        val incoming = Intent(LocationSensorManager.ACTION_REQUEST_ACCURATE_LOCATION_UPDATE).apply {
+            putExtra("extra-extra", "payload")
+        }
+        RequestAccurateLocationReceiver().onReceive(context, incoming)
+
+        verify(exactly = 1) { context.sendBroadcast(any()) }
+        assertEquals(
+            LocationSensorManager.ACTION_REQUEST_ACCURATE_LOCATION_UPDATE,
+            forwarded.captured.action,
+        )
+        assertEquals(
+            ComponentName(context, LocationSensorManager::class.java),
+            forwarded.captured.component,
+        )
+        assertEquals(null, forwarded.captured.extras)
+    }
+
+    @Test
+    fun `Given unexpected action when receiving then do not forward anything`() {
+        val context = mockk<Context>(relaxed = true)
+
+        val incoming = Intent("io.homeassistant.companion.android.background.PROCESS_UPDATES")
+        RequestAccurateLocationReceiver().onReceive(context, incoming)
+
+        verify(exactly = 0) { context.sendBroadcast(any()) }
+    }
+
+    @Test
+    fun `Given null action when receiving then do not forward anything`() {
+        val context = mockk<Context>(relaxed = true)
+
+        RequestAccurateLocationReceiver().onReceive(context, Intent())
+
+        verify(exactly = 0) { context.sendBroadcast(any()) }
+    }
+}

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -245,12 +245,18 @@
         <receiver
             android:name=".sensors.LocationSensorManager"
             android:enabled="true"
+            android:exported="false" />
+
+        <!--Exported proxy for the public REQUEST_ACCURATE_UPDATE action, used by external
+        automation tools such as Tasker (see https://github.com/home-assistant/android/pull/5509).
+        LocationSensorManager itself stays unexported. Exposing this receiver is safe: no data
+        leaves Home Assistant, and the action only triggers a sensor update with no other side
+        effects.-->
+        <receiver
+            android:name=".sensors.RequestAccurateLocationReceiver"
+            android:enabled="true"
             android:exported="true"
             tools:ignore="ExportedReceiver">
-            <!--As discussed in https://github.com/home-assistant/android/pull/5509 we are ok
-            about exposing this receiver since the data are not leaking outside of Home Assistant.
-            And Action would just force the update of the sensor nothing else.
-            -->
             <intent-filter>
                 <action android:name="io.homeassistant.companion.android.background.REQUEST_ACCURATE_UPDATE" />
             </intent-filter>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR is the follow up of #5509 to actually stop exporting the `LocationSensorManager` since it is not needed. It introduce another receiver that is exported but limited to only receiving the `ACTION_REQUEST_ACCURATE_LOCATION_UPDATE` action nothing else.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.