### PR TITLE
Prevent unregistering actionReceiver twice and handle weird lifecycle

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
@@ -68,11 +68,27 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
     }
     private var isServiceReady = false
 
+    /**
+     * One-way latch set once the service has begun tearing down (via [onShutdown] or [onDestroy]).
+     *
+     * The platform documents that [onReady] may be delivered after teardown and that no fixed
+     * lifecycle order can be relied upon. Because [serviceScope] is cancelled during teardown and
+     * cannot be reused, the instance can never function again, so any such late [onReady] is ignored.
+     */
+    private var isTornDown = false
+
     /** Non-null only while the receiver is registered (between [onReady] and [onShutdown]). */
     private var actionReceiver: BroadcastReceiver? = null
 
     override fun onReady() {
         super.onReady()
+        if (isTornDown) {
+            // The system can deliver onReady even after onShutdown/onDestroy while it is winding the
+            // service down. Registering a receiver on the dying context would later crash in
+            // onShutdown, so ignore this spurious signal
+            Timber.w("Ignoring onReady delivered after shutdown")
+            return
+        }
         isServiceReady = true
         Timber.d("VoiceInteractionService is ready")
         actionReceiver = object : BroadcastReceiver() {
@@ -102,12 +118,30 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
 
     override fun onShutdown() {
         super.onShutdown()
+        isTornDown = true
         isServiceReady = false
         Timber.d("VoiceInteractionService is shutting down")
-        actionReceiver?.let(::unregisterReceiver)
-        actionReceiver = null
+        actionReceiver?.let { receiver ->
+            actionReceiver = null
+            try {
+                unregisterReceiver(receiver)
+            } catch (e: IllegalArgumentException) {
+                // On some devices the framework tears down the receiver registration before
+                // onShutdown() runs while the service instance (and this field) survives. There is
+                // no API to query whether a receiver is still registered, so swallowing this is the
+                // documented way to handle the resulting "Receiver not registered" error
+                Timber.w(e, "Action receiver was already unregistered")
+            }
+        }
         // Don't use stopListening() as it launches a coroutine that may not complete before cancel
         serviceScope.cancel()
+    }
+
+    override fun onDestroy() {
+        // onShutdown is not guaranteed to run before onDestroy, so latch teardown here too to keep
+        // a late onReady from re-initializing an already-destroyed instance
+        isTornDown = true
+        super.onDestroy()
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionService.kt
@@ -68,13 +68,7 @@ class AssistVoiceInteractionService : VoiceInteractionService() {
     }
     private var isServiceReady = false
 
-    /**
-     * One-way latch set once the service has begun tearing down (via [onShutdown] or [onDestroy]).
-     *
-     * The platform documents that [onReady] may be delivered after teardown and that no fixed
-     * lifecycle order can be relied upon. Because [serviceScope] is cancelled during teardown and
-     * cannot be reused, the instance can never function again, so any such late [onReady] is ignored.
-     */
+    /** One-way latch set once the service has begun tearing down (via [onShutdown] or [onDestroy]). */
     private var isTornDown = false
 
     /** Non-null only while the receiver is registered (between [onReady] and [onShutdown]). */

--- a/app/src/test/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionServiceTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/assist/service/AssistVoiceInteractionServiceTest.kt
@@ -329,6 +329,62 @@ class AssistVoiceInteractionServiceTest {
     }
 
     @Test
+    fun `Given service shut down when onReady delivered again then do not register receiver`() = runTest {
+        service.onReady()
+        advanceUntilIdle()
+        service.onShutdown()
+        advanceUntilIdle()
+
+        service.onReady()
+        advanceUntilIdle()
+
+        assertTrue(ACTION_START_LISTENING !in getRegisteredReceiverActions())
+    }
+
+    @Test
+    fun `Given service shut down when onReady delivered and wake word enabled then do not start listening`() = runTest {
+        coEvery { assistConfigManager.isWakeWordEnabled() } returns true
+        coEvery { assistConfigManager.getSelectedWakeWordModel() } returns microWakeWordModelConfigs[0]
+
+        service.onShutdown()
+        advanceUntilIdle()
+
+        service.onReady()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { wakeWordListener.start(any(), any()) }
+    }
+
+    @Test
+    fun `Given service destroyed when onReady delivered again then do not register receiver`() = runTest {
+        service.onDestroy()
+
+        service.onReady()
+        advanceUntilIdle()
+
+        assertTrue(ACTION_START_LISTENING !in getRegisteredReceiverActions())
+    }
+
+    @Test
+    fun `Given receiver already unregistered when onShutdown then do not crash`() = runTest {
+        service.onReady()
+        advanceUntilIdle()
+
+        // Simulate the framework removing the registration out from under the service
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val receiver = Shadows.shadowOf(application).registeredReceivers
+            .first { wrapper ->
+                (0 until wrapper.intentFilter.countActions())
+                    .any { wrapper.intentFilter.getAction(it) == ACTION_START_LISTENING }
+            }
+            .broadcastReceiver
+        application.unregisterReceiver(receiver)
+
+        // Should not throw
+        service.onShutdown()
+    }
+
+    @Test
     fun `Given context when startListening then send START_LISTENING broadcast with package`() {
         assertAction(ACTION_START_LISTENING, AssistVoiceInteractionService::startListening)
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We have 1k users impacted by a crash of the `AssistVoiceInteractionService` while `onShutdown` is invoked, this PR catch the exception. It seems to happen because the system already unregistered the `actionReceiver`.
<img width="1465" height="73" alt="image" src="https://github.com/user-attachments/assets/e8f77965-0028-471f-93ea-1d78f8361996" />

This PR also handle some weirdness of the lifecycle of the service here the documentation of `onReady`

```
    /**
     * Called during service initialization to tell you when the system is ready
     * to receive interaction from it. You should generally do initialization here
     * rather than in {@link #onCreate}. Methods such as {@link #showSession} will
     * not be operational until this point.
     *
     * <p>Note: Under some circumstances, it is possible for {@link #onReady} to be called after
     * {@link #onDestroy} has been called. This can happen in cases where the system is in the
     * process of shutting down the service, but the {@code IVoiceInteractionManagerService}
     * still sends a final "ready" signal. Therefore, implementations must be prepared for
     * {@link #onReady} to be called even after {@link #onDestroy}, and should not rely on a
     * fixed lifecycle order.
     */
```

and onShutdown

```
    /**
     * Called during service de-initialization to tell you when the system is shutting the
     * service down.
     * At this point this service may no longer be the active {@link VoiceInteractionService}.
     *
     * <p>Note: After this method is called, it is possible for other methods on this service
     * to be called, including {@link #onReady}. Implementations should be prepared to handle
     * this case gracefully.
     */
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.