### PR TITLE
Add incoming external bus messages for Matter/Thread

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -625,6 +625,13 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                 result.event?.let { _events.tryEmit(it) }
             }
 
+            is FrontendHandlerEvent.StartMatterCommissioning,
+            is FrontendHandlerEvent.ImportThreadCredentials,
+            -> {
+                // Matter/Thread handling lands in a follow-up PR
+                Timber.d("Matter/Thread event received but not yet handled: $result")
+            }
+
             is FrontendHandlerEvent.ConfigSent,
             is FrontendHandlerEvent.UnknownMessage,
             is FrontendHandlerEvent.EntityAddToActionsSent,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
@@ -268,3 +268,34 @@ data class EntityAddToPayload(
     @SerialName("entity_id") val entityId: String,
     @SerialName("app_payload") val appPayload: String,
 )
+
+/**
+ * Message requesting the app to start the Matter device commissioning flow.
+ *
+ * The frontend sends this when the user picks "Add Matter device" in the integrations UI. The app
+ * is expected to drive the Google Play Services Matter commissioning intent and, once it
+ * resolves, send back a [io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage]
+ * correlated by [id] (success or failure).
+ *
+ * Will not be sent by the frontend when the device reports
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResult.canCommissionMatter] = `false`.
+ */
+@Serializable
+@SerialName("matter/commission")
+data class MatterCommissionMessage(override val id: Int? = null) : IncomingExternalBusMessage
+
+/**
+ * Message requesting the app to share its locally-stored Thread credentials with the Home Assistant
+ * server via Google Play Services' Thread Network APIs.
+ *
+ * The frontend sends this when the user opens the "Share Thread credentials" flow. The app is
+ * expected to retrieve the preferred Thread dataset, push it to the server, and send back a
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage] correlated by
+ * [id] (success or failure).
+ *
+ * Will not be sent by the frontend when the device reports
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResult.canImportThreadCredentials] = `false`.
+ */
+@Serializable
+@SerialName("thread/import_credentials")
+data class ThreadImportCredentialsMessage(override val id: Int? = null) : IncomingExternalBusMessage

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendHandlerEvent.kt
@@ -102,6 +102,33 @@ sealed interface FrontendHandlerEvent {
      */
     data class ConfigureImprovDevice(val deviceName: String) : FrontendHandlerEvent
 
+    /**
+     * Frontend requested the Matter device commissioning flow to be launched.
+     *
+     * The ViewModel drives the Google Play Services Matter intent and, once it resolves, replies
+     * to the frontend with a
+     * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage] correlated
+     * by [messageId].
+     *
+     * @param messageId Correlation id from the incoming `matter/commission` message. Null when the
+     *   frontend omitted it — the response will then carry a null id and the frontend will ignore it.
+     */
+    data class StartMatterCommissioning(val messageId: Int?) : FrontendHandlerEvent
+
+    /**
+     * Frontend requested the app to share its locally-stored Thread credentials with the server.
+     *
+     * The ViewModel reads the preferred Thread dataset via Google Play Services, forwards it to
+     * the server, and replies to the frontend with a
+     * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage] correlated
+     * by [messageId].
+     *
+     * @param messageId Correlation id from the incoming `thread/import_credentials` message. Null
+     *   when the frontend omitted it — the response will then carry a null id and the frontend
+     *   will ignore it.
+     */
+    data class ImportThreadCredentials(val messageId: Int?) : FrontendHandlerEvent
+
     sealed interface ExoPlayerAction : FrontendHandlerEvent {
 
         /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
@@ -22,11 +22,13 @@ import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticMe
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ImprovConfigureDeviceMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ImprovScanMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.IncomingExternalBusMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.MatterCommissionMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenAssistMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenAssistSettingsMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenSettingsMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.TagWriteMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ThemeUpdateMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ThreadImportCredentialsMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.UnknownIncomingMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResultMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.EntityAddToActionsResultMessage
@@ -256,6 +258,16 @@ class FrontendMessageHandler @Inject constructor(
                 val action = ExternalEntityAddToAction.appPayloadToAction(message.payload.appPayload)
                 val event = entityAddToHandler.execute(message.payload.entityId, action)
                 FrontendHandlerEvent.EntityAddToExecuted(event)
+            }
+
+            is MatterCommissionMessage -> {
+                Timber.d("matter/commission received with id: ${message.id}")
+                FrontendHandlerEvent.StartMatterCommissioning(messageId = message.id)
+            }
+
+            is ThreadImportCredentialsMessage -> {
+                Timber.d("thread/import_credentials received with id: ${message.id}")
+                FrontendHandlerEvent.ImportThreadCredentials(messageId = message.id)
             }
 
             is UnknownIncomingMessage -> {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessageTest.kt
@@ -273,4 +273,44 @@ class IncomingExternalBusMessageTest {
         assertEquals("light.living_room", addToMessage.payload.entityId)
         assertEquals("dGVzdA==", addToMessage.payload.appPayload)
     }
+
+    @Test
+    fun `Given matter commission JSON then parses to MatterCommissionMessage`() {
+        val json = """{"type":"matter/commission","id":60}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(MatterCommissionMessage::class.java, message)
+        assertEquals(60, (message as MatterCommissionMessage).id)
+    }
+
+    @Test
+    fun `Given matter commission JSON without id then parses to MatterCommissionMessage with null id`() {
+        val json = """{"type":"matter/commission"}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(MatterCommissionMessage::class.java, message)
+        assertNull((message as MatterCommissionMessage).id)
+    }
+
+    @Test
+    fun `Given thread import_credentials JSON then parses to ThreadImportCredentialsMessage`() {
+        val json = """{"type":"thread/import_credentials","id":61}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ThreadImportCredentialsMessage::class.java, message)
+        assertEquals(61, (message as ThreadImportCredentialsMessage).id)
+    }
+
+    @Test
+    fun `Given thread import_credentials JSON without id then parses to ThreadImportCredentialsMessage with null id`() {
+        val json = """{"type":"thread/import_credentials"}"""
+
+        val message = frontendExternalBusJson.decodeFromString<IncomingExternalBusMessage>(json)
+
+        assertInstanceOf(ThreadImportCredentialsMessage::class.java, message)
+        assertNull((message as ThreadImportCredentialsMessage).id)
+    }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -32,6 +32,7 @@ import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticTy
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ImprovConfigureDeviceMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ImprovConfigureDevicePayload
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ImprovScanMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.MatterCommissionMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenAssistMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenAssistPayload
 import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenAssistSettingsMessage
@@ -39,6 +40,7 @@ import io.homeassistant.companion.android.frontend.externalbus.incoming.OpenSett
 import io.homeassistant.companion.android.frontend.externalbus.incoming.TagWriteMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.TagWritePayload
 import io.homeassistant.companion.android.frontend.externalbus.incoming.ThemeUpdateMessage
+import io.homeassistant.companion.android.frontend.externalbus.incoming.ThreadImportCredentialsMessage
 import io.homeassistant.companion.android.frontend.externalbus.incoming.UnknownIncomingMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.OutgoingExternalBusMessage
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.ResultMessage
@@ -374,6 +376,58 @@ class FrontendMessageHandlerTest {
             val result = awaitItem()
             assertTrue(result is FrontendHandlerEvent.ConfigureImprovDevice)
             assertEquals("Smart Plug", (result as FrontendHandlerEvent.ConfigureImprovDevice).deviceName)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given matter commission message when messageResults then emits StartMatterCommissioning with id`() = runTest {
+        val message = MatterCommissionMessage(id = 60)
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val result = awaitItem()
+            assertTrue(result is FrontendHandlerEvent.StartMatterCommissioning)
+            assertEquals(60, (result as FrontendHandlerEvent.StartMatterCommissioning).messageId)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given matter commission message without id when messageResults then emits StartMatterCommissioning with null id`() = runTest {
+        val message = MatterCommissionMessage(id = null)
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val result = awaitItem()
+            assertTrue(result is FrontendHandlerEvent.StartMatterCommissioning)
+            assertEquals(null, (result as FrontendHandlerEvent.StartMatterCommissioning).messageId)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given thread import_credentials message when messageResults then emits ImportThreadCredentials with id`() = runTest {
+        val message = ThreadImportCredentialsMessage(id = 61)
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val result = awaitItem()
+            assertTrue(result is FrontendHandlerEvent.ImportThreadCredentials)
+            assertEquals(61, (result as FrontendHandlerEvent.ImportThreadCredentials).messageId)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given thread import_credentials message without id when messageResults then emits ImportThreadCredentials with null id`() = runTest {
+        val message = ThreadImportCredentialsMessage(id = null)
+        every { externalBusRepository.incomingMessages() } returns flowOf(message)
+
+        handler.messageResults().test {
+            val result = awaitItem()
+            assertTrue(result is FrontendHandlerEvent.ImportThreadCredentials)
+            assertEquals(null, (result as FrontendHandlerEvent.ImportThreadCredentials).messageId)
             expectNoEvents()
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Add incoming external bus messages for matter and mapping into the ViewModel with dumb logs to prepare the impl of the matter onboarding flow.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.