### PR TITLE
Add Android Assist VAD timing settings

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistViewModel.kt
@@ -21,6 +21,7 @@ import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineResponse
 import io.homeassistant.companion.android.common.util.AudioUrlPlayer
+import io.homeassistant.companion.android.settings.assist.AssistConfigManager
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
@@ -36,6 +37,7 @@ class AssistViewModel @AssistedInject constructor(
     serverManager: ServerManager,
     @Assisted initialAudioStrategy: AssistAudioStrategy,
     audioUrlPlayer: AudioUrlPlayer,
+    private val assistConfigManager: AssistConfigManager,
     application: Application,
 ) : AssistViewModelBase(serverManager, initialAudioStrategy, audioUrlPlayer, application) {
 
@@ -434,6 +436,7 @@ class AssistViewModel @AssistedInject constructor(
             text = text,
             pipeline = selectedPipeline,
             wakeWordPhrase = wakeWord,
+            vadSettingsProvider = assistConfigManager::getVadSettings,
         ) { event ->
             when (event) {
                 is AssistEvent.Message -> {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistConfigManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistConfigManager.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RequiresPermission
 import dagger.hilt.android.qualifiers.ApplicationContext
 import io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService
 import io.homeassistant.companion.android.assist.wakeword.MicroWakeWordModelConfig
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.common.util.SuspendLazy
@@ -51,6 +52,12 @@ interface AssistConfigManager {
      */
     @RequiresPermission(Manifest.permission.RECORD_AUDIO)
     suspend fun setSelectedWakeWordModel(model: MicroWakeWordModelConfig)
+
+    suspend fun getVadSettings(): AssistVadSettings
+
+    suspend fun setVadSilenceSeconds(seconds: Double?)
+
+    suspend fun setVadTimeoutSeconds(seconds: Double?)
 }
 
 class AssistConfigManagerImpl @Inject constructor(
@@ -100,5 +107,15 @@ class AssistConfigManagerImpl @Inject constructor(
         if (model.wakeWord != previousWakeWord && prefsRepository.isWakeWordEnabled()) {
             AssistVoiceInteractionService.startListening(context)
         }
+    }
+
+    override suspend fun getVadSettings(): AssistVadSettings = prefsRepository.getAssistVadSettings()
+
+    override suspend fun setVadSilenceSeconds(seconds: Double?) {
+        prefsRepository.setAssistVadSilenceSeconds(seconds)
+    }
+
+    override suspend fun setVadTimeoutSeconds(seconds: Double?) {
+        prefsRepository.setAssistVadTimeoutSeconds(seconds)
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -45,6 +46,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -63,6 +65,7 @@ import io.homeassistant.companion.android.common.compose.composable.HALabel
 import io.homeassistant.companion.android.common.compose.composable.HALoading
 import io.homeassistant.companion.android.common.compose.composable.HASettingsCard
 import io.homeassistant.companion.android.common.compose.composable.HASwitch
+import io.homeassistant.companion.android.common.compose.composable.HATextField
 import io.homeassistant.companion.android.common.compose.composable.LabelVariant
 import io.homeassistant.companion.android.common.compose.theme.HADimens
 import io.homeassistant.companion.android.common.compose.theme.HARadius
@@ -149,6 +152,8 @@ fun AssistSettingsScreen(viewModel: AssistSettingsViewModel, modifier: Modifier 
             onSelectWakeWord = viewModel::onSelectWakeWordModel,
             onStartTestWakeWord = { viewModel.setTestingWakeWord(true) },
             onStopTestWakeWord = { viewModel.setTestingWakeWord(false) },
+            onVadSilenceSecondsChange = viewModel::onVadSilenceSecondsChanged,
+            onVadTimeoutSecondsChange = viewModel::onVadTimeoutSecondsChanged,
             modifier = Modifier.padding(contentPadding),
         )
     }
@@ -164,6 +169,8 @@ internal fun AssistSettingsContent(
     onSelectWakeWord: (MicroWakeWordModelConfig) -> Unit,
     onStartTestWakeWord: () -> Unit,
     onStopTestWakeWord: () -> Unit,
+    onVadSilenceSecondsChange: (String) -> Unit,
+    onVadTimeoutSecondsChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -188,6 +195,19 @@ internal fun AssistSettingsContent(
 
             Spacer(modifier = Modifier.height(HADimens.SPACE2))
 
+            SectionHeader(
+                text = stringResource(commonR.string.assist_voice_input_title),
+                modifier = Modifier.padding(bottom = HADimens.SPACE1),
+            )
+            VoiceInputSection(
+                vadSilenceSeconds = uiState.vadSilenceSeconds,
+                vadTimeoutSeconds = uiState.vadTimeoutSeconds,
+                onVadSilenceSecondsChange = onVadSilenceSecondsChange,
+                onVadTimeoutSecondsChange = onVadTimeoutSecondsChange,
+            )
+
+            Spacer(modifier = Modifier.height(HADimens.SPACE2))
+
             // Wake Word Section
             Row(
                 horizontalArrangement = Arrangement.spacedBy(HADimens.SPACE2),
@@ -205,6 +225,39 @@ internal fun AssistSettingsContent(
                 onSelectWakeWord = onSelectWakeWord,
                 onStartTestWakeWord = onStartTestWakeWord,
                 onStopTestWakeWord = onStopTestWakeWord,
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceInputSection(
+    vadSilenceSeconds: String,
+    vadTimeoutSeconds: String,
+    onVadSilenceSecondsChange: (String) -> Unit,
+    onVadTimeoutSecondsChange: (String) -> Unit,
+) {
+    val decimalKeyboard = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+
+    HASettingsCard {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(HADimens.SPACE3),
+        ) {
+            HATextField(
+                value = vadSilenceSeconds,
+                onValueChange = onVadSilenceSecondsChange,
+                label = { Text(stringResource(commonR.string.assist_vad_silence_seconds)) },
+                placeholder = { Text(stringResource(commonR.string.assist_vad_default_placeholder)) },
+                keyboardOptions = decimalKeyboard,
+                maxLines = 1,
+            )
+            HATextField(
+                value = vadTimeoutSeconds,
+                onValueChange = onVadTimeoutSecondsChange,
+                label = { Text(stringResource(commonR.string.assist_vad_timeout_seconds)) },
+                placeholder = { Text(stringResource(commonR.string.assist_vad_default_placeholder)) },
+                keyboardOptions = decimalKeyboard,
+                maxLines = 1,
             )
         }
     }
@@ -446,6 +499,8 @@ private fun AssistSettingsContentPreview() {
             onSelectWakeWord = {},
             onStartTestWakeWord = {},
             onStopTestWakeWord = {},
+            onVadSilenceSecondsChange = {},
+            onVadTimeoutSecondsChange = {},
         )
     }
 }
@@ -468,6 +523,8 @@ private fun AssistSettingsContentNotDefaultPreview() {
             onSelectWakeWord = {},
             onStartTestWakeWord = {},
             onStopTestWakeWord = {},
+            onVadSilenceSecondsChange = {},
+            onVadTimeoutSecondsChange = {},
         )
     }
 }
@@ -490,6 +547,8 @@ private fun AssistSettingsContentUnsupportedDevicePreview() {
             onSelectWakeWord = {},
             onStartTestWakeWord = {},
             onStopTestWakeWord = {},
+            onVadSilenceSecondsChange = {},
+            onVadTimeoutSecondsChange = {},
         )
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModel.kt
@@ -7,6 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.assist.wakeword.MicroWakeWordModelConfig
+import io.homeassistant.companion.android.common.data.prefs.normalizedAssistVadSecondsInputOrNull
+import io.homeassistant.companion.android.common.data.prefs.toAssistVadSecondsInput
+import io.homeassistant.companion.android.common.data.prefs.toAssistVadSecondsOrNull
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.Job
@@ -70,8 +73,8 @@ class AssistSettingsViewModel @Inject internal constructor(
                     isWakeWordEnabled = isEnabled,
                     selectedWakeWordModel = selectedModel,
                     availableModels = models,
-                    vadSilenceSeconds = vadSettings.silenceSeconds.toInputText(),
-                    vadTimeoutSeconds = vadSettings.timeoutSeconds.toInputText(),
+                    vadSilenceSeconds = vadSettings.silenceSeconds.toAssistVadSecondsInput(),
+                    vadTimeoutSeconds = vadSettings.timeoutSeconds.toAssistVadSecondsInput(),
                 )
             }
         }
@@ -155,31 +158,18 @@ class AssistSettingsViewModel @Inject internal constructor(
     }
 
     fun onVadSilenceSecondsChanged(value: String) {
-        val input = value.sanitizedSecondsInput() ?: return
+        val input = value.normalizedAssistVadSecondsInputOrNull() ?: return
         _uiState.update { it.copy(vadSilenceSeconds = input) }
         viewModelScope.launch {
-            assistConfigManager.setVadSilenceSeconds(input.toPositiveSecondsOrNull())
+            assistConfigManager.setVadSilenceSeconds(input.toAssistVadSecondsOrNull())
         }
     }
 
     fun onVadTimeoutSecondsChanged(value: String) {
-        val input = value.sanitizedSecondsInput() ?: return
+        val input = value.normalizedAssistVadSecondsInputOrNull() ?: return
         _uiState.update { it.copy(vadTimeoutSeconds = input) }
         viewModelScope.launch {
-            assistConfigManager.setVadTimeoutSeconds(input.toPositiveSecondsOrNull())
+            assistConfigManager.setVadTimeoutSeconds(input.toAssistVadSecondsOrNull())
         }
     }
-}
-
-private fun String.sanitizedSecondsInput(): String? {
-    if (isEmpty()) return this
-    if (count { it == '.' } > 1) return null
-    return takeIf { it.all { char -> char.isDigit() || char == '.' } }
-}
-
-private fun String.toPositiveSecondsOrNull(): Double? = toDoubleOrNull()?.takeIf { it > 0.0 }
-
-private fun Double?.toInputText(): String {
-    val value = this ?: return ""
-    return if (value == value.toLong().toDouble()) value.toLong().toString() else value.toString()
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModel.kt
@@ -28,6 +28,8 @@ data class AssistSettingsUiState(
     val availableModels: List<MicroWakeWordModelConfig> = emptyList(),
     val isTestingWakeWord: Boolean = false,
     val wakeWordDetected: Boolean = false,
+    val vadSilenceSeconds: String = "",
+    val vadTimeoutSeconds: String = "",
 )
 
 @VisibleForTesting
@@ -54,6 +56,7 @@ class AssistSettingsViewModel @Inject internal constructor(
             var isEnabled = assistConfigManager.isWakeWordEnabled()
             val selectedModel = assistConfigManager.getSelectedWakeWordModel() ?: models.firstOrNull()
             val isDefaultAssistant = defaultAssistantManager.isDefaultAssistant()
+            val vadSettings = assistConfigManager.getVadSettings()
 
             if (!isDefaultAssistant && isEnabled) {
                 assistConfigManager.setWakeWordEnabled(false)
@@ -67,6 +70,8 @@ class AssistSettingsViewModel @Inject internal constructor(
                     isWakeWordEnabled = isEnabled,
                     selectedWakeWordModel = selectedModel,
                     availableModels = models,
+                    vadSilenceSeconds = vadSettings.silenceSeconds.toInputText(),
+                    vadTimeoutSeconds = vadSettings.timeoutSeconds.toInputText(),
                 )
             }
         }
@@ -148,4 +153,33 @@ class AssistSettingsViewModel @Inject internal constructor(
         wakeWordResetJob?.cancel()
         _uiState.update { it.copy(isTestingWakeWord = testing, wakeWordDetected = false) }
     }
+
+    fun onVadSilenceSecondsChanged(value: String) {
+        val input = value.sanitizedSecondsInput() ?: return
+        _uiState.update { it.copy(vadSilenceSeconds = input) }
+        viewModelScope.launch {
+            assistConfigManager.setVadSilenceSeconds(input.toPositiveSecondsOrNull())
+        }
+    }
+
+    fun onVadTimeoutSecondsChanged(value: String) {
+        val input = value.sanitizedSecondsInput() ?: return
+        _uiState.update { it.copy(vadTimeoutSeconds = input) }
+        viewModelScope.launch {
+            assistConfigManager.setVadTimeoutSeconds(input.toPositiveSecondsOrNull())
+        }
+    }
+}
+
+private fun String.sanitizedSecondsInput(): String? {
+    if (isEmpty()) return this
+    if (count { it == '.' } > 1) return null
+    return takeIf { it.all { char -> char.isDigit() || char == '.' } }
+}
+
+private fun String.toPositiveSecondsOrNull(): Double? = toDoubleOrNull()?.takeIf { it > 0.0 }
+
+private fun Double?.toInputText(): String {
+    val value = this ?: return ""
+    return if (value == value.toLong().toDouble()) value.toLong().toString() else value.toString()
 }

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreenScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreenScreenshotTest.kt
@@ -58,6 +58,8 @@ class AssistSettingsScreenScreenshotTest {
                 onSelectWakeWord = {},
                 onStartTestWakeWord = {},
                 onStopTestWakeWord = {},
+                onVadSilenceSecondsChange = {},
+                onVadTimeoutSecondsChange = {},
             )
         }
     }
@@ -83,6 +85,8 @@ class AssistSettingsScreenScreenshotTest {
                 onSelectWakeWord = {},
                 onStartTestWakeWord = {},
                 onStopTestWakeWord = {},
+                onVadSilenceSecondsChange = {},
+                onVadTimeoutSecondsChange = {},
             )
         }
     }
@@ -106,6 +110,8 @@ class AssistSettingsScreenScreenshotTest {
                 onSelectWakeWord = {},
                 onStartTestWakeWord = {},
                 onStopTestWakeWord = {},
+                onVadSilenceSecondsChange = {},
+                onVadTimeoutSecondsChange = {},
             )
         }
     }
@@ -131,6 +137,8 @@ class AssistSettingsScreenScreenshotTest {
                 onSelectWakeWord = {},
                 onStartTestWakeWord = {},
                 onStopTestWakeWord = {},
+                onVadSilenceSecondsChange = {},
+                onVadTimeoutSecondsChange = {},
             )
         }
     }
@@ -156,6 +164,8 @@ class AssistSettingsScreenScreenshotTest {
                 onSelectWakeWord = {},
                 onStartTestWakeWord = {},
                 onStopTestWakeWord = {},
+                onVadSilenceSecondsChange = {},
+                onVadTimeoutSecondsChange = {},
             )
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/assist/AssistViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/assist/AssistViewModelTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.pm.PackageManager
 import io.homeassistant.companion.android.common.assist.AssistAudioStrategy
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerConnectionStateProvider
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.servers.UrlState
@@ -21,6 +22,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ge
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.TtsOutputResponse
 import io.homeassistant.companion.android.common.util.AudioUrlPlayer
 import io.homeassistant.companion.android.common.util.PlaybackState
+import io.homeassistant.companion.android.settings.assist.AssistConfigManager
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import io.mockk.coEvery
@@ -56,6 +58,7 @@ class AssistViewModelTest {
     private val application: Application = mockk(relaxed = true)
     private val webSocketRepository: WebSocketRepository = mockk(relaxed = true)
     private val integrationRepository: IntegrationRepository = mockk(relaxed = true)
+    private val assistConfigManager: AssistConfigManager = mockk(relaxed = true)
 
     private lateinit var viewModel: AssistViewModel
 
@@ -98,6 +101,7 @@ class AssistViewModelTest {
         coEvery { integrationRepository.getLastUsedPipelineId() } returns null
         coEvery { integrationRepository.getLastUsedPipelineSttSupport() } returns false
         coEvery { integrationRepository.setLastUsedPipeline(any(), any()) } returns Unit
+        coEvery { assistConfigManager.getVadSettings() } returns AssistVadSettings()
         coEvery { serverManager.getServer(any<Int>()) } returns mockk(relaxed = true)
         coEvery { serverManager.servers() } returns listOf()
     }
@@ -106,6 +110,7 @@ class AssistViewModelTest {
         return AssistViewModel(
             serverManager = serverManager,
             audioUrlPlayer = audioUrlPlayer,
+            assistConfigManager = assistConfigManager,
             application = application,
             initialAudioStrategy = object : AssistAudioStrategy {
                 override suspend fun audioData(): Flow<ShortArray> = emptyFlow()
@@ -153,7 +158,15 @@ class AssistViewModelTest {
          */
         private fun setupVoicePipeline() {
             coEvery {
-                webSocketRepository.runAssistPipelineForVoice(any(), any(), anyNullable(), anyNullable(), anyNullable())
+                webSocketRepository.runAssistPipelineForVoice(
+                    any(),
+                    any(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                )
             } returns pipelineEvents
         }
 
@@ -343,7 +356,15 @@ class AssistViewModelTest {
         fun `Given voice active mode when CLOSE_INACTIVE elapses then shouldFinish is false`() = runTest {
             setupVoicePipeline()
             coEvery {
-                webSocketRepository.runAssistPipelineForVoice(any(), any(), anyNullable(), anyNullable(), anyNullable())
+                webSocketRepository.runAssistPipelineForVoice(
+                    any(),
+                    any(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                )
             } returns flow { awaitCancellation() }
 
             viewModel = createAndInitialize(hasPermission = true)
@@ -390,7 +411,15 @@ class AssistViewModelTest {
         fun `Given voice inactive mode with placeholder message when CLOSE_INACTIVE elapses then shouldFinish is false`() = runTest {
             setupVoicePipeline()
             coEvery {
-                webSocketRepository.runAssistPipelineForVoice(any(), any(), anyNullable(), anyNullable(), anyNullable())
+                webSocketRepository.runAssistPipelineForVoice(
+                    any(),
+                    any(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                    anyNullable(),
+                )
             } returns flow { awaitCancellation() }
 
             viewModel = createAndInitialize(hasPermission = true)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/assist/AssistViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/assist/AssistViewModelTest.kt
@@ -165,7 +165,6 @@ class AssistViewModelTest {
                     anyNullable(),
                     anyNullable(),
                     anyNullable(),
-                    anyNullable(),
                 )
             } returns pipelineEvents
         }
@@ -363,7 +362,6 @@ class AssistViewModelTest {
                     anyNullable(),
                     anyNullable(),
                     anyNullable(),
-                    anyNullable(),
                 )
             } returns flow { awaitCancellation() }
 
@@ -414,7 +412,6 @@ class AssistViewModelTest {
                 webSocketRepository.runAssistPipelineForVoice(
                     any(),
                     any(),
-                    anyNullable(),
                     anyNullable(),
                     anyNullable(),
                     anyNullable(),

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistConfigManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistConfigManagerTest.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.settings.assist
 import android.content.Context
 import io.homeassistant.companion.android.assist.service.AssistVoiceInteractionService
 import io.homeassistant.companion.android.assist.wakeword.MicroWakeWordModelConfig
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.util.FailFastExtension
@@ -235,6 +236,32 @@ class AssistConfigManagerTest {
 
             coVerify { prefsRepository.setSelectedWakeWord("Okay Nabu") }
             coVerify(exactly = 0) { AssistVoiceInteractionService.startListening(any()) }
+        }
+    }
+
+    @Nested
+    inner class VadSettingsTest {
+
+        @Test
+        fun `Given VAD settings when getVadSettings then returns preferences`() = runTest {
+            val settings = AssistVadSettings(silenceSeconds = 1.5, timeoutSeconds = 30.0)
+            coEvery { prefsRepository.getAssistVadSettings() } returns settings
+
+            assertEquals(settings, manager.getVadSettings())
+        }
+
+        @Test
+        fun `Given silence seconds when setVadSilenceSeconds then saves preference`() = runTest {
+            manager.setVadSilenceSeconds(1.5)
+
+            coVerify { prefsRepository.setAssistVadSilenceSeconds(1.5) }
+        }
+
+        @Test
+        fun `Given timeout seconds when setVadTimeoutSeconds then saves preference`() = runTest {
+            manager.setVadTimeoutSeconds(30.0)
+
+            coVerify { prefsRepository.setAssistVadTimeoutSeconds(30.0) }
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModelTest.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.settings.assist
 
 import android.content.Intent
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.testing.unit.ConsoleLogExtension
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import io.homeassistant.companion.android.util.microWakeWordModelConfigs
@@ -37,6 +38,7 @@ class AssistSettingsViewModelTest {
         coEvery { assistConfigManager.getAvailableModels() } returns microWakeWordModelConfigs
         coEvery { assistConfigManager.isWakeWordEnabled() } returns false
         coEvery { assistConfigManager.getSelectedWakeWordModel() } returns microWakeWordModelConfigs[0]
+        coEvery { assistConfigManager.getVadSettings() } returns AssistVadSettings()
         every { defaultAssistantManager.isDefaultAssistant() } returns true
     }
 
@@ -65,6 +67,22 @@ class AssistSettingsViewModelTest {
             assertTrue(state.isWakeWordEnabled)
             assertEquals(microWakeWordModelConfigs[0], state.selectedWakeWordModel)
             assertEquals(microWakeWordModelConfigs, state.availableModels)
+            assertEquals("", state.vadSilenceSeconds)
+            assertEquals("", state.vadTimeoutSeconds)
+        }
+
+        @Test
+        fun `Given VAD settings when initialized then load values`() = runTest {
+            coEvery { assistConfigManager.getVadSettings() } returns AssistVadSettings(
+                silenceSeconds = 1.25,
+                timeoutSeconds = 30.0,
+            )
+
+            viewModel = createViewModel()
+            runCurrent()
+
+            assertEquals("1.25", viewModel.uiState.value.vadSilenceSeconds)
+            assertEquals("30", viewModel.uiState.value.vadTimeoutSeconds)
         }
 
         @Test
@@ -294,6 +312,45 @@ class AssistSettingsViewModelTest {
             runCurrent()
 
             assertFalse(viewModel.uiState.value.wakeWordDetected)
+        }
+    }
+
+    @Nested
+    inner class VadSettingsTest {
+
+        @Test
+        fun `Given valid silence seconds when changed then update and save`() = runTest {
+            viewModel = createViewModel()
+            runCurrent()
+
+            viewModel.onVadSilenceSecondsChanged("1.5")
+            runCurrent()
+
+            assertEquals("1.5", viewModel.uiState.value.vadSilenceSeconds)
+            coVerify { assistConfigManager.setVadSilenceSeconds(1.5) }
+        }
+
+        @Test
+        fun `Given valid timeout seconds when changed then update and save`() = runTest {
+            viewModel = createViewModel()
+            runCurrent()
+
+            viewModel.onVadTimeoutSecondsChanged("45")
+            runCurrent()
+
+            assertEquals("45", viewModel.uiState.value.vadTimeoutSeconds)
+            coVerify { assistConfigManager.setVadTimeoutSeconds(45.0) }
+        }
+
+        @Test
+        fun `Given blank value when changed then clear setting`() = runTest {
+            viewModel = createViewModel()
+            runCurrent()
+
+            viewModel.onVadSilenceSecondsChanged("")
+            runCurrent()
+
+            coVerify { assistConfigManager.setVadSilenceSeconds(null) }
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsViewModelTest.kt
@@ -319,11 +319,11 @@ class AssistSettingsViewModelTest {
     inner class VadSettingsTest {
 
         @Test
-        fun `Given valid silence seconds when changed then update and save`() = runTest {
+        fun `Given comma decimal silence seconds when changed then normalize and save`() = runTest {
             viewModel = createViewModel()
             runCurrent()
 
-            viewModel.onVadSilenceSecondsChanged("1.5")
+            viewModel.onVadSilenceSecondsChanged("1,5")
             runCurrent()
 
             assertEquals("1.5", viewModel.uiState.value.vadSilenceSeconds)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -155,8 +155,7 @@ abstract class AssistViewModelBase(
                         pipelineId = pipeline?.id,
                         conversationId = conversationId,
                         wakeWordPhrase = wakeWordPhrase,
-                        vadSilenceSeconds = vadSettings.silenceSeconds,
-                        vadTimeoutSeconds = vadSettings.timeoutSeconds,
+                        vadSettings = vadSettings,
                     )
                 } else {
                     serverManager.integrationRepository(selectedServerId).getAssistResponse(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBase.kt
@@ -7,6 +7,7 @@ import androidx.annotation.VisibleForTesting.Companion.PROTECTED
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.servers.UrlState
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineError
@@ -139,6 +140,7 @@ abstract class AssistViewModelBase(
         text: String?,
         pipeline: AssistPipelineResponse?,
         wakeWordPhrase: String? = null,
+        vadSettingsProvider: suspend () -> AssistVadSettings = { AssistVadSettings() },
         onEvent: (AssistEvent) -> Unit,
     ) {
         val isVoice = text == null
@@ -146,12 +148,15 @@ abstract class AssistViewModelBase(
         job = viewModelScope.launch {
             val flow = try {
                 if (isVoice) {
+                    val vadSettings = vadSettingsProvider()
                     serverManager.webSocketRepository(selectedServerId).runAssistPipelineForVoice(
                         sampleRate = VOICE_SAMPLE_RATE,
                         outputTts = pipeline?.ttsEngine?.isNotBlank() == true,
                         pipelineId = pipeline?.id,
                         conversationId = conversationId,
                         wakeWordPhrase = wakeWordPhrase,
+                        vadSilenceSeconds = vadSettings.silenceSeconds,
+                        vadTimeoutSeconds = vadSettings.timeoutSeconds,
                     )
                 } else {
                     serverManager.integrationRepository(selectedServerId).getAssistResponse(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -32,6 +32,8 @@ data class AutoFavorite(val serverId: Int, val entityId: String) : Parcelable
  */
 data class ZoomSettings(val zoomLevel: Int = DEFAULT_ZOOM_LEVEL, val pinchToZoomEnabled: Boolean = false)
 
+data class AssistVadSettings(val silenceSeconds: Double? = null, val timeoutSeconds: Double? = null)
+
 private const val DEFAULT_ZOOM_LEVEL = 100
 
 interface PrefsRepository {
@@ -160,6 +162,12 @@ interface PrefsRepository {
     suspend fun getSelectedWakeWord(): String?
 
     suspend fun setSelectedWakeWord(wakeWord: String)
+
+    suspend fun getAssistVadSettings(): AssistVadSettings
+
+    suspend fun setAssistVadSilenceSeconds(seconds: Double?)
+
+    suspend fun setAssistVadTimeoutSeconds(seconds: Double?)
 
     suspend fun addAllowedTag(tag: String)
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepository.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.HAGesture
+import java.math.BigDecimal
 import kotlinx.coroutines.flow.Flow
 import kotlinx.parcelize.Parcelize
 
@@ -33,6 +34,20 @@ data class AutoFavorite(val serverId: Int, val entityId: String) : Parcelable
 data class ZoomSettings(val zoomLevel: Int = DEFAULT_ZOOM_LEVEL, val pinchToZoomEnabled: Boolean = false)
 
 data class AssistVadSettings(val silenceSeconds: Double? = null, val timeoutSeconds: Double? = null)
+
+fun String.normalizedAssistVadSecondsInputOrNull(): String? {
+    val normalized = replace(',', '.')
+    if (normalized.isEmpty()) return normalized
+    if (normalized.count { it == '.' } > 1) return null
+    return normalized.takeIf { it.all { char -> char.isDigit() || char == '.' } }
+}
+
+fun String?.toAssistVadSecondsOrNull(): Double? =
+    this?.normalizedAssistVadSecondsInputOrNull()?.toDoubleOrNull()?.takeIf { it.isFinite() && it > 0.0 }
+
+fun Double.toAssistVadSecondsString(): String = BigDecimal.valueOf(this).stripTrailingZeros().toPlainString()
+
+fun Double?.toAssistVadSecondsInput(): String = this?.toAssistVadSecondsString().orEmpty()
 
 private const val DEFAULT_ZOOM_LEVEL = 100
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -47,6 +47,8 @@ private const val PREF_CHANGE_LOG_POPUP_ENABLED = "change_log_popup_enabled"
 private const val PREF_SHOW_PRIVACY_HINT = "show_privacy_hint"
 private const val PREF_WAKE_WORD_ENABLED = "wake_word_enabled"
 private const val PREF_SELECTED_WAKE_WORD = "selected_wake_word"
+private const val PREF_ASSIST_VAD_SILENCE_SECONDS = "assist_vad_silence_seconds"
+private const val PREF_ASSIST_VAD_TIMEOUT_SECONDS = "assist_vad_timeout_seconds"
 private const val PREF_ALLOWED_TAGS = "allowed_tags"
 
 /**
@@ -404,6 +406,29 @@ internal class PrefsRepositoryImpl @Inject constructor(
         localStorage().putString(PREF_SELECTED_WAKE_WORD, wakeWord)
     }
 
+    override suspend fun getAssistVadSettings(): AssistVadSettings {
+        return AssistVadSettings(
+            silenceSeconds = localStorage().getString(PREF_ASSIST_VAD_SILENCE_SECONDS).toPositiveDoubleOrNull(),
+            timeoutSeconds = localStorage().getString(PREF_ASSIST_VAD_TIMEOUT_SECONDS).toPositiveDoubleOrNull(),
+        )
+    }
+
+    override suspend fun setAssistVadSilenceSeconds(seconds: Double?) {
+        setAssistVadSeconds(PREF_ASSIST_VAD_SILENCE_SECONDS, seconds)
+    }
+
+    override suspend fun setAssistVadTimeoutSeconds(seconds: Double?) {
+        setAssistVadSeconds(PREF_ASSIST_VAD_TIMEOUT_SECONDS, seconds)
+    }
+
+    private suspend fun setAssistVadSeconds(key: String, seconds: Double?) {
+        if (seconds == null || seconds <= 0.0) {
+            localStorage().remove(key)
+        } else {
+            localStorage().putString(key, seconds.toString())
+        }
+    }
+
     override suspend fun addAllowedTag(tag: String) {
         val approved = getAllowedTags().toMutableSet()
         if (approved.add(tag)) {
@@ -419,3 +444,5 @@ internal class PrefsRepositoryImpl @Inject constructor(
         localStorage().remove(PREF_ALLOWED_TAGS)
     }
 }
+
+private fun String?.toPositiveDoubleOrNull(): Double? = this?.toDoubleOrNull()?.takeIf { it > 0.0 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -408,8 +408,8 @@ internal class PrefsRepositoryImpl @Inject constructor(
 
     override suspend fun getAssistVadSettings(): AssistVadSettings {
         return AssistVadSettings(
-            silenceSeconds = localStorage().getString(PREF_ASSIST_VAD_SILENCE_SECONDS).toPositiveDoubleOrNull(),
-            timeoutSeconds = localStorage().getString(PREF_ASSIST_VAD_TIMEOUT_SECONDS).toPositiveDoubleOrNull(),
+            silenceSeconds = localStorage().getString(PREF_ASSIST_VAD_SILENCE_SECONDS).toAssistVadSecondsOrNull(),
+            timeoutSeconds = localStorage().getString(PREF_ASSIST_VAD_TIMEOUT_SECONDS).toAssistVadSecondsOrNull(),
         )
     }
 
@@ -422,10 +422,10 @@ internal class PrefsRepositoryImpl @Inject constructor(
     }
 
     private suspend fun setAssistVadSeconds(key: String, seconds: Double?) {
-        if (seconds == null || seconds <= 0.0) {
+        if (seconds == null || !seconds.isFinite() || seconds <= 0.0) {
             localStorage().remove(key)
         } else {
-            localStorage().putString(key, seconds.toString())
+            localStorage().putString(key, seconds.toAssistVadSecondsString())
         }
     }
 
@@ -444,5 +444,3 @@ internal class PrefsRepositoryImpl @Inject constructor(
         localStorage().remove(PREF_ALLOWED_TAGS)
     }
 }
-
-private fun String?.toPositiveDoubleOrNull(): Double? = this?.toDoubleOrNull()?.takeIf { it > 0.0 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.common.data.websocket
 
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketRepositoryImpl
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
@@ -127,8 +128,7 @@ interface WebSocketRepository {
         pipelineId: String? = null,
         conversationId: String? = null,
         wakeWordPhrase: String? = null,
-        vadSilenceSeconds: Double? = null,
-        vadTimeoutSeconds: Double? = null,
+        vadSettings: AssistVadSettings? = null,
     ): Flow<AssistPipelineEvent>?
 
     /**

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/WebSocketRepository.kt
@@ -127,6 +127,8 @@ interface WebSocketRepository {
         pipelineId: String? = null,
         conversationId: String? = null,
         wakeWordPhrase: String? = null,
+        vadSilenceSeconds: Double? = null,
+        vadTimeoutSeconds: Double? = null,
     ): Flow<AssistPipelineEvent>?
 
     /**

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -258,6 +258,8 @@ class WebSocketRepositoryImpl internal constructor(
         pipelineId: String?,
         conversationId: String?,
         wakeWordPhrase: String?,
+        vadSilenceSeconds: Double?,
+        vadTimeoutSeconds: Double?,
     ): Flow<AssistPipelineEvent>? {
         val data = buildMap {
             put("start_stage", "stt")
@@ -267,6 +269,8 @@ class WebSocketRepositoryImpl internal constructor(
                 buildMap<String, Any?> {
                     put("sample_rate", sampleRate)
                     wakeWordPhrase?.let { put("wake_word_phrase", it) }
+                    vadSilenceSeconds?.let { put("vad_silence_seconds", it) }
+                    vadTimeoutSeconds?.let { put("vad_timeout_seconds", it) }
                 },
             )
             put("conversation_id", conversationId)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImpl.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.data.websocket.impl
 import io.homeassistant.companion.android.common.data.integration.ActionData
 import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.TODO_DOMAIN
 import io.homeassistant.companion.android.common.data.integration.impl.entities.EntityResponse
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketCore
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
@@ -258,8 +259,7 @@ class WebSocketRepositoryImpl internal constructor(
         pipelineId: String?,
         conversationId: String?,
         wakeWordPhrase: String?,
-        vadSilenceSeconds: Double?,
-        vadTimeoutSeconds: Double?,
+        vadSettings: AssistVadSettings?,
     ): Flow<AssistPipelineEvent>? {
         val data = buildMap {
             put("start_stage", "stt")
@@ -269,8 +269,8 @@ class WebSocketRepositoryImpl internal constructor(
                 buildMap<String, Any?> {
                     put("sample_rate", sampleRate)
                     wakeWordPhrase?.let { put("wake_word_phrase", it) }
-                    vadSilenceSeconds?.let { put("vad_silence_seconds", it) }
-                    vadTimeoutSeconds?.let { put("vad_timeout_seconds", it) }
+                    vadSettings?.silenceSeconds?.let { put("vad_silence_seconds", it) }
+                    vadSettings?.timeoutSeconds?.let { put("vad_timeout_seconds", it) }
                 },
             )
             put("conversation_id", conversationId)

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1223,6 +1223,10 @@
     <string name="assist_default_assistant_disabled">Home Assistant is not your default assistant</string>
     <string name="assist_set_default">Set as default</string>
     <string name="assist_summary">Configure Assist for this device</string>
+    <string name="assist_voice_input_title">Voice input</string>
+    <string name="assist_vad_silence_seconds">End-of-speech silence (seconds)</string>
+    <string name="assist_vad_timeout_seconds">Command timeout (seconds)</string>
+    <string name="assist_vad_default_placeholder">Default</string>
     <string name="assist_wake_word_title">Wake word</string>
     <string name="assist_wake_word_enable">Enable wake word detection</string>
     <string name="assist_wake_word_model">Wake word</string>

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBaseTest.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.assist
 
 import android.app.Application
 import android.content.pm.PackageManager
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AssistPipelineError
@@ -66,7 +67,7 @@ class AssistViewModelBaseTest {
         coEvery { serverManager.webSocketRepository(any()) } returns webSocketRepository
         coEvery { webSocketRepository.sendVoiceData(any(), any()) } returns true
         coEvery {
-            webSocketRepository.runAssistPipelineForVoice(any(), any(), any(), any(), any())
+            webSocketRepository.runAssistPipelineForVoice(any(), any(), any(), any(), any(), any(), any())
         } returns pipelineEventsFlow
 
         viewModel = TestAssistViewModel(
@@ -277,6 +278,8 @@ class AssistViewModelBaseTest {
                 pipelineId = any(),
                 conversationId = any(),
                 wakeWordPhrase = wakePhrase,
+                vadSilenceSeconds = any(),
+                vadTimeoutSeconds = any(),
             )
         }
     }
@@ -294,6 +297,29 @@ class AssistViewModelBaseTest {
                 pipelineId = any(),
                 conversationId = any(),
                 wakeWordPhrase = null,
+                vadSilenceSeconds = any(),
+                vadTimeoutSeconds = any(),
+            )
+        }
+    }
+
+    @Test
+    fun `Given VAD settings When voice pipeline started Then settings are passed to WebSocket`() = runTest {
+        val vadSettings = AssistVadSettings(silenceSeconds = 1.25, timeoutSeconds = 30.0)
+
+        viewModel.setupRecorder()
+        viewModel.runVoicePipeline(vadSettings = vadSettings)
+        advanceUntilIdle()
+
+        coVerify {
+            webSocketRepository.runAssistPipelineForVoice(
+                sampleRate = any(),
+                outputTts = any(),
+                pipelineId = any(),
+                conversationId = any(),
+                wakeWordPhrase = any(),
+                vadSilenceSeconds = 1.25,
+                vadTimeoutSeconds = 30.0,
             )
         }
     }
@@ -459,11 +485,13 @@ class AssistViewModelBaseTest {
         fun runVoicePipeline(
             pipeline: AssistPipelineResponse? = null,
             wakeWordPhrase: String? = null,
+            vadSettings: AssistVadSettings = AssistVadSettings(),
         ) {
             runAssistPipelineInternal(
                 text = null, // null means voice pipeline
                 pipeline = pipeline,
                 wakeWordPhrase = wakeWordPhrase,
+                vadSettingsProvider = { vadSettings },
                 onEvent = { receivedEvents += it },
             )
         }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/assist/AssistViewModelBaseTest.kt
@@ -67,7 +67,7 @@ class AssistViewModelBaseTest {
         coEvery { serverManager.webSocketRepository(any()) } returns webSocketRepository
         coEvery { webSocketRepository.sendVoiceData(any(), any()) } returns true
         coEvery {
-            webSocketRepository.runAssistPipelineForVoice(any(), any(), any(), any(), any(), any(), any())
+            webSocketRepository.runAssistPipelineForVoice(any(), any(), any(), any(), any(), any())
         } returns pipelineEventsFlow
 
         viewModel = TestAssistViewModel(
@@ -278,8 +278,7 @@ class AssistViewModelBaseTest {
                 pipelineId = any(),
                 conversationId = any(),
                 wakeWordPhrase = wakePhrase,
-                vadSilenceSeconds = any(),
-                vadTimeoutSeconds = any(),
+                vadSettings = any(),
             )
         }
     }
@@ -297,8 +296,7 @@ class AssistViewModelBaseTest {
                 pipelineId = any(),
                 conversationId = any(),
                 wakeWordPhrase = null,
-                vadSilenceSeconds = any(),
-                vadTimeoutSeconds = any(),
+                vadSettings = any(),
             )
         }
     }
@@ -318,8 +316,7 @@ class AssistViewModelBaseTest {
                 pipelineId = any(),
                 conversationId = any(),
                 wakeWordPhrase = any(),
-                vadSilenceSeconds = 1.25,
-                vadTimeoutSeconds = 30.0,
+                vadSettings = vadSettings,
             )
         }
     }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -212,6 +212,43 @@ class PrefsRepositoryImplTest {
     }
 
     @Test
+    fun `Given no Assist VAD settings when getting prefs then returns empty settings`() = runTest {
+        coEvery { localStorage.getString("assist_vad_silence_seconds") } returns null
+        coEvery { localStorage.getString("assist_vad_timeout_seconds") } returns null
+
+        assertEquals(AssistVadSettings(), repository.getAssistVadSettings())
+    }
+
+    @Test
+    fun `Given Assist VAD settings when getting prefs then returns parsed settings`() = runTest {
+        coEvery { localStorage.getString("assist_vad_silence_seconds") } returns "1.25"
+        coEvery { localStorage.getString("assist_vad_timeout_seconds") } returns "30"
+
+        assertEquals(
+            AssistVadSettings(silenceSeconds = 1.25, timeoutSeconds = 30.0),
+            repository.getAssistVadSettings(),
+        )
+    }
+
+    @Test
+    fun `Given Assist VAD setting when saving silence seconds then writes string value`() = runTest {
+        coEvery { localStorage.putString(any(), any()) } returns Unit
+
+        repository.setAssistVadSilenceSeconds(1.25)
+
+        coVerify { localStorage.putString("assist_vad_silence_seconds", "1.25") }
+    }
+
+    @Test
+    fun `Given Assist VAD setting when clearing timeout seconds then removes value`() = runTest {
+        coEvery { localStorage.remove(any()) } returns Unit
+
+        repository.setAssistVadTimeoutSeconds(null)
+
+        coVerify { localStorage.remove("assist_vad_timeout_seconds") }
+    }
+
+    @Test
     fun `Given no approved tags when listing then returns empty list`() = runTest {
         coEvery { localStorage.getStringSet("allowed_tags") } returns null
 

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -231,12 +231,12 @@ class PrefsRepositoryImplTest {
     }
 
     @Test
-    fun `Given Assist VAD setting when saving silence seconds then writes string value`() = runTest {
+    fun `Given Assist VAD setting when saving silence seconds then writes normalized value`() = runTest {
         coEvery { localStorage.putString(any(), any()) } returns Unit
 
-        repository.setAssistVadSilenceSeconds(1.25)
+        repository.setAssistVadSilenceSeconds(1.0)
 
-        coVerify { localStorage.putString("assist_vad_silence_seconds", "1.25") }
+        coVerify { localStorage.putString("assist_vad_silence_seconds", "1") }
     }
 
     @Test

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImplTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.data.websocket.impl
 
+import io.homeassistant.companion.android.common.data.prefs.AssistVadSettings
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketCore
 import io.homeassistant.companion.android.common.data.websocket.impl.WebSocketConstants.SUBSCRIBE_TYPE_ASSIST_PIPELINE_RUN
@@ -117,8 +118,7 @@ class WebSocketRepositoryImplTest {
                 pipelineId = null,
                 conversationId = null,
                 wakeWordPhrase = null,
-                vadSilenceSeconds = 1.25,
-                vadTimeoutSeconds = 30.0,
+                vadSettings = AssistVadSettings(silenceSeconds = 1.25, timeoutSeconds = 30.0),
             )
 
             @Suppress("UNCHECKED_CAST")

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/websocket/impl/WebSocketRepositoryImplTest.kt
@@ -103,6 +103,28 @@ class WebSocketRepositoryImplTest {
             @Suppress("UNCHECKED_CAST")
             val input = dataSlot.captured["input"] as Map<String, Any?>
             assertFalse(input.containsKey("wake_word_phrase"))
+            assertFalse(input.containsKey("vad_silence_seconds"))
+            assertFalse(input.containsKey("vad_timeout_seconds"))
+        }
+
+        @Test
+        fun `Given VAD settings When running pipeline Then settings are included in input`() = runTest {
+            val dataSlot = captureSubscribeData()
+
+            repository.runAssistPipelineForVoice(
+                sampleRate = VOICE_SAMPLE_RATE,
+                outputTts = true,
+                pipelineId = null,
+                conversationId = null,
+                wakeWordPhrase = null,
+                vadSilenceSeconds = 1.25,
+                vadTimeoutSeconds = 30.0,
+            )
+
+            @Suppress("UNCHECKED_CAST")
+            val input = dataSlot.captured["input"] as Map<String, Any?>
+            assertEquals(1.25, input["vad_silence_seconds"])
+            assertEquals(30.0, input["vad_timeout_seconds"])
         }
 
         @ParameterizedTest(name = "Given outputTts={0} When running pipeline Then end_stage is {1}")


### PR DESCRIPTION
## Summary
Adds optional Assist silence and timeout overrides for voice runs. Related: home-assistant/core#122177.

## Checklist
- [x] New or updated tests have been added to cover the changes following the testing guidelines.
- [x] The code follows the project's code style and best practices.
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible.