### PR TITLE
Add Health Connect nutrition sensor support

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -28,6 +28,7 @@ import androidx.health.connect.client.records.HeightRecord
 import androidx.health.connect.client.records.HydrationRecord
 import androidx.health.connect.client.records.LeanBodyMassRecord
 import androidx.health.connect.client.records.MealType
+import androidx.health.connect.client.records.NutritionRecord
 import androidx.health.connect.client.records.OxygenSaturationRecord
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.RespiratoryRateRecord
@@ -251,6 +252,17 @@ class HealthConnectSensorManager : SensorManager {
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
         )
 
+        val nutrition = SensorManager.BasicSensor(
+            id = "health_connect_nutrition",
+            type = "sensor",
+            commonR.string.basic_sensor_name_nutrition,
+            commonR.string.sensor_description_nutrition,
+            "mdi:food-apple",
+            deviceClass = "energy",
+            unitOfMeasurement = "kcal",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
         val oxygenSaturation = SensorManager.BasicSensor(
             id = "health_connect_oxygen_saturation",
             type = "sensor",
@@ -365,6 +377,7 @@ class HealthConnectSensorManager : SensorManager {
             height.id to HeightRecord::class,
             hydration.id to HydrationRecord::class,
             leanBodyMass.id to LeanBodyMassRecord::class,
+            nutrition.id to NutritionRecord::class,
             oxygenSaturation.id to OxygenSaturationRecord::class,
             respiratoryRate.id to RespiratoryRateRecord::class,
             restingHeartRate.id to RestingHeartRateRecord::class,
@@ -449,6 +462,9 @@ class HealthConnectSensorManager : SensorManager {
         }
         if (isEnabled(context, leanBodyMass)) {
             updateLeanBodyMassSensor(context)
+        }
+        if (isEnabled(context, nutrition)) {
+            updateNutritionSensor(context)
         }
         if (isEnabled(context, oxygenSaturation)) {
             updateOxygenSaturationSensor(context)
@@ -796,6 +812,42 @@ class HealthConnectSensorManager : SensorManager {
         )
     }
 
+    private suspend fun updateNutritionSensor(context: Context) {
+        val healthConnectClient = getOrCreateHealthConnectClient(context) ?: return
+        val nutritionRequest = buildReadRecordsRequest(NutritionRecord::class)
+        val response = healthConnectClient.readRecordsOrNull(nutritionRequest)
+        if (response == null || response.records.isEmpty()) {
+            return
+        }
+
+        val record = response.records.last()
+        val energyKcal = record.energy?.inKilocalories ?: 0.0
+        val attributes = mutableMapOf<String, Any>(
+            "endTime" to record.endTime,
+            "mealType" to getMealType(record.mealType),
+            "source" to record.metadata.dataOrigin.packageName,
+        )
+
+        record.energyFromFat?.inKilocalories?.let { attributes["energyFromFat"] = it }
+        record.totalCarbohydrate?.inGrams?.let { attributes["totalCarbohydrate"] = it }
+        record.protein?.inGrams?.let { attributes["protein"] = it }
+        record.totalFat?.inGrams?.let { attributes["totalFat"] = it }
+        record.sugar?.inGrams?.let { attributes["sugar"] = it }
+        record.dietaryFiber?.inGrams?.let { attributes["dietaryFiber"] = it }
+        record.sodium?.inGrams?.let { attributes["sodium"] = it }
+        record.saturatedFat?.inGrams?.let { attributes["saturatedFat"] = it }
+        record.transFat?.inGrams?.let { attributes["transFat"] = it }
+        record.unsaturatedFat?.inGrams?.let { attributes["unsaturatedFat"] = it }
+
+        onSensorUpdated(
+            context,
+            nutrition,
+            BigDecimal(energyKcal).setScale(2, RoundingMode.HALF_EVEN),
+            nutrition.statelessIcon,
+            attributes = attributes,
+        )
+    }
+
     private suspend fun updateOxygenSaturationSensor(context: Context) {
         val healthConnectClient = getOrCreateHealthConnectClient(context) ?: return
         val oxygenSaturationRequest = buildReadRecordsRequest(OxygenSaturationRecord::class)
@@ -968,6 +1020,7 @@ class HealthConnectSensorManager : SensorManager {
                 height,
                 hydration,
                 leanBodyMass,
+                nutrition,
                 oxygenSaturation,
                 respiratoryRate,
                 restingHeartRate,

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,6 +2,7 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2026.5.4 - Main" versioncode="3">
+        <change>Added Health Connect nutrition sensor support with nutrient attributes</change>
         <change>Added support for Android 17's local network permission</change>
         <change>Bug fixes and dependency updates</change>
     </release>

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.NutritionRecord
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.mockk.every
 import io.mockk.mockk
@@ -50,6 +51,29 @@ class HealthConnectSensorManagerTest {
         assertEquals(
             available,
             permissions.contains(HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `Given nutrition sensor when getting permissions then includes nutrition read permission`(
+        backgroundReadAvailable: Boolean,
+    ) {
+        mockkObject(healthConnectClient.features)
+        every {
+            healthConnectClient.features.getFeatureStatus(HealthConnectFeatures.FEATURE_READ_HEALTH_DATA_IN_BACKGROUND)
+        } returns
+            if (backgroundReadAvailable) {
+                HealthConnectFeatures.FEATURE_STATUS_AVAILABLE
+            } else {
+                HealthConnectFeatures.FEATURE_STATUS_UNAVAILABLE
+            }
+
+        val permissions = sensorManager.requiredPermissions(context, HealthConnectSensorManager.nutrition.id)
+
+        assertEquals(
+            true,
+            permissions.contains(HealthPermission.getReadPermission(NutritionRecord::class)),
         )
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1365,6 +1365,8 @@
     <string name="sensor_description_heart_rate_variability">Last recorded heart rate variability from Health Connect</string>
     <string name="basic_sensor_name_hydration">Daily hydration</string>
     <string name="sensor_description_hydration">Total hydration in milliliters since midnight from Health Connect</string>
+    <string name="basic_sensor_name_nutrition">Nutrition</string>
+    <string name="sensor_description_nutrition">Latest nutrition entry from Health Connect with macro nutrients as attributes</string>
     <string name="basic_sensor_name_resting_heart_rate">Resting heart rate</string>
     <string name="sensor_description_resting_heart_rate">Last recorded resting heart rate from Health Connect</string>
     <string name="domain_number">Number</string>


### PR DESCRIPTION
## Summary
Add a new Health Connect nutrition sensor to the Android companion app.

This change introduces support for syncing the latest Health Connect `NutritionRecord` into Home Assistant as a sensor entity (`health_connect_nutrition`) with additional nutrient-related attributes.

Motivation:
- Extend Health Connect coverage to nutrition data for users already syncing health metrics

Impact:
- Users can enable and sync nutrition information from Health Connect
- No Home Assistant Core backend changes are required because mobile app sensor payloads already support additional attributes

## Checklist
- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
N/A - no new custom UI layout was introduced. This PR adds an additional supported Health Connect sensor type within existing system/app flows.

## Link to pull request in documentation repositories
User Documentation: home-assistant/companion.home-assistant#N/A
Developer Documentation: home-assistant/developers.home-assistant#N/A

## Any other notes
Validation performed locally:
- `./gradlew :app:testFullDebugUnitTest --tests io.homeassistant.companion.android.sensors.HealthConnectSensorManagerTest` ✅
- `./gradlew ktlintCheck :build-logic:convention:ktlintCheck --continue` ✅
- `./gradlew test` was attempted but is currently blocked by pre-existing unrelated local minimal/wear test-classpath issues (for example unresolved Wear/GMS references in existing `app/src/test/.../settings/wear/*` tests)
