### PR TITLE
Build a dumb event.json instead of storing one

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -27,7 +27,12 @@ jobs:
     steps:
       # Surface this job's own success/failure as a check on the PR commit.
       # workflow_run jobs are detached from the PR, so the status is not shown
-      # otherwise. Every input here comes from the trusted workflow_run context
+      # otherwise. A check run created via the API for a PR-head SHA gets grouped
+      # under an arbitrary existing check suite on that commit (here CodeQL's, so
+      # it renders as "CodeQL / Instrumentation Test app (dynamic)"); the suite
+      # cannot be chosen via the API. We accept that prefix to stay consistent
+      # with the publish-unit-test-result-action check below, which has the same
+      # limitation. Every input here comes from the trusted workflow_run context
       # (no fork-controlled data is consumed).
       - name: Create PR check (in progress)
         id: create_check
@@ -162,15 +167,35 @@ jobs:
           name: Instrumentation Test app results
           path: pr-artifacts/Instrumentation Test app results
 
+      # Build a minimal event payload from the trusted workflow_run context.
+      # Supplying any event_file flips the is_fork check to false in the
+      # publish-unit-test-result-action source
+      # (publish_test_results.py: `is_fork = event_file is None and ...`), so it
+      # publishes the check run instead of disabling it for fork PRs. We build
+      # the payload here from trusted context rather than forwarding the real
+      # pull_request payload, which on a fork PR could be forged.
+      # The PR for the failures comment is resolved from the commit SHA via the
+      # API (the action's publisher.py get_pulls_from_commit), so no PR number
+      # is needed here.
+      #
+      # This payload is intentionally minimal: it was verified sufficient against
+      # publish-unit-test-result-action (the pinned SHA below). Every
+      # other event field the action reads degrades gracefully when absent (it
+      # only drops the cosmetic "vs base"/"vs earlier" deltas). If you bump the
+      # action version, re-check which event fields it reads and update this.
+      - name: Build minimal event payload
+        env:
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+        run: |
+          jq -n --arg head "$HEAD_REPO" \
+            '{pull_request: {head: {repo: {full_name: $head}}}}' > event.json
+
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           event_name: ${{ github.event.workflow_run.event }}
-          # Original pull_request payload uploaded by the "Event File" job in
-          # pr.yml. Required so the action does not treat fork PRs as read-only
-          # and disable check runs (see publish_test_results.py is_fork logic).
-          event_file: "pr-artifacts/event-file/event.json"
+          event_file: "event.json"
           comment_mode: "failures"
           action_fail: true
           files: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -359,22 +359,6 @@ jobs:
             app/build/outputs/apk/androidTest/minimal/debug/app-minimal-debug-androidTest.apk
             devices.txt
 
-  # The original pull_request event payload must be forwarded to the
-  # PR Emulator.wtf workflow (which runs on workflow_run and only sees the
-  # workflow_run payload). publish-unit-test-result-action needs it to create
-  # check runs for fork PRs instead of disabling them.
-  event_file:
-    name: "Event File"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Upload event file
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: event-file
-          retention-days: 1
-          if-no-files-found: error
-          path: ${{ github.event_path }}
-
   instrumentation_test:
     name: "Instrumentation Tests"
     needs: [lint, lockfiles, ktlint]


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Based on the code of the action to report test we don't need to have a full fledge `event.json` file it only requires some field to actually reports things. To avoid storing the file as an artifact I decided to build a very dumb one in the pr-emulator-wtf workflow. The downside is that we are loosing some cosmetic on the comments that is left on the PR like the ability to detect the numbers of test VS another run like +x tests, but it is acceptable.

I've also noticed that the checks where under the group `CodeQL/*` prefix unfortunately we cannot change it with the API of Github it might be something internally that does this.

<img width="767" height="116" alt="image" src="https://github.com/user-attachments/assets/b9fc38f6-be29-46e6-a243-3195e9a59306" />
