### PR TITLE
Downgrade stopServiceResolution listener-not-registered to a warning

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -206,9 +206,7 @@ private fun ProducerScope<NsdServiceInfo>.getDiscoveryListener(): NsdManager.Dis
     }
 }
 
-private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(
-    onDone: () -> Unit,
-): NsdManager.ResolveListener {
+private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(onDone: () -> Unit): NsdManager.ResolveListener {
     return object : NsdManager.ResolveListener {
         override fun onResolveFailed(serviceInfo: NsdServiceInfo?, errorCode: Int) {
             Timber.w("Failed to resolve information for service: $serviceInfo, error code $errorCode skipping")

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -150,14 +150,19 @@ internal class HomeAssistantSearcherImpl @Inject constructor(
         Timber.d("Got service info $serviceInfo")
 
         callbackFlow {
-            val listener = getResolvedListener()
+            // The platform auto-unregisters the resolve listener once it fires
+            // onServiceResolved/onResolveFailed, so stopServiceResolution would
+            // throw "listener not registered" on the happy path. Only call it
+            // if the collector cancelled before resolution completed.
+            var resolutionCompleted = false
+            val listener = getResolvedListener { resolutionCompleted = true }
 
             @Suppress("DEPRECATION")
             // We cannot use registerServiceInfoCallback since it is only available in API 34
             nsdManager.resolveService(serviceInfo, listener)
 
             awaitClose {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (!resolutionCompleted && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                     try {
                         nsdManager.stopServiceResolution(listener)
                     } catch (e: Exception) {
@@ -201,10 +206,13 @@ private fun ProducerScope<NsdServiceInfo>.getDiscoveryListener(): NsdManager.Dis
     }
 }
 
-private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManager.ResolveListener {
+private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(
+    onDone: () -> Unit,
+): NsdManager.ResolveListener {
     return object : NsdManager.ResolveListener {
         override fun onResolveFailed(serviceInfo: NsdServiceInfo?, errorCode: Int) {
             Timber.w("Failed to resolve information for service: $serviceInfo, error code $errorCode skipping")
+            onDone()
             close()
         }
 
@@ -213,6 +221,7 @@ private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManag
             serviceInfo?.toHomeAssistantInstance()?.let { instance ->
                 trySend(instance)
             }
+            onDone()
             close()
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -150,21 +150,23 @@ internal class HomeAssistantSearcherImpl @Inject constructor(
         Timber.d("Got service info $serviceInfo")
 
         callbackFlow {
-            // The platform auto-unregisters the resolve listener once it fires
-            // onServiceResolved/onResolveFailed, so stopServiceResolution would
-            // throw "listener not registered" on the happy path. Only call it
-            // if the collector cancelled before resolution completed.
-            var resolutionCompleted = false
-            val listener = getResolvedListener { resolutionCompleted = true }
+            val listener = getResolvedListener()
 
             @Suppress("DEPRECATION")
             // We cannot use registerServiceInfoCallback since it is only available in API 34
             nsdManager.resolveService(serviceInfo, listener)
 
             awaitClose {
-                if (!resolutionCompleted && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
                     try {
                         nsdManager.stopServiceResolution(listener)
+                    } catch (e: IllegalArgumentException) {
+                        // On devices with T SDK extension < 22, NsdManager throws when the
+                        // listener is already unregistered (which happens automatically after
+                        // onServiceResolved/onResolveFailed fires). The call is still needed
+                        // for devices where auto-unregistration is not guaranteed, so we keep
+                        // it and just downgrade the expected case to a warning without a stack.
+                        Timber.w("stopServiceResolution: listener already unregistered: ${e.message}")
                     } catch (e: Exception) {
                         Timber.e(e, "Failed to stop service resolution")
                     }
@@ -206,11 +208,10 @@ private fun ProducerScope<NsdServiceInfo>.getDiscoveryListener(): NsdManager.Dis
     }
 }
 
-private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(onDone: () -> Unit): NsdManager.ResolveListener {
+private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManager.ResolveListener {
     return object : NsdManager.ResolveListener {
         override fun onResolveFailed(serviceInfo: NsdServiceInfo?, errorCode: Int) {
             Timber.w("Failed to resolve information for service: $serviceInfo, error code $errorCode skipping")
-            onDone()
             close()
         }
 
@@ -219,7 +220,6 @@ private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(onDone: () 
             serviceInfo?.toHomeAssistantInstance()?.let { instance ->
                 trySend(instance)
             }
-            onDone()
             close()
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
On API 34+ the NSD framework auto-unregisters the resolve listener once `onServiceResolved`/`onResolveFailed` fires, so the unconditional `stopServiceResolution` call in `awaitClose` throws `IllegalArgumentException: listener not registered` on the happy path and logs an error-level stack trace per discovered instance. This is noisy and misleading — it looks like a real failure but isn't.

The call itself is still required: per the platform documentation, devices with T SDK extension < 22 do not auto-unregister, so skipping the call would leak listeners on those devices. Instead, catch `IllegalArgumentException` specifically and log it at warning level without a stack trace, since on modern devices this branch is the expected outcome rather than an error. Other exceptions still log at error level with a stack.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

## Link to pull request in documentation repositories
<!--
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#

<!--
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes
<!--
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
