### PR TITLE
Use workflow_run to trigger emulator.wtf tests

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -5,6 +5,10 @@ on: # yamllint disable-line rule:truthy
     workflows: ['Pull Request']
     types: [completed]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -13,13 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     environment: ui-test
     if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion != 'cancelled' &&
-      github.event.workflow_run.conclusion != 'skipped'
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion != 'cancelled'
+      && github.event.workflow_run.conclusion != 'skipped'
     permissions:
       id-token: write  # Needed for OIDC authentication
       actions: read  # Needed for retrieving artifacts
     steps:
+      # Halt before spending any emulator.wtf credits if the triggering Pull Request
+      # workflow did not succeed (publish_test_results still runs afterward to
+      # aggregate whatever results pr.yml produced).
+      - name: Halt if triggering workflow did not succeed
+        if: github.event.workflow_run.conclusion != 'success'
+        env:
+          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        run: |
+          echo "::error::Triggering 'Pull Request' workflow concluded as '$CONCLUSION'; skipping emulator.wtf to save resources"
+          exit 1
+
       - name: Download emulator.wtf inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -54,7 +54,7 @@ jobs:
             exit 1
           fi
           while IFS= read -r line; do
-            if [[ ! "$line" =~ ^model=Pixel7,version=[0-9]+$ ]]; then
+            if [[ ! "$line" =~ ^model=Pixel7,version=(2[3-9]|3[0-9]|40)$ ]]; then
               echo "::error::Invalid line in devices.txt"
               exit 1
             fi

--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -1,0 +1,122 @@
+name: PR Emulator.wtf
+
+on: # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows: ['Pull Request']
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  emulator_wtf:
+    name: "Instrumentation Test app"
+    runs-on: ubuntu-latest
+    environment: ui-test
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled' &&
+      github.event.workflow_run.conclusion != 'skipped'
+    permissions:
+      id-token: write  # Needed for OIDC authentication
+      actions: read  # Needed for retrieving artifacts
+    steps:
+      - name: Download emulator.wtf inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: emulator-wtf-inputs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: emulator-wtf-inputs
+
+      - name: Load device list
+        id: devices
+        # The artifact comes from a PR build that may originate from a fork; validate
+        # every line strictly before piping the contents into GITHUB_OUTPUT to prevent
+        # heredoc-terminator injection.
+        run: |
+          if [ ! -s emulator-wtf-inputs/devices.txt ]; then
+            echo "::error::devices.txt is empty or missing"
+            exit 1
+          fi
+          while IFS= read -r line; do
+            if [[ ! "$line" =~ ^model=Pixel7,version=[0-9]+$ ]]; then
+              echo "::error::Invalid line in devices.txt"
+              exit 1
+            fi
+          done < emulator-wtf-inputs/devices.txt
+          {
+            echo 'list<<DEVICES_EOF'
+            cat emulator-wtf-inputs/devices.txt
+            echo 'DEVICES_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: emulator-wtf/actions/configure-credentials@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
+        with:
+          oidc-configuration-id: ${{ vars.EMULATOR_WTF_OIDC_CONFIGURATION_ID }}
+
+      - name: Run tests full
+        uses: emulator-wtf/actions/run-tests@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
+        with:
+          devices: ${{ steps.devices.outputs.list }}
+          app: emulator-wtf-inputs/app/build/outputs/apk/full/debug/app-full-debug.apk
+          test: emulator-wtf-inputs/app/build/outputs/apk/androidTest/full/debug/app-full-debug-androidTest.apk
+          outputs-dir: build/test-results/full
+
+      - name: Run tests minimal
+        uses: emulator-wtf/actions/run-tests@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
+        with:
+          devices: ${{ steps.devices.outputs.list }}
+          app: emulator-wtf-inputs/app/build/outputs/apk/minimal/debug/app-minimal-debug.apk
+          test: emulator-wtf-inputs/app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk
+          outputs-dir: build/test-results/minimal
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Instrumentation Test app results
+          path: |
+            **/build/test-results/**/TEST-*.xml
+            **/build/test-results/**/results.xml
+
+      - name: Upload test reports
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: Instrumentation Test app reports
+          path: build/test-results/**
+
+  publish_test_results:
+    name: "Publish Tests Results"
+    needs: [emulator_wtf]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+      contents: read
+    steps:
+      - name: Download artifacts from pr.yml run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: pr-artifacts
+
+      - name: Download emulator.wtf results from this run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Instrumentation Test app results
+          path: pr-artifacts/Instrumentation Test app results
+
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_name: ${{ github.event.workflow_run.event }}
+          comment_mode: "failures"
+          action_fail: true
+          files: |
+            pr-artifacts/**/TEST-*.xml
+            pr-artifacts/**/results.xml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -319,13 +319,10 @@ jobs:
         with:
           test-name: Unit test
 
-  instrumentation_test_app:
-    name: "Instrumentation Test app"
+  build_emulator_wtf_apks:
+    name: "Build Emulator.wtf APKs"
     needs: [lint, lockfiles, ktlint]
     runs-on: ubuntu-latest
-    environment: ui-test
-    permissions:
-      id-token: write # Needed for OIDC authentication
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -340,42 +337,27 @@ jobs:
         run: ./gradlew :app:assembleDebug :app:assembleAndroidTest -Pabis=x86,x86_64
 
       - name: Build device list
-        id: devices
         run: |
           MIN=$(grep '^androidSdk-min' gradle/libs.versions.toml | cut -d'"' -f2)
           MAX=$(grep '^androidSdk-target' gradle/libs.versions.toml | cut -d'"' -f2)
           {
-            echo 'list<<DEVICES_EOF'
             for v in $(seq "$MIN" "$MAX"); do
               echo "model=Pixel7,version=$v"
             done
-            echo 'DEVICES_EOF'
-          } >> "$GITHUB_OUTPUT"
+          } > devices.txt
 
-      - uses: emulator-wtf/actions/configure-credentials@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
+      - name: Upload emulator.wtf inputs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          oidc-configuration-id: ${{ vars.EMULATOR_WTF_OIDC_CONFIGURATION_ID }} # This is retrieved from the emulator.wtf console
-
-      - name: Run tests full
-        uses: emulator-wtf/actions/run-tests@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
-        with:
-          devices: ${{ steps.devices.outputs.list }}
-          app: app/build/outputs/apk/full/debug/app-full-debug.apk
-          test: app/build/outputs/apk/androidTest/full/debug/app-full-debug-androidTest.apk
-          outputs-dir: build/test-results/full
-
-      - name: Run tests minimal
-        uses: emulator-wtf/actions/run-tests@42753a2a6bda2e657741a7385131bf61db464899 # v1.0.0
-        with:
-          devices: ${{ steps.devices.outputs.list }}
-          app: app/build/outputs/apk/minimal/debug/app-minimal-debug.apk
-          test: app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk
-          outputs-dir: build/test-results/minimal
-
-      - uses: ./.github/actions/upload-test-results
-        if: always()
-        with:
-          test-name: Instrumentation Test app
+          name: emulator-wtf-inputs
+          retention-days: 1
+          if-no-files-found: error
+          path: |
+            app/build/outputs/apk/full/debug/app-full-debug.apk
+            app/build/outputs/apk/minimal/debug/app-minimal-debug.apk
+            app/build/outputs/apk/androidTest/full/debug/app-full-debug-androidTest.apk
+            app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk
+            devices.txt
 
   instrumentation_test:
     name: "Instrumentation Tests"
@@ -451,28 +433,3 @@ jobs:
         if: always()
         with:
           test-name: Instrumentation test (API${{ matrix.configuration.api-level }}) ${{ matrix.configuration.target }}
-
-  publish_test_results:
-    name: "Publish Tests Results"
-    needs: [instrumentation_test, unit_tests, screenshot_test, instrumentation_test_app]
-    runs-on: ubuntu-latest
-    permissions:
-      checks: write
-      pull-requests: write
-    if: always()
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-
-      - name: Publish Test Results EnricoMi
-        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
-        if: always()
-        with:
-          comment_mode: "failures"
-          # We want to fail the build to block the merge if any test fail it allows us simplify the setup of the protected branch.
-          action_fail: true
-          files: |
-            **/androidTest-results/**/TEST-*.xml
-            **/build/test-results/**/TEST-*.xml
-            **/build/test-results/**/results.xml


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Emulator.wtf currently can't run on PRs from forks. The authentication uses OIDC, which would require allowing anyone with a fork to authenticate against our Emulator.wtf account  and we only want our own repo to be able to do that.
  
  This PR adds a new `PR Emulator.wtf` workflow that is triggered by `workflow_run` once the main `Pull Request` workflow completes. Because workflow_run-triggered workflows always execute in the base-repo context (regardless of whether the PR comes from a fork), it can use OIDC credentials safely. The new workflow runs the Emulator.wtf jobs and takes over the test-results reporting that the original publish_test_results job used to handle.