### PR TITLE
Use GH instead of softprops/action-gh-release

### DIFF
--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           echo $VERSION_CODE > ./app/build/outputs/version_code.txt
 
-      - name: Create or update GitHub Pre-Release
+      - name: Create draft GitHub Pre-Release
         if: github.event.inputs.beta == 'true'
         shell: bash
         env:
@@ -103,18 +103,28 @@ jobs:
             ./app/src/main/res/xml/locales_config.xml
           )
 
-          # If a release already exists for this tag, update its assets and release metadata.
-          if gh release view "$REL_VERSION" >/dev/null 2>&1; then
-            gh release upload "$REL_VERSION" "${assets[@]}" --clobber
-            gh release edit "$REL_VERSION" \
-              --draft=false \
-              --prerelease \
-              --notes-file ./app/build/outputs/changelogGithub
-          else
-            gh release create "$REL_VERSION" "${assets[@]}" \
+          # Immutable releases lock their assets at publish time, so we create the release as a
+          # draft first and attach assets while it is still mutable. The next step publishes it.
+          # On re-runs, --clobber keeps the upload idempotent as long as the previous attempt
+          # did not get past the publish step.
+          if ! gh release view "$REL_VERSION" >/dev/null 2>&1; then
+            gh release create "$REL_VERSION" \
+              --draft \
               --prerelease \
               --notes-file ./app/build/outputs/changelogGithub
           fi
+
+          gh release upload "$REL_VERSION" "${assets[@]}" --clobber
+
+      - name: Publish Pre-Release
+        if: github.event.inputs.beta == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REL_VERSION: ${{ steps.rel_number.outputs.version }}
+        run: |
+          gh release edit "$REL_VERSION" \
+            --draft=false \
+            --notes-file ./app/build/outputs/changelogGithub
 
       - name: Deploy to Firebase
         env:

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -103,7 +103,7 @@ jobs:
             ./app/src/main/res/xml/locales_config.xml
           )
 
-          # If the prerelease already exists, publish it by updating assets and clearing draft mode.
+          # If a release already exists for this tag, update its assets and release metadata.
           if gh release view "$REL_VERSION" >/dev/null 2>&1; then
             gh release upload "$REL_VERSION" "${assets[@]}" --clobber
             gh release edit "$REL_VERSION" \

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -83,15 +83,16 @@ jobs:
         run: |
           echo $VERSION_CODE > ./app/build/outputs/version_code.txt
 
-      - name: Create draft Github Pre-Release
+      - name: Create or update GitHub Pre-Release
         if: github.event.inputs.beta == 'true'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          tag_name: ${{ steps.rel_number.outputs.version }}
-          body_path: ./app/build/outputs/changelogGithub
-          draft: true
-          prerelease: true
-          files: |
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REL_VERSION: ${{ steps.rel_number.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          assets=(
             ./app/build/outputs/apk/full/release/app-full-release.apk
             ./app/build/outputs/apk/minimal/release/app-minimal-release.apk
             ./app/build/outputs/version_code.txt
@@ -100,12 +101,20 @@ jobs:
             ./automotive/build/outputs/apk/minimal/release/automotive-minimal-release.apk
             ./strings.zip
             ./app/src/main/res/xml/locales_config.xml
+          )
 
-      - name: Publish Pre-Release
-        if: github.event.inputs.beta == 'true'
-        run: gh release edit ${{ steps.rel_number.outputs.version }} --draft=false
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # If the prerelease already exists, publish it by updating assets and clearing draft mode.
+          if gh release view "$REL_VERSION" >/dev/null 2>&1; then
+            gh release upload "$REL_VERSION" "${assets[@]}" --clobber
+            gh release edit "$REL_VERSION" \
+              --draft=false \
+              --prerelease \
+              --notes-file ./app/build/outputs/changelogGithub
+          else
+            gh release create "$REL_VERSION" "${assets[@]}" \
+              --prerelease \
+              --notes-file ./app/build/outputs/changelogGithub
+          fi
 
       - name: Deploy to Firebase
         env:


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We should avoid using an external action when we can do the same operation with the tool already available it limits our attack surface. It is also one less thing to update.

This address two warning from zizmor

```
info[template-injection]: code injection via template expansion
   --> ./.github/workflows/onPush.yml:106:34
    |
106 |         run: gh release edit ${{ steps.rel_number.outputs.version }} --draft=false
    |         --- this run block       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ may expand into attacker-controllable code
    |
    = note: audit confidence → Low
    = note: this finding has an auto-fix

info[superfluous-actions]: action functionality is already included by the runner
  --> ./.github/workflows/onPush.yml:88:15
   |
86 |       - name: Create draft Github Pre-Release
   |         ------------------------------------- this step
87 |         if: github.event.inputs.beta == 'true'
88 |         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ use `gh release` in a script step
   |
   = note: audit confidence → High
```