### PR TITLE
Add Wear Dashboard state cache and update coordinator in :common

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardBindingKey.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardBindingKey.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+
+/**
+ * Generates stable cache lookup keys for [WearDashboardBinding] values.
+ */
+object WearDashboardBindingKey {
+    /**
+     * Returns a cache key for bindings that resolve at runtime, or null for constants.
+     */
+    fun keyFor(binding: WearDashboardBinding): String? = when (binding) {
+        is WearDashboardBinding.Constant -> null
+        is WearDashboardBinding.EntityState -> buildString {
+            append("entity:")
+            append(binding.entityId)
+            binding.attribute?.let { attribute ->
+                append(":attr:")
+                append(attribute)
+            }
+        }
+        is WearDashboardBinding.Template -> "template:${binding.template}"
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRenderer.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRenderer.kt
@@ -1,0 +1,22 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardCapabilities
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardResolvedState
+
+/**
+ * Renders a Wear Dashboard page into a native surface-specific representation.
+ *
+ * @param T The renderer output type, such as a ProtoLayout [LayoutElement] or Compose UI tree.
+ */
+interface WearDashboardRenderer<T> {
+    /**
+     * Renders the requested page from [config] using resolved [state] and device [capabilities].
+     */
+    fun render(
+        config: WearDashboardConfig,
+        pageId: String,
+        state: WearDashboardResolvedState,
+        capabilities: WearDashboardCapabilities,
+    ): T
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepository.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepository.kt
@@ -1,0 +1,47 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+
+/**
+ * Persists Wear Dashboard configurations and tile-to-dashboard mappings.
+ */
+interface WearDashboardRepository {
+
+    /** Returns all stored dashboard configs keyed by dashboard ID. */
+    suspend fun getAllDashboards(): Map<String, WearDashboardConfig>
+
+    /** Returns the dashboard config for [id], or `null` when it is not stored. */
+    suspend fun getDashboard(id: String): WearDashboardConfig?
+
+    /** Stores or replaces a single dashboard config keyed by [WearDashboardConfig.id]. */
+    suspend fun setDashboard(config: WearDashboardConfig)
+
+    /** Replaces all stored dashboard configs with [configs]. */
+    suspend fun setAllDashboards(configs: Map<String, WearDashboardConfig>)
+
+    /**
+     * Removes the dashboard config for [id].
+     *
+     * @return The removed config, or `null` when [id] was not stored.
+     */
+    suspend fun removeDashboard(id: String): WearDashboardConfig?
+
+    /** Returns tile instance IDs mapped to their assigned dashboard ID. */
+    suspend fun getTileDashboardMapping(): Map<Int, String>
+
+    /** Assigns [dashboardId] to the Wear Tile instance identified by [tileId]. */
+    suspend fun setTileDashboard(tileId: Int, dashboardId: String)
+
+    /** Removes the dashboard assignment for [tileId], if present. */
+    suspend fun removeTileDashboard(tileId: Int)
+
+    /**
+     * Returns the dashboard ID assigned to [tileId], migrating a legacy unknown tile ID when needed.
+     *
+     * @return The assigned dashboard ID, or `null` when this tile has no dashboard assignment.
+     */
+    suspend fun getDashboardTileAssignmentAndSaveTileId(tileId: Int): String?
+
+    /** Removes the dashboard assignment for [tileId], if present. */
+    suspend fun removeDashboardTileAssignment(tileId: Int)
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepositoryImpl.kt
@@ -1,0 +1,116 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import androidx.annotation.VisibleForTesting
+import io.homeassistant.companion.android.common.data.LocalStorage
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.wearDashboardJson
+import io.homeassistant.companion.android.di.qualifiers.NamedWearStorage
+import javax.inject.Inject
+import kotlinx.serialization.SerializationException
+import timber.log.Timber
+
+internal class WearDashboardRepositoryImpl @Inject constructor(
+    @NamedWearStorage private val localStorage: LocalStorage,
+) : WearDashboardRepository {
+
+    companion object {
+        @VisibleForTesting
+        const val PREF_WEAR_DASHBOARDS = "wear_dashboards"
+
+        @VisibleForTesting
+        const val PREF_WEAR_DASHBOARD_TILES = "wear_dashboard_tiles"
+
+        @VisibleForTesting
+        const val UNKNOWN_TILE_ID = -1
+    }
+
+    override suspend fun getAllDashboards(): Map<String, WearDashboardConfig> = readDashboards()
+
+    override suspend fun getDashboard(id: String): WearDashboardConfig? = readDashboards()[id]
+
+    override suspend fun setDashboard(config: WearDashboardConfig) {
+        val dashboards = readDashboards().toMutableMap()
+        dashboards[config.id] = config
+        writeDashboards(dashboards)
+    }
+
+    override suspend fun setAllDashboards(configs: Map<String, WearDashboardConfig>) {
+        writeDashboards(configs)
+    }
+
+    override suspend fun removeDashboard(id: String): WearDashboardConfig? {
+        val dashboards = readDashboards().toMutableMap()
+        val removed = dashboards.remove(id) ?: return null
+        writeDashboards(dashboards)
+        return removed
+    }
+
+    override suspend fun getTileDashboardMapping(): Map<Int, String> = readTileMapping()
+
+    override suspend fun setTileDashboard(tileId: Int, dashboardId: String) {
+        val mapping = readTileMapping().toMutableMap()
+        mapping[tileId] = dashboardId
+        writeTileMapping(mapping)
+    }
+
+    override suspend fun removeTileDashboard(tileId: Int) {
+        removeDashboardTileAssignment(tileId)
+    }
+
+    override suspend fun getDashboardTileAssignmentAndSaveTileId(tileId: Int): String? {
+        val mapping = readTileMapping()
+        return if (UNKNOWN_TILE_ID in mapping && tileId !in mapping) {
+            val dashboardId = mapping[UNKNOWN_TILE_ID] ?: return null
+            val updated = mapping.toMutableMap()
+            updated.remove(UNKNOWN_TILE_ID)
+            updated[tileId] = dashboardId
+            writeTileMapping(updated)
+            dashboardId
+        } else {
+            mapping[tileId]
+        }
+    }
+
+    override suspend fun removeDashboardTileAssignment(tileId: Int) {
+        val mapping = readTileMapping().toMutableMap()
+        if (mapping.remove(tileId) != null) {
+            writeTileMapping(mapping)
+        }
+    }
+
+    private suspend fun readDashboards(): Map<String, WearDashboardConfig> {
+        val json = localStorage.getString(PREF_WEAR_DASHBOARDS) ?: return emptyMap()
+        return try {
+            wearDashboardJson.decodeFromString<Map<String, WearDashboardConfig>>(json)
+        } catch (e: SerializationException) {
+            Timber.e(e, "Failed to parse wear dashboards from storage")
+            emptyMap()
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Failed to parse wear dashboards from storage")
+            emptyMap()
+        }
+    }
+
+    private suspend fun writeDashboards(configs: Map<String, WearDashboardConfig>) {
+        val json = wearDashboardJson.encodeToString(configs)
+        localStorage.putString(PREF_WEAR_DASHBOARDS, json)
+    }
+
+    private suspend fun readTileMapping(): Map<Int, String> {
+        val json = localStorage.getString(PREF_WEAR_DASHBOARD_TILES) ?: return emptyMap()
+        return try {
+            wearDashboardJson.decodeFromString<Map<String, String>>(json).mapKeys { it.key.toInt() }
+        } catch (e: SerializationException) {
+            Timber.e(e, "Failed to parse wear dashboard tile mapping from storage")
+            emptyMap()
+        } catch (e: IllegalArgumentException) {
+            Timber.e(e, "Failed to parse wear dashboard tile mapping from storage")
+            emptyMap()
+        }
+    }
+
+    private suspend fun writeTileMapping(mapping: Map<Int, String>) {
+        val json = wearDashboardJson.encodeToString(mapping.mapKeys { it.key.toString() })
+        localStorage.putString(PREF_WEAR_DASHBOARD_TILES, json)
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardAction.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardAction.kt
@@ -1,0 +1,42 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * An explicit action triggered from a dashboard component interaction.
+ */
+@Serializable
+sealed interface WearDashboardAction {
+
+    /** Toggles a Home Assistant entity that supports toggle semantics. */
+    @Serializable
+    @SerialName("toggle_entity")
+    data class ToggleEntity(val entityId: String) : WearDashboardAction
+
+    /** Calls a Home Assistant service with optional service data. */
+    @Serializable
+    @SerialName("call_service")
+    data class CallService(
+        val domain: String,
+        val service: String,
+        val data: Map<String, JsonElement> = emptyMap(),
+        val requiresConfirmation: Boolean = false,
+    ) : WearDashboardAction
+
+    /** Navigates to another page within the same dashboard. */
+    @Serializable
+    @SerialName("navigate")
+    data class Navigate(val dashboardId: String, val pageId: String) : WearDashboardAction
+
+    /** Requests a refresh of the current dashboard surface. */
+    @Serializable
+    @SerialName("refresh")
+    data object Refresh : WearDashboardAction
+
+    /** Opens the full Wear dashboard activity for richer interaction. */
+    @Serializable
+    @SerialName("open_full_dashboard")
+    data class OpenFullDashboard(val dashboardId: String, val pageId: String? = null) : WearDashboardAction
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardBinding.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardBinding.kt
@@ -1,0 +1,27 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+
+/**
+ * Describes how a dashboard value is resolved from Home Assistant state or templates.
+ */
+@Serializable
+sealed interface WearDashboardBinding {
+
+    /** A fixed value that does not change at runtime. */
+    @Serializable
+    @SerialName("constant")
+    data class Constant(val value: JsonElement) : WearDashboardBinding
+
+    /** The state or attribute of a Home Assistant entity. */
+    @Serializable
+    @SerialName("entity_state")
+    data class EntityState(val entityId: String, val attribute: String? = null) : WearDashboardBinding
+
+    /** A Home Assistant Jinja template evaluated at runtime. */
+    @Serializable
+    @SerialName("template")
+    data class Template(val template: String) : WearDashboardBinding
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardCapabilities.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardCapabilities.kt
@@ -1,0 +1,96 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+/**
+ * Physical screen shape of the Wear device.
+ */
+enum class ScreenShape {
+    Round,
+    Square,
+}
+
+/**
+ * Coarse screen size bucket used to apply layout limits on constrained surfaces.
+ */
+enum class ScreenSizeBucket {
+    Small,
+    Medium,
+    Large,
+}
+
+/**
+ * Device and platform capabilities that constrain dashboard rendering.
+ */
+data class WearDashboardCapabilities(
+    val screenShape: ScreenShape,
+    val screenSizeBucket: ScreenSizeBucket,
+    val screenWidthDp: Int,
+    val screenHeightDp: Int,
+    val sdkInt: Int,
+    val maxComponentTreeDepth: Int,
+    val maxChildrenPerContainer: Int,
+    val maxDynamicExpressions: Int,
+    val supportsDynamicExpressions: Boolean,
+    val supportsScrollableLayout: Boolean,
+    val supportsOngoingActivity: Boolean,
+) {
+    companion object {
+        private const val SMALL_SCREEN_MAX_DP = 180
+        private const val MEDIUM_SCREEN_MAX_DP = 224
+        private const val DEFAULT_MAX_COMPONENT_TREE_DEPTH = 5
+        private const val DEFAULT_MAX_CHILDREN_PER_CONTAINER = 6
+        private const val DEFAULT_MAX_DYNAMIC_EXPRESSIONS = 4
+        private const val DYNAMIC_EXPRESSIONS_MIN_SDK = 34
+        private const val ONGOING_ACTIVITY_MIN_SDK = 30
+
+        /**
+         * Derives capabilities from device display parameters.
+         */
+        fun fromDeviceParameters(
+            screenWidthDp: Int,
+            screenHeightDp: Int,
+            screenShape: ScreenShape,
+            sdkInt: Int,
+        ): WearDashboardCapabilities {
+            val sizeReferenceDp = when (screenShape) {
+                ScreenShape.Round -> minOf(screenWidthDp, screenHeightDp)
+                ScreenShape.Square -> screenWidthDp
+            }
+            return WearDashboardCapabilities(
+                screenShape = screenShape,
+                screenSizeBucket = sizeBucketFor(sizeReferenceDp),
+                screenWidthDp = screenWidthDp,
+                screenHeightDp = screenHeightDp,
+                sdkInt = sdkInt,
+                maxComponentTreeDepth = DEFAULT_MAX_COMPONENT_TREE_DEPTH,
+                maxChildrenPerContainer = DEFAULT_MAX_CHILDREN_PER_CONTAINER,
+                maxDynamicExpressions = DEFAULT_MAX_DYNAMIC_EXPRESSIONS,
+                supportsDynamicExpressions = sdkInt >= DYNAMIC_EXPRESSIONS_MIN_SDK,
+                supportsScrollableLayout = true,
+                supportsOngoingActivity = sdkInt >= ONGOING_ACTIVITY_MIN_SDK,
+            )
+        }
+
+        /**
+         * Returns conservative defaults when device parameters are unavailable.
+         */
+        fun defaults(): WearDashboardCapabilities = WearDashboardCapabilities(
+            screenShape = ScreenShape.Round,
+            screenSizeBucket = ScreenSizeBucket.Medium,
+            screenWidthDp = 200,
+            screenHeightDp = 200,
+            sdkInt = DYNAMIC_EXPRESSIONS_MIN_SDK,
+            maxComponentTreeDepth = DEFAULT_MAX_COMPONENT_TREE_DEPTH,
+            maxChildrenPerContainer = DEFAULT_MAX_CHILDREN_PER_CONTAINER,
+            maxDynamicExpressions = DEFAULT_MAX_DYNAMIC_EXPRESSIONS,
+            supportsDynamicExpressions = true,
+            supportsScrollableLayout = true,
+            supportsOngoingActivity = true,
+        )
+
+        private fun sizeBucketFor(sizeReferenceDp: Int): ScreenSizeBucket = when {
+            sizeReferenceDp <= SMALL_SCREEN_MAX_DP -> ScreenSizeBucket.Small
+            sizeReferenceDp <= MEDIUM_SCREEN_MAX_DP -> ScreenSizeBucket.Medium
+            else -> ScreenSizeBucket.Large
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardComponent.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardComponent.kt
@@ -1,0 +1,121 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Semantic dashboard component tree node independent of any Android UI framework.
+ */
+@Serializable
+sealed interface WearDashboardComponent {
+    val id: String?
+    val visible: WearDashboardBinding?
+    val tapAction: WearDashboardAction?
+    val holdAction: WearDashboardAction?
+
+    /** Static or dynamically bound text content. */
+    @Serializable
+    @SerialName("text")
+    data class Text(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val text: WearDashboardBinding,
+    ) : WearDashboardComponent
+
+    /** An icon resolved from a binding, typically an MDI icon name. */
+    @Serializable
+    @SerialName("icon")
+    data class Icon(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val icon: WearDashboardBinding,
+    ) : WearDashboardComponent
+
+    /** A tappable control with optional icon and label bindings. */
+    @Serializable
+    @SerialName("button")
+    data class Button(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val text: WearDashboardBinding? = null,
+        val icon: WearDashboardBinding? = null,
+    ) : WearDashboardComponent
+
+    /** A compact status indicator for entity states such as doors, locks, or batteries. */
+    @Serializable
+    @SerialName("status_chip")
+    data class StatusChip(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val state: WearDashboardBinding,
+        val label: WearDashboardBinding? = null,
+    ) : WearDashboardComponent
+
+    /** A circular progress indicator bound to a numeric value. */
+    @Serializable
+    @SerialName("progress_ring")
+    data class ProgressRing(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val value: WearDashboardBinding,
+        val min: Int = 0,
+        val max: Int = 100,
+    ) : WearDashboardComponent
+
+    /** Horizontally arranges a limited number of child components. */
+    @Serializable
+    @SerialName("row")
+    data class Row(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Vertically arranges a limited number of child components. */
+    @Serializable
+    @SerialName("column")
+    data class Column(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Overlays child components, useful for progress rings with centered text. */
+    @Serializable
+    @SerialName("box")
+    data class Box(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val children: List<WearDashboardComponent> = emptyList(),
+    ) : WearDashboardComponent
+
+    /** Renders one branch based on binding truthiness. */
+    @Serializable
+    @SerialName("conditional")
+    data class Conditional(
+        override val id: String? = null,
+        override val visible: WearDashboardBinding? = null,
+        override val tapAction: WearDashboardAction? = null,
+        override val holdAction: WearDashboardAction? = null,
+        val condition: WearDashboardBinding,
+        val then: WearDashboardComponent,
+        @SerialName("else")
+        val elseComponent: WearDashboardComponent? = null,
+    ) : WearDashboardComponent
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardConfig.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardConfig.kt
@@ -1,0 +1,16 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Top-level Wear Dashboard configuration persisted as canonical JSON.
+ */
+@Serializable
+data class WearDashboardConfig(
+    val version: Int = WearDashboardSchemaVersion.CURRENT_VERSION,
+    val id: String,
+    val title: String? = null,
+    val pages: List<WearDashboardPage>,
+    val surfaces: WearDashboardSurfaces = WearDashboardSurfaces(),
+    val refreshPolicy: WearDashboardRefreshPolicy = WearDashboardRefreshPolicy.OnEnter,
+)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardJson.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardJson.kt
@@ -1,0 +1,18 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+
+/**
+ * Kotlinx serialization [Json] instance for Wear Dashboard configuration.
+ *
+ * Uses camelCase property names and a `type` discriminator for polymorphic types.
+ * Unknown JSON keys are ignored so older clients can read configs from newer schema versions.
+ */
+@OptIn(ExperimentalSerializationApi::class)
+val wearDashboardJson = Json {
+    ignoreUnknownKeys = true
+    classDiscriminator = "type"
+    encodeDefaults = false
+    prettyPrint = false
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardPage.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardPage.kt
@@ -1,0 +1,9 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A single page within a Wear Dashboard configuration.
+ */
+@Serializable
+data class WearDashboardPage(val id: String, val title: String? = null, val root: WearDashboardComponent)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardRefreshPolicy.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardRefreshPolicy.kt
@@ -1,0 +1,31 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Describes when a dashboard surface should refresh its resolved state.
+ */
+@Serializable
+sealed interface WearDashboardRefreshPolicy {
+
+    /** Refresh when the user enters the dashboard surface. */
+    @Serializable
+    @SerialName("on_enter")
+    data object OnEnter : WearDashboardRefreshPolicy
+
+    /** Refresh when a referenced entity changes state. */
+    @Serializable
+    @SerialName("on_entity_change")
+    data object OnEntityChange : WearDashboardRefreshPolicy
+
+    /** Refresh on a fixed interval. */
+    @Serializable
+    @SerialName("interval")
+    data class Interval(val seconds: Int) : WearDashboardRefreshPolicy
+
+    /** Refresh only when explicitly requested by the user or an action. */
+    @Serializable
+    @SerialName("manual")
+    data object Manual : WearDashboardRefreshPolicy
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSchemaVersion.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSchemaVersion.kt
@@ -1,0 +1,17 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+/**
+ * Supported Wear Dashboard schema versions.
+ */
+object WearDashboardSchemaVersion {
+    /** Current schema version written by this client. */
+    const val CURRENT_VERSION: Int = 1
+
+    /** Schema versions that this client can read and validate. */
+    val SUPPORTED_VERSIONS: List<Int> = listOf(CURRENT_VERSION)
+
+    /**
+     * Returns whether [version] is supported by this client.
+     */
+    fun isSupported(version: Int): Boolean = version in SUPPORTED_VERSIONS
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSurfaces.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/model/WearDashboardSurfaces.kt
@@ -1,0 +1,25 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Maps a dashboard to the pages used by each native Wear surface.
+ */
+@Serializable
+data class WearDashboardSurfaces(
+    val tile: WearDashboardTileSurface? = null,
+    val app: WearDashboardAppSurface? = null,
+    val ongoingActivity: WearDashboardOngoingActivitySurface? = null,
+)
+
+/** Tile surface configuration referencing a compact dashboard page. */
+@Serializable
+data class WearDashboardTileSurface(val page: String)
+
+/** Full Wear app surface configuration referencing a start page. */
+@Serializable
+data class WearDashboardAppSurface(val startPage: String)
+
+/** Ongoing Activity surface configuration referencing an activity page. */
+@Serializable
+data class WearDashboardOngoingActivitySurface(val page: String)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValue.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValue.kt
@@ -1,0 +1,19 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+/**
+ * A resolved runtime value for a dashboard binding.
+ */
+sealed interface ResolvedComponentValue {
+
+    /** A textual binding value. */
+    data class TextValue(val text: String) : ResolvedComponentValue
+
+    /** A numeric binding value. */
+    data class NumberValue(val number: Double) : ResolvedComponentValue
+
+    /** A boolean binding value. */
+    data class BooleanValue(val value: Boolean) : ResolvedComponentValue
+
+    /** A binding value that could not be classified or parsed. */
+    data class Unknown(val raw: String?) : ResolvedComponentValue
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValueExtensions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/ResolvedComponentValueExtensions.kt
@@ -1,0 +1,11 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+/**
+ * Returns a display string for this resolved binding value.
+ */
+fun ResolvedComponentValue.toDisplayString(): String = when (this) {
+    is ResolvedComponentValue.TextValue -> text
+    is ResolvedComponentValue.NumberValue -> number.toString()
+    is ResolvedComponentValue.BooleanValue -> value.toString()
+    is ResolvedComponentValue.Unknown -> raw.orEmpty()
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardDependencyExtractor.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardDependencyExtractor.kt
@@ -1,0 +1,200 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * A binding reference discovered while walking a dashboard component tree.
+ */
+data class WearDashboardBindingDependency(
+    val path: String,
+    val binding: WearDashboardBinding,
+)
+
+/**
+ * Dependencies required to resolve runtime state for a dashboard configuration.
+ */
+data class WearDashboardDependencies(
+    val entityIds: Set<String>,
+    val templates: Set<String>,
+    val bindings: List<WearDashboardBindingDependency>,
+)
+
+/**
+ * Extracts entity IDs, templates, and binding paths from a dashboard configuration.
+ */
+object WearDashboardDependencyExtractor {
+
+    /**
+     * Finds all entity IDs, templates, and binding paths referenced by [config].
+     */
+    fun extract(config: WearDashboardConfig): WearDashboardDependencies {
+        val entityIds = linkedSetOf<String>()
+        val templates = linkedSetOf<String>()
+        val bindings = mutableListOf<WearDashboardBindingDependency>()
+
+        config.pages.forEach { page ->
+            collectComponentDependencies(
+                component = page.root,
+                componentPath = page.root.id ?: page.id,
+                entityIds = entityIds,
+                templates = templates,
+                bindings = bindings,
+            )
+        }
+
+        return WearDashboardDependencies(
+            entityIds = entityIds,
+            templates = templates,
+            bindings = bindings,
+        )
+    }
+
+    private fun collectComponentDependencies(
+        component: WearDashboardComponent,
+        componentPath: String,
+        entityIds: MutableSet<String>,
+        templates: MutableSet<String>,
+        bindings: MutableList<WearDashboardBindingDependency>,
+    ) {
+        collectBinding(component.visible, "$componentPath.visible", entityIds, templates, bindings)
+        collectActionDependencies(component.tapAction, entityIds)
+        collectActionDependencies(component.holdAction, entityIds)
+
+        when (component) {
+            is WearDashboardComponent.Text -> {
+                collectBinding(component.text, "$componentPath.text", entityIds, templates, bindings)
+            }
+
+            is WearDashboardComponent.Icon -> {
+                collectBinding(component.icon, "$componentPath.icon", entityIds, templates, bindings)
+            }
+
+            is WearDashboardComponent.Button -> {
+                component.text?.let {
+                    collectBinding(it, "$componentPath.text", entityIds, templates, bindings)
+                }
+                component.icon?.let {
+                    collectBinding(it, "$componentPath.icon", entityIds, templates, bindings)
+                }
+            }
+
+            is WearDashboardComponent.StatusChip -> {
+                collectBinding(component.state, "$componentPath.state", entityIds, templates, bindings)
+                component.label?.let {
+                    collectBinding(it, "$componentPath.label", entityIds, templates, bindings)
+                }
+            }
+
+            is WearDashboardComponent.ProgressRing -> {
+                collectBinding(component.value, "$componentPath.value", entityIds, templates, bindings)
+            }
+
+            is WearDashboardComponent.Row -> {
+                component.children.forEachIndexed { index, child ->
+                    collectComponentDependencies(
+                        component = child,
+                        componentPath = childPath(componentPath, child, index),
+                        entityIds = entityIds,
+                        templates = templates,
+                        bindings = bindings,
+                    )
+                }
+            }
+
+            is WearDashboardComponent.Column -> {
+                component.children.forEachIndexed { index, child ->
+                    collectComponentDependencies(
+                        component = child,
+                        componentPath = childPath(componentPath, child, index),
+                        entityIds = entityIds,
+                        templates = templates,
+                        bindings = bindings,
+                    )
+                }
+            }
+
+            is WearDashboardComponent.Box -> {
+                component.children.forEachIndexed { index, child ->
+                    collectComponentDependencies(
+                        component = child,
+                        componentPath = childPath(componentPath, child, index),
+                        entityIds = entityIds,
+                        templates = templates,
+                        bindings = bindings,
+                    )
+                }
+            }
+
+            is WearDashboardComponent.Conditional -> {
+                collectBinding(
+                    component.condition,
+                    "$componentPath.condition",
+                    entityIds,
+                    templates,
+                    bindings,
+                )
+                collectComponentDependencies(
+                    component = component.then,
+                    componentPath = childPath(componentPath, component.then, 0),
+                    entityIds = entityIds,
+                    templates = templates,
+                    bindings = bindings,
+                )
+                component.elseComponent?.let { elseComponent ->
+                    collectComponentDependencies(
+                        component = elseComponent,
+                        componentPath = childPath(componentPath, elseComponent, 1),
+                        entityIds = entityIds,
+                        templates = templates,
+                        bindings = bindings,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun childPath(parentPath: String, child: WearDashboardComponent, index: Int): String {
+        return child.id ?: "$parentPath.$index"
+    }
+
+    private fun collectBinding(
+        binding: WearDashboardBinding?,
+        path: String,
+        entityIds: MutableSet<String>,
+        templates: MutableSet<String>,
+        bindings: MutableList<WearDashboardBindingDependency>,
+    ) {
+        if (binding == null) return
+        bindings += WearDashboardBindingDependency(path = path, binding = binding)
+        when (binding) {
+            is WearDashboardBinding.EntityState -> entityIds += binding.entityId
+            is WearDashboardBinding.Template -> templates += binding.template
+            is WearDashboardBinding.Constant -> Unit
+        }
+    }
+
+    private fun collectActionDependencies(action: WearDashboardAction?, entityIds: MutableSet<String>) {
+        when (action) {
+            is WearDashboardAction.ToggleEntity -> entityIds += action.entityId
+            is WearDashboardAction.CallService -> {
+                action.data["entity_id"]?.let { entityIdElement ->
+                    entityIdFromJson(entityIdElement)?.let { entityIds += it }
+                }
+            }
+            is WearDashboardAction.Navigate,
+            is WearDashboardAction.Refresh,
+            is WearDashboardAction.OpenFullDashboard,
+            null,
+            -> Unit
+        }
+    }
+
+    private fun entityIdFromJson(element: JsonElement): String? {
+        return (element as? JsonPrimitive)?.takeIf { it.isString }?.content
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardResolvedState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardResolvedState.kt
@@ -1,0 +1,15 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import kotlin.time.Instant
+
+/**
+ * Resolved binding values used when rendering a dashboard.
+ */
+data class WearDashboardResolvedState(
+    val values: Map<String, ResolvedComponentValue> = emptyMap(),
+    val isStale: Boolean = false,
+    val lastUpdated: Instant? = null,
+) {
+    /** Display strings keyed by [io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardBindingKey]. */
+    val bindingValues: Map<String, String> = values.mapValues { (_, value) -> value.toDisplayString() }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCache.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCache.kt
@@ -1,0 +1,24 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * In-memory cache of resolved dashboard state keyed by dashboard ID.
+ */
+interface WearDashboardStateCache {
+
+    /** Returns the latest cached state for [dashboardId], or `null` when none is cached. */
+    fun getState(dashboardId: String): WearDashboardResolvedState?
+
+    /** Emits cached state updates for [dashboardId]. */
+    fun observeState(dashboardId: String): Flow<WearDashboardResolvedState?>
+
+    /** Stores [state] for [dashboardId] and notifies observers. */
+    suspend fun updateState(dashboardId: String, state: WearDashboardResolvedState)
+
+    /** Removes cached state for [dashboardId]. */
+    suspend fun clearState(dashboardId: String)
+
+    /** Clears all cached dashboard state. */
+    suspend fun clearAll()
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCacheExtensions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCacheExtensions.kt
@@ -1,0 +1,5 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+/** Returns cached resolved state for [dashboardId], or `null` when none is cached. */
+fun WearDashboardStateCache.getResolvedState(dashboardId: String): WearDashboardResolvedState? =
+    getState(dashboardId)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCacheImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardStateCacheImpl.kt
@@ -1,0 +1,39 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal class WearDashboardStateCacheImpl @Inject constructor() : WearDashboardStateCache {
+
+    private val states = MutableStateFlow<Map<String, WearDashboardResolvedState>>(emptyMap())
+    private val mutex = Mutex()
+
+    override fun getState(dashboardId: String): WearDashboardResolvedState? = states.value[dashboardId]
+
+    override fun observeState(dashboardId: String): Flow<WearDashboardResolvedState?> {
+        return states.map { it[dashboardId] }
+    }
+
+    override suspend fun updateState(dashboardId: String, state: WearDashboardResolvedState) {
+        mutex.withLock {
+            states.update { current -> current + (dashboardId to state) }
+        }
+    }
+
+    override suspend fun clearState(dashboardId: String) {
+        mutex.withLock {
+            states.update { current -> current - dashboardId }
+        }
+    }
+
+    override suspend fun clearAll() {
+        mutex.withLock {
+            states.value = emptyMap()
+        }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardUpdateCoordinator.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardUpdateCoordinator.kt
@@ -1,0 +1,32 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import kotlinx.coroutines.flow.SharedFlow
+
+/**
+ * Coordinates Home Assistant subscriptions and writes resolved dashboard state to the cache.
+ */
+interface WearDashboardUpdateCoordinator {
+
+    /**
+     * Starts tracking state for [dashboardId] using the stored dashboard configuration.
+     *
+     * Calling this again for the same ID restarts subscriptions.
+     */
+    fun startTracking(dashboardId: String)
+
+    /** Stops tracking and cancels subscriptions for [dashboardId]. */
+    fun stopTracking(dashboardId: String)
+
+    /** Stops tracking for all dashboards. */
+    fun stopAll()
+
+    /**
+     * Emits dashboard IDs that should request a Wear Tile update.
+     *
+     * Emissions are throttled to at most one request every two seconds per dashboard.
+     */
+    val tileUpdateRequests: SharedFlow<String>
+
+    /** Forces an immediate refresh of cached state for [dashboardId]. */
+    suspend fun refreshNow(dashboardId: String)
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardUpdateCoordinatorImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardUpdateCoordinatorImpl.kt
@@ -1,0 +1,334 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardBindingKey
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepository
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import javax.inject.Inject
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonPrimitive
+import timber.log.Timber
+
+@OptIn(ExperimentalTime::class)
+internal class WearDashboardUpdateCoordinatorImpl @Inject constructor(
+    private val serverManager: ServerManager,
+    private val dashboardRepository: WearDashboardRepository,
+    private val stateCache: WearDashboardStateCache,
+    private val clock: Clock = Clock.System,
+) : WearDashboardUpdateCoordinator {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val trackingJobs = mutableMapOf<String, Job>()
+    private val jobsMutex = Mutex()
+    private val entityStates = mutableMapOf<String, MutableMap<String, Entity>>()
+    private val templateValues = mutableMapOf<String, MutableMap<String, String?>>()
+    private val stateMutex = Mutex()
+    private val lastTileUpdateRequest = mutableMapOf<String, Instant>()
+    private val tileUpdateThrottle = 2.seconds
+
+    private val _tileUpdateRequests = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    override val tileUpdateRequests = _tileUpdateRequests.asSharedFlow()
+
+    override fun startTracking(dashboardId: String) {
+        scope.launch {
+            jobsMutex.withLock {
+                trackingJobs.remove(dashboardId)?.cancel()
+                trackingJobs[dashboardId] = scope.launch {
+                    trackDashboard(dashboardId)
+                }
+            }
+        }
+    }
+
+    override fun stopTracking(dashboardId: String) {
+        scope.launch {
+            jobsMutex.withLock {
+                trackingJobs.remove(dashboardId)?.cancel()
+            }
+            stateMutex.withLock {
+                entityStates.remove(dashboardId)
+                templateValues.remove(dashboardId)
+                lastTileUpdateRequest.remove(dashboardId)
+            }
+        }
+    }
+
+    override fun stopAll() {
+        scope.launch {
+            jobsMutex.withLock {
+                trackingJobs.values.forEach { it.cancel() }
+                trackingJobs.clear()
+            }
+            stateMutex.withLock {
+                entityStates.clear()
+                templateValues.clear()
+                lastTileUpdateRequest.clear()
+            }
+        }
+    }
+
+    override suspend fun refreshNow(dashboardId: String) {
+        val config = dashboardRepository.getDashboard(dashboardId) ?: return
+        val integrationRepository = integrationRepositoryOrNull() ?: run {
+            markStale(dashboardId)
+            return
+        }
+        refreshState(
+            dashboardId = dashboardId,
+            config = config,
+            integrationRepository = integrationRepository,
+            requestTileUpdate = true,
+        )
+    }
+
+    private suspend fun trackDashboard(dashboardId: String) {
+        val config = dashboardRepository.getDashboard(dashboardId)
+        if (config == null) {
+            Timber.w("Cannot track missing wear dashboard id=$dashboardId")
+            return
+        }
+
+        val dependencies = WearDashboardDependencyExtractor.extract(config)
+        val integrationRepository = integrationRepositoryOrNull()
+        if (integrationRepository == null) {
+            markStale(dashboardId)
+            return
+        }
+
+        refreshState(
+            dashboardId = dashboardId,
+            config = config,
+            integrationRepository = integrationRepository,
+            requestTileUpdate = false,
+        )
+
+        val entityIds = dependencies.entityIds.toList()
+        if (entityIds.isNotEmpty()) {
+            val entityUpdates = integrationRepository.getEntityUpdates(entityIds)
+            if (entityUpdates != null) {
+                try {
+                    entityUpdates.collect { entity ->
+                        updateEntityState(dashboardId, config, entity)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Wear dashboard entity subscription failed for id=$dashboardId")
+                    markStale(dashboardId)
+                }
+            } else {
+                markStale(dashboardId)
+            }
+        }
+
+        dependencies.templates.forEach { template ->
+            val templateUpdates = integrationRepository.getTemplateUpdates(template)
+            if (templateUpdates == null) {
+                markStale(dashboardId)
+                return@forEach
+            }
+            scope.launch {
+                try {
+                    templateUpdates.collect { rendered ->
+                        updateTemplateValue(dashboardId, config, template, rendered)
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "Wear dashboard template subscription failed for id=$dashboardId")
+                    markStale(dashboardId)
+                }
+            }
+        }
+    }
+
+    private suspend fun integrationRepositoryOrNull(): IntegrationRepository? {
+        return try {
+            if (!serverManager.isRegistered()) return null
+            serverManager.integrationRepository()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IllegalStateException) {
+            Timber.w(e, "No integration repository available for wear dashboard updates")
+            null
+        }
+    }
+
+    private suspend fun updateEntityState(
+        dashboardId: String,
+        config: WearDashboardConfig,
+        entity: Entity,
+    ) {
+        stateMutex.withLock {
+            entityStates.getOrPut(dashboardId) { mutableMapOf() }[entity.entityId] = entity
+        }
+        publishResolvedState(dashboardId, config, isStale = false, requestTileUpdate = true)
+    }
+
+    private suspend fun updateTemplateValue(
+        dashboardId: String,
+        config: WearDashboardConfig,
+        template: String,
+        rendered: String?,
+    ) {
+        stateMutex.withLock {
+            templateValues.getOrPut(dashboardId) { mutableMapOf() }[template] = rendered
+        }
+        publishResolvedState(dashboardId, config, isStale = false, requestTileUpdate = true)
+    }
+
+    private suspend fun refreshState(
+        dashboardId: String,
+        config: WearDashboardConfig,
+        integrationRepository: IntegrationRepository,
+        requestTileUpdate: Boolean,
+    ) {
+        val dependencies = WearDashboardDependencyExtractor.extract(config)
+        val entitiesById = integrationRepository.getEntities()
+            ?.associateBy { it.entityId }
+            .orEmpty()
+
+        stateMutex.withLock {
+            val entityMap = entityStates.getOrPut(dashboardId) { mutableMapOf() }
+            dependencies.entityIds.forEach { entityId ->
+                entitiesById[entityId]?.let { entityMap[entityId] = it }
+            }
+
+            val templateMap = templateValues.getOrPut(dashboardId) { mutableMapOf() }
+            dependencies.templates.forEach { template ->
+                if (template !in templateMap) {
+                    templateMap[template] = integrationRepository.renderTemplate(template, emptyMap())
+                }
+            }
+        }
+
+        publishResolvedState(
+            dashboardId = dashboardId,
+            config = config,
+            isStale = false,
+            requestTileUpdate = requestTileUpdate,
+        )
+    }
+
+    private suspend fun publishResolvedState(
+        dashboardId: String,
+        config: WearDashboardConfig,
+        isStale: Boolean,
+        requestTileUpdate: Boolean,
+    ) {
+        val dependencies = WearDashboardDependencyExtractor.extract(config)
+        val (entities, templates) = stateMutex.withLock {
+            entityStates[dashboardId].orEmpty() to templateValues[dashboardId].orEmpty()
+        }
+
+        val values = buildMap {
+            dependencies.bindings.forEach { dependency ->
+                val key = WearDashboardBindingKey.keyFor(dependency.binding) ?: return@forEach
+                put(
+                    key,
+                    resolveBinding(
+                        binding = dependency.binding,
+                        entities = entities,
+                        templates = templates,
+                    ),
+                )
+            }
+        }
+
+        stateCache.updateState(
+            dashboardId = dashboardId,
+            state = WearDashboardResolvedState(
+                values = values,
+                isStale = isStale,
+                lastUpdated = clock.now(),
+            ),
+        )
+
+        if (requestTileUpdate) {
+            requestTileUpdateIfAllowed(dashboardId)
+        }
+    }
+
+    private suspend fun markStale(dashboardId: String) {
+        val current = stateCache.getState(dashboardId)
+        stateCache.updateState(
+            dashboardId = dashboardId,
+            state = (current ?: WearDashboardResolvedState()).copy(isStale = true),
+        )
+    }
+
+    private suspend fun requestTileUpdateIfAllowed(dashboardId: String) {
+        val now = clock.now()
+        val shouldEmit = stateMutex.withLock {
+            val lastRequest = lastTileUpdateRequest[dashboardId]
+            if (lastRequest == null || now - lastRequest >= tileUpdateThrottle) {
+                lastTileUpdateRequest[dashboardId] = now
+                true
+            } else {
+                false
+            }
+        }
+        if (shouldEmit) {
+            _tileUpdateRequests.tryEmit(dashboardId)
+        }
+    }
+
+    private fun resolveBinding(
+        binding: WearDashboardBinding,
+        entities: Map<String, Entity>,
+        templates: Map<String, String?>,
+    ): ResolvedComponentValue {
+        return when (binding) {
+            is WearDashboardBinding.Constant -> resolveConstant(binding.value)
+            is WearDashboardBinding.EntityState -> {
+                val entity = entities[binding.entityId]
+                if (entity == null) {
+                    ResolvedComponentValue.Unknown(null)
+                } else {
+                    val raw = binding.attribute?.let { attribute ->
+                        entity.attributes[attribute]?.toString()
+                    } ?: entity.state
+                    resolveRawValue(raw)
+                }
+            }
+            is WearDashboardBinding.Template -> {
+                resolveRawValue(templates[binding.template])
+            }
+        }
+    }
+
+    private fun resolveConstant(value: JsonElement): ResolvedComponentValue {
+        return when (value) {
+            is JsonPrimitive -> {
+                val content = if (value.isString) value.content else value.toString()
+                resolveRawValue(content)
+            }
+            else -> ResolvedComponentValue.Unknown(value.toString())
+        }
+    }
+
+    private fun resolveRawValue(raw: String?): ResolvedComponentValue {
+        if (raw == null) return ResolvedComponentValue.Unknown(null)
+        raw.toBooleanStrictOrNull()?.let { return ResolvedComponentValue.BooleanValue(it) }
+        raw.toDoubleOrNull()?.let { return ResolvedComponentValue.NumberValue(it) }
+        return ResolvedComponentValue.TextValue(raw)
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/validation/WearDashboardValidation.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/validation/WearDashboardValidation.kt
@@ -1,0 +1,220 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.validation
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardRefreshPolicy
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardSchemaVersion
+
+/** Maximum allowed depth of the component tree, including the root component. */
+const val WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH = 5
+
+/** Maximum number of children allowed in layout container components. */
+const val WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER = 6
+
+/** Minimum interval in seconds for periodic refresh policies. */
+const val WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS = 1
+
+private val ENTITY_ID_PATTERN = Regex("^[a-z][a-z0-9_]*\\.[a-z0-9_]+$")
+private val IDENTIFIER_PATTERN = Regex("^[a-z][a-z0-9_]*$")
+
+/**
+ * A single validation issue found in a dashboard configuration.
+ */
+data class ValidationError(val path: String, val message: String)
+
+/**
+ * Result of validating a [WearDashboardConfig].
+ */
+data class ValidationResult(val errors: List<ValidationError>) {
+    /** Whether the configuration passed all validation checks. */
+    val isValid: Boolean get() = errors.isEmpty()
+}
+
+/**
+ * Validates a Wear Dashboard configuration and returns structured errors.
+ */
+fun validate(config: WearDashboardConfig): ValidationResult {
+    val errors = mutableListOf<ValidationError>()
+    validateConfig(config, errors)
+    return ValidationResult(errors)
+}
+
+private fun validateConfig(config: WearDashboardConfig, errors: MutableList<ValidationError>) {
+    if (config.id.isBlank()) {
+        errors += ValidationError("id", "Dashboard id must not be blank")
+    }
+    if (!WearDashboardSchemaVersion.isSupported(config.version)) {
+        errors += ValidationError(
+            "version",
+            "Unsupported schema version ${config.version}; supported: ${WearDashboardSchemaVersion.SUPPORTED_VERSIONS}",
+        )
+    }
+    if (config.pages.isEmpty()) {
+        errors += ValidationError("pages", "At least one page is required")
+    }
+
+    val pageIds = mutableSetOf<String>()
+    config.pages.forEachIndexed { index, page ->
+        val pagePath = "pages[$index]"
+        if (page.id.isBlank()) {
+            errors += ValidationError("$pagePath.id", "Page id must not be blank")
+        } else if (!pageIds.add(page.id)) {
+            errors += ValidationError("$pagePath.id", "Duplicate page id '${page.id}'")
+        }
+        validateComponent(page.root, "$pagePath.root", depth = 1, errors)
+    }
+
+    validateSurfaces(config, pageIds, errors)
+    validateRefreshPolicy(config.refreshPolicy, "refreshPolicy", errors)
+}
+
+private fun validateSurfaces(config: WearDashboardConfig, pageIds: Set<String>, errors: MutableList<ValidationError>) {
+    config.surfaces.tile?.page?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.tile.page", "Unknown page id '$pageId'")
+        }
+    }
+    config.surfaces.app?.startPage?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.app.startPage", "Unknown page id '$pageId'")
+        }
+    }
+    config.surfaces.ongoingActivity?.page?.let { pageId ->
+        if (pageId !in pageIds) {
+            errors += ValidationError("surfaces.ongoingActivity.page", "Unknown page id '$pageId'")
+        }
+    }
+}
+
+private fun validateRefreshPolicy(
+    policy: WearDashboardRefreshPolicy,
+    path: String,
+    errors: MutableList<ValidationError>,
+) {
+    if (policy is WearDashboardRefreshPolicy.Interval && policy.seconds < WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS) {
+        errors += ValidationError(
+            "$path.seconds",
+            "Refresh interval must be at least $WEAR_DASHBOARD_MIN_REFRESH_INTERVAL_SECONDS second",
+        )
+    }
+}
+
+private fun validateComponent(
+    component: WearDashboardComponent,
+    path: String,
+    depth: Int,
+    errors: MutableList<ValidationError>,
+) {
+    if (depth > WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH) {
+        errors += ValidationError(
+            path,
+            "Component tree exceeds maximum depth of $WEAR_DASHBOARD_MAX_COMPONENT_TREE_DEPTH",
+        )
+        return
+    }
+
+    component.visible?.let { validateBinding(it, "$path.visible", errors) }
+    component.tapAction?.let { validateAction(it, "$path.tapAction", errors) }
+    component.holdAction?.let { validateAction(it, "$path.holdAction", errors) }
+
+    when (component) {
+        is WearDashboardComponent.Text -> validateBinding(component.text, "$path.text", errors)
+        is WearDashboardComponent.Icon -> validateBinding(component.icon, "$path.icon", errors)
+        is WearDashboardComponent.Button -> {
+            component.text?.let { validateBinding(it, "$path.text", errors) }
+            component.icon?.let { validateBinding(it, "$path.icon", errors) }
+            if (component.text == null && component.icon == null) {
+                errors += ValidationError(path, "Button must define text or icon")
+            }
+        }
+        is WearDashboardComponent.StatusChip -> {
+            validateBinding(component.state, "$path.state", errors)
+            component.label?.let { validateBinding(it, "$path.label", errors) }
+        }
+        is WearDashboardComponent.ProgressRing -> {
+            validateBinding(component.value, "$path.value", errors)
+            if (component.min >= component.max) {
+                errors += ValidationError(path, "Progress ring min must be less than max")
+            }
+        }
+        is WearDashboardComponent.Row -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Column -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Box -> validateContainerChildren(component.children, path, depth, errors)
+        is WearDashboardComponent.Conditional -> {
+            validateBinding(component.condition, "$path.condition", errors)
+            validateComponent(component.then, "$path.then", depth + 1, errors)
+            component.elseComponent?.let { validateComponent(it, "$path.else", depth + 1, errors) }
+        }
+    }
+}
+
+private fun validateContainerChildren(
+    children: List<WearDashboardComponent>,
+    path: String,
+    depth: Int,
+    errors: MutableList<ValidationError>,
+) {
+    if (children.size > WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER) {
+        errors += ValidationError(
+            "$path.children",
+            "Container exceeds maximum of $WEAR_DASHBOARD_MAX_CHILDREN_PER_CONTAINER children",
+        )
+    }
+    children.forEachIndexed { index, child ->
+        validateComponent(child, "$path.children[$index]", depth + 1, errors)
+    }
+}
+
+private fun validateBinding(binding: WearDashboardBinding, path: String, errors: MutableList<ValidationError>) {
+    when (binding) {
+        is WearDashboardBinding.EntityState -> validateEntityId(binding.entityId, path, errors)
+        is WearDashboardBinding.Template -> {
+            if (binding.template.isBlank()) {
+                errors += ValidationError(path, "Template must not be blank")
+            }
+        }
+        is WearDashboardBinding.Constant -> Unit
+    }
+}
+
+private fun validateAction(action: WearDashboardAction, path: String, errors: MutableList<ValidationError>) {
+    when (action) {
+        is WearDashboardAction.ToggleEntity -> validateEntityId(action.entityId, path, errors)
+        is WearDashboardAction.CallService -> {
+            validateIdentifier(action.domain, "$path.domain", "domain", errors)
+            validateIdentifier(action.service, "$path.service", "service", errors)
+        }
+        is WearDashboardAction.Navigate -> {
+            if (action.dashboardId.isBlank()) {
+                errors += ValidationError("$path.dashboardId", "Dashboard id must not be blank")
+            }
+            if (action.pageId.isBlank()) {
+                errors += ValidationError("$path.pageId", "Page id must not be blank")
+            }
+        }
+        is WearDashboardAction.OpenFullDashboard -> {
+            if (action.dashboardId.isBlank()) {
+                errors += ValidationError("$path.dashboardId", "Dashboard id must not be blank")
+            }
+        }
+        is WearDashboardAction.Refresh -> Unit
+    }
+}
+
+private fun validateEntityId(entityId: String, path: String, errors: MutableList<ValidationError>) {
+    if (entityId.isBlank()) {
+        errors += ValidationError(path, "Entity id must not be blank")
+    } else if (!ENTITY_ID_PATTERN.matches(entityId)) {
+        errors += ValidationError(path, "Invalid entity id '$entityId'")
+    }
+}
+
+private fun validateIdentifier(value: String, path: String, label: String, errors: MutableList<ValidationError>) {
+    if (value.isBlank()) {
+        errors += ValidationError(path, "$label must not be blank")
+    } else if (!IDENTIFIER_PATTERN.matches(value)) {
+        errors += ValidationError(path, "Invalid $label '$value'")
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/di/WearDashboardModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/di/WearDashboardModule.kt
@@ -6,6 +6,10 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepository
 import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepositoryImpl
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardStateCache
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardStateCacheImpl
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardUpdateCoordinator
+import io.homeassistant.companion.android.common.data.wear.dashboard.state.WearDashboardUpdateCoordinatorImpl
 import javax.inject.Singleton
 
 @Module
@@ -17,4 +21,16 @@ internal abstract class WearDashboardModule {
     internal abstract fun bindWearDashboardRepository(
         impl: WearDashboardRepositoryImpl,
     ): WearDashboardRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun bindWearDashboardStateCache(
+        impl: WearDashboardStateCacheImpl,
+    ): WearDashboardStateCache
+
+    @Binds
+    @Singleton
+    internal abstract fun bindWearDashboardUpdateCoordinator(
+        impl: WearDashboardUpdateCoordinatorImpl,
+    ): WearDashboardUpdateCoordinator
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/di/WearDashboardModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/di/WearDashboardModule.kt
@@ -1,0 +1,20 @@
+package io.homeassistant.companion.android.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepository
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepositoryImpl
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal abstract class WearDashboardModule {
+
+    @Binds
+    @Singleton
+    internal abstract fun bindWearDashboardRepository(
+        impl: WearDashboardRepositoryImpl,
+    ): WearDashboardRepository
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardCapabilitiesTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardCapabilitiesTest.kt
@@ -1,0 +1,76 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.ScreenShape
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.ScreenSizeBucket
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardCapabilities
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+class WearDashboardCapabilitiesTest {
+    @ParameterizedTest
+    @MethodSource("roundScreenSizeBuckets")
+    fun `Given round screen dimensions when deriving capabilities then size bucket matches`(
+        widthDp: Int,
+        heightDp: Int,
+        expectedBucket: ScreenSizeBucket,
+    ) {
+        val capabilities = WearDashboardCapabilities.fromDeviceParameters(
+            screenWidthDp = widthDp,
+            screenHeightDp = heightDp,
+            screenShape = ScreenShape.Round,
+            sdkInt = 34,
+        )
+
+        assertEquals(expectedBucket, capabilities.screenSizeBucket)
+        assertEquals(ScreenShape.Round, capabilities.screenShape)
+    }
+
+    @ParameterizedTest
+    @MethodSource("squareScreenSizeBuckets")
+    fun `Given square screen width when deriving capabilities then size bucket uses width`(
+        widthDp: Int,
+        heightDp: Int,
+        expectedBucket: ScreenSizeBucket,
+    ) {
+        val capabilities = WearDashboardCapabilities.fromDeviceParameters(
+            screenWidthDp = widthDp,
+            screenHeightDp = heightDp,
+            screenShape = ScreenShape.Square,
+            sdkInt = 34,
+        )
+
+        assertEquals(expectedBucket, capabilities.screenSizeBucket)
+    }
+
+    @Test
+    fun `Given defaults when reading capabilities then conservative values are returned`() {
+        val capabilities = WearDashboardCapabilities.defaults()
+
+        assertEquals(ScreenShape.Round, capabilities.screenShape)
+        assertEquals(ScreenSizeBucket.Medium, capabilities.screenSizeBucket)
+        assertEquals(5, capabilities.maxComponentTreeDepth)
+        assertEquals(6, capabilities.maxChildrenPerContainer)
+    }
+
+    companion object {
+        @JvmStatic
+        fun roundScreenSizeBuckets(): List<Arguments> = listOf(
+            Arguments.of(170, 170, ScreenSizeBucket.Small),
+            Arguments.of(180, 220, ScreenSizeBucket.Small),
+            Arguments.of(200, 200, ScreenSizeBucket.Medium),
+            Arguments.of(224, 224, ScreenSizeBucket.Medium),
+            Arguments.of(225, 225, ScreenSizeBucket.Large),
+            Arguments.of(240, 240, ScreenSizeBucket.Large),
+        )
+
+        @JvmStatic
+        fun squareScreenSizeBuckets(): List<Arguments> = listOf(
+            Arguments.of(180, 220, ScreenSizeBucket.Small),
+            Arguments.of(200, 240, ScreenSizeBucket.Medium),
+            Arguments.of(225, 280, ScreenSizeBucket.Large),
+        )
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardConfigSerializationTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardConfigSerializationTest.kt
@@ -1,0 +1,63 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.wearDashboardJson
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class WearDashboardConfigSerializationTest {
+    @Test
+    fun `Given car dashboard JSON when deserializing then round-trip preserves config`() {
+        val decoded = wearDashboardJson.decodeFromString<WearDashboardConfig>(
+            WearDashboardTestFixtures.CAR_DASHBOARD_JSON,
+        )
+
+        val encoded = wearDashboardJson.encodeToString(decoded)
+        val roundTripped = wearDashboardJson.decodeFromString<WearDashboardConfig>(encoded)
+
+        assertEquals(decoded, roundTripped)
+    }
+
+    @Test
+    fun `Given car dashboard object when serializing and deserializing then values match`() {
+        val config = WearDashboardTestFixtures.carDashboard
+
+        val roundTripped = wearDashboardJson.decodeFromString<WearDashboardConfig>(
+            wearDashboardJson.encodeToString(config),
+        )
+
+        assertEquals(config, roundTripped)
+    }
+
+    @Test
+    fun `Given JSON with unknown keys when deserializing then keys are ignored`() {
+        val jsonWithUnknownKeys = """
+            {
+              "version": 1,
+              "id": "car",
+              "futureField": "ignored",
+              "pages": [
+                {
+                  "id": "compact",
+                  "deprecatedTitle": "Old",
+                  "root": {
+                    "type": "text",
+                    "futureComponentField": true,
+                    "text": {
+                      "type": "constant",
+                      "value": "Hello",
+                      "extra": 1
+                    }
+                  }
+                }
+              ]
+            }
+        """.trimIndent()
+
+        val config = wearDashboardJson.decodeFromString<WearDashboardConfig>(jsonWithUnknownKeys)
+
+        assertEquals("car", config.id)
+        assertEquals(1, config.pages.size)
+        assertEquals("compact", config.pages.first().id)
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepositoryTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardRepositoryTest.kt
@@ -1,0 +1,131 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.LocalStorage
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepositoryImpl.Companion.PREF_WEAR_DASHBOARDS
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardRepositoryImpl.Companion.PREF_WEAR_DASHBOARD_TILES
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.wearDashboardJson
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class WearDashboardRepositoryTest {
+
+    private val localStorage = mockk<LocalStorage>()
+    private lateinit var repository: WearDashboardRepository
+
+    @BeforeEach
+    fun setup() {
+        repository = WearDashboardRepositoryImpl(localStorage)
+    }
+
+    @Test
+    fun `Given dashboard config when storing then it serializes into wear dashboards preference`() = runTest {
+        val slot = slot<String>()
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARDS) } returns null
+        coJustRun { localStorage.putString(PREF_WEAR_DASHBOARDS, capture(slot)) }
+
+        repository.setDashboard(WearDashboardTestFixtures.carDashboard)
+
+        val stored = wearDashboardJson.decodeFromString<Map<String, WearDashboardConfig>>(slot.captured)
+        assertEquals(WearDashboardTestFixtures.carDashboard, stored["car"])
+    }
+
+    @Test
+    fun `Given stored dashboards when reading then configs deserialize from preference`() = runTest {
+        val json = wearDashboardJson.encodeToString(mapOf("car" to WearDashboardTestFixtures.carDashboard))
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARDS) } returns json
+
+        val result = repository.getAllDashboards()
+
+        assertEquals(WearDashboardTestFixtures.carDashboard, result["car"])
+    }
+
+    @Test
+    fun `Given invalid dashboard json when reading then empty map is returned`() = runTest {
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARDS) } returns "{ invalid"
+
+        val result = repository.getAllDashboards()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `Given tile mapping when storing then it serializes into tile preference`() = runTest {
+        val slot = slot<String>()
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARD_TILES) } returns null
+        coJustRun { localStorage.putString(PREF_WEAR_DASHBOARD_TILES, capture(slot)) }
+
+        repository.setTileDashboard(tileId = 3, dashboardId = "car")
+
+        assertEquals("""{"3":"car"}""", slot.captured)
+    }
+
+    @Test
+    fun `Given stored tile mapping when reading then mapping deserializes from preference`() = runTest {
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARD_TILES) } returns """{"1":"car","2":"home"}"""
+
+        val result = repository.getTileDashboardMapping()
+
+        assertEquals(mapOf(1 to "car", 2 to "home"), result)
+    }
+
+    @Test
+    fun `Given dashboard id when removing then config is deleted and returned`() = runTest {
+        val json = wearDashboardJson.encodeToString(mapOf("car" to WearDashboardTestFixtures.carDashboard))
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARDS) } returnsMany listOf(
+            json,
+            "{}",
+        )
+        coJustRun { localStorage.putString(PREF_WEAR_DASHBOARDS, any()) }
+
+        val removed = repository.removeDashboard("car")
+
+        assertEquals(WearDashboardTestFixtures.carDashboard, removed)
+        coVerify { localStorage.putString(PREF_WEAR_DASHBOARDS, "{}") }
+    }
+
+    @Test
+    fun `Given missing dashboard id when removing then null is returned`() = runTest {
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARDS) } returns "{}"
+
+        val removed = repository.removeDashboard("missing")
+
+        assertNull(removed)
+    }
+
+    @Test
+    fun `Given unknown tile id mapping when saving tile id then assignment migrates to tile`() = runTest {
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARD_TILES) } returnsMany listOf(
+            """{"-1":"car"}""",
+            """{"3":"car"}""",
+        )
+        coJustRun { localStorage.putString(PREF_WEAR_DASHBOARD_TILES, any()) }
+
+        val result = repository.getDashboardTileAssignmentAndSaveTileId(tileId = 3)
+
+        assertEquals("car", result)
+        coVerify { localStorage.putString(PREF_WEAR_DASHBOARD_TILES, """{"3":"car"}""") }
+    }
+
+    @Test
+    fun `Given tile assignment when removing dashboard tile then mapping is cleared`() = runTest {
+        coEvery { localStorage.getString(PREF_WEAR_DASHBOARD_TILES) } returnsMany listOf(
+            """{"3":"car"}""",
+            "{}",
+        )
+        coJustRun { localStorage.putString(PREF_WEAR_DASHBOARD_TILES, any()) }
+
+        repository.removeDashboardTileAssignment(tileId = 3)
+
+        coVerify { localStorage.putString(PREF_WEAR_DASHBOARD_TILES, "{}") }
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardTestFixtures.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardTestFixtures.kt
@@ -1,0 +1,151 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAppSurface
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardPage
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardSurfaces
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardTileSurface
+import kotlinx.serialization.json.JsonPrimitive
+
+internal object WearDashboardTestFixtures {
+    val carDashboard: WearDashboardConfig = WearDashboardConfig(
+        version = 1,
+        id = "car",
+        title = "Car",
+        surfaces = WearDashboardSurfaces(
+            tile = WearDashboardTileSurface(page = "compact"),
+            app = WearDashboardAppSurface(startPage = "compact"),
+        ),
+        pages = listOf(
+            WearDashboardPage(
+                id = "compact",
+                title = "Car",
+                root = WearDashboardComponent.Box(
+                    id = "root",
+                    children = listOf(
+                        WearDashboardComponent.ProgressRing(
+                            id = "battery_ring",
+                            value = WearDashboardBinding.EntityState(entityId = "sensor.car_battery"),
+                            min = 0,
+                            max = 100,
+                        ),
+                        WearDashboardComponent.Text(
+                            id = "battery_text",
+                            text = WearDashboardBinding.Template(
+                                template = "{{ states('sensor.car_battery') }}%",
+                            ),
+                        ),
+                        WearDashboardComponent.Row(
+                            id = "actions",
+                            children = listOf(
+                                WearDashboardComponent.Button(
+                                    id = "lock",
+                                    icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:lock")),
+                                    tapAction = WearDashboardAction.CallService(
+                                        domain = "button",
+                                        service = "press",
+                                        data = mapOf("entity_id" to JsonPrimitive("button.car_lock")),
+                                    ),
+                                ),
+                                WearDashboardComponent.Button(
+                                    id = "climate",
+                                    icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:air-conditioner")),
+                                    tapAction = WearDashboardAction.CallService(
+                                        domain = "button",
+                                        service = "press",
+                                        data = mapOf(
+                                            "entity_id" to JsonPrimitive("button.car_start_air_conditioner"),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    const val CAR_DASHBOARD_JSON = """
+        {
+          "version": 1,
+          "id": "car",
+          "title": "Car",
+          "surfaces": {
+            "tile": { "page": "compact" },
+            "app": { "startPage": "compact" }
+          },
+          "pages": [
+            {
+              "id": "compact",
+              "title": "Car",
+              "root": {
+                "type": "box",
+                "id": "root",
+                "children": [
+                  {
+                    "type": "progress_ring",
+                    "id": "battery_ring",
+                    "value": {
+                      "type": "entity_state",
+                      "entityId": "sensor.car_battery"
+                    },
+                    "min": 0,
+                    "max": 100
+                  },
+                  {
+                    "type": "text",
+                    "id": "battery_text",
+                    "text": {
+                      "type": "template",
+                      "template": "{{ states('sensor.car_battery') }}%"
+                    }
+                  },
+                  {
+                    "type": "row",
+                    "id": "actions",
+                    "children": [
+                      {
+                        "type": "button",
+                        "id": "lock",
+                        "icon": {
+                          "type": "constant",
+                          "value": "mdi:lock"
+                        },
+                        "tapAction": {
+                          "type": "call_service",
+                          "domain": "button",
+                          "service": "press",
+                          "data": {
+                            "entity_id": "button.car_lock"
+                          }
+                        }
+                      },
+                      {
+                        "type": "button",
+                        "id": "climate",
+                        "icon": {
+                          "type": "constant",
+                          "value": "mdi:air-conditioner"
+                        },
+                        "tapAction": {
+                          "type": "call_service",
+                          "domain": "button",
+                          "service": "press",
+                          "data": {
+                            "entity_id": "button.car_start_air_conditioner"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+    """
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardValidationTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/WearDashboardValidationTest.kt
@@ -1,0 +1,71 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardAction
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardBinding
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardComponent
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardConfig
+import io.homeassistant.companion.android.common.data.wear.dashboard.model.WearDashboardPage
+import io.homeassistant.companion.android.common.data.wear.dashboard.validation.validate
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WearDashboardValidationTest {
+    @Test
+    fun `Given valid car dashboard when validating then result is valid`() {
+        val result = validate(WearDashboardTestFixtures.carDashboard)
+
+        assertTrue(result.isValid)
+        assertTrue(result.errors.isEmpty())
+    }
+
+    @Test
+    fun `Given duplicate page ids when validating then result reports duplicate error`() {
+        val config = WearDashboardTestFixtures.carDashboard.copy(
+            pages = listOf(
+                WearDashboardPage(
+                    id = "compact",
+                    root = WearDashboardComponent.Text(
+                        text = WearDashboardBinding.Constant(JsonPrimitive("A")),
+                    ),
+                ),
+                WearDashboardPage(
+                    id = "compact",
+                    root = WearDashboardComponent.Text(
+                        text = WearDashboardBinding.Constant(JsonPrimitive("B")),
+                    ),
+                ),
+            ),
+        )
+
+        val result = validate(config)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.path.endsWith(".id") && it.message.contains("Duplicate") })
+    }
+
+    @Test
+    fun `Given invalid service action when validating then result reports service error`() {
+        val config = WearDashboardConfig(
+            id = "invalid-service",
+            pages = listOf(
+                WearDashboardPage(
+                    id = "main",
+                    root = WearDashboardComponent.Button(
+                        icon = WearDashboardBinding.Constant(JsonPrimitive("mdi:lock")),
+                        tapAction = WearDashboardAction.CallService(
+                            domain = "",
+                            service = "press",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = validate(config)
+
+        assertFalse(result.isValid)
+        assertTrue(result.errors.any { it.path.contains("domain") })
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardDependencyExtractorTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/wear/dashboard/state/WearDashboardDependencyExtractorTest.kt
@@ -1,0 +1,30 @@
+package io.homeassistant.companion.android.common.data.wear.dashboard.state
+
+import io.homeassistant.companion.android.common.data.wear.dashboard.WearDashboardTestFixtures
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class WearDashboardDependencyExtractorTest {
+
+    @Test
+    fun `Given car dashboard when extracting dependencies then entity ids and templates are found`() {
+        val dependencies = WearDashboardDependencyExtractor.extract(WearDashboardTestFixtures.carDashboard)
+
+        assertEquals(
+            setOf("sensor.car_battery", "button.car_lock", "button.car_start_air_conditioner"),
+            dependencies.entityIds,
+        )
+        assertEquals(setOf("{{ states('sensor.car_battery') }}%"), dependencies.templates)
+    }
+
+    @Test
+    fun `Given car dashboard when extracting dependencies then binding paths include text and value bindings`() {
+        val dependencies = WearDashboardDependencyExtractor.extract(WearDashboardTestFixtures.carDashboard)
+        val paths = dependencies.bindings.map { it.path }.toSet()
+
+        assertTrue("battery_ring.value" in paths)
+        assertTrue("battery_text.text" in paths)
+        assertTrue("lock.icon" in paths)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds in-memory state cache for resolved dashboard component values
- Adds update coordinator that subscribes to entity/template changes with throttled tile refresh signals
- Adds dependency extractor for binding keys and unit tests

Depends on #6931.

## Test plan

- [x] `./gradlew :common:test`