### PR TITLE
Rename FrontendGestureHandler to FrontendGestureManager

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -25,7 +25,7 @@ import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalB
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.SuccessResultMessage
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserRequest
-import io.homeassistant.companion.android.frontend.gesture.FrontendGestureHandler
+import io.homeassistant.companion.android.frontend.gesture.FrontendGestureManager
 import io.homeassistant.companion.android.frontend.gesture.GestureResult
 import io.homeassistant.companion.android.frontend.handler.FrontendBusObserver
 import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent
@@ -88,7 +88,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val permissionManager: PermissionManager,
     private val frontendJsBridgeFactory: FrontendJsBridgeFactory,
     private val downloadManager: FrontendDownloadManager,
-    private val gestureHandler: FrontendGestureHandler,
+    private val gestureManager: FrontendGestureManager,
     private val prefsRepository: PrefsRepository,
     private val dialogManager: FrontendDialogManager,
     private val fileChooserManager: FileChooserManager,
@@ -108,7 +108,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         permissionManager: PermissionManager,
         frontendJsBridgeFactory: FrontendJsBridgeFactory,
         downloadManager: FrontendDownloadManager,
-        gestureHandler: FrontendGestureHandler,
+        gestureManager: FrontendGestureManager,
         prefsRepository: PrefsRepository,
         dialogManager: FrontendDialogManager,
         fileChooserManager: FileChooserManager,
@@ -125,7 +125,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         permissionManager = permissionManager,
         frontendJsBridgeFactory = frontendJsBridgeFactory,
         downloadManager = downloadManager,
-        gestureHandler = gestureHandler,
+        gestureManager = gestureManager,
         prefsRepository = prefsRepository,
         dialogManager = dialogManager,
         fileChooserManager = fileChooserManager,
@@ -466,7 +466,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
      */
     fun onGesture(direction: GestureDirection, pointerCount: Int) {
         viewModelScope.launch {
-            val result = gestureHandler.handleGesture(
+            val result = gestureManager.handleGesture(
                 serverId = _viewState.value.serverId,
                 direction = direction,
                 pointerCount = pointerCount,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
@@ -24,7 +24,7 @@ import timber.log.Timber
  * go through [FrontendExternalBusRepository].
  */
 @ViewModelScoped
-class FrontendGestureHandler @Inject constructor(
+class FrontendGestureManager @Inject constructor(
     private val prefsRepository: PrefsRepository,
     private val externalBusRepository: FrontendExternalBusRepository,
     private val serverManager: ServerManager,

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -31,7 +31,7 @@ import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalB
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.externalbus.outgoing.SuccessResultMessage
 import io.homeassistant.companion.android.frontend.filechooser.FileChooserManager
-import io.homeassistant.companion.android.frontend.gesture.FrontendGestureHandler
+import io.homeassistant.companion.android.frontend.gesture.FrontendGestureManager
 import io.homeassistant.companion.android.frontend.gesture.GestureResult
 import io.homeassistant.companion.android.frontend.handler.FrontendBusObserver
 import io.homeassistant.companion.android.frontend.handler.FrontendHandlerEvent
@@ -89,7 +89,7 @@ class FrontendViewModelTest {
     private val permissionManager: PermissionManager = mockk(relaxed = true)
     private val frontendJsBridgeFactory: FrontendJsBridgeFactory = mockk(relaxed = true)
     private val downloadManager: FrontendDownloadManager = mockk(relaxed = true)
-    private val gestureHandler: FrontendGestureHandler = mockk(relaxed = true)
+    private val gestureManager: FrontendGestureManager = mockk(relaxed = true)
     private val zoomSettingsFlow = MutableStateFlow(ZoomSettings())
     private val autoPlayVideoFlow = MutableStateFlow(false)
     private val screenOrientationFlow = MutableStateFlow(ScreenOrientation.SYSTEM)
@@ -140,7 +140,7 @@ class FrontendViewModelTest {
             permissionManager = permissionManager,
             frontendJsBridgeFactory = frontendJsBridgeFactory,
             downloadManager = downloadManager,
-            gestureHandler = gestureHandler,
+            gestureManager = gestureManager,
             prefsRepository = prefsRepository,
             dialogManager = dialogManager,
             fileChooserManager = fileChooserManager,
@@ -613,7 +613,7 @@ class FrontendViewModelTest {
                 UrlLoadResult.Success(url = "https://server2.com?external_auth=1", serverId = 2),
             )
             coEvery {
-                gestureHandler.handleGesture(serverId = any(), direction = any(), pointerCount = any())
+                gestureManager.handleGesture(serverId = any(), direction = any(), pointerCount = any())
             } returns GestureResult.SwitchServer(2)
 
             val viewModel = createViewModel(serverId = 1)
@@ -637,7 +637,7 @@ class FrontendViewModelTest {
 
             val clearHistory = WebViewAction.ClearHistory()
             coEvery {
-                gestureHandler.handleGesture(serverId = any(), direction = any(), pointerCount = any())
+                gestureManager.handleGesture(serverId = any(), direction = any(), pointerCount = any())
             } returns GestureResult.PerformWebViewActionThen(
                 action = clearHistory,
                 then = {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManagerTest.kt
@@ -23,16 +23,16 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @OptIn(EvaluateJavascriptUsage::class)
-class FrontendGestureHandlerTest {
+class FrontendGestureManagerTest {
 
     private val prefsRepository: PrefsRepository = mockk()
     private val externalBusRepository: FrontendExternalBusRepository = mockk(relaxed = true)
     private val serverManager: ServerManager = mockk()
-    private lateinit var handler: FrontendGestureHandler
+    private lateinit var manager: FrontendGestureManager
 
     @BeforeEach
     fun setup() {
-        handler = FrontendGestureHandler(
+        manager = FrontendGestureManager(
             prefsRepository = prefsRepository,
             externalBusRepository = externalBusRepository,
             serverManager = serverManager,
@@ -43,7 +43,7 @@ class FrontendGestureHandlerTest {
     fun `Given NONE action when handleGesture then returns Ignored`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_LEFT_TWO) } returns GestureAction.NONE
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -57,7 +57,7 @@ class FrontendGestureHandlerTest {
     fun `Given SHOW_SIDEBAR action when handleGesture then sends ShowSidebarMessage`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_RIGHT_TWO) } returns GestureAction.SHOW_SIDEBAR
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.RIGHT,
             pointerCount = 2,
@@ -78,7 +78,7 @@ class FrontendGestureHandlerTest {
         )
         coEvery { serverManager.getServer(1) } returns server
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.UP,
             pointerCount = 2,
@@ -105,7 +105,7 @@ class FrontendGestureHandlerTest {
         )
         coEvery { serverManager.getServer(1) } returns server
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.UP,
             pointerCount = 2,
@@ -126,7 +126,7 @@ class FrontendGestureHandlerTest {
         )
         coEvery { serverManager.getServer(1) } returns server
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.DOWN,
             pointerCount = 2,
@@ -147,7 +147,7 @@ class FrontendGestureHandlerTest {
         )
         coEvery { serverManager.getServer(1) } returns server
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.DOWN,
             pointerCount = 2,
@@ -161,7 +161,7 @@ class FrontendGestureHandlerTest {
     fun `Given QUICKBAR_ENTITIES when handleGesture then dispatches E key`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_LEFT_TWO) } returns GestureAction.QUICKBAR_ENTITIES
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -175,7 +175,7 @@ class FrontendGestureHandlerTest {
     fun `Given QUICKBAR_COMMANDS when handleGesture then dispatches C key`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_LEFT_TWO) } returns GestureAction.QUICKBAR_COMMANDS
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -189,7 +189,7 @@ class FrontendGestureHandlerTest {
     fun `Given OPEN_ASSIST when handleGesture then returns Navigate to Assist`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_UP_THREE) } returns GestureAction.OPEN_ASSIST
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 42,
             direction = GestureDirection.UP,
             pointerCount = 3,
@@ -207,7 +207,7 @@ class FrontendGestureHandlerTest {
     fun `Given OPEN_APP_SETTINGS when handleGesture then returns Navigate to Settings`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_DOWN_THREE) } returns GestureAction.OPEN_APP_SETTINGS
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.DOWN,
             pointerCount = 3,
@@ -222,7 +222,7 @@ class FrontendGestureHandlerTest {
     fun `Given OPEN_APP_DEVELOPER when handleGesture then returns Navigate to Developer Settings`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_RIGHT_THREE) } returns GestureAction.OPEN_APP_DEVELOPER
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.RIGHT,
             pointerCount = 3,
@@ -237,7 +237,7 @@ class FrontendGestureHandlerTest {
     fun `Given NAVIGATE_FORWARD when handleGesture then returns WebViewAction Forward`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_RIGHT_TWO) } returns GestureAction.NAVIGATE_FORWARD
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.RIGHT,
             pointerCount = 2,
@@ -251,7 +251,7 @@ class FrontendGestureHandlerTest {
     fun `Given NAVIGATE_RELOAD when handleGesture then returns WebViewAction Reload`() = runTest {
         coEvery { prefsRepository.getGestureAction(HAGesture.SWIPE_DOWN_TWO) } returns GestureAction.NAVIGATE_RELOAD
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.DOWN,
             pointerCount = 2,
@@ -267,7 +267,7 @@ class FrontendGestureHandlerTest {
         val serverA = mockServer(url = "https://a.test", name = "A", serverId = 1)
         coEvery { serverManager.servers() } returns listOf(serverA)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -284,7 +284,7 @@ class FrontendGestureHandlerTest {
         val serverC = mockServer(url = "https://c.test", name = "C", serverId = 3)
         coEvery { serverManager.servers() } returns listOf(serverA, serverB, serverC)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 2,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -300,7 +300,7 @@ class FrontendGestureHandlerTest {
         val serverB = mockServer(url = "https://b.test", name = "B", serverId = 2)
         coEvery { serverManager.servers() } returns listOf(serverA, serverB)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 2,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -317,7 +317,7 @@ class FrontendGestureHandlerTest {
         val serverC = mockServer(url = "https://c.test", name = "C", serverId = 3)
         coEvery { serverManager.servers() } returns listOf(serverA, serverB, serverC)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 2,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -334,7 +334,7 @@ class FrontendGestureHandlerTest {
         val serverC = mockServer(url = "https://c.test", name = "C", serverId = 3)
         coEvery { serverManager.servers() } returns listOf(serverA, serverB, serverC)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -349,7 +349,7 @@ class FrontendGestureHandlerTest {
         val onlyServer = mockServer(url = "https://a.test", name = "A", serverId = 1)
         coEvery { serverManager.servers() } returns listOf(onlyServer)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -364,7 +364,7 @@ class FrontendGestureHandlerTest {
         val onlyServer = mockServer(url = "https://a.test", name = "A", serverId = 1)
         coEvery { serverManager.servers() } returns listOf(onlyServer)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -380,7 +380,7 @@ class FrontendGestureHandlerTest {
         val serverB = mockServer(url = "https://b.test", name = "B", serverId = 2)
         coEvery { serverManager.servers() } returns listOf(serverA, serverB)
 
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 99,
             direction = GestureDirection.LEFT,
             pointerCount = 2,
@@ -391,7 +391,7 @@ class FrontendGestureHandlerTest {
 
     @Test
     fun `Given unsupported pointer count when handleGesture then returns Ignored`() = runTest {
-        val result = handler.handleGesture(
+        val result = manager.handleGesture(
             serverId = 1,
             direction = GestureDirection.LEFT,
             pointerCount = 1,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While writing the documentation of the new architecture https://github.com/home-assistant/developers.home-assistant/pull/2965 we found some inconsistency in the naming that needs to be addressed. The `GestureHandler` was in fact a Manager since has per definition it doesn't use any other Manager (except the `ServerManager` that is an exception).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.