### PR TITLE
Make a dedicated webkit renovate group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -100,7 +100,14 @@
                 '!androidx.compose{/,}**',
                 '!androidx.navigation:navigation-compose{/,}**',
                 '!androidx.wear.compose{/,}**',
+                '!androidx.webkit{/,}**',
                 'androidx.{/,}**',
+            ],
+        },
+        {
+            groupName: 'androidx.webkit:*',
+            matchPackageNames: [
+                'androidx.webkit:{/,}**',
             ],
         },
         {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Webkit got a minSDK bump and prevent us from merging it into the app because it would mean increase our min SDK too. For reference check https://github.com/home-assistant/android/pull/6824

This PR extract the webkit deps into its own renovate group to not prevent androidx updates for other libraries like media.