### PR TITLE
Add notification when background need local network permission

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/location/HighAccuracyLocationService.kt
@@ -19,17 +19,35 @@ import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.util.CHANNEL_HIGH_ACCURACY
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.util.ForegroundServiceLauncher
 import kotlin.math.abs
 import kotlin.math.roundToInt
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class HighAccuracyLocationService : Service() {
+
+    @EntryPoint
+    @InstallIn(SingletonComponent::class)
+    interface HighAccuracyLocationServiceEntryPoint {
+        fun checkLocalNetworkPermission(): CheckLocalNetworkPermissionUseCase
+    }
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     companion object {
         private lateinit var notificationBuilder: NotificationCompat.Builder
@@ -169,15 +187,28 @@ class HighAccuracyLocationService : Service() {
 
         val intervalInSeconds =
             intent?.getIntExtra("intervalInSeconds", DEFAULT_UPDATE_INTERVAL_SECONDS) ?: DEFAULT_UPDATE_INTERVAL_SECONDS
-        requestLocationUpdates(intervalInSeconds)
 
-        Timber.d("High accuracy location service (Interval: ${intervalInSeconds}s) started -> onStartCommand")
+        val checkLocalNetworkPermission = EntryPointAccessors
+            .fromApplication(applicationContext, HighAccuracyLocationServiceEntryPoint::class.java)
+            .checkLocalNetworkPermission()
+
+        serviceScope.launch {
+            if (!checkLocalNetworkPermission()) {
+                Timber.d("Stopping high-accuracy location service: ACCESS_LOCAL_NETWORK permission missing")
+                stopSelf()
+                return@launch
+            }
+            requestLocationUpdates(intervalInSeconds)
+            Timber.d("High accuracy location service (Interval: ${intervalInSeconds}s) started -> onStartCommand")
+        }
+
         return START_NOT_STICKY
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
+        serviceScope.cancel()
         fusedLocationProviderClient?.removeLocationUpdates(getLocationUpdateIntent())
 
         LAUNCHER.onServiceDestroy(this)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManager.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.os.Build
 import android.webkit.PermissionRequest as WebViewPermissionRequest
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.NotificationStatusProvider
 import io.homeassistant.companion.android.common.util.PermissionChecker
 import io.homeassistant.companion.android.common.util.SdkVersion
@@ -44,6 +45,7 @@ internal class PermissionManager @Inject constructor(
     @FcmSupport private val fcmSupport: Boolean,
     private val notificationStatusProvider: NotificationStatusProvider,
     private val permissionChecker: PermissionChecker,
+    private val checkLocalNetworkPermissionUseCase: CheckLocalNetworkPermissionUseCase,
 ) {
 
     private val queue = SingleSlotQueue<PermissionRequest>()
@@ -100,9 +102,13 @@ internal class PermissionManager @Inject constructor(
         if (permissionChecker.hasPermission(Manifest.permission.ACCESS_LOCAL_NETWORK)) return true
 
         Timber.d("Local network permission required, awaiting user response")
-        return queue.awaitResult { onResult ->
+        val granted = queue.awaitResult { onResult ->
             PermissionRequest.LocalNetwork(onResult = onResult)
         }
+        // Idempotent reconcile so the background-work notification (if any) is cleared as soon
+        // as the user grants the permission via this flow.
+        checkLocalNetworkPermissionUseCase()
+        return granted
     }
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -40,6 +40,7 @@ import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.authenticator.Authenticator.Companion.AuthenticationResult
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.compose.theme.HATheme
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.launch.applock.HazeLockOverlay
 import io.homeassistant.companion.android.sensors.SensorReceiver
@@ -88,6 +89,9 @@ class LaunchActivity : AppCompatActivity() {
 
     @Inject
     internal lateinit var checkLocationDisabled: CheckLocationDisabledUseCase
+
+    @Inject
+    internal lateinit var checkLocalNetworkPermission: CheckLocalNetworkPermissionUseCase
 
     @Inject
     internal lateinit var changeLog: ChangeLog
@@ -232,6 +236,7 @@ class LaunchActivity : AppCompatActivity() {
             lifecycleScope.launch {
                 WebsocketManager.start(this@LaunchActivity)
                 checkLocationDisabled()
+                checkLocalNetworkPermission()
                 changeLog.showChangeLog(this@LaunchActivity, forceShow = false)
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorWorker.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorWorker.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 import io.homeassistant.companion.android.common.sensors.SensorWorkerBase
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import java.util.concurrent.TimeUnit
 
 class SensorWorker(appContext: Context, workerParams: WorkerParameters) : SensorWorkerBase(appContext, workerParams) {
@@ -37,19 +38,19 @@ class SensorWorker(appContext: Context, workerParams: WorkerParameters) : Sensor
     @InstallIn(SingletonComponent::class)
     interface SensorWorkerEntryPoint {
         fun serverManager(): ServerManager
+        fun checkLocalNetworkPermission(): CheckLocalNetworkPermissionUseCase
+    }
+
+    private val entryPoint by lazy {
+        EntryPointAccessors.fromApplication(appContext, SensorWorkerEntryPoint::class.java)
     }
 
     override val serverManager: ServerManager
-        get() {
-            return EntryPointAccessors.fromApplication(
-                appContext,
-                SensorWorkerEntryPoint::class.java,
-            )
-                .serverManager()
-        }
+        get() = entryPoint.serverManager()
 
     override val sensorReceiver: SensorReceiverBase
-        get() {
-            return SensorReceiver()
-        }
+        get() = SensorReceiver()
+
+    override val checkLocalNetworkPermission: CheckLocalNetworkPermissionUseCase
+        get() = entryPoint.checkLocalNetworkPermission()
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -28,6 +28,7 @@ import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.CHANNEL_WEBSOCKET
 import io.homeassistant.companion.android.common.util.CHANNEL_WEBSOCKET_ISSUES
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
@@ -102,6 +103,8 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
     private val serverManager: ServerManager = entryPoint.serverManager()
     private val messagingManager: MessagingManager = entryPoint.messagingManager()
     private val settingsDao: SettingsDao = entryPoint.settingsDao()
+    private val checkLocalNetworkPermission: CheckLocalNetworkPermissionUseCase =
+        entryPoint.checkLocalNetworkPermission()
 
     @EntryPoint
     @InstallIn(SingletonComponent::class)
@@ -109,9 +112,14 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
         fun serverManager(): ServerManager
         fun messagingManager(): MessagingManager
         fun settingsDao(): SettingsDao
+        fun checkLocalNetworkPermission(): CheckLocalNetworkPermissionUseCase
     }
 
     override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        if (!checkLocalNetworkPermission()) {
+            Timber.d("Skipping websocket work: ACCESS_LOCAL_NETWORK permission missing")
+            return@withContext Result.success()
+        }
         if (!shouldWeRun()) {
             return@withContext Result.success()
         }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
@@ -384,6 +384,7 @@ class FrontendScreenTest {
         fcmSupport = false,
         notificationStatusProvider = mockk(relaxed = true),
         permissionChecker = { false },
+        checkLocalNetworkPermissionUseCase = mockk(relaxed = true),
     )
 
     private fun AndroidComposeTestRule<ActivityScenarioRule<HiltComponentActivity>, HiltComponentActivity>.setFrontendScreen(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/permissions/PermissionManagerTest.kt
@@ -5,6 +5,7 @@ import android.webkit.PermissionRequest as WebViewPermissionRequest
 import app.cash.turbine.turbineScope
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.NotificationStatusProvider
 import io.homeassistant.companion.android.common.util.PermissionChecker
 import io.homeassistant.companion.android.common.util.SdkVersion
@@ -44,6 +45,7 @@ class PermissionManagerTest {
     private val integrationRepository: IntegrationRepository = mockk(relaxed = true)
     private val notificationStatusProvider: NotificationStatusProvider = mockk()
     private val permissionChecker: PermissionChecker = mockk()
+    private val checkLocalNetworkPermissionUseCase: CheckLocalNetworkPermissionUseCase = mockk(relaxed = true)
 
     private val serverId = 1
 
@@ -68,6 +70,7 @@ class PermissionManagerTest {
             fcmSupport = hasFcmPushSupport,
             notificationStatusProvider = notificationStatusProvider,
             permissionChecker = permissionChecker,
+            checkLocalNetworkPermissionUseCase = checkLocalNetworkPermissionUseCase,
         )
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/websocket/WebsocketManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/websocket/WebsocketManagerTest.kt
@@ -10,6 +10,7 @@ import androidx.work.testing.TestListenableWorkerBuilder
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.settings.SensorUpdateFrequencySetting
 import io.homeassistant.companion.android.database.settings.Setting
@@ -53,10 +54,14 @@ class WebsocketManagerTest {
             // Test does not cover websocket monitoring right now, failsafe to end quickly if it tries
             coEvery { webSocketRepository(any()) } throws IllegalStateException("Test should not interact with WS")
         }
+        val checkLocalNetworkPermission = mockk<CheckLocalNetworkPermissionUseCase>().also {
+            coEvery { it() } returns true
+        }
 
         override fun serverManager(): ServerManager = serverManager
         override fun messagingManager(): MessagingManager = messagingManager
         override fun settingsDao(): SettingsDao = dao
+        override fun checkLocalNetworkPermission(): CheckLocalNetworkPermissionUseCase = checkLocalNetworkPermission
     }
 
     private fun mockSetting(setting: WebsocketSetting) {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorWorkerBase.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkerParameters
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.CHANNEL_SENSOR_WORKER
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.DatabaseEntryPoint
 import java.lang.IllegalStateException
@@ -25,6 +26,7 @@ abstract class SensorWorkerBase(val appContext: Context, workerParams: WorkerPar
 
     protected abstract val serverManager: ServerManager
     protected abstract val sensorReceiver: SensorReceiverBase
+    protected abstract val checkLocalNetworkPermission: CheckLocalNetworkPermissionUseCase
 
     companion object {
         const val TAG = "SensorWorker"
@@ -42,6 +44,10 @@ abstract class SensorWorkerBase(val appContext: Context, workerParams: WorkerPar
                 serverManager.integrationRepository(it.id).isHomeAssistantVersionAtLeast(2022, 6, 0)
             }
         ) {
+            if (!checkLocalNetworkPermission()) {
+                Timber.d("Skipping sensor update: ACCESS_LOCAL_NETWORK permission missing")
+                return@withContext Result.success()
+            }
             createNotificationChannel()
             val notification = NotificationCompat.Builder(applicationContext, CHANNEL_SENSOR_WORKER)
                 .setSmallIcon(commonR.drawable.ic_stat_ic_notification)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/AppNotifChannels.kt
@@ -12,6 +12,7 @@ const val CHANNEL_WEBSOCKET = "Websocket"
 const val CHANNEL_WEBSOCKET_ISSUES = "Websocket Issues"
 const val CHANNEL_HIGH_ACCURACY = "High accuracy location"
 const val CHANNEL_DATABASE = "App Database"
+const val CHANNEL_LOCAL_NETWORK_PERMISSION = "LocalNetworkPermission"
 const val CHANNEL_LOCATION_DISABLED = "Location disabled"
 const val CHANNEL_DOWNLOADS = "downloads"
 const val CHANNEL_GENERAL = "general"
@@ -33,6 +34,7 @@ val appCreatedChannels = listOf(
     CHANNEL_WEBSOCKET_ISSUES,
     CHANNEL_HIGH_ACCURACY,
     CHANNEL_DATABASE,
+    CHANNEL_LOCAL_NETWORK_PERMISSION,
     CHANNEL_LOCATION_DISABLED,
     CHANNEL_DOWNLOADS,
     CHANNEL_GENERAL,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/CheckLocalNetworkPermissionUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/CheckLocalNetworkPermissionUseCase.kt
@@ -1,0 +1,144 @@
+package io.homeassistant.companion.android.common.util
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.graphics.Color
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.util.isPubliclyAccessible
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val LOCAL_NETWORK_PERMISSION_WARN_TAG = "LocalNetworkPermissionWarning"
+
+/**
+ * Posts and dismisses the persistent system notification shown when background work cannot
+ * proceed because the `ACCESS_LOCAL_NETWORK` runtime permission is missing.
+ */
+@VisibleForTesting
+internal object LocalNetworkPermissionWarning {
+
+    /**
+     * Posts the warning notification listing the [affectedServers] whose local URLs cannot be
+     * reached without the permission. Tapping the notification launches the app, which surfaces
+     * the existing in-app permission request through `PermissionManager.checkLocalNetworkPermission()`.
+     */
+    @SuppressLint("MissingPermission")
+    fun show(context: Context, affectedServers: List<Server>) {
+        val notificationManager = NotificationManagerCompat.from(context)
+        if (notificationManager.getActiveNotification(
+                LOCAL_NETWORK_PERMISSION_WARN_TAG,
+                LOCAL_NETWORK_PERMISSION_WARN_TAG.hashCode(),
+            ) != null
+        ) {
+            return
+        }
+
+        ensureChannel(context, notificationManager)
+
+        val names = affectedServers.joinToString { it.friendlyName }
+        val message = context.getString(commonR.string.local_network_permission_message, names)
+
+        val launchIntent = context.packageManager
+            .getLaunchIntentForPackage(context.packageName)
+            ?.apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+            ?: Intent()
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(context, CHANNEL_LOCAL_NETWORK_PERMISSION)
+            .setSmallIcon(commonR.drawable.ic_stat_ic_notification)
+            .setColor(Color.RED)
+            .setOngoing(true)
+            .setContentTitle(context.getString(commonR.string.local_network_permission_title))
+            .setContentText(context.getString(commonR.string.local_network_permission_short_message))
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(false)
+            .build()
+
+        notificationManager.notify(
+            LOCAL_NETWORK_PERMISSION_WARN_TAG,
+            LOCAL_NETWORK_PERMISSION_WARN_TAG.hashCode(),
+            notification,
+        )
+    }
+
+    /** Dismisses any previously posted notification. Safe to call when nothing is posted. */
+    fun cancel(context: Context) {
+        NotificationManagerCompat.from(context).cancel(
+            tag = LOCAL_NETWORK_PERMISSION_WARN_TAG,
+            id = LOCAL_NETWORK_PERMISSION_WARN_TAG.hashCode(),
+            cancelGroup = false,
+        )
+    }
+
+    private fun ensureChannel(context: Context, notificationManager: NotificationManagerCompat) {
+        if (!SdkVersion.isAtLeast(Build.VERSION_CODES.O)) return
+        if (notificationManager.getNotificationChannel(CHANNEL_LOCAL_NETWORK_PERMISSION) != null) return
+        val channel = NotificationChannel(
+            CHANNEL_LOCAL_NETWORK_PERMISSION,
+            context.getString(commonR.string.local_network_permission_warn_channel),
+            NotificationManager.IMPORTANCE_HIGH,
+        )
+        notificationManager.createNotificationChannel(channel)
+    }
+}
+
+/**
+ * Checks whether the app currently holds the `ACCESS_LOCAL_NETWORK` runtime permission required
+ * to reach Home Assistant servers on the local network.
+ *
+ * Returns `true` when the caller may proceed with background network work, `false` when it must
+ * abort. When `false` is returned a persistent user-visible notification has already been posted
+ * via [LocalNetworkPermissionWarning]. The use case is idempotent it also dismisses any
+ * previously posted notification when the permission is now granted, the OS predates API 37, or
+ * no configured server uses a local URL.
+ *
+ * Safe to call from any dispatcher.
+ */
+@Singleton
+class CheckLocalNetworkPermissionUseCase @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val permissionChecker: PermissionChecker,
+    private val serverManager: ServerManager,
+) {
+    suspend operator fun invoke(): Boolean {
+        if (!SdkVersion.isAtLeast(Build.VERSION_CODES.CINNAMON_BUN)) {
+            return true
+        }
+        if (permissionChecker.hasPermission(Manifest.permission.ACCESS_LOCAL_NETWORK)) {
+            LocalNetworkPermissionWarning.cancel(context)
+            return true
+        }
+        val affected = serversWithLocalUrls()
+        if (affected.isEmpty()) {
+            LocalNetworkPermissionWarning.cancel(context)
+            return true
+        }
+        LocalNetworkPermissionWarning.show(context, affected)
+        return false
+    }
+
+    private suspend fun serversWithLocalUrls(): List<Server> = serverManager.servers().filter { server ->
+        server.connection.httpUrls.any {
+            !it.isPubliclyAccessible()
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -158,6 +158,11 @@ suspend fun URL.isPubliclyAccessible(): Boolean {
     return isPubliclyAccessible(host)
 }
 
+/** [HttpUrl] overload — see [URL.isPubliclyAccessible] for behavior. */
+suspend fun HttpUrl.isPubliclyAccessible(): Boolean {
+    return isPubliclyAccessible(host)
+}
+
 private suspend fun isPubliclyAccessible(fqdn: String): Boolean {
     // Check TLD
     val localTlds = listOf(".local", ".lan", ".home", ".internal", ".localdomain")

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -392,6 +392,10 @@
     <string name="template_widgets">Template widgets</string>
     <string name="loading_entities">Please wait while we load your entities</string>
     <string name="loading">Loading…</string>
+    <string name="local_network_permission_message">Home Assistant needs the local network permission to reach %1$s. Background updates have been paused. Tap to grant access.</string>
+    <string name="local_network_permission_short_message">Home Assistant needs the local network permission for background updates</string>
+    <string name="local_network_permission_title">Local network access required</string>
+    <string name="local_network_permission_warn_channel">Local network permission warning</string>
     <string name="location_disabled_dialog_message">%1$s\nDo you want to enable location?</string>
     <string name="location_disabled_notification_message">Location is required for the following enabled option(s). If you do not enable location, the sensor(s)/setting(s) will not work!\n\n%1$s</string>
     <string name="location_disabled_notification_short_message">Some options require location to work</string>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -392,10 +392,10 @@
     <string name="template_widgets">Template widgets</string>
     <string name="loading_entities">Please wait while we load your entities</string>
     <string name="loading">Loading…</string>
-    <string name="local_network_permission_message">Home Assistant needs the local network permission to reach %1$s. Background updates have been paused. Tap to grant access.</string>
-    <string name="local_network_permission_short_message">Home Assistant needs the local network permission for background updates</string>
+    <string name="local_network_permission_message">Home Assistant needs permission to access your local network to reach %1$s. Background updates have been paused. Tap to grant access.</string>
+    <string name="local_network_permission_short_message">Home Assistant needs local network access for background updates</string>
     <string name="local_network_permission_title">Local network access required</string>
-    <string name="local_network_permission_warn_channel">Local network permission warning</string>
+    <string name="local_network_permission_warn_channel">Local network access warning</string>
     <string name="location_disabled_dialog_message">%1$s\nDo you want to enable location?</string>
     <string name="location_disabled_notification_message">Location is required for the following enabled option(s). If you do not enable location, the sensor(s)/setting(s) will not work!\n\n%1$s</string>
     <string name="location_disabled_notification_short_message">Some options require location to work</string>

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/CheckLocalNetworkPermissionUseCaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/CheckLocalNetworkPermissionUseCaseTest.kt
@@ -1,0 +1,173 @@
+package io.homeassistant.companion.android.common.util
+
+import android.Manifest
+import android.content.Context
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.database.server.ServerConnectionInfo
+import io.homeassistant.companion.android.database.server.ServerSessionInfo
+import io.homeassistant.companion.android.database.server.ServerUserInfo
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val API_PRE_LOCAL_NETWORK_PERMISSION = 36 // BAKLAVA
+private const val API_WITH_LOCAL_NETWORK_PERMISSION = 37 // CINNAMON_BUN
+
+class CheckLocalNetworkPermissionUseCaseTest {
+
+    private lateinit var context: Context
+    private lateinit var serverManager: ServerManager
+    private lateinit var useCase: CheckLocalNetworkPermissionUseCase
+
+    @BeforeEach
+    fun setUp() {
+        context = mockk(relaxed = true)
+        serverManager = mockk(relaxed = true)
+        mockkObject(LocalNetworkPermissionWarning)
+        every { LocalNetworkPermissionWarning.show(any(), any()) } just runs
+        every { LocalNetworkPermissionWarning.cancel(any()) } just runs
+        useCase = newUseCase(permissionGranted = false)
+        stubSystemSdkVersion(currentSdk = API_WITH_LOCAL_NETWORK_PERMISSION)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SdkVersion.sdkInt = 0
+        unmockkObject(LocalNetworkPermissionWarning)
+    }
+
+    @Test
+    fun `Given pre-API-37 device when invoked then returns true and notification handler untouched`() = runTest {
+        stubSystemSdkVersion(currentSdk = API_PRE_LOCAL_NETWORK_PERMISSION)
+
+        val result = useCase()
+
+        assertTrue(result)
+        verify(exactly = 0) { LocalNetworkPermissionWarning.show(any(), any()) }
+        verify(exactly = 0) { LocalNetworkPermissionWarning.cancel(any()) }
+    }
+
+    @Test
+    fun `Given permission granted when invoked then returns true and cancels notification`() = runTest {
+        useCase = newUseCase(permissionGranted = true)
+
+        val result = useCase()
+
+        assertTrue(result)
+        verify(exactly = 1) { LocalNetworkPermissionWarning.cancel(context) }
+        verify(exactly = 0) { LocalNetworkPermissionWarning.show(any(), any()) }
+    }
+
+    @Test
+    fun `Given permission missing and no servers when invoked then returns true and cancels notification`() = runTest {
+        coEvery { serverManager.servers() } returns emptyList()
+
+        val result = useCase()
+
+        assertTrue(result)
+        verify(exactly = 1) { LocalNetworkPermissionWarning.cancel(context) }
+        verify(exactly = 0) { LocalNetworkPermissionWarning.show(any(), any()) }
+    }
+
+    @Test
+    fun `Given permission missing and only remote servers when invoked then returns true and cancels notification`() = runTest {
+        coEvery { serverManager.servers() } returns listOf(
+            server(id = 1, externalUrl = "https://8.8.8.8:8123", internalUrl = null),
+        )
+
+        val result = useCase()
+
+        assertTrue(result)
+        verify(exactly = 1) { LocalNetworkPermissionWarning.cancel(context) }
+        verify(exactly = 0) { LocalNetworkPermissionWarning.show(any(), any()) }
+    }
+
+    @Test
+    fun `Given permission missing and a server with local internal URL when invoked then returns false and shows notification`() = runTest {
+        val localServer = server(
+            id = 1,
+            externalUrl = "https://8.8.8.8:8123",
+            internalUrl = "http://192.168.1.10:8123",
+        )
+        coEvery { serverManager.servers() } returns listOf(localServer)
+
+        val result = useCase()
+
+        assertFalse(result)
+        verify(exactly = 1) { LocalNetworkPermissionWarning.show(context, listOf(localServer)) }
+        verify(exactly = 0) { LocalNetworkPermissionWarning.cancel(any()) }
+    }
+
+    @Test
+    fun `Given permission missing and a server with local external URL when invoked then returns false and shows notification`() = runTest {
+        val localServer = server(id = 1, externalUrl = "http://10.0.0.5:8123", internalUrl = null)
+        coEvery { serverManager.servers() } returns listOf(localServer)
+
+        val result = useCase()
+
+        assertFalse(result)
+        verify(exactly = 1) { LocalNetworkPermissionWarning.show(context, listOf(localServer)) }
+    }
+
+    @Test
+    fun `Given permission flips from missing to granted between calls when invoked twice then second call cancels notification`() = runTest {
+        val localServer = server(
+            id = 1,
+            externalUrl = "https://8.8.8.8:8123",
+            internalUrl = "http://192.168.1.10:8123",
+        )
+        coEvery { serverManager.servers() } returns listOf(localServer)
+
+        var granted = false
+        useCase = CheckLocalNetworkPermissionUseCase(
+            context = context,
+            permissionChecker = PermissionChecker { granted },
+            serverManager = serverManager,
+        )
+
+        val first = useCase()
+        granted = true
+        val second = useCase()
+
+        assertFalse(first)
+        assertTrue(second)
+        coVerify(exactly = 1) { LocalNetworkPermissionWarning.show(context, listOf(localServer)) }
+        coVerify(exactly = 1) { LocalNetworkPermissionWarning.cancel(context) }
+    }
+
+    private fun newUseCase(permissionGranted: Boolean): CheckLocalNetworkPermissionUseCase = CheckLocalNetworkPermissionUseCase(
+        context = context,
+        permissionChecker = { permission ->
+            permissionGranted && permission == Manifest.permission.ACCESS_LOCAL_NETWORK
+        },
+        serverManager = serverManager,
+    )
+
+    private fun stubSystemSdkVersion(currentSdk: Int) {
+        SdkVersion.sdkInt = currentSdk
+    }
+
+    private fun server(id: Int, externalUrl: String, internalUrl: String?): Server = Server(
+        id = id,
+        _name = "Server $id",
+        connection = ServerConnectionInfo(
+            externalUrl = externalUrl,
+            internalUrl = internalUrl,
+        ),
+        session = ServerSessionInfo(),
+        user = ServerUserInfo(),
+    )
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/LocalNetworkPermissionWarningTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/LocalNetworkPermissionWarningTest.kt
@@ -1,0 +1,97 @@
+package io.homeassistant.companion.android.common.util
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.database.server.ServerConnectionInfo
+import io.homeassistant.companion.android.database.server.ServerSessionInfo
+import io.homeassistant.companion.android.database.server.ServerUserInfo
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class LocalNetworkPermissionWarningTest {
+
+    private lateinit var context: Context
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    @Test
+    fun `Given show called when single server then posts ongoing notification with content intent`() {
+        LocalNetworkPermissionWarning.show(context, affectedServers = listOf(server(id = 1, name = "Home")))
+
+        val posted = shadowOf(notificationManager).allNotifications
+        assertEquals(1, posted.size)
+        val notif = posted.first()
+        assertTrue(
+            "notification must be ongoing",
+            notif.flags and Notification.FLAG_ONGOING_EVENT != 0,
+        )
+        assertNotNull("must have a content intent", notif.contentIntent)
+    }
+
+    @Test
+    fun `Given show called twice when one is already visible then second call is a no-op`() {
+        LocalNetworkPermissionWarning.show(context, affectedServers = listOf(server(id = 1, name = "Home")))
+        LocalNetworkPermissionWarning.show(
+            context,
+            affectedServers = listOf(
+                server(id = 1, name = "Home"),
+                server(id = 2, name = "Cabin"),
+            ),
+        )
+
+        // Re-posting an already-visible notification would trip Android's noisy-notifications
+        // rate limiter, so the second show() must short-circuit. Exactly one notification stays.
+        assertEquals(1, shadowOf(notificationManager).allNotifications.size)
+    }
+
+    @Test
+    fun `Given show then cancel when called then notification is removed`() {
+        LocalNetworkPermissionWarning.show(context, affectedServers = listOf(server(id = 1, name = "Home")))
+        LocalNetworkPermissionWarning.cancel(context)
+
+        assertEquals(0, shadowOf(notificationManager).allNotifications.size)
+    }
+
+    @Test
+    fun `Given cancel when nothing posted then no error`() {
+        LocalNetworkPermissionWarning.cancel(context)
+        assertEquals(0, shadowOf(notificationManager).allNotifications.size)
+    }
+
+    @Test
+    fun `Given show when called then channel is registered`() {
+        LocalNetworkPermissionWarning.show(context, affectedServers = listOf(server(id = 1, name = "Home")))
+
+        val channel = notificationManager.getNotificationChannel(CHANNEL_LOCAL_NETWORK_PERMISSION)
+        assertNotNull(channel)
+        assertEquals(NotificationManager.IMPORTANCE_HIGH, channel.importance)
+    }
+
+    private fun server(id: Int, name: String): Server = Server(
+        id = id,
+        _name = name,
+        connection = ServerConnectionInfo(
+            externalUrl = "http://192.168.1.$id:8123",
+        ),
+        session = ServerSessionInfo(),
+        user = ServerUserInfo(),
+    )
+}

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorWorker.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/sensors/SensorWorker.kt
@@ -14,6 +14,7 @@ import dagger.hilt.components.SingletonComponent
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.sensors.SensorReceiverBase
 import io.homeassistant.companion.android.common.sensors.SensorWorkerBase
+import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import java.util.concurrent.TimeUnit
 
 class SensorWorker(appContext: Context, workerParams: WorkerParameters) : SensorWorkerBase(appContext, workerParams) {
@@ -37,19 +38,19 @@ class SensorWorker(appContext: Context, workerParams: WorkerParameters) : Sensor
     @InstallIn(SingletonComponent::class)
     interface SensorWorkerEntryPoint {
         fun serverManager(): ServerManager
+        fun checkLocalNetworkPermission(): CheckLocalNetworkPermissionUseCase
+    }
+
+    private val entryPoint by lazy {
+        EntryPointAccessors.fromApplication(appContext, SensorWorkerEntryPoint::class.java)
     }
 
     override val serverManager: ServerManager
-        get() {
-            return EntryPointAccessors.fromApplication(
-                appContext,
-                SensorWorkerEntryPoint::class.java,
-            )
-                .serverManager()
-        }
+        get() = entryPoint.serverManager()
 
     override val sensorReceiver: SensorReceiverBase
-        get() {
-            return SensorReceiver()
-        }
+        get() = SensorReceiver()
+
+    override val checkLocalNetworkPermission: CheckLocalNetworkPermissionUseCase
+        get() = entryPoint.checkLocalNetworkPermission()
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Based on #6874, this add a notification when the local network permission is not granted but needed when something from the background is going to try to make a call like update the sensors. It tries to follow the same design as the one for location.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="108" height="240" alt="image" src="https://github.com/user-attachments/assets/283bf15d-3fd0-467f-ba32-81bb96d29133" />
