### PR TITLE
Add Wear Dashboard schema, validation, and capabilities in :common

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardBindingKey.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardBindingKey.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+
+/**
+ * Generates stable cache lookup keys for [WearDashboardBinding] values.
+ */
+object WearDashboardBindingKey {
+    /**
+     * Returns a cache key for bindings that resolve at runtime, or null for constants.
+     */
+    fun keyFor(binding: WearDashboardBinding): String? = when (binding) {
+        is WearDashboardBinding.Constant -> null
+        is WearDashboardBinding.EntityState -> buildString {
+            append("entity:")
+            append(binding.entityId)
+            binding.attribute?.let { attribute ->
+                append(":attr:")
+                append(attribute)
+            }
+        }
+        is WearDashboardBinding.Template -> "template:${binding.template}"
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRenderer.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRenderer.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardCapabilities
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardResolvedState
+
+/**
+ * Renders a Wear Dashboard page into a native surface-specific representation.
+ *
+ * @param T The renderer output type, such as a ProtoLayout [LayoutElement] or Compose UI tree.
+ */
+interface WearDashboardRenderer<T> {
+    /**
+     * Renders the requested page from [config] using resolved [state] and device [capabilities].
+     */
+    fun render(
+        config: WearDashboardConfig,
+        pageId: String,
+        state: WearDashboardResolvedState,
+        capabilities: WearDashboardCapabilities,
+    ): T
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardAction.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardAction.kt
@@ -1,0 +1,42 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * An explicit action triggered from a dashboard component interaction.
+ */
+@Serializable
+sealed interface WearDashboardAction {
+
+    /** Toggles a Home Assistant entity that supports toggle semantics. */
+    @Serializable
+    @SerialName("toggle_entity")
+    data class ToggleEntity(val entityId: String) : WearDashboardAction
+
+    /** Calls a Home Assistant service with optional service data. */
+    @Serializable
+    @SerialName("call_service")
+    data class CallService(
+        val domain: String,
+        val service: String,
+        val data: Map<String, JsonElement> = emptyMap(),
+        val requiresConfirmation: Boolean = false,
+    ) : WearDashboardAction
+
+    /** Navigates to another page within the same dashboard. */
+    @Serializable
+    @SerialName("navigate")
+    data class Navigate(val dashboardId: String, val pageId: String) : WearDashboardAction
+
+    /** Requests a refresh of the current dashboard surface. */
+    @Serializable
+    @SerialName("refresh")
+    data object Refresh : WearDashboardAction
+
+    /** Opens the full Wear dashboard activity for richer interaction. */
+    @Serializable
+    @SerialName("open_full_dashboard")
+    data class OpenFullDashboard(val dashboardId: String, val pageId: String? = null) : WearDashboardAction
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardBinding.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardBinding.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Describes how a dashboard value is resolved from Home Assistant state or templates.
+ */
+@Serializable
+sealed interface WearDashboardBinding {
+
+    /** A fixed value that does not change at runtime. */
+    @Serializable
+    @SerialName("constant")
+    data class Constant(val value: JsonElement) : WearDashboardBinding
+
+    /** The state or attribute of a Home Assistant entity. */
+    @Serializable
+    @SerialName("entity_state")
+    data class EntityState(val entityId: String, val attribute: String? = null) : WearDashboardBinding
+
+    /** A Home Assistant Jinja template evaluated at runtime. */
+    @Serializable
+    @SerialName("template")
+    data class Template(val template: String) : WearDashboardBinding
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardCapabilities.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardCapabilities.kt
@@ -1,0 +1,96 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+/**
+ * Physical screen shape of the Wear device.
+ */
+enum class ScreenShape {
+    Round,
+    Square,
+}
+
+/**
+ * Coarse screen size bucket used to apply layout limits on constrained surfaces.
+ */
+enum class ScreenSizeBucket {
+    Small,
+    Medium,
+    Large,
+}
+
+/**
+ * Device and platform capabilities that constrain dashboard rendering.
+ */
+data class WearDashboardCapabilities(
+    val screenShape: ScreenShape,
+    val screenSizeBucket: ScreenSizeBucket,
+    val screenWidthDp: Int,
+    val screenHeightDp: Int,
+    val sdkInt: Int,
+    val maxComponentTreeDepth: Int,
+    val maxChildrenPerContainer: Int,
+    val maxDynamicExpressions: Int,
+    val supportsDynamicExpressions: Boolean,
+    val supportsScrollableLayout: Boolean,
+    val supportsOngoingActivity: Boolean,
+) {
+    companion object {
+        private const val SMALL_SCREEN_MAX_DP = 180
+        private const val MEDIUM_SCREEN_MAX_DP = 224
+        private const val DEFAULT_MAX_COMPONENT_TREE_DEPTH = 5
+        private const val DEFAULT_MAX_CHILDREN_PER_CONTAINER = 6
+        private const val DEFAULT_MAX_DYNAMIC_EXPRESSIONS = 4
+        private const val DYNAMIC_EXPRESSIONS_MIN_SDK = 34
+        private const val ONGOING_ACTIVITY_MIN_SDK = 30
+
+        /**
+         * Derives capabilities from device display parameters.
+         */
+        fun fromDeviceParameters(
+            screenWidthDp: Int,
+            screenHeightDp: Int,
+            screenShape: ScreenShape,
+            sdkInt: Int,
+        ): WearDashboardCapabilities {
+            val sizeReferenceDp = when (screenShape) {
+                ScreenShape.Round -> minOf(screenWidthDp, screenHeightDp)
+                ScreenShape.Square -> screenWidthDp
+            }
+            return WearDashboardCapabilities(
+                screenShape = screenShape,
+                screenSizeBucket = sizeBucketFor(sizeReferenceDp),
+                screenWidthDp = screenWidthDp,
+                screenHeightDp = screenHeightDp,
+                sdkInt = sdkInt,
+                maxComponentTreeDepth = DEFAULT_MAX_COMPONENT_TREE_DEPTH,
+                maxChildrenPerContainer = DEFAULT_MAX_CHILDREN_PER_CONTAINER,
+                maxDynamicExpressions = DEFAULT_MAX_DYNAMIC_EXPRESSIONS,
+                supportsDynamicExpressions = sdkInt >= DYNAMIC_EXPRESSIONS_MIN_SDK,
+                supportsScrollableLayout = true,
+                supportsOngoingActivity = sdkInt >= ONGOING_ACTIVITY_MIN_SDK,
+            )
+        }
+
+        /**
+         * Returns conservative defaults when device parameters are unavailable.
+         */
+        fun defaults(): WearDashboardCapabilities = WearDashboardCapabilities(
+            screenShape = ScreenShape.Round,
+            screenSizeBucket = ScreenSizeBucket.Medium,
+            screenWidthDp = 200,
+            screenHeightDp = 200,
+            sdkInt = DYNAMIC_EXPRESSIONS_MIN_SDK,
+            maxComponentTreeDepth = DEFAULT_MAX_COMPONENT_TREE_DEPTH,
+            maxChildrenPerContainer = DEFAULT_MAX_CHILDREN_PER_CONTAINER,
+            maxDynamicExpressions = DEFAULT_MAX_DYNAMIC_EXPRESSIONS,
+            supportsDynamicExpressions = true,
+            supportsScrollableLayout = true,
+            supportsOngoingActivity = true,
+        )
+
+        private fun sizeBucketFor(sizeReferenceDp: Int): ScreenSizeBucket = when {
+            sizeReferenceDp <= SMALL_SCREEN_MAX_DP -> ScreenSizeBucket.Small
+            sizeReferenceDp <= MEDIUM_SCREEN_MAX_DP -> ScreenSizeBucket.Medium
+            else -> ScreenSizeBucket.Large
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardComponent.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardComponent.kt
@@ -1,0 +1,121 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Semantic dashboard component tree node independent of any Android UI framework.
+ */
+@Serializable
+sealed interface WearDashboardComponent {
+    val id: String?
+    val visible: WearDashboardBinding?
+    val tapAction: WearDashboardAction?
+    val holdAction: WearDashboardAction?
+
+    /** Static or dynamically bound text content. */
+    @Serializable
+    @SerialName("text")
+    data class Text(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val text: WearDashboardBinding,
+    ) : WearDashboardComponent
+
+    /** An icon resolved from a binding, typically an MDI icon name. */
+    @Serializable
+    @SerialName("icon")
+    data class Icon(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val icon: WearDashboardBinding,
+    ) : WearDashboardComponent
+
+    /** A tappable control with optional icon and label bindings. */
+    @Serializable
+    @SerialName("button")
+    data class Button(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val text: WearDashboardBinding? = null,
+        val icon: WearDashboardBinding? = null,
+    ) : WearDashboardComponent
+
+    /** A compact status indicator for entity states such as doors, locks, or batteries. */
+    @Serializable
+    @SerialName("status_chip")
+    data class StatusChip(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val state: WearDashboardBinding,
+        val label: WearDashboardBinding? = null,
+    ) : WearDashboardComponent
+
+    /** A circular progress indicator bound to a numeric value. */
+    @Serializable
+    @SerialName("progress_ring")
+    data class ProgressRing(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val value: WearDashboardBinding,
+        val min: Int = 0,
+        val max: Int = 100,
+    ) : WearDashboardComponent
+
+    /** Horizontally arranges a limited number of child components. */
+    @Serializable
+    @SerialName("row")
+    data class Row(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Vertically arranges a limited number of child components. */
+    @Serializable
+    @SerialName("column")
+    data class Column(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Overlays child components, useful for progress rings with centered text. */
+    @Serializable
+    @SerialName("box")
+    data class Box(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Renders one branch based on binding truthiness. */
+    @Serializable
+    @SerialName("conditional")
+    data class Conditional(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val condition: WearDashboardBinding,
+        val then: WearDashboardComponent,
+        @SerialName("else")
+        val elseComponent: WearDashboardComponent? = null,
+    ) : WearDashboardComponent
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardConfig.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardConfig.kt
@@ -1,0 +1,16 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Top-level Wear Dashboard configuration persisted as canonical JSON.
+ */
+@Serializable
+data class WearDashboardConfig(
+    val version: Int = WearDashboardSchemaVersion.CURRENT_VERSION,
+    val id: String,
+    val title: String? = null,
+    val pages: List<WearDashboardPage>,
+    val surfaces: WearDashboardSurfaces = WearDashboardSurfaces(),
+    val refreshPolicy: WearDashboardRefreshPolicy = WearDashboardRefreshPolicy.OnEnter,
+)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardJson.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardJson.kt
@@ -1,0 +1,18 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+
+/**
+ * Kotlinx serialization [Json] instance for Wear Dashboard configuration.
+ *
+ * Uses camelCase property names and a `type` discriminator for polymorphic types.
+ * Unknown JSON keys are ignored so older clients can read configs from newer schema versions.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+val wearDashboardJson = Json {
+    ignoreUnknownKeys = true
+    classDiscriminator = "type"
+    encodeDefaults = false
+    prettyPrint = false
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardPage.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardPage.kt
@@ -1,0 +1,9 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A single page within a Wear Dashboard configuration.
+ */
+@Serializable
+data class WearDashboardPage(val id: String, val title: String? = null, val root: WearDashboardComponent)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardRefreshPolicy.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardRefreshPolicy.kt
@@ -1,0 +1,31 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Describes when a dashboard surface should refresh its resolved state.
+ */
+@Serializable
+sealed interface WearDashboardRefreshPolicy {
+
+    /** Refresh when the user enters the dashboard surface. */
+    @Serializable
+    @SerialName("on_enter")
+    data object OnEnter : WearDashboardRefreshPolicy
+
+    /** Refresh when a referenced entity changes state. */
+    @Serializable
+    @SerialName("on_entity_change")
+    data object OnEntityChange : WearDashboardRefreshPolicy
+
+    /** Refresh on a fixed interval. */
+    @Serializable
+    @SerialName("interval")
+    data class Interval(val seconds: Int) : WearDashboardRefreshPolicy
+
+    /** Refresh only when explicitly requested by the user or an action. */
+    @Serializable
+    @SerialName("manual")
+    data object Manual : WearDashboardRefreshPolicy
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSchemaVersion.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSchemaVersion.kt
@@ -1,0 +1,17 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+/**
+ * Supported Wear Dashboard schema versions.
+ */
+object WearDashboardSchemaVersion {
+    /** Current schema version written by this client. */
+    const val CURRENT_VERSION: Int = 1
+
+    /** Schema versions that this client can read and validate. */
+    val SUPPORTED_VERSIONS: List<Int> = listOf(CURRENT_VERSION)
+
+    /**
+     * Returns whether [version] is supported by this client.
+     */
+    fun isSupported(version: Int): Boolean = version in SUPPORTED_VERSIONS
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSurfaces.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSurfaces.kt
@@ -1,0 +1,25 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Maps a dashboard to the pages used by each native Wear surface.
+ */
+@Serializable
+data class WearDashboardSurfaces(
+    val tile: WearDashboardTileSurface? = null,
+    val app: WearDashboardAppSurface? = null,
+    val ongoingActivity: WearDashboardOngoingActivitySurface? = null,
+)
+
+/** Tile surface configuration referencing a compact dashboard page. */
+@Serializable
+data class WearDashboardTileSurface(val page: String)
+
+/** Full Wear app surface configuration referencing a start page. */
+@Serializable
+data class WearDashboardAppSurface(val startPage: String)
+
+/** Ongoing Activity surface configuration referencing an activity page. */
+@Serializable
+data class WearDashboardOngoingActivitySurface(val page: String)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValue.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValue.kt
@@ -1,0 +1,19 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+/**
+ * A resolved runtime value for a dashboard binding.
+ */
+sealed interface ResolvedComponentValue {
+
+    /** A textual binding value. */
+    data class TextValue(val text: String) : ResolvedComponentValue
+
+    /** A numeric binding value. */
+    data class NumberValue(val number: Double) : ResolvedComponentValue
+
+    /** A boolean binding value. */
+    data class BooleanValue(val value: Boolean) : ResolvedComponentValue
+
+    /** A binding value that could not be classified or parsed. */
+    data class Unknown(val raw: String?) : ResolvedComponentValue
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValueExtensions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValueExtensions.kt
@@ -1,0 +1,11 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+/**
+ * Returns a display string for this resolved binding value.
+ */
+fun ResolvedComponentValue.toDisplayString(): String = when (this) {
+    is ResolvedComponentValue.TextValue -> text
+    is ResolvedComponentValue.NumberValue -> number.toString()
+    is ResolvedComponentValue.BooleanValue -> value.toString()
+    is ResolvedComponentValue.Unknown -> raw.orEmpty()
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardResolvedState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardResolvedState.kt
@@ -1,0 +1,15 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import kotlin.time.Instant
+
+/**
+ * Resolved binding values used when rendering a dashboard.
+ */
+data class WearDashboardResolvedState(
+    val values: Map<String, ResolvedComponentValue> = emptyMap(),
+    val isStale: Boolean = false,
+    val lastUpdated: Instant? = null,
+) {
+    /** Display strings keyed by [io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardBindingKey]. */
+    val bindingValues: Map<String, String> = values.mapValues { (_, value) -> value.toDisplayString() }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/validation/WearDashboardValidation.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/validation/WearDashboardValidation.kt
@@ -1,0 +1,220 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.validation
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardRefreshPolicy
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardSchemaVersion
+
+/** Maximum allowed depth of the component tree, including the root component. */
+const val WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH = 5
+
+/** Maximum number of children allowed in layout container components. */
+const val WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER = 6
+
+/** Minimum interval in seconds for periodic refresh policies. */
+const val WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS = 1
+
+private val ENTITY_ID_PATTERN = Regex("^[a-z][a-z0-9_]*\\.[a-z0-9_]+$")
+private val IDENTIFIER_PATTERN = Regex("^[a-z][a-z0-9_]*$")
+
+/**
+ * A single validation issue found in a dashboard configuration.
+ */
+data class ValidationError(val path: String, val message: String)
+
+/**
+ * Result of validating a [WearDashboardConfig].
+ */
+data class ValidationResult(val errors: List<ValidationError>) {
+    /** Whether the configuration passed all validation checks. */
+    val isValid: Boolean get() = errors.isEmpty()
+}
+
+/**
+ * Validates a Wear Dashboard configuration and returns structured errors.
+ */
+fun validate(config: WearDashboardConfig): ValidationResult {
+    val errors = mutableListOf<ValidationError>()
+    validateConfig(config, errors)
+    return ValidationResult(errors)
+}
+
+private fun validateConfig(config: WearDashboardConfig, errors: MutableList<ValidationError>) {
+    if (config.id.isBlank()) {
+        errors += ValidationError("id", "Dashboard id must not be blank")
+    }
+    if (!WearDashboardSchemaVersion.isSupported(config.version)) {
+        errors += ValidationError(
+            "version",
+            "Unsupported schema version ${config.version}; supported: ${WearDashboardSchemaVersion.SUPPORTED_VERSIONS}",
+        )
+    }
+    if (config.pages.isEmpty()) {
+        errors += ValidationError("pages", "At least one page is required")
+    }
+
+    val pageIds = mutableSetOf<String>()
+    config.pages.forEachIndexed { index, page ->
+        val pagePath = "pages[$index]"
+        if (page.id.isBlank()) {
+            errors += ValidationError("$pagePath.id", "Page id must not be blank")
+        } else if (!pageIds.add(page.id)) {
+            errors += ValidationError("$pagePath.id", "Duplicate page id '${page.id}'")
+        }
+        validateComponent(page.root, "$pagePath.root", depth = 1, errors)
+    }
+
+    validateSurfaces(config, pageIds, errors)
+    validateRefreshPolicy(config.refreshPolicy, "refreshPolicy", errors)
+}
+
+private fun validateSurfaces(config: WearDashboardConfig, pageIds: Set<String>, errors: MutableList<ValidationError>) {
+    config.surfaces.tile?.page?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.tile.page", "Unknown page id '$pageId'")
+        }
+    }
+    config.surfaces.app?.startPage?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.app.startPage", "Unknown page id '$pageId'")
+        }
+    }
+    config.surfaces.ongoingActivity?.page?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.ongoingActivity.page", "Unknown page id '$pageId'")
+        }
+    }
+}
+
+private fun validateRefreshPolicy(
+    policy: WearDashboardRefreshPolicy,
+    path: String,
+    errors: MutableList<ValidationError>,
+) {
+    if (policy is WearDashboardRefreshPolicy.Interval && policy.seconds < WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS) {
+        errors += ValidationError(
+            "$path.seconds",
+            "Refresh interval must be at least $WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS second",
+        )
+    }
+}
+
+private fun validateComponent(
+    component: WearDashboardComponent,
+    path: String,
+    depth: Int,
+    errors: MutableList<ValidationError>,
+) {
+    if (depth > WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH) {
+        errors += ValidationError(
+            path,
+            "Component tree exceeds maximum depth of $WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH",
+        )
+        return
+    }
+
+    component.visible?.let { validateBinding(it, "$path.visible", errors) }
+    component.tapAction?.let { validateAction(it, "$path.tapAction", errors) }
+    component.holdAction?.let { validateAction(it, "$path.holdAction", errors) }
+
+    when (component) {
+        is WearDashboardComponent.Text -> validateBinding(component.text, "$path.text", errors)
+        is WearDashboardComponent.Icon -> validateBinding(component.icon, "$path.icon", errors)
+        is WearDashboardComponent.Button -> {
+            component.text?.let { validateBinding(it, "$path.text", errors) }
+            component.icon?.let { validateBinding(it, "$path.icon", errors) }
+            if (component.text == null && component.icon == null) {
+                errors += ValidationError(path, "Button must define text or icon")
+            }
+        }
+        is WearDashboardComponent.StatusChip -> {
+            validateBinding(component.state, "$path.state", errors)
+            component.label?.let { validateBinding(it, "$path.label", errors) }
+        }
+        is WearDashboardComponent.ProgressRing -> {
+            validateBinding(component.value, "$path.value", errors)
+            if (component.min >= component.max) {
+                errors += ValidationError(path, "Progress ring min must be less than max")
+            }
+        }
+        is WearDashboardComponent.Row -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Column -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Box -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Conditional -> {
+            validateBinding(component.condition, "$path.condition", errors)
+            validateComponent(component.then, "$path.then", depth + 1, errors)
+            component.elseComponent?.let { validateComponent(it, "$path.else", depth + 1, errors) }
+        }
+    }
+}
+
+private fun validateContainerChildren(
+    children: List<WearDashboardComponent>,
+    path: String,
+    depth: Int,
+    errors: MutableList<ValidationError>,
+) {
+    if (children.size > WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER) {
+        errors += ValidationError(
+            "$path.children",
+            "Container exceeds maximum of $WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER children",
+        )
+    }
+    children.forEachIndexed { index, child ->
+        validateComponent(child, "$path.children[$index]", depth + 1, errors)
+    }
+}
+
+private fun validateBinding(binding: WearDashboardBinding, path: String, errors: MutableList<ValidationError>) {
+    when (binding) {
+        is WearDashboardBinding.EntityState -> validateEntityId(binding.entityId, path, errors)
+        is WearDashboardBinding.Template -> {
+            if (binding.template.isBlank()) {
+                errors += ValidationError(path, "Template must not be blank")
+            }
+        }
+        is WearDashboardBinding.Constant -> Unit
+    }
+}
+
+private fun validateAction(action: WearDashboardAction, path: String, errors: MutableList<ValidationError>) {
+    when (action) {
+        is WearDashboardAction.ToggleEntity -> validateEntityId(action.entityId, path, errors)
+        is WearDashboardAction.CallService -> {
+            validateIdentifier(action.domain, "$path.domain", "domain", errors)
+            validateIdentifier(action.service, "$path.service", "service", errors)
+        }
+        is WearDashboardAction.Navigate -> {
+            if (action.dashboardId.isBlank()) {
+                errors += ValidationError("$path.dashboardId", "Dashboard id must not be blank")
+            }
+            if (action.pageId.isBlank()) {
+                errors += ValidationError("$path.pageId", "Page id must not be blank")
+            }
+        }
+        is WearDashboardAction.OpenFullDashboard -> {
+            if (action.dashboardId.isBlank()) {
+                errors += ValidationError("$path.dashboardId", "Dashboard id must not be blank")
+            }
+        }
+        is WearDashboardAction.Refresh -> Unit
+    }
+}
+
+private fun validateEntityId(entityId: String, path: String, errors: MutableList<ValidationError>) {
+    if (entityId.isBlank()) {
+        errors += ValidationError(path, "Entity id must not be blank")
+    } else if (!ENTITY_ID_PATTERN.matches(entityId)) {
+        errors += ValidationError(path, "Invalid entity id '$entityId'")
+    }
+}
+
+private fun validateIdentifier(value: String, path: String, label: String, errors: MutableList<ValidationError>) {
+    if (value.isBlank()) {
+        errors += ValidationError(path, "$label must not be blank")
+    } else if (!IDENTIFIER_PATTERN.matches(value)) {
+        errors += ValidationError(path, "Invalid $label '$value'")
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardCapabilitiesTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardCapabilitiesTest.kt
@@ -1,0 +1,76 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.ScreenShape
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.ScreenSizeBucket
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardCapabilities
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class WearDashboardCapabilitiesTest {
+    @ParameterizedTest
+    @MethodSource("roundScreenSizeBuckets")
+    fun `Given round screen dimensions when deriving capabilities then size bucket matches`(
+        widthDp: Int,
+        heightDp: Int,
+        expectedBucket: ScreenSizeBucket,
+    ) {
+        val capabilities = WearDashboardCapabilities.fromDeviceParameters(
+            screenWidthDp = widthDp,
+            screenHeightDp = heightDp,
+            screenShape = ScreenShape.Round,
+            sdkInt = 34,
+        )
+
+        assertEquals(expectedBucket, capabilities.screenSizeBucket)
+        assertEquals(ScreenShape.Round, capabilities.screenShape)
+    }
+
+    @ParameterizedTest
+    @MethodSource("squareScreenSizeBuckets")
+    fun `Given square screen width when deriving capabilities then size bucket uses width`(
+        widthDp: Int,
+        heightDp: Int,
+        expectedBucket: ScreenSizeBucket,
+    ) {
+        val capabilities = WearDashboardCapabilities.fromDeviceParameters(
+            screenWidthDp = widthDp,
+            screenHeightDp = heightDp,
+            screenShape = ScreenShape.Square,
+            sdkInt = 34,
+        )
+
+        assertEquals(expectedBucket, capabilities.screenSizeBucket)
+    }
+
+    @Test
+    fun `Given defaults when reading capabilities then conservative values are returned`() {
+        val capabilities = WearDashboardCapabilities.defaults()
+
+        assertEquals(ScreenShape.Round, capabilities.screenShape)
+        assertEquals(ScreenSizeBucket.Medium, capabilities.screenSizeBucket)
+        assertEquals(5, capabilities.maxComponentTreeDepth)
+        assertEquals(6, capabilities.maxChildrenPerContainer)
+    }
+
+    companion object {
+        @JvmStatic
+        fun roundScreenSizeBuckets(): List<Arguments> = listOf(
+            Arguments.of(170, 170, ScreenSizeBucket.Small),
+            Arguments.of(180, 220, ScreenSizeBucket.Small),
+            Arguments.of(200, 200, ScreenSizeBucket.Medium),
+            Arguments.of(224, 224, ScreenSizeBucket.Medium),
+            Arguments.of(225, 225, ScreenSizeBucket.Large),
+            Arguments.of(240, 240, ScreenSizeBucket.Large),
+        )
+
+        @JvmStatic
+        fun squareScreenSizeBuckets(): List<Arguments> = listOf(
+            Arguments.of(180, 220, ScreenSizeBucket.Small),
+            Arguments.of(200, 240, ScreenSizeBucket.Medium),
+            Arguments.of(225, 280, ScreenSizeBucket.Large),
+        )
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardConfigSerializationTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardConfigSerializationTest.kt
@@ -1,0 +1,63 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.wearDashboardJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WearDashboardConfigSerializationTest {
+    @Test
+    fun `Given car dashboard JSON when deserializing then round-trip preserves config`() {
+        val decoded = wearDashboardJson.decodeFromString<WearDashboardConfig>(
+            WearDashboardTestFixtures.CAR_DASHBOARD_JSON,
+        )
+
+        val encoded = wearDashboardJson.encodeToString(decoded)
+        val roundTripped = wearDashboardJson.decodeFromString<WearDashboardConfig>(encoded)
+
+        assertEquals(decoded, roundTripped)
+    }
+
+    @Test
+    fun `Given car dashboard object when serializing and deserializing then values match`() {
+        val config = WearDashboardTestFixtures.carDashboard
+
+        val roundTripped = wearDashboardJson.decodeFromString<WearDashboardConfig>(
+            wearDashboardJson.encodeToString(config),
+        )
+
+        assertEquals(config, roundTripped)
+    }
+
+    @Test
+    fun `Given JSON with unknown keys when deserializing then keys are ignored`() {
+        val jsonWithUnknownKeys = """
+            {
+              "version": 1,
+              "id": "car",
+              "futureField": "ignored",
+              "pages": [
+                {
+                  "id": "compact",
+                  "deprecatedTitle": "Old",
+                  "root": {
+                    "type": "text",
+                    "futureComponentField": true,
+                    "text": {
+                      "type": "constant",
+                      "value": "Hello",
+                      "extra": 1
+                    }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val config = wearDashboardJson.decodeFromString<WearDashboardConfig>(jsonWithUnknownKeys)
+
+        assertEquals("car", config.id)
+        assertEquals(1, config.pages.size)
+        assertEquals("compact", config.pages.first().id)
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardTestFixtures.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardTestFixtures.kt
@@ -1,0 +1,151 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAppSurface
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardPage
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardSurfaces
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardTileSurface
+import kotlinx.serialization.json.JsonPrimitive
+
+internal object WearDashboardTestFixtures {
+    val carDashboard: WearDashboardConfig = WearDashboardConfig(
+        version = 1,
+        id = "car",
+        title = "Car",
+        surfaces = WearDashboardSurfaces(
+            tile = WearDashboardTileSurface(page = "compact"),
+            app = WearDashboardAppSurface(startPage = "compact"),
+        ),
+        pages = listOf(
+            WearDashboardPage(
+                id = "compact",
+                title = "Car",
+                root = WearDashboardComponent.Box(
+                    id = "root",
+                    children = listOf(
+                        WearDashboardComponent.ProgressRing(
+                            id = "battery_ring",
+                            value = WearDashboardBinding.EntityState(entityId = "sensor.car_battery"),
+                            min = 0,
+                            max = 100,
+                        ),
+                        WearDashboardComponent.Text(
+                            id = "battery_text",
+                            text = WearDashboardBinding.Template(
+                                template = "{{ states('sensor.car_battery') }}%",
+                            ),
+                        ),
+                        WearDashboardComponent.Row(
+                            id = "actions",
+                            children = listOf(
+                                WearDashboardComponent.Button(
+                                    id = "lock",
+                                    icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:lock")),
+                                    tapAction = WearDashboardAction.CallService(
+                                        domain = "button",
+                                        service = "press",
+                                        data = mapOf("entity_id" to JsonPrimitive("button.car_lock")),
+                                    ),
+                                ),
+                                WearDashboardComponent.Button(
+                                    id = "climate",
+                                    icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:air-conditioner")),
+                                    tapAction = WearDashboardAction.CallService(
+                                        domain = "button",
+                                        service = "press",
+                                        data = mapOf(
+                                            "entity_id" to JsonPrimitive("button.car_start_air_conditioner"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    const val CAR_DASHBOARD_JSON = """
+        {
+          "version": 1,
+          "id": "car",
+          "title": "Car",
+          "surfaces": {
+            "tile": { "page": "compact" },
+            "app": { "startPage": "compact" }
+          },
+          "pages": [
+            {
+              "id": "compact",
+              "title": "Car",
+              "root": {
+                "type": "box",
+                "id": "root",
+                "children": [
+                  {
+                    "type": "progress_ring",
+                    "id": "battery_ring",
+                    "value": {
+                      "type": "entity_state",
+                      "entityId": "sensor.car_battery"
+                    },
+                    "min": 0,
+                    "max": 100
+                  },
+                  {
+                    "type": "text",
+                    "id": "battery_text",
+                    "text": {
+                      "type": "template",
+                      "template": "{{ states('sensor.car_battery') }}%"
+                    }
+                  },
+                  {
+                    "type": "row",
+                    "id": "actions",
+                    "children": [
+                      {
+                        "type": "button",
+                        "id": "lock",
+                        "icon": {
+                          "type": "constant",
+                          "value": "mdi:lock"
+                        },
+                        "tapAction": {
+                          "type": "call_service",
+                          "domain": "button",
+                          "service": "press",
+                          "data": {
+                            "entity_id": "button.car_lock"
+                          }
+                        }
+                      },
+                      {
+                        "type": "button",
+                        "id": "climate",
+                        "icon": {
+                          "type": "constant",
+                          "value": "mdi:air-conditioner"
+                        },
+                        "tapAction": {
+                          "type": "call_service",
+                          "domain": "button",
+                          "service": "press",
+                          "data": {
+                            "entity_id": "button.car_start_air_conditioner"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+    """
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardValidationTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardValidationTest.kt
@@ -1,0 +1,71 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardPage
+import io.homeassistant.companion.android.common.data.wear.dashboard.validation.validate
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WearDashboardValidationTest {
+    @Test
+    fun `Given valid car dashboard when validating then result is valid`() {
+        val result = validate(WearDashboardTestFixtures.carDashboard)
+
+        assertTrue(result.isValid)
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
+    fun `Given duplicate page ids when validating then result reports duplicate error`() {
+        val config = WearDashboardTestFixtures.carDashboard.copy(
+            pages = listOf(
+                WearDashboardPage(
+                    id = "compact",
+                    root = WearDashboardComponent.Text(
+                        text = WearDashboardBinding.Constant(JsonPrimitive("A")),
+                    ),
+                ),
+                WearDashboardPage(
+                    id = "compact",
+                    root = WearDashboardComponent.Text(
+                        text = WearDashboardBinding.Constant(JsonPrimitive("B")),
+                    ),
+                ),
+            ),
+        )
+
+        val result = validate(config)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.path.endsWith(".id") && it.message.contains("Duplicate") })
+    }
+
+    @Test
+    fun `Given invalid service action when validating then result reports service error`() {
+        val config = WearDashboardConfig(
+            id = "invalid-service",
+            pages = listOf(
+                WearDashboardPage(
+                    id = "main",
+                    root = WearDashboardComponent.Button(
+                        icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:lock")),
+                        tapAction = WearDashboardAction.CallService(
+                            domain = "",
+                            service = "press",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = validate(config)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.path.contains("domain") })
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the shared Wear Dashboard config model (`WearDashboardConfig`, pages, components, bindings, actions) with JSON serialization
- Adds validation rules and `WearDashboardCapabilities` for surface-specific layout limits
- Adds minimal resolved-state types and renderer interface used by later Wear tile and sync PRs
- Includes unit tests for serialization, validation, and capabilities

Depends on #6929 for the implementation plan docs (independent file paths; can merge in either order).

## Test plan

- [x] `./gradlew :common:test`