### PR TITLE
Allow test reporting to work even without emulator.wtf results

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -161,7 +161,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-artifacts
 
+      # If emulator_wtf halted or failed before running tests, it uploads no
+      # results artifact, and downloading it by name errors. Tolerate that so we
+      # still publish the pr.yml results below. We cannot gate on
+      # needs.emulator_wtf.result because a real test failure also fails the job
+      # yet does produce this artifact, which we must still publish.
       - name: Download emulator.wtf results from this run
+        continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: Instrumentation Test app results


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
When the main `Pull Request` workflow fail we don't run the emulator.wtf tests to avoid wasting resources. It means we don't store the test result artifacts. The `Test result` job should not fail if it is missing, this PR address this.