### PR TITLE
Make FrontendDialogManager more generic for Confirm dialog

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -345,7 +345,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             },
             onJsConfirm = { message, jsResult ->
                 viewModelScope.launch {
-                    if (dialogManager.showJsConfirm(message)) jsResult.confirm() else jsResult.cancel()
+                    if (dialogManager.showConfirm(message)) jsResult.confirm() else jsResult.cancel()
                 }
                 true
             },

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/dialog/FrontendDialogManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/dialog/FrontendDialogManager.kt
@@ -39,7 +39,7 @@ internal class FrontendDialogManager @Inject constructor() {
      * Returns `true` if the user confirmed, `false` if they cancelled. The slot is freed
      * before returning, including on cancellation of the calling coroutine.
      */
-    suspend fun showJsConfirm(message: String): Boolean = queue.awaitResult { onResult ->
+    suspend fun showConfirm(message: String): Boolean = queue.awaitResult { onResult ->
         FrontendDialog.Confirm(
             message = message,
             onConfirm = { onResult(true) },

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/dialog/FrontendDialogManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/dialog/FrontendDialogManagerTest.kt
@@ -15,10 +15,10 @@ import org.junit.jupiter.api.assertNull
 class FrontendDialogManagerTest {
 
     @Test
-    fun `Given JS confirm shown when user confirms then suspend returns true and slot clears`() = runTest {
+    fun `Given confirm shown when user confirms then suspend returns true and slot clears`() = runTest {
         val manager = FrontendDialogManager()
 
-        val outcome = async { manager.showJsConfirm("Are you sure?") }
+        val outcome = async { manager.showConfirm("Are you sure?") }
         advanceUntilIdle()
 
         val pending = assertInstanceOf(FrontendDialog.Confirm::class.java, manager.pendingDialog.value)
@@ -33,10 +33,10 @@ class FrontendDialogManagerTest {
     }
 
     @Test
-    fun `Given JS confirm shown when user cancels then suspend returns false and slot clears`() = runTest {
+    fun `Given confirm shown when user cancels then suspend returns false and slot clears`() = runTest {
         val manager = FrontendDialogManager()
 
-        val outcome = async { manager.showJsConfirm("Discard?") }
+        val outcome = async { manager.showConfirm("Discard?") }
         advanceUntilIdle()
         (manager.pendingDialog.value as FrontendDialog.Confirm).onCancel()
         advanceUntilIdle()
@@ -46,10 +46,10 @@ class FrontendDialogManagerTest {
     }
 
     @Test
-    fun `Given JS confirm in flight when scope cancels then slot is cleared`() = runTest {
+    fun `Given confirm in flight when scope cancels then slot is cleared`() = runTest {
         val manager = FrontendDialogManager()
 
-        val outcome = async { manager.showJsConfirm("Confirm?") }
+        val outcome = async { manager.showConfirm("Confirm?") }
         advanceUntilIdle()
         assertInstanceOf(FrontendDialog.Confirm::class.java, manager.pendingDialog.value)
 
@@ -63,9 +63,9 @@ class FrontendDialogManagerTest {
     fun `Given dialog shown when second show then it queues until first completes`() = runTest {
         val manager = FrontendDialogManager()
 
-        val first = async { manager.showJsConfirm("first") }
+        val first = async { manager.showConfirm("first") }
         advanceUntilIdle()
-        val second = async { manager.showJsConfirm("second") }
+        val second = async { manager.showConfirm("second") }
         advanceUntilIdle()
 
         assertEquals("first", (manager.pendingDialog.value as FrontendDialog.Confirm).message)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/SingleSlotQueue.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/SingleSlotQueue.kt
@@ -57,7 +57,7 @@ class SingleSlotQueue<T : Any>(private val _state: MutableStateFlow<T?> = Mutabl
      *
      * Typical usage:
      * ```
-     * suspend fun showJsConfirm(message: String): Boolean = queue.awaitResult { onResult ->
+     * suspend fun showConfirm(message: String): Boolean = queue.awaitResult { onResult ->
      *     FrontendDialog.Confirm(
      *         message = message,
      *         onConfirm = { onResult(true) },


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Small adjustment in the `FrontendDialogManager` to be agnostic of the caller for Confirmation dialog, it was introduce for JS dialogs to confirm but we could use for something else. The documentation was already generic so this change is a simple rename.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
