### PR TITLE
More strictly reject notifications without a valid server in the app

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -88,6 +88,7 @@ import io.homeassistant.companion.android.settings.assist.DefaultAssistantManage
 import io.homeassistant.companion.android.util.FlashlightHelper
 import io.homeassistant.companion.android.util.PermissionRequestMediator
 import io.homeassistant.companion.android.util.UrlUtil
+import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.vehicle.HaCarAppService
 import io.homeassistant.companion.android.websocket.WebsocketManager
 import io.homeassistant.companion.android.webview.WebViewActivity
@@ -329,11 +330,21 @@ class MessagingManager @Inject constructor(
             }
 
             val serverId = jsonData[NotificationData.WEBHOOK_ID]?.let { webhookId ->
-                serverManager.getServer(webhookId = webhookId)?.id
+                val serverForWebhook = serverManager.getServer(webhookId = webhookId)?.id
+                if (serverForWebhook == null) {
+                    Timber.w(
+                        "Received notification with webhook ID ${sensitive(
+                            webhookId,
+                        )} but no matching server, ignoring",
+                    )
+                    return@launch
+                }
+
+                serverForWebhook
             } ?: ServerManager.SERVER_ID_ACTIVE
 
             if (serverManager.getServer(serverId) == null) {
-                Timber.w("Received notification but no server for it, discarding")
+                Timber.w("Received notification but no server available, ignoring")
                 return@launch
             }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -304,7 +304,7 @@ class MessagingManager @Inject constructor(
                 } ?: return@launch
             } else {
                 val jsonObject = jsonData.toJsonObject()
-                val receivedServer = jsonData[NotificationData.WEBHOOK_ID]?.let {
+                val receivedServerId = jsonData[NotificationData.WEBHOOK_ID]?.let {
                     serverManager.getServer(webhookId = it)?.id
                 }
                 val notificationRow =
@@ -314,14 +314,14 @@ class MessagingManager @Inject constructor(
                         jsonData[NotificationData.MESSAGE].toString(),
                         jsonObject.toString(),
                         source,
-                        receivedServer,
+                        receivedServerId,
                     )
                 notificationId = notificationDao.add(notificationRow)
 
                 val confirmation = jsonData[CONFIRMATION]?.toBoolean() ?: false
                 if (confirmation) {
                     try {
-                        serverManager.integrationRepository(receivedServer ?: ServerManager.SERVER_ID_ACTIVE)
+                        serverManager.integrationRepository(receivedServerId ?: ServerManager.SERVER_ID_ACTIVE)
                             .fireEvent("mobile_app_notification_received", jsonData)
                     } catch (e: Exception) {
                         Timber.e(e, "Unable to send notification received event")
@@ -329,8 +329,8 @@ class MessagingManager @Inject constructor(
                 }
             }
 
-            val serverId = jsonData[NotificationData.WEBHOOK_ID]?.let { webhookId ->
-                val serverForWebhook = serverManager.getServer(webhookId = webhookId)?.id
+            val webhookServerId = jsonData[NotificationData.WEBHOOK_ID]?.let { webhookId ->
+                val serverForWebhook = serverManager.getServer(webhookId = webhookId)
                 if (serverForWebhook == null) {
                     Timber.w(
                         "Received notification with webhook ID ${sensitive(
@@ -340,17 +340,17 @@ class MessagingManager @Inject constructor(
                     return@launch
                 }
 
-                serverForWebhook
+                serverForWebhook.id
             } ?: ServerManager.SERVER_ID_ACTIVE
 
-            if (serverManager.getServer(serverId) == null) {
+            if (serverManager.getServer(webhookServerId) == null) {
                 Timber.w("Received notification but no server available, ignoring")
                 return@launch
             }
 
-            jsonData = jsonData + mutableMapOf<String, String>().apply { put(THIS_SERVER_ID, serverId.toString()) }
+            jsonData = jsonData + mutableMapOf<String, String>().apply { put(THIS_SERVER_ID, webhookServerId.toString()) }
 
-            val allowCommands = serverManager.integrationRepository(serverId).isTrusted()
+            val allowCommands = serverManager.integrationRepository(webhookServerId).isTrusted()
             when {
                 jsonData[NotificationData.MESSAGE] == REQUEST_LOCATION_UPDATE && allowCommands -> {
                     Timber.d("Request location update")

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -348,7 +348,8 @@ class MessagingManager @Inject constructor(
                 return@launch
             }
 
-            jsonData = jsonData + mutableMapOf<String, String>().apply { put(THIS_SERVER_ID, webhookServerId.toString()) }
+            jsonData =
+                jsonData + mutableMapOf<String, String>().apply { put(THIS_SERVER_ID, webhookServerId.toString()) }
 
             val allowCommands = serverManager.integrationRepository(webhookServerId).isTrusted()
             when {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -25,6 +25,7 @@ import io.homeassistant.companion.android.database.notification.NotificationDao
 import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.database.sensor.SensorDao
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import io.homeassistant.companion.android.util.sensitive
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -47,9 +48,9 @@ class MessagingManager @Inject constructor(
 
             val jsonData = notificationData as Map<String, String>?
             val jsonObject = jsonData?.toJsonObject()
-            val serverId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let {
+            val receivedServer = jsonData?.get(NotificationData.WEBHOOK_ID)?.let {
                 serverManager.getServer(webhookId = it)?.id
-            } ?: ServerManager.SERVER_ID_ACTIVE
+            }
             val notificationRow =
                 NotificationItem(
                     0,
@@ -57,11 +58,26 @@ class MessagingManager @Inject constructor(
                     notificationData[NotificationData.MESSAGE].toString(),
                     jsonObject.toString(),
                     source,
-                    serverId,
+                    receivedServer,
                 )
             notificationDao.add(notificationRow)
+
+            val serverId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let { webhookId ->
+                val serverForWebhook = serverManager.getServer(webhookId = webhookId)?.id
+                if (serverForWebhook == null) {
+                    Timber.w(
+                        "Received notification with webhook ID ${sensitive(
+                            webhookId,
+                        )} but no matching server, ignoring",
+                    )
+                    return@launch
+                }
+
+                serverForWebhook
+            } ?: ServerManager.SERVER_ID_ACTIVE
+
             if (serverManager.getServer(serverId) == null) {
-                Timber.w("Received notification but no server for it, discarding")
+                Timber.w("Received notification but no server available, ignoring")
                 return@launch
             }
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -48,7 +48,8 @@ class MessagingManager @Inject constructor(
 
             val jsonData = notificationData as Map<String, String>?
             val jsonObject = jsonData?.toJsonObject()
-            val receivedServerId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let {
+            val receivedWebhookId = jsonData?.get(NotificationData.WEBHOOK_ID)
+            val receivedServerId = receivedWebhookId?.let {
                 serverManager.getServer(webhookId = it)?.id
             }
             val notificationRow =
@@ -62,7 +63,7 @@ class MessagingManager @Inject constructor(
                 )
             notificationDao.add(notificationRow)
 
-            val webhookServerId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let { webhookId ->
+            val webhookServerId = receivedWebhookId?.let { webhookId ->
                 val serverForWebhook = serverManager.getServer(webhookId = webhookId)
                 if (serverForWebhook == null) {
                     Timber.w(

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -48,7 +48,7 @@ class MessagingManager @Inject constructor(
 
             val jsonData = notificationData as Map<String, String>?
             val jsonObject = jsonData?.toJsonObject()
-            val receivedServer = jsonData?.get(NotificationData.WEBHOOK_ID)?.let {
+            val receivedServerId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let {
                 serverManager.getServer(webhookId = it)?.id
             }
             val notificationRow =
@@ -58,12 +58,12 @@ class MessagingManager @Inject constructor(
                     notificationData[NotificationData.MESSAGE].toString(),
                     jsonObject.toString(),
                     source,
-                    receivedServer,
+                    receivedServerId,
                 )
             notificationDao.add(notificationRow)
 
-            val serverId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let { webhookId ->
-                val serverForWebhook = serverManager.getServer(webhookId = webhookId)?.id
+            val webhookServerId = jsonData?.get(NotificationData.WEBHOOK_ID)?.let { webhookId ->
+                val serverForWebhook = serverManager.getServer(webhookId = webhookId)
                 if (serverForWebhook == null) {
                     Timber.w(
                         "Received notification with webhook ID ${sensitive(
@@ -73,15 +73,15 @@ class MessagingManager @Inject constructor(
                     return@launch
                 }
 
-                serverForWebhook
+                serverForWebhook.id
             } ?: ServerManager.SERVER_ID_ACTIVE
 
-            if (serverManager.getServer(serverId) == null) {
+            if (serverManager.getServer(webhookServerId) == null) {
                 Timber.w("Received notification but no server available, ignoring")
                 return@launch
             }
 
-            val allowCommands = serverManager.integrationRepository(serverId).isTrusted()
+            val allowCommands = serverManager.integrationRepository(webhookServerId).isTrusted()
             val message = notificationData[NotificationData.MESSAGE]
             when {
                 message == NotificationData.CLEAR_NOTIFICATION && !notificationData["tag"].isNullOrBlank() -> {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Following [a user report](https://discord.com/channels/330944238910963714/1509048773773496320) about unwanted notifications, I had another look at our validation for notifications. This PR changes processing of notifications to more strictly reject (ignore) notifications that are received if no matching server can be found.

There are two possible scenarios for valid notifications:
- no webhook ID in payload: old server, match to in-app active server
- webhook ID in payload: match to server with that ID in the database

If a notification payload is received with a webhook ID but the app doesn't have a server with that ID in the database, it should be ignored to avoid processing messages from servers removed from the app. That previously didn't work, as this incorrectly triggered the "no webhook ID in payload" fallback. This PR fixes it.

Related: #6921

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction). _No, MessagingManager has no tests and this isn't trivial to introduce right now._
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->