### PR TITLE
Request ACCESS_LOCAL_NETWORK when needed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30"/>

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -511,6 +511,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private fun loadServer() {
         urlFlowJob?.cancel()
         urlFlowJob = viewModelScope.launch {
+            permissionManager.checkLocalNetworkPermission()
             val currentState = _viewState.value
             val path = when (currentState) {
                 is FrontendViewState.LoadServer -> currentState.path

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.frontend.permissions
 
+import android.Manifest
 import android.annotation.SuppressLint
 import android.os.Build
 import android.webkit.PermissionRequest as WebViewPermissionRequest
@@ -99,6 +100,29 @@ internal class PermissionManager @VisibleForTesting constructor(
         }
         if (granted != null) {
             onNotificationPermissionResult(serverId = serverId, granted = granted)
+        }
+    }
+
+    /**
+     * Ensures the app has Android 17+'s local network access permission so the WebView and
+     * websocket layers can reach a Home Assistant instance over the LAN.
+     *
+     * Returns `true` immediately on pre-API 37 devices (local network access is implicit) and when
+     * the permission is already granted. Otherwise enqueues a [PermissionRequest.LocalNetwork],
+     * suspends until the user responds, and returns whether they granted it. Callers should still
+     * attempt the URL load on denial — the cloud fallback or non-LAN setups may continue to work.
+     *
+     * @return `true` if local network access is available (granted or not required); `false` if the
+     *         user declined the permission
+     */
+    @SuppressLint("NewApi")
+    suspend fun checkLocalNetworkPermission(): Boolean {
+        if (sdkInt < Build.VERSION_CODES.CINNAMON_BUN) return true
+        if (permissionChecker.hasPermission(Manifest.permission.ACCESS_LOCAL_NETWORK)) return true
+
+        Timber.d("Local network permission required, awaiting user response")
+        return queue.awaitResult { onResult ->
+            PermissionRequest.LocalNetwork(onResult = onResult)
         }
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionRequest.kt
@@ -49,6 +49,19 @@ internal sealed interface PermissionRequest {
         SinglePermission(permission = Manifest.permission.WRITE_EXTERNAL_STORAGE)
 
     /**
+     * A request for the Android 17+ local network access permission
+     * ([Manifest.permission.ACCESS_LOCAL_NETWORK]).
+     *
+     * Required so the WebView and websocket layers can reach a Home Assistant instance over the
+     * LAN once API 37 enforcement is active. The permission shares the `NEARBY_DEVICES` group
+     * with Bluetooth, so users who have already granted any other permission in that group
+     * (e.g. `BLUETOOTH_SCAN`) will see the request auto-grant without UI.
+     */
+    @RequiresApi(Build.VERSION_CODES.CINNAMON_BUN)
+    class LocalNetwork(override val onResult: (Boolean) -> Unit) :
+        SinglePermission(permission = Manifest.permission.ACCESS_LOCAL_NETWORK)
+
+    /**
      * A notification permission request rendered as a bottom sheet (with an explicit allow/deny)
      * before the system dialog, plus a separate dismiss path when the user closes the sheet without
      * answering. Modelled as its own top-level category — not a [SinglePermission] — because

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/OnboardingNavigation.kt
@@ -249,19 +249,38 @@ private fun NavGraphBuilder.commonScreens(
             if (navController.canGoBack()) {
                 navController.popBackStack()
             } else {
-                // This should only happens when we open the onboarding from the settings.
+                // This should only happen when we open the onboarding from the settings.
                 // Once we have a navigation graph for the whole app this could be dropped.
                 // For more context see: https://github.com/home-assistant/android/pull/5897#pullrequestreview-3316313923
                 (navController.context as? Activity)?.finish()
             }
         },
         onManualSetupClick = navController::navigateToManualServer,
+        onLocalNetworkPermissionDenied = {
+            // Replace ServerDiscovery on the back stack so that pressing back from ManualServer
+            // returns to the entry before discovery (e.g. Welcome) instead of bouncing back
+            // through the denied-permission redirect.
+            navController.navigateToManualServer(
+                navOptions = navOptions {
+                    popUpTo<ServerDiscoveryRoute> { inclusive = true }
+                },
+            )
+        },
         onHelpClick = {
             navController.navigateToUri(URL_GETTING_STARTED_DOCUMENTATION, onShowSnackbar)
         },
     )
     manualServerScreen(
-        onBackClick = navController::popBackStack,
+        onBackClick = {
+            if (navController.canGoBack()) {
+                navController.popBackStack()
+            } else {
+                // This should only happen when we open the onboarding from the settings with local network permission rejected.
+                // Once we have a navigation graph for the whole app this could be dropped.
+                // For more context see: https://github.com/home-assistant/android/pull/5897#pullrequestreview-3316313923
+                (navController.context as? Activity)?.finish()
+            }
+        },
         onConnectTo = {
             navController.navigateToConnection(it.toString())
         },
@@ -336,6 +355,7 @@ private fun NavController.navigateAfterDeviceRegistration(
             hasPlainTextAccess = hasPlainTextAccess,
             navOptions = navOptions,
         )
+
         else -> navigateToLocationForSecureConnectionConditionally(
             serverId = serverId,
             hasPlainTextAccess = hasPlainTextAccess,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryScreen.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.onboarding.serverdiscovery
 
+import android.Manifest
+import android.os.Build
 import androidx.annotation.VisibleForTesting
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.LinearEasing
@@ -45,6 +47,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -65,6 +68,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.isGranted
+import com.google.accompanist.permissions.rememberPermissionState
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.compose.composable.HAAccentButton
@@ -97,10 +103,20 @@ internal fun ServerDiscoveryScreen(
     onConnectClick: (server: URL) -> Unit,
     onHelpClick: suspend () -> Unit,
     onManualSetupClick: () -> Unit,
+    onLocalNetworkPermissionDenied: () -> Unit,
     viewModel: ServerDiscoveryViewModel,
     modifier: Modifier = Modifier,
 ) {
+    val permissionGranted = rememberLocalNetworkPermissionGranted(
+        onDenied = onLocalNetworkPermissionDenied,
+    )
+
+    // Until the permission is granted, render nothing so the user doesn't briefly see the
+    // discovery UI before the denial-handler navigates away or the dialog dismisses.
+    if (!permissionGranted) return
+
     val discoveryState by viewModel.discoveryFlow.collectAsStateWithLifecycle(Started)
+    LaunchedEffect(Unit) { viewModel.onLocalNetworkPermissionChecked() }
 
     ServerDiscoveryScreen(
         discoveryState = discoveryState,
@@ -111,6 +127,32 @@ internal fun ServerDiscoveryScreen(
         onManualSetupClick = onManualSetupClick,
         modifier = modifier,
     )
+}
+
+/**
+ * Manages the Android 17+ `ACCESS_LOCAL_NETWORK` permission for the discovery screen.
+ *
+ * Returns `true` once the screen can render LAN-dependent UI safely — either the permission is
+ * not required on this SDK, was already granted on entry, or has just been granted via the
+ * system dialog. On the first composition where it is not yet granted, the system dialog is
+ * launched. If the user denies, [onDenied] fires and the returned value stays `false` (the
+ * caller is expected to navigate away). Discovery cannot succeed without the permission, so the
+ * screen redirects to manual setup rather than leaving the user on an empty discovery list that
+ * will eventually time out.
+ */
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+private fun rememberLocalNetworkPermissionGranted(onDenied: () -> Unit): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) return true
+
+    val permissionState = rememberPermissionState(Manifest.permission.ACCESS_LOCAL_NETWORK) { granted ->
+        if (!granted) onDenied()
+    }
+    val granted = permissionState.status.isGranted
+    LaunchedEffect(Unit) {
+        if (!granted) permissionState.launchPermissionRequest()
+    }
+    return granted
 }
 
 @Composable

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
@@ -92,9 +92,25 @@ internal class ServerDiscoveryViewModel @VisibleForTesting constructor(
      */
     val discoveryFlow = _discoveryFlow.delayFirstThrottle(DELAY_BEFORE_DISPLAY_DISCOVERY)
 
-    init {
-        discoverInstances()
+    /**
+     * Guards [onLocalNetworkPermissionChecked] against starting discovery more than once across
+     * recompositions or repeated permission-result callbacks from the screen.
+     */
+    private var discoveryStarted = false
 
+    /**
+     * Notifies the ViewModel that the screen has finished the Android 17+ local network
+     * permission flow (either granted, denied, or skipped on pre-API 37 devices) and discovery
+     * can now begin. Subsequent calls are no-ops.
+     *
+     * Discovery is gated on this signal because NSD can't reach LAN-served Home Assistant
+     * instances on Android 17+ without `ACCESS_LOCAL_NETWORK`; starting earlier would risk a
+     * silent failure followed by a [NoServerFound] timeout that hides the real cause.
+     */
+    fun onLocalNetworkPermissionChecked() {
+        if (discoveryStarted) return
+        discoveryStarted = true
+        discoverInstances()
         watchForNoServerFound()
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigation.kt
@@ -40,6 +40,7 @@ internal fun NavGraphBuilder.serverDiscoveryScreen(
     onBackClick: () -> Unit,
     onHelpClick: suspend () -> Unit,
     onManualSetupClick: () -> Unit,
+    onLocalNetworkPermissionDenied: () -> Unit,
 ) {
     composable<ServerDiscoveryRoute> {
         ServerDiscoveryScreen(
@@ -47,6 +48,7 @@ internal fun NavGraphBuilder.serverDiscoveryScreen(
             onBackClick = onBackClick,
             onHelpClick = onHelpClick,
             onManualSetupClick = onManualSetupClick,
+            onLocalNetworkPermissionDenied = onLocalNetworkPermissionDenied,
             viewModel = hiltViewModel(),
         )
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -65,6 +65,7 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.graphics.ColorUtils
@@ -213,6 +214,19 @@ class WebViewActivity :
                 presenter.startScanningForImprov()
             }
         }
+
+    /**
+     * Android 17+ requires `ACCESS_LOCAL_NETWORK` for any LAN traffic. Once the user grants it
+     * after the WebView has already attempted to load, reload so the in-flight or failed-LAN
+     * connection is retried with permission. Denial is left to surface through the existing
+     * connection-error UI.
+     */
+    private val requestLocalNetworkPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted && ::webView.isInitialized) {
+                webView.reload()
+            }
+        }
     private val writeNfcTag = registerForActivityResult(WriteNfcTag()) { messageId ->
         sendExternalBusMessage(
             ExternalBusMessage(
@@ -358,6 +372,8 @@ class WebViewActivity :
         }
 
         super.onCreate(savedInstanceState)
+
+        maybeRequestLocalNetworkPermission()
 
         if (intent.extras?.containsKey(EXTRA_SERVER) == true) {
             intent.extras?.getInt(EXTRA_SERVER)?.let {
@@ -1334,6 +1350,25 @@ class WebViewActivity :
     override fun onStart() {
         super.onStart()
         presenter.onStart(this)
+    }
+
+    /**
+     * Requests `ACCESS_LOCAL_NETWORK` on Android 17+ if it is not already granted.
+     *
+     * The system permission dialog is asynchronous: the WebView keeps loading in parallel, and
+     * a successful grant triggers a reload via [requestLocalNetworkPermission]. On pre-API 37
+     * devices the permission does not exist and no action is taken.
+     */
+    private fun maybeRequestLocalNetworkPermission() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.CINNAMON_BUN) return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                android.Manifest.permission.ACCESS_LOCAL_NETWORK,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        requestLocalNetworkPermission.launch(android.Manifest.permission.ACCESS_LOCAL_NETWORK)
     }
 
     override fun onResume() {

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,6 +2,7 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2026.5.4 - Main" versioncode="3">
+        <change>Added support for Android 17's local network permission</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.5.4 - Wear" versioncode="2">

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
@@ -533,6 +533,62 @@ class PermissionManagerTest {
 
     // endregion
 
+    // region Local network permission (Android 17+)
+
+    @Nested
+    inner class CheckLocalNetworkPermission {
+
+        @Test
+        fun `Given pre-API 37 then returns true without checking permission`() = runTest {
+            val manager = createManager(sdkInt = Build.VERSION_CODES.CINNAMON_BUN - 1)
+            assertTrue(manager.checkLocalNetworkPermission())
+            assertNull(manager.pendingPermissionRequest.value)
+        }
+
+        @Test
+        fun `Given API 37 when permission already granted then returns true`() = runTest {
+            every { permissionChecker.hasPermission(android.Manifest.permission.ACCESS_LOCAL_NETWORK) } returns true
+
+            val manager = createManager(sdkInt = Build.VERSION_CODES.CINNAMON_BUN)
+            assertTrue(manager.checkLocalNetworkPermission())
+            assertNull(manager.pendingPermissionRequest.value)
+        }
+
+        @Test
+        fun `Given API 37 when permission not granted then emits pending request`() = runTest {
+            every { permissionChecker.hasPermission(android.Manifest.permission.ACCESS_LOCAL_NETWORK) } returns false
+
+            val manager = createManager(sdkInt = Build.VERSION_CODES.CINNAMON_BUN)
+            val result = async { manager.checkLocalNetworkPermission() }
+            advanceUntilIdle()
+
+            val pending = manager.pendingPermissionRequest.value
+            assertInstanceOf(PermissionRequest.LocalNetwork::class.java, pending)
+            assertEquals(listOf(android.Manifest.permission.ACCESS_LOCAL_NETWORK), pending?.permissions)
+
+            (pending as PermissionRequest.LocalNetwork).onResult(true)
+            advanceUntilIdle()
+            assertTrue(result.await())
+            assertNull(manager.pendingPermissionRequest.value)
+        }
+
+        @Test
+        fun `Given API 37 when user denies then returns false`() = runTest {
+            every { permissionChecker.hasPermission(android.Manifest.permission.ACCESS_LOCAL_NETWORK) } returns false
+
+            val manager = createManager(sdkInt = Build.VERSION_CODES.CINNAMON_BUN)
+            val result = async { manager.checkLocalNetworkPermission() }
+            advanceUntilIdle()
+            (manager.pendingPermissionRequest.value as PermissionRequest.LocalNetwork).onResult(false)
+            advanceUntilIdle()
+
+            assertFalse(result.await())
+            assertNull(manager.pendingPermissionRequest.value)
+        }
+    }
+
+    // endregion
+
     // region Guard against concurrent requests
 
     @Nested

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/BaseOnboardingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/BaseOnboardingNavigationTest.kt
@@ -59,6 +59,7 @@ internal abstract class BaseOnboardingNavigationTest {
         hideExistingServers: Boolean = false,
         skipWelcome: Boolean = false,
         hasLocationTracking: Boolean = true,
+        permissionResultRegistry: ActivityResultRegistry = FakePermissionResultRegistry(grantAll = true),
     ) {
         composeTestRule.setContent {
             navController = TestNavHostController(LocalContext.current)
@@ -66,8 +67,7 @@ internal abstract class BaseOnboardingNavigationTest {
 
             CompositionLocalProvider(
                 LocalActivityResultRegistryOwner provides object : ActivityResultRegistryOwner {
-                    override val activityResultRegistry: ActivityResultRegistry =
-                        FakePermissionResultRegistry(true)
+                    override val activityResultRegistry: ActivityResultRegistry = permissionResultRegistry
                 },
             ) {
                 NavHost(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModelTest.kt
@@ -45,6 +45,37 @@ private class ServerDiscoveryViewModelTest {
 
     private fun createViewModel(discoveryMode: ServerDiscoveryMode = ServerDiscoveryMode.NORMAL) {
         viewModel = ServerDiscoveryViewModel(discoveryMode, searcher, serverManager)
+        // Existing tests assert behavior that depends on discovery having started; mirror the
+        // screen's permission-checked callback so they don't all have to opt in individually.
+        viewModel.onLocalNetworkPermissionChecked()
+    }
+
+    @Test
+    fun `Given local network permission not yet checked then no server discovery is started and NoServerFound is not emitted`() = runTest {
+        viewModel = ServerDiscoveryViewModel(ServerDiscoveryMode.NORMAL, searcher, serverManager)
+
+        viewModel.discoveryFlow.test {
+            assertEquals(Started, awaitItem())
+            advanceTimeBy(TIMEOUT_NO_SERVER_FOUND * 2)
+            runCurrent()
+            // Discovery hasn't started, so the no-server timeout never fires
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given local network permission checked twice then discovery is only started once`() = runTest {
+        viewModel = ServerDiscoveryViewModel(ServerDiscoveryMode.NORMAL, searcher, serverManager)
+        viewModel.onLocalNetworkPermissionChecked()
+        viewModel.onLocalNetworkPermissionChecked()
+
+        viewModel.discoveryFlow.test {
+            assertEquals(Started, awaitItem())
+            advanceTimeBy(TIMEOUT_NO_SERVER_FOUND)
+            // A single NoServerFound — not duplicated — proves discovery wasn't started twice
+            assertEquals(NoServerFound, awaitItem())
+            expectNoEvents()
+        }
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.onboarding.serverdiscovery.navigation
 
+import android.os.Build
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
@@ -38,6 +39,7 @@ import io.homeassistant.companion.android.onboarding.welcome.navigation.WelcomeR
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
 import io.homeassistant.companion.android.testing.unit.TestSharedFlow
 import io.homeassistant.companion.android.testing.unit.stringResource
+import io.homeassistant.companion.android.util.FakePermissionResultRegistry
 import io.homeassistant.companion.android.util.compose.navigateToUri
 import io.mockk.coVerify
 import io.mockk.every
@@ -50,6 +52,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.consumeAsFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -114,6 +117,31 @@ internal class ServerDiscoveryNavigationTest : BaseOnboardingNavigationTest() {
     fun `Given skipWelcome without urlToOnboard when starting then show ServerDiscovery`() {
         testNavigation(skipWelcome = true) {
             assertTrue(navController.currentBackStackEntry?.destination?.hasRoute<ServerDiscoveryRoute>() == true)
+        }
+    }
+
+    /**
+     * On Android 17+, entering the discovery screen requests
+     * `ACCESS_LOCAL_NETWORK`. A denial routes the user directly to ManualServer because
+     * LAN-based discovery cannot succeed without the permission. Pressing back from
+     * ManualServer must not bounce the user back to ServerDiscovery (which would re-detect the
+     * denial and re-redirect) — the discovery destination is popped from the back stack.
+     */
+    @Test
+    @Ignore("Robolectric 4.16.1 does not support API 37; re-enable once robolectric-target-sdk reaches 37")
+    @Config(sdk = [Build.VERSION_CODES.CINNAMON_BUN])
+    fun `Given API 37 with denied local network permission when entering ServerDiscovery then routes to ManualServer and back skips ServerDiscovery`() {
+        setContent(
+            skipWelcome = true,
+            permissionResultRegistry = FakePermissionResultRegistry(grantedPermissions = emptySet()),
+        )
+        runTest(mainDispatcherRule.testDispatcher) {
+            composeTestRule.apply {
+                waitForIdle()
+                assertTrue(
+                    navController.currentBackStackEntry?.destination?.hasRoute<ManualServerRoute>() == true,
+                )
+            }
         }
     }
 

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30"/>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Add support for the new [ACCESS_LOCAL_NETWORK](https://developer.android.com/reference/android/Manifest.permission#ACCESS_LOCAL_NETWORK) permission. Add to the current flow request to access the local network, the logic is kept dumb without checking the server it is connecting to to keep it simple.

Added to
- onboarding when reaching server discovery (permission with a blank screen behind) if rejected then it redirect to manual server
- WebViewActivity when opening the app it is going to show the error but on top require the permission (it's best effort since we want to drop it)
- FrontendScreen properly ask for permission while the UI is still loading and if rejected proper error screen

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I've ignored a test because Robolectric is not yet ready for API 37. 

Since we are not targetting yet API 37 we might have issues if someone discard the permission from the settings manually but that should probably not happen and we can manually help on discord or github or the user will simply enable it back. 

I've bump the target to 37 and no issue but I don't want yet to make this jump because we need to test more any regression based on the changes made by Google.