### PR TITLE
Fix LocalStorage `observeChanges` ignores later keys

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
@@ -114,9 +114,8 @@ class LocalStorageImpl(sharedPreferences: suspend () -> SharedPreferences) : Loc
 
     override fun observeChanges(vararg keys: String): Flow<String> = callbackFlow {
         val prefs = sharedPreferences()
-        val watched = keys.toSet()
         val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
-            if (changedKey != null && changedKey in watched) {
+            if (changedKey != null && changedKey in keys) {
                 trySend(changedKey)
             }
         }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/LocalStorageImpl.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -115,16 +114,15 @@ class LocalStorageImpl(sharedPreferences: suspend () -> SharedPreferences) : Loc
 
     override fun observeChanges(vararg keys: String): Flow<String> = callbackFlow {
         val prefs = sharedPreferences()
-        keys.forEach { key ->
-            val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
-                if (changedKey == key) {
-                    launch { send(key) }
-                }
+        val watched = keys.toSet()
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { _, changedKey ->
+            if (changedKey != null && changedKey in watched) {
+                trySend(changedKey)
             }
-            prefs.registerOnSharedPreferenceChangeListener(listener)
-            awaitClose {
-                prefs.unregisterOnSharedPreferenceChangeListener(listener)
-            }
+        }
+        prefs.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose {
+            prefs.unregisterOnSharedPreferenceChangeListener(listener)
         }
     }
 

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/LocalStorageImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/LocalStorageImplTest.kt
@@ -55,4 +55,15 @@ class LocalStorageImplTest {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `Given observing multiple keys when any watched key changes then the changed key is emitted`() = runTest {
+        localStorage.observeChanges("first_key", "second_key").test {
+            listenerSlot.captured.onSharedPreferenceChanged(sharedPreferences, "first_key")
+            assertEquals("first_key", awaitItem())
+            listenerSlot.captured.onSharedPreferenceChanged(sharedPreferences, "second_key")
+            assertEquals("second_key", awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

In `LocalStorageImpl.observeChanges`, `awaitClose` was placed inside the `keys.forEach` loop, the coroutine suspended after the first iteration, so the listeners for the remaining keys were never registered. The first key was effectively the only one observed, changes to later keys are ignored silently.

This fix replaces the per-key listeners with a single listener that filters by the watched key set and registers/unregisters once.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.