### PR TITLE
Use LaunchActivity in HaControlsPanel

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -145,6 +145,18 @@
             </intent-filter>
         </activity-alias>
 
+        <!--
+        Non-exported entry point that lets internal callers (currently the device controls panel)
+        bring up the dashboard over the keyguard. LaunchActivity only honors
+        setShowWhenLocked when the inbound intent is routed through this alias, so external apps
+        hitting the public LaunchActivity intent-filters cannot force the activity to render over
+        the lock screen.
+        -->
+        <activity-alias
+            android:name="io.homeassistant.companion.android.launch.LaunchOverLockScreen"
+            android:exported="false"
+            android:targetActivity="io.homeassistant.companion.android.launch.LaunchActivity" />
+
         <!-- Start things like SensorWorker on device boot -->
         <receiver android:name=".websocket.WebsocketBroadcastReceiver"
             android:exported="true">

--- a/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -23,9 +23,12 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.WIPFeature
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.servers.ServerManager.Companion.SERVER_ID_ACTIVE
+import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
@@ -66,16 +69,24 @@ class HaControlsPanelActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val serverId = prefsRepository.getControlsPanelServer() ?: serverManager.getServer()?.id
             val path = prefsRepository.getControlsPanelPath()
-            Timber.d("Launching WebView…")
-            startActivity(
+            val intent = if (WIPFeature.USE_FRONTEND_V2) {
+                Timber.d("Launching LaunchActivity…")
+                LaunchActivity.newInstance(
+                    context = this@HaControlsPanelActivity,
+                    deepLink = LaunchActivity.DeepLink.NavigateTo(path = path, serverId = serverId ?: SERVER_ID_ACTIVE),
+                    showWhenLocked = true,
+                )
+            } else {
+                Timber.d("Launching WebView…")
                 WebViewActivity.newInstance(
                     context = this@HaControlsPanelActivity,
                     path = path,
                     serverId = serverId,
                 ).apply {
                     putExtra(WebViewActivity.EXTRA_SHOW_WHEN_LOCKED, true)
-                },
-            )
+                }
+            }
+            startActivity(intent)
             overridePendingTransition(0, 0) // Disable activity start/stop animation
 
             // The device controls panel can flicker if this activity finishes to quickly, so handle

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.launch
 
 import android.app.PictureInPictureParams
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
@@ -56,7 +57,16 @@ import kotlinx.parcelize.Parcelize
 
 private const val DEEP_LINK_KEY = "deep_link_key"
 
-private const val EXTRA_SHOW_WHEN_LOCKED = "show_when_locked"
+/**
+ * Fully qualified class name of the non-exported `<activity-alias>` declared in the manifest.
+ *
+ * Trusted in-process callers route through this alias to bring up the dashboard over the
+ * keyguard. [LaunchActivity.onCreate] only calls [android.app.Activity.setShowWhenLocked] when
+ * the inbound intent's component matches it — because the alias is `android:exported="false"`,
+ * external apps cannot use it and therefore cannot force the activity to render over the lock
+ * screen by themselves.
+ */
+private const val LOCK_SCREEN_ALIAS_CLASS = "io.homeassistant.companion.android.launch.LaunchOverLockScreen"
 
 /**
  * Main entry point of the application, responsible for holding the whole navigation graph
@@ -115,13 +125,23 @@ class LaunchActivity : AppCompatActivity() {
     }
 
     companion object {
+        /**
+         * Builds an intent to start [LaunchActivity].
+         *
+         * @param showWhenLocked when `true`, routes through the non-exported
+         *   `LaunchOverLockScreen` activity-alias so the dashboard renders over the keyguard.
+         *   Intended for trusted in-process callers (e.g. the device controls panel) — external
+         *   apps cannot reach the alias and therefore cannot opt into this behavior.
+         */
         fun newInstance(context: Context, deepLink: DeepLink? = null, showWhenLocked: Boolean = false): Intent {
-            return Intent(context, LaunchActivity::class.java).apply {
+            return Intent().apply {
+                component = if (showWhenLocked) {
+                    ComponentName(context, LOCK_SCREEN_ALIAS_CLASS)
+                } else {
+                    ComponentName(context, LaunchActivity::class.java)
+                }
                 if (deepLink != null) {
                     putExtra(DEEP_LINK_KEY, deepLink)
-                }
-                if (showWhenLocked) {
-                    putExtra(EXTRA_SHOW_WHEN_LOCKED, showWhenLocked)
                 }
             }
         }
@@ -137,9 +157,12 @@ class LaunchActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // Must run before super.onCreate so the window flag is set before the platform decides
-        // whether to draw over the keyguard. Only applied when the caller opts in explicitly.
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && intent.hasExtra(EXTRA_SHOW_WHEN_LOCKED)) {
-            setShowWhenLocked(intent.getBooleanExtra(EXTRA_SHOW_WHEN_LOCKED, false))
+        // whether to draw over the keyguard. Gated on the non-exported [LOCK_SCREEN_ALIAS_CLASS]
+        // so external apps reaching the public LAUNCHER intent-filter cannot force this on.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 &&
+            intent.component?.className == LOCK_SCREEN_ALIAS_CLASS
+        ) {
+            setShowWhenLocked(true)
         }
 
         super.onCreate(savedInstanceState)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -56,6 +56,8 @@ import kotlinx.parcelize.Parcelize
 
 private const val DEEP_LINK_KEY = "deep_link_key"
 
+private const val EXTRA_SHOW_WHEN_LOCKED = "show_when_locked"
+
 /**
  * Main entry point of the application, responsible for holding the whole navigation graph
  * and triggering lifecycle-based refresh of background work.
@@ -113,10 +115,13 @@ class LaunchActivity : AppCompatActivity() {
     }
 
     companion object {
-        fun newInstance(context: Context, deepLink: DeepLink? = null): Intent {
+        fun newInstance(context: Context, deepLink: DeepLink? = null, showWhenLocked: Boolean = false): Intent {
             return Intent(context, LaunchActivity::class.java).apply {
                 if (deepLink != null) {
                     putExtra(DEEP_LINK_KEY, deepLink)
+                }
+                if (showWhenLocked) {
+                    putExtra(EXTRA_SHOW_WHEN_LOCKED, showWhenLocked)
                 }
             }
         }
@@ -131,6 +136,12 @@ class LaunchActivity : AppCompatActivity() {
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // Must run before super.onCreate so the window flag is set before the platform decides
+        // whether to draw over the keyguard. Only applied when the caller opts in explicitly.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && intent.hasExtra(EXTRA_SHOW_WHEN_LOCKED)) {
+            setShowWhenLocked(intent.getBooleanExtra(EXTRA_SHOW_WHEN_LOCKED, false))
+        }
+
         super.onCreate(savedInstanceState)
         val splashScreen = installSplashScreen()
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -151,6 +151,28 @@ class LaunchActivityTest {
         }
     }
 
+    @Test
+    fun `Given showWhenLocked is true when launched then activity is shown over the lock screen`() {
+        val intent = LaunchActivity.newInstance(ApplicationProvider.getApplicationContext(), showWhenLocked = true)
+
+        ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                assertTrue(shadowOf(activity).showWhenLocked)
+            }
+        }
+    }
+
+    @Test
+    fun `Given showWhenLocked is false when launched then activity is not shown over the lock screen`() {
+        val intent = LaunchActivity.newInstance(ApplicationProvider.getApplicationContext(), showWhenLocked = false)
+
+        ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse(shadowOf(activity).showWhenLocked)
+            }
+        }
+    }
+
     private fun setPipFeatureAvailable(available: Boolean) {
         val context = ApplicationProvider.getApplicationContext<Context>()
         shadowOf(context.packageManager)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.launch
 
 import android.app.Activity
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.util.Rational
 import androidx.lifecycle.Lifecycle
@@ -165,6 +166,23 @@ class LaunchActivityTest {
     @Test
     fun `Given showWhenLocked is false when launched then activity is not shown over the lock screen`() {
         val intent = LaunchActivity.newInstance(ApplicationProvider.getApplicationContext(), showWhenLocked = false)
+
+        ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                assertFalse(shadowOf(activity).showWhenLocked)
+            }
+        }
+    }
+
+    @Test
+    fun `Given intent targets LaunchActivity directly with legacy extra then activity is not shown over the lock screen`() {
+        // Models a hostile or stale caller that targets the exported LaunchActivity component
+        // directly and tries to opt into the lock-screen behavior via the legacy extra. The
+        // gating now lives on the non-exported alias, so direct-component intents must never
+        // flip the window flag — regardless of any extra they carry.
+        val intent = Intent(ApplicationProvider.getApplicationContext(), LaunchActivity::class.java).apply {
+            putExtra("show_when_locked", true)
+        }
 
         ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 9.2.0" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.0)" variant="all" version="9.2.0">
+<issues format="6" by="lint 9.2.1" type="baseline" client="gradle" dependencies="false" name="AGP (9.2.1)" variant="all" version="9.2.1">
 
     <issue
         id="MissingPermission"
@@ -85,7 +85,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1097"
+            line="1094"
             column="17"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="321"
+            line="327"
             column="27"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="919"
+            line="929"
             column="27"/>
     </issue>
 
@@ -338,7 +338,7 @@
         errorLine2="      ~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/launch/LaunchActivity.kt"
-            line="72"
+            line="84"
             column="7"/>
     </issue>
 
@@ -382,7 +382,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"
-            line="436"
+            line="446"
             column="13"/>
     </issue>
 
@@ -811,7 +811,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/vehicle/DomainListScreen.kt"
-            line="24"
+            line="25"
             column="1"/>
     </issue>
 
@@ -899,7 +899,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/HomeAssistantApplication.kt"
-            line="233"
+            line="242"
             column="13"/>
     </issue>
 
@@ -910,7 +910,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/HomeAssistantApplication.kt"
-            line="243"
+            line="252"
             column="13"/>
     </issue>
 
@@ -921,7 +921,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/HomeAssistantApplication.kt"
-            line="298"
+            line="307"
             column="13"/>
     </issue>
 
@@ -1070,12 +1070,23 @@
 
     <issue
         id="ObsoleteSdkInt"
+        message="Unnecessary; `SDK_INT` is always >= 29"
+        errorLine1="        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 &amp;&amp;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/launch/LaunchActivity.kt"
+            line="162"
+            column="13"/>
+    </issue>
+
+    <issue
+        id="ObsoleteSdkInt"
         message="Unnecessary; `SDK_INT` is never &lt; 29"
         errorLine1="            if (Build.VERSION.SDK_INT &lt; Build.VERSION_CODES.O) return"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/launch/LaunchActivity.kt"
-            line="215"
+            line="249"
             column="17"/>
     </issue>
 
@@ -1108,7 +1119,7 @@
         errorLine2="                            ^">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/sensors/LocationSensorManager.kt"
-            line="853"
+            line="864"
             column="29"/>
     </issue>
 
@@ -1119,7 +1130,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/sensors/LocationSensorManager.kt"
-            line="955"
+            line="966"
             column="40"/>
     </issue>
 
@@ -1130,7 +1141,7 @@
         errorLine2="             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*7}/io/homeassistant/companion/android/sensors/LocationSensorManager.kt"
-            line="1350"
+            line="1361"
             column="14"/>
     </issue>
 
@@ -1152,7 +1163,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/vehicle/MainVehicleScreen.kt"
-            line="44"
+            line="45"
             column="1"/>
     </issue>
 
@@ -1350,7 +1361,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="642"
+            line="639"
             column="13"/>
     </issue>
 
@@ -1361,7 +1372,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1027"
+            line="1024"
             column="17"/>
     </issue>
 
@@ -1372,7 +1383,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1084"
+            line="1081"
             column="13"/>
     </issue>
 
@@ -1383,7 +1394,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1130"
+            line="1127"
             column="21"/>
     </issue>
 
@@ -1394,7 +1405,7 @@
         errorLine2="                                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1177"
+            line="1174"
             column="50"/>
     </issue>
 
@@ -1405,7 +1416,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/notifications/MessagingManager.kt"
-            line="1746"
+            line="1743"
             column="13"/>
     </issue>
 
@@ -2230,7 +2241,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="355"
+            line="354"
             column="13"/>
     </issue>
 
@@ -2241,7 +2252,7 @@
         errorLine2="                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="663"
+            line="662"
             column="21"/>
     </issue>
 
@@ -2252,7 +2263,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="771"
+            line="770"
             column="13"/>
     </issue>
 
@@ -2263,7 +2274,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/webview/WebViewActivity.kt"
-            line="1582"
+            line="1579"
             column="17"/>
     </issue>
 
@@ -2927,7 +2938,7 @@
         errorLine2="^">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/util/compose/Theme.kt"
-            line="152"
+            line="155"
             column="1"/>
     </issue>
 
@@ -3433,19 +3444,8 @@
         errorLine2="        ~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt"
-            line="93"
+            line="104"
             column="9"/>
-    </issue>
-
-    <issue
-        id="ComposeUnstableReceiver"
-        message="Instance composable functions on non-stable classes will always be recomposed. If possible, make the receiver type stable or refactor this function if that isn&apos;t possible. See https://slackhq.github.io/compose-lints/rules/#unstable-receivers for more information."
-        errorLine1="        fun TodoState.getColors(): ColorProviders {"
-        errorLine2="            ~~~~~~~~~">
-        <location
-            file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/widgets/todo/TodoWidgetState.kt"
-            line="46"
-            column="13"/>
     </issue>
 
     <issue

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -271,6 +271,18 @@
             </intent-filter>
         </receiver>
 
+        <!--
+        Non-exported entry point that lets internal callers (currently the device controls panel)
+        bring up the dashboard over the keyguard. LaunchActivity only honors
+        setShowWhenLocked when the inbound intent is routed through this alias, so external apps
+        hitting the public LaunchActivity intent-filters cannot force the activity to render over
+        the lock screen.
+        -->
+        <activity-alias
+            android:name="io.homeassistant.companion.android.launch.LaunchOverLockScreen"
+            android:exported="false"
+            android:targetActivity="io.homeassistant.companion.android.launch.LaunchActivity" />
+
         <activity android:name=".launch.LaunchActivity"
             android:exported="true"
             android:supportsPictureInPicture="true"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to be able to use the FrontendScreen in the lock screen when using a dashboard has ControlPanel we need the LaunchActivity to set the `setShowWhenLocked` flag. Today it is behind the WIPFeature.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.