### PR TITLE
Enable check update from pr-emulator-wtf workflow

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -23,7 +23,29 @@ jobs:
     permissions:
       id-token: write  # Needed for OIDC authentication
       actions: read  # Needed for retrieving artifacts
+      checks: write  # Needed to publish this job's status as a PR check
     steps:
+      # Surface this job's own success/failure as a check on the PR commit.
+      # workflow_run jobs are detached from the PR, so the status is not shown
+      # otherwise. Every input here comes from the trusted workflow_run context
+      # (no fork-controlled data is consumed).
+      - name: Create PR check (in progress)
+        id: create_check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DETAILS_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          check_id=$(gh api --method POST \
+            "repos/$REPO/check-runs" \
+            -f name="Instrumentation Test app" \
+            -f head_sha="$HEAD_SHA" \
+            -f status="in_progress" \
+            -f details_url="$DETAILS_URL" \
+            --jq '.id')
+          echo "check_id=$check_id" >> "$GITHUB_OUTPUT"
+
       # Halt before spending any emulator.wtf credits if the triggering Pull Request
       # workflow did not succeed (publish_test_results still runs afterward to
       # aggregate whatever results pr.yml produced).
@@ -101,6 +123,21 @@ jobs:
           name: Instrumentation Test app reports
           path: build/test-results/**
 
+      # job.status reflects everything above (halt, downloads, test runs) and is
+      # one of success/failure/cancelled, all valid check-run conclusions.
+      - name: Finalize PR check
+        if: always() && steps.create_check.outputs.check_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          CHECK_ID: ${{ steps.create_check.outputs.check_id }}
+          CONCLUSION: ${{ job.status }}
+        run: |
+          gh api --method PATCH \
+            "repos/$REPO/check-runs/$CHECK_ID" \
+            -f status="completed" \
+            -f conclusion="$CONCLUSION"
+
   publish_test_results:
     name: "Publish Tests Results"
     needs: [emulator_wtf]
@@ -130,6 +167,10 @@ jobs:
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_name: ${{ github.event.workflow_run.event }}
+          # Original pull_request payload uploaded by the "Event File" job in
+          # pr.yml. Required so the action does not treat fork PRs as read-only
+          # and disable check runs (see publish_test_results.py is_fork logic).
+          event_file: "pr-artifacts/event-file/event.json"
           comment_mode: "failures"
           action_fail: true
           files: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -359,6 +359,22 @@ jobs:
             app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk
             devices.txt
 
+  # The original pull_request event payload must be forwarded to the
+  # PR Emulator.wtf workflow (which runs on workflow_run and only sees the
+  # workflow_run payload). publish-unit-test-result-action needs it to create
+  # check runs for fork PRs instead of disabling them.
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload event file
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: event-file
+          retention-days: 1
+          if-no-files-found: error
+          path: ${{ github.event_path }}
+
   instrumentation_test:
     name: "Instrumentation Tests"
     needs: [lint, lockfiles, ktlint]


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to get the `pr-emulator-wtf.yml` workflow to report checks to github we need to upload the `event.json` file and give more rights to the `emaultor_wtf` job to be able to call the check API.