### PR TITLE
Fix crash on start in release due to WebView remote debug pref

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import timber.log.Timber
 
@@ -105,7 +106,13 @@ open class HomeAssistantApplication :
                 prefsRepository.isCrashReporting(),
             )
             initCrashSaving(applicationContext)
-            WebView.setWebContentsDebuggingEnabled(BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled())
+
+            val webViewDebug = BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled()
+            withContext(Dispatchers.Main) {
+                // Release builds require calling this on the main thread
+                WebView.setWebContentsDebuggingEnabled(webViewDebug)
+            }
+
             languagesManager.applyCurrentLang()
             nightModeManager.applyCurrentNightMode()
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes a crash on start in release builds on start after merging #6813 due to calling `WebView.setWebContentsDebuggingEnabled` not on the main thread, by moving this call to the main thread.

This doesn't seem to be an issue in debug builds, and also isn't a timing issue (removing `BuildConfig.DEBUG` from the condition or introducing artificial delays doesn't introduce the crash in debug).

The preference change in settings is already done on the main thread.

```
FATAL EXCEPTION: DefaultDispatcher-worker-3
Process: io.homeassistant.companion.android, PID: 5477
java.lang.RuntimeException: Toggling of Web Contents Debugging must be done on the UI thread
 at WV.y3.o(chromium-SystemWebViewGoogle6432.aab-stable-772713703:3)
 at WV.vf2.g(chromium-SystemWebViewGoogle6432.aab-stable-772713703:115)
 at com.android.webview.chromium.WebViewChromiumFactoryProvider$StaticsAdapter.setWebContentsDebuggingEnabled(chromium-SystemWebViewGoogle6432.aab-stable-772713703:33)
 at android.webkit.WebView.setWebContentsDebuggingEnabled(WebView.java:2032)
 at io.homeassistant.companion.android.HomeAssistantApplication$onCreate$1$1.invokeSuspend(HomeAssistantApplication.kt:115)
 at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
 at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
 at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:807)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
 at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
 Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [StandaloneCoroutine{Cancelling}@6f4696, Dispatchers.IO]
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->