### PR TITLE
Fix file uploads in onboarding WebView (e.g. backup restore)

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -70,10 +69,10 @@ internal fun ConnectionScreen(
     isLoading: Boolean,
     isError: Boolean,
     webViewClient: WebViewClient,
+    webChromeClient: WebChromeClient,
     onBackClick: () -> Unit,
     onWebViewCreationFailed: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
-    webChromeClient: WebChromeClient = remember { WebChromeClient() },
     pendingFileChooser: FileChooserRequest? = null,
 ) {
     FileChooserEffect(pendingRequest = pendingFileChooser)
@@ -139,6 +138,7 @@ private fun ConnectionScreenPreview() {
             isLoading = false,
             isError = false,
             webViewClient = WebViewClient(),
+            webChromeClient = WebChromeClient(),
             onBackClick = {},
             onWebViewCreationFailed = {},
             modifier = Modifier.fillMaxSize(),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreen.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.onboarding.connection
 
+import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import androidx.annotation.VisibleForTesting
 import androidx.compose.foundation.Image
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -26,6 +28,8 @@ import androidx.compose.ui.unit.dp
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
 import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
+import io.homeassistant.companion.android.frontend.filechooser.FileChooserEffect
+import io.homeassistant.companion.android.frontend.filechooser.FileChooserRequest
 import io.homeassistant.companion.android.loading.LoadingScreen
 import io.homeassistant.companion.android.util.compose.HAPreviews
 import io.homeassistant.companion.android.util.compose.webview.HAWebView
@@ -44,6 +48,7 @@ internal fun ConnectionScreen(onBackClick: () -> Unit, viewModel: ConnectionView
     val url by viewModel.urlFlow.collectAsState()
     val isLoading by viewModel.isLoadingFlow.collectAsState()
     val error by viewModel.errorFlow.collectAsState()
+    val pendingFileChooser by viewModel.pendingFileChooser.collectAsState()
     val isError = error != null
 
     ConnectionScreen(
@@ -51,6 +56,8 @@ internal fun ConnectionScreen(onBackClick: () -> Unit, viewModel: ConnectionView
         isLoading = isLoading,
         isError = isError,
         webViewClient = viewModel.webViewClient,
+        webChromeClient = viewModel.webChromeClient,
+        pendingFileChooser = pendingFileChooser,
         onBackClick = onBackClick,
         onWebViewCreationFailed = viewModel::onWebViewCreationFailed,
         modifier = modifier,
@@ -66,7 +73,11 @@ internal fun ConnectionScreen(
     onBackClick: () -> Unit,
     onWebViewCreationFailed: (Throwable) -> Unit,
     modifier: Modifier = Modifier,
+    webChromeClient: WebChromeClient = remember { WebChromeClient() },
+    pendingFileChooser: FileChooserRequest? = null,
 ) {
+    FileChooserEffect(pendingRequest = pendingFileChooser)
+
     Box(modifier = modifier.testTag(CONNECTION_SCREEN_TAG)) {
         Spacer(
             modifier = Modifier
@@ -84,6 +95,7 @@ internal fun ConnectionScreen(
                         .windowInsetsPadding(WindowInsets.safeDrawing),
                     configure = {
                         this.webViewClient = webViewClient
+                        this.webChromeClient = webChromeClient
                         loadUrl(url)
                     },
                     onBackPressed = onBackClick,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -133,17 +133,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     val webChromeClient: HAWebChromeClient = HAWebChromeClient(
         onShowFileChooser = { filePathCallback, fileChooserParams ->
             viewModelScope.launch {
-                var delivered = false
-                try {
-                    val uris = fileChooserManager.pickFiles(fileChooserParams)
-                    delivered = true
-                    filePathCallback.onReceiveValue(uris)
-                } finally {
-                    // Ensure the WebView's file input is unblocked even if the coroutine is
-                    // cancelled (e.g. ViewModel cleared) or pickFiles throws, otherwise the
-                    // `<input type="file">` element would stay in a stuck pending state.
-                    if (!delivered) filePathCallback.onReceiveValue(null)
-                }
+                filePathCallback.onReceiveValue(fileChooserManager.pickFiles(fileChooserParams))
             }
             true
         },

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -128,15 +128,22 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     /**
      * [WebChromeClient][android.webkit.WebChromeClient] used by the onboarding WebView.
      *
-     * The Home Assistant onboarding flow (e.g. backup restore) renders `<input type="file">`
-     * elements; without an `onShowFileChooser` override these clicks are silently dropped by
-     * the system WebView. This delegates to [FileChooserManager] so the request survives
-     * configuration changes and reuses the same flow as the main frontend WebView.
+     * The Home Assistant onboarding flow could request a file selection (e.g. backup restore).
      */
     val webChromeClient: HAWebChromeClient = HAWebChromeClient(
         onShowFileChooser = { filePathCallback, fileChooserParams ->
             viewModelScope.launch {
-                filePathCallback.onReceiveValue(fileChooserManager.pickFiles(fileChooserParams))
+                var delivered = false
+                try {
+                    val uris = fileChooserManager.pickFiles(fileChooserParams)
+                    delivered = true
+                    filePathCallback.onReceiveValue(uris)
+                } finally {
+                    // Ensure the WebView's file input is unblocked even if the coroutine is
+                    // cancelled (e.g. ViewModel cleared) or pickFiles throws, otherwise the
+                    // `<input type="file">` element would stay in a stuck pending state.
+                    if (!delivered) filePathCallback.onReceiveValue(null)
+                }
             }
             true
         },

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -14,13 +14,17 @@ import io.homeassistant.companion.android.common.data.connectivity.ConnectivityC
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckState
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionErrorStateProvider
+import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
+import io.homeassistant.companion.android.frontend.filechooser.FileChooserRequest
 import io.homeassistant.companion.android.onboarding.connection.navigation.ConnectionRoute
+import io.homeassistant.companion.android.util.HAWebChromeClient
 import io.homeassistant.companion.android.util.HAWebViewClient
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -65,6 +69,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     private val rawUrl: String,
     private val webViewClientFactory: HAWebViewClientFactory,
     private val connectivityCheckRepository: ConnectivityCheckRepository,
+    private val fileChooserManager: FileChooserManager,
 ) : ViewModel(),
     FrontendConnectionErrorStateProvider {
 
@@ -73,7 +78,13 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         savedStateHandle: SavedStateHandle,
         webViewClientFactory: HAWebViewClientFactory,
         connectivityCheckRepository: ConnectivityCheckRepository,
-    ) : this(savedStateHandle.toRoute<ConnectionRoute>().url, webViewClientFactory, connectivityCheckRepository)
+        fileChooserManager: FileChooserManager,
+    ) : this(
+        savedStateHandle.toRoute<ConnectionRoute>().url,
+        webViewClientFactory,
+        connectivityCheckRepository,
+        fileChooserManager,
+    )
 
     private val rawUri: Uri by lazy { rawUrl.toUri() }
 
@@ -113,6 +124,26 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         onUrlIntercepted = ::interceptRedirectIfRequired,
         onPageFinished = { _isLoadingFlow.update { false } },
     )
+
+    /**
+     * [WebChromeClient][android.webkit.WebChromeClient] used by the onboarding WebView.
+     *
+     * The Home Assistant onboarding flow (e.g. backup restore) renders `<input type="file">`
+     * elements; without an `onShowFileChooser` override these clicks are silently dropped by
+     * the system WebView. This delegates to [FileChooserManager] so the request survives
+     * configuration changes and reuses the same flow as the main frontend WebView.
+     */
+    val webChromeClient: HAWebChromeClient = HAWebChromeClient(
+        onShowFileChooser = { filePathCallback, fileChooserParams ->
+            viewModelScope.launch {
+                filePathCallback.onReceiveValue(fileChooserManager.pickFiles(fileChooserParams))
+            }
+            true
+        },
+    )
+
+    /** The current pending file chooser request from the WebView, or `null` if none. */
+    val pendingFileChooser: StateFlow<FileChooserRequest?> = fileChooserManager.pendingFileChooser
 
     init {
         viewModelScope.launch {

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenshotTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.onboarding.connection
 
+import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import androidx.compose.runtime.Composable
 import com.android.tools.screenshot.PreviewTest
@@ -18,6 +19,7 @@ class ConnectionScreenshotTest {
                 isLoading = true,
                 isError = false,
                 webViewClient = WebViewClient(),
+                webChromeClient = WebChromeClient(),
                 onBackClick = {},
                 onWebViewCreationFailed = {},
             )
@@ -34,6 +36,7 @@ class ConnectionScreenshotTest {
                 isLoading = false,
                 isError = false,
                 webViewClient = WebViewClient(),
+                webChromeClient = WebChromeClient(),
                 onBackClick = {},
                 onWebViewCreationFailed = {},
             )
@@ -50,6 +53,7 @@ class ConnectionScreenshotTest {
                 isLoading = false,
                 isError = true,
                 webViewClient = WebViewClient(),
+                webChromeClient = WebChromeClient(),
                 onBackClick = {},
                 onWebViewCreationFailed = {},
             )

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/WearOnboardingNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/WearOnboardingNavigationTest.kt
@@ -122,6 +122,7 @@ internal class WearOnboardingNavigationTest {
         every { navigationEventsFlow } returns connectionNavigationEventFlow
         every { errorFlow } returns MutableStateFlow(null)
         every { connectivityCheckState } returns MutableStateFlow(ConnectivityCheckState())
+        every { pendingFileChooser } returns MutableStateFlow(null)
     }
 
     private val selectedUri = mockk<Uri>()

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionScreenTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.onboarding.connection
 
+import android.webkit.WebChromeClient
 import android.webkit.WebViewClient
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
@@ -44,6 +45,7 @@ class ConnectionScreenTest {
                     isError = false,
                     url = null,
                     webViewClient = WebViewClient(),
+                    webChromeClient = WebChromeClient(),
                     onWebViewCreationFailed = {},
                 )
             }
@@ -61,6 +63,7 @@ class ConnectionScreenTest {
                     isError = false,
                     url = "",
                     webViewClient = WebViewClient(),
+                    webChromeClient = WebChromeClient(),
                     onWebViewCreationFailed = {},
                 )
             }
@@ -79,6 +82,7 @@ class ConnectionScreenTest {
                     isError = false,
                     url = "",
                     webViewClient = WebViewClient(),
+                    webChromeClient = WebChromeClient(),
                     onWebViewCreationFailed = {},
                 )
             }
@@ -97,6 +101,7 @@ class ConnectionScreenTest {
                     isError = true,
                     url = "",
                     webViewClient = WebViewClient(),
+                    webChromeClient = WebChromeClient(),
                     onWebViewCreationFailed = {},
                 )
             }
@@ -119,6 +124,7 @@ class ConnectionScreenTest {
                     isError = false,
                     url = "",
                     webViewClient = WebViewClient(),
+                    webChromeClient = WebChromeClient(),
                     onWebViewCreationFailed = {},
                 )
             }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -464,8 +464,10 @@ class ConnectionViewModelTest {
         )
         advanceUntilIdle()
 
+        val pending = viewModel.pendingFileChooser.value
+        assertNotNull(pending)
         val uris = arrayOf(mockk<Uri>())
-        viewModel.pendingFileChooser.value!!.onResult(uris)
+        pending!!.onResult(uris)
         advanceUntilIdle()
 
         verify { filePathCallback.onReceiveValue(uris) }
@@ -490,7 +492,9 @@ class ConnectionViewModelTest {
         )
         advanceUntilIdle()
 
-        viewModel.pendingFileChooser.value!!.onResult(null)
+        val pending = viewModel.pendingFileChooser.value
+        assertNotNull(pending)
+        pending!!.onResult(null)
         advanceUntilIdle()
 
         verify { filePathCallback.onReceiveValue(null) }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -13,6 +13,7 @@ import io.homeassistant.companion.android.common.data.connectivity.ConnectivityC
 import io.homeassistant.companion.android.common.data.connectivity.ConnectivityCheckState
 import io.homeassistant.companion.android.common.data.keychain.KeyChainRepository
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
+import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import io.homeassistant.companion.android.util.HAWebViewClient
@@ -75,6 +76,7 @@ class ConnectionViewModelTest {
         }
     }
     private val connectivityCheckRepository: ConnectivityCheckRepository = mockk()
+    private val fileChooserManager = FileChooserManager()
 
     @BeforeEach
     fun setup() {
@@ -85,7 +87,7 @@ class ConnectionViewModelTest {
     @ParameterizedTest
     @ValueSource(strings = ["http://homeassistant.local:8123", "https://cloud.ui.nabu.casa"])
     fun `Given a valid http url when buildAuthUrl then urlFlow emits correct auth url and isLoading is false`(baseUrl: String) = runTest {
-        val viewModel = ConnectionViewModel(baseUrl, webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel(baseUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val urlFlow = viewModel.urlFlow.testIn(backgroundScope)
@@ -116,7 +118,7 @@ class ConnectionViewModelTest {
     @ValueSource(strings = ["http://homeassistant.local:8123", "https://cloud.ui.nabu.casa"])
     fun `Given a valid http url with suffix when buildAuthUrl then urlFlow emits correct auth url with path stripped`(baseUrl: String) = runTest {
         val suffix = "/hello?query=param&isHA=true#segment"
-        val viewModel = ConnectionViewModel("$baseUrl$suffix", webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel("$baseUrl$suffix", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val urlFlow = viewModel.urlFlow.testIn(backgroundScope)
@@ -133,7 +135,7 @@ class ConnectionViewModelTest {
     @Test
     fun `Given a malformed url when buildAuthUrl then errorFlow emits malformed url error`() = runTest {
         val malformedUrl = "not_a_url"
-        val viewModel = ConnectionViewModel(malformedUrl, webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel(malformedUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -162,7 +164,7 @@ class ConnectionViewModelTest {
         val authCode = "test_auth_code"
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -191,7 +193,7 @@ class ConnectionViewModelTest {
     fun `Given auth callback uri without code when shouldRedirect then no event and returns false`() = runTest {
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = null)
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -219,7 +221,7 @@ class ConnectionViewModelTest {
             isOpaque = true,
         )
 
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
@@ -240,7 +242,7 @@ class ConnectionViewModelTest {
 
     @Test
     fun `Given unmatching uri and webview not null when shouldRedirect is invoked then open in external browser and return true`() = runTest {
-        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel("http://homeassistant.local:8123", webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         // Used to parse the rawUrl given in the constructor of ConnectionViewModel
         mockUriParse()
@@ -327,7 +329,7 @@ class ConnectionViewModelTest {
         val connectivityFlow = MutableSharedFlow<ConnectivityCheckState>()
         every { connectivityCheckRepository.runChecks(rawUrl) } returns connectivityFlow
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
         val webView = mockWebView()
 
         advanceUntilIdle()
@@ -368,7 +370,7 @@ class ConnectionViewModelTest {
 
         every { connectivityCheckRepository.runChecks(rawUrl) } returnsMany listOf(first, second)
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
 
         // When: first click on "Run checks"
         viewModel.runConnectivityChecks()
@@ -397,7 +399,7 @@ class ConnectionViewModelTest {
         val connectivityFlow = MutableSharedFlow<ConnectivityCheckState>()
         every { connectivityCheckRepository.runChecks(rawUrl) } returns connectivityFlow
 
-        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository)
+        val viewModel = ConnectionViewModel(rawUrl, webViewClientFactory, connectivityCheckRepository, fileChooserManager)
         advanceUntilIdle()
 
         assertNull(viewModel.errorFlow.value)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -1,6 +1,8 @@
 package io.homeassistant.companion.android.onboarding.connection
 
 import android.net.Uri
+import android.webkit.ValueCallback
+import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -417,5 +419,81 @@ class ConnectionViewModelTest {
         assertEquals("dlopen failed: libwebviewchromium.so is 32-bit", error.errorDetails)
         assertEquals("class java.lang.UnsatisfiedLinkError", error.rawErrorType)
         verify(exactly = 1) { connectivityCheckRepository.runChecks(rawUrl) }
+    }
+
+    @Test
+    fun `Given webChromeClient when onShowFileChooser is invoked then pendingFileChooser exposes the params`() = runTest {
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
+        val fileChooserParams = mockk<WebChromeClient.FileChooserParams>(relaxed = true)
+
+        val handled = viewModel.webChromeClient.onShowFileChooser(
+            mockk(relaxed = true),
+            filePathCallback,
+            fileChooserParams,
+        )
+        advanceUntilIdle()
+
+        assertTrue(handled)
+        val pending = viewModel.pendingFileChooser.value
+        assertNotNull(pending)
+        assertTrue(pending!!.fileChooserParams === fileChooserParams)
+    }
+
+    @Test
+    fun `Given pending file chooser when result delivered then filePathCallback receives uris and slot clears`() = runTest {
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
+
+        viewModel.webChromeClient.onShowFileChooser(
+            mockk(relaxed = true),
+            filePathCallback,
+            mockk(relaxed = true),
+        )
+        advanceUntilIdle()
+
+        val uris = arrayOf(mockk<Uri>())
+        viewModel.pendingFileChooser.value!!.onResult(uris)
+        advanceUntilIdle()
+
+        verify { filePathCallback.onReceiveValue(uris) }
+        assertNull(viewModel.pendingFileChooser.value)
+    }
+
+    @Test
+    fun `Given pending file chooser when user cancels then filePathCallback receives null and slot clears`() = runTest {
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        val filePathCallback = mockk<ValueCallback<Array<Uri>>>(relaxed = true)
+
+        viewModel.webChromeClient.onShowFileChooser(
+            mockk(relaxed = true),
+            filePathCallback,
+            mockk(relaxed = true),
+        )
+        advanceUntilIdle()
+
+        viewModel.pendingFileChooser.value!!.onResult(null)
+        advanceUntilIdle()
+
+        verify { filePathCallback.onReceiveValue(null) }
+        assertNull(viewModel.pendingFileChooser.value)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/navigation/ServerDiscoveryNavigationTest.kt
@@ -111,6 +111,7 @@ internal class ServerDiscoveryNavigationTest : BaseOnboardingNavigationTest() {
         every { navigationEventsFlow } returns connectionNavigationEventFlow
         every { errorFlow } returns MutableStateFlow(null)
         every { connectivityCheckState } returns MutableStateFlow(ConnectivityCheckState())
+        every { pendingFileChooser } returns MutableStateFlow(null)
     }
 
     @Test


### PR DESCRIPTION
## Summary

The onboarding WebView in `ConnectionScreen` only had a `WebViewClient` configured and no `WebChromeClient`. Because the default `WebChromeClient.onShowFileChooser()` returns `false`, every `<input type=\"file\">` click in the HA onboarding frontend was silently dropped — including the backup restore upload, where clicking the file picker did nothing at all.

Fix: reuse the existing `FileChooserManager` + `FileChooserEffect` + `HAWebChromeClient` plumbing that was added for the new `FrontendScreen`. The onboarding WebView now uses the same code path:

- `ConnectionViewModel` injects `FileChooserManager`, exposes `pendingFileChooser`, and builds an `HAWebChromeClient` whose `onShowFileChooser` delegates to `fileChooserManager.pickFiles(...)`.
- `ConnectionScreen` collects `pendingFileChooser`, wires the chrome client into `HAWebView`, and renders `FileChooserEffect` so the system picker is actually launched and results are delivered back to the WebView.

Tested manually only insofar as the unit + screen tests pass; I have not yet driven a full onboarding flow on a device to confirm a `.tar` backup uploads end-to-end (the picker now opens, but Android's picker can report `.tar` as `application/octet-stream`, which the HA frontend rejects client-side — that's a separate issue if it bites).

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

Notes on the checklist:
- Tests: the existing `ConnectionViewModelTest` instantiations were updated to pass the new `FileChooserManager` dependency. No dedicated new test was added for the chooser path itself — the wiring is identical to `FrontendScreen` which is already covered.
- Thorough testing: only unit/screen tests run; no on-device verification of an actual backup upload yet (see Summary).

## Screenshots

N/A — behavior fix; no visual change to native UI.

## Link to pull request in documentation repositories

<!-- No doc change required: this restores expected behavior of an existing screen. -->

## Any other notes

The file chooser code path is shared with the (debug-only) `FrontendScreen` via `FileChooserManager`/`FileChooserEffect`. `ConnectionScreen` is not on the `USE_FRONTEND_V2` migration path — it's a separate WebView used during onboarding — so this fix is needed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)