### PR TITLE
Rename FrontendEntityAddToHandler to FrontendEntityAddToManager

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/addto/FrontendEntityAddToManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/addto/FrontendEntityAddToManager.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
- * Handles the "Add To" functionality for Home Assistant entities, allowing users to add entities
+ * Manages the "Add To" functionality for Home Assistant entities, allowing users to add entities
  * to various Android platform features and connected devices.
  *
  * This class provides two main capabilities:
@@ -37,7 +37,7 @@ import timber.log.Timber
  * The available actions depend on the entity's domain and current system state (for example, watch connectivity,
  * shortcut limits).
  */
-class FrontendEntityAddToHandler @VisibleForTesting constructor(
+class FrontendEntityAddToManager @VisibleForTesting constructor(
     private val context: Context,
     private val serverManager: ServerManager,
     private val prefsRepository: PrefsRepository,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandler.kt
@@ -7,7 +7,7 @@ import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.di.qualifiers.IsAutomotive
 import io.homeassistant.companion.android.frontend.EvaluateJavascriptUsage
 import io.homeassistant.companion.android.frontend.WebViewAction
-import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToHandler
+import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToManager
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
 import io.homeassistant.companion.android.frontend.externalbus.incoming.BarcodeCloseMessage
@@ -78,7 +78,7 @@ class FrontendMessageHandler @Inject constructor(
     private val sessionManager: ServerSessionManager,
     private val downloadManager: FrontendDownloadManager,
     private val bluetoothCapabilities: BluetoothCapabilities,
-    private val entityAddToHandler: FrontendEntityAddToHandler,
+    private val entityAddToManager: FrontendEntityAddToManager,
     @param:IsAutomotive private val isAutomotive: Boolean,
 ) : FrontendJsHandler,
     FrontendBusObserver {
@@ -271,7 +271,7 @@ class FrontendMessageHandler @Inject constructor(
 
             is EntityAddToGetActionsMessage -> {
                 Timber.d("Entity add_to get_actions request received for: ${message.payload.entityId}")
-                val actions = entityAddToHandler.getActionsForEntity(message.payload.entityId)
+                val actions = entityAddToManager.getActionsForEntity(message.payload.entityId)
                 externalBusRepository.send(EntityAddToActionsResultMessage(id = message.id, actions = actions))
                 FrontendHandlerEvent.EntityAddToActionsSent
             }
@@ -279,7 +279,7 @@ class FrontendMessageHandler @Inject constructor(
             is EntityAddToMessage -> {
                 Timber.d("Entity add_to request received for: ${message.payload.entityId}")
                 val action = ExternalEntityAddToAction.appPayloadToAction(message.payload.appPayload)
-                val event = entityAddToHandler.execute(message.payload.entityId, action)
+                val event = entityAddToManager.execute(message.payload.entityId, action)
                 FrontendHandlerEvent.EntityAddToExecuted(event)
             }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -119,7 +119,7 @@ import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import io.homeassistant.companion.android.databinding.DialogAuthenticationBinding
 import io.homeassistant.companion.android.frontend.EvaluateJavascriptUsage
-import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToHandler
+import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToManager
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge.Companion.EXPECTED_GET_AUTH_CALLBACK
@@ -273,7 +273,7 @@ class WebViewActivity :
     lateinit var appVersionProvider: AppVersionProvider
 
     @Inject
-    lateinit var entityAddToHandler: FrontendEntityAddToHandler
+    lateinit var entityAddToManager: FrontendEntityAddToManager
 
     @Inject
     lateinit var dataUriDownloadManager: DataUriDownloadManager
@@ -1198,7 +1198,7 @@ class WebViewActivity :
         if (entityId != null && appPayload != null) {
             val action = ExternalEntityAddToAction.appPayloadToAction(appPayload)
             lifecycleScope.launch {
-                when (val event = entityAddToHandler.execute(entityId, action)) {
+                when (val event = entityAddToManager.execute(entityId, action)) {
                     is FrontendEvent.NavigateToWidgetConfig -> {
                         startActivity(event.widgetType.toConfigureIntent(this@WebViewActivity, event.entityId))
                     }
@@ -1222,7 +1222,7 @@ class WebViewActivity :
         val entityId = payload?.getStringOrNull("entity_id")
         entityId?.let {
             lifecycleScope.launch {
-                val actions = entityAddToHandler.getActionsForEntity(entityId)
+                val actions = entityAddToManager.getActionsForEntity(entityId)
                 sendExternalBusMessage(
                     EntityAddToActionsResponse(
                         id = json["id"],

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/addto/FrontendEntityAddToManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/addto/FrontendEntityAddToManagerTest.kt
@@ -37,7 +37,7 @@ import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 
 @ExperimentalCoroutinesApi
-class FrontendEntityAddToHandlerTest {
+class FrontendEntityAddToManagerTest {
 
     private lateinit var serverManager: ServerManager
     private lateinit var prefsRepository: PrefsRepository
@@ -69,7 +69,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "vehicle.test"
         coJustRun { prefsRepository.addAutoFavorite(any()) }
 
-        val event = createHandler().execute(entityId, EntityAddToAction.AndroidAutoFavorite)
+        val event = createManager().execute(entityId, EntityAddToAction.AndroidAutoFavorite)
 
         coVerify { prefsRepository.addAutoFavorite(AutoFavorite(serverId, entityId)) }
         assertEquals(FrontendEvent.ShowSnackbar(commonR.string.add_to_android_auto_success), event)
@@ -81,7 +81,7 @@ class FrontendEntityAddToHandlerTest {
         FailFast.setHandler { throwable, _ -> throwableCaptured = throwable }
         coEvery { serverManager.getServer() } returns null
 
-        val event = createHandler().execute("vehicle.test", EntityAddToAction.AndroidAutoFavorite)
+        val event = createManager().execute("vehicle.test", EntityAddToAction.AndroidAutoFavorite)
 
         assertNotNull(throwableCaptured)
         coVerify(exactly = 0) { prefsRepository.addAutoFavorite(any()) }
@@ -93,7 +93,7 @@ class FrontendEntityAddToHandlerTest {
     fun `Given null server when getting actionsForEntity then return empty list`() = runTest {
         coEvery { serverManager.getServer() } returns null
 
-        val actions = createHandler().getActionsForEntity("light.test")
+        val actions = createManager().getActionsForEntity("light.test")
 
         assertEquals(emptyList<ExternalEntityAddToAction>(), actions)
     }
@@ -102,7 +102,7 @@ class FrontendEntityAddToHandlerTest {
     fun `Given entity returns null when getting actionsForEntity then return empty list`() = runTest {
         coEvery { integrationRepository.getEntity("light.nonexistent") } returns null
 
-        val actions = createHandler().getActionsForEntity("light.nonexistent")
+        val actions = createManager().getActionsForEntity("light.nonexistent")
 
         assertEquals(emptyList<ExternalEntityAddToAction>(), actions)
     }
@@ -111,7 +111,7 @@ class FrontendEntityAddToHandlerTest {
     fun `Given entity throws when getting actionsForEntity then return empty list`() = runTest {
         coEvery { integrationRepository.getEntity(any()) } throws RuntimeException("Not found")
 
-        val actions = createHandler().getActionsForEntity("light.nonexistent")
+        val actions = createManager().getActionsForEntity("light.nonexistent")
 
         assertEquals(emptyList<ExternalEntityAddToAction>(), actions)
     }
@@ -121,7 +121,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "automation.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler().getActionsForEntity(entityId)
+        val actions = createManager().getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget), actions.unwrap())
     }
@@ -131,7 +131,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "alarm_control_panel.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler(isFullFlavor = true).getActionsForEntity(entityId)
+        val actions = createManager(isFullFlavor = true).getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget, EntityAddToAction.AndroidAutoFavorite), actions.unwrap())
     }
@@ -141,7 +141,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "alarm_control_panel.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler(isFullFlavor = false).getActionsForEntity(entityId)
+        val actions = createManager(isFullFlavor = false).getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget), actions.unwrap())
     }
@@ -151,7 +151,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "$MEDIA_PLAYER_DOMAIN.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler().getActionsForEntity(entityId)
+        val actions = createManager().getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget, EntityAddToAction.MediaPlayerWidget), actions.unwrap())
     }
@@ -161,7 +161,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "$TODO_DOMAIN.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler().getActionsForEntity(entityId)
+        val actions = createManager().getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget, EntityAddToAction.TodoWidget), actions.unwrap())
     }
@@ -171,7 +171,7 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "$CAMERA_DOMAIN.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler().getActionsForEntity(entityId)
+        val actions = createManager().getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget, EntityAddToAction.CameraWidget), actions.unwrap())
     }
@@ -181,52 +181,52 @@ class FrontendEntityAddToHandlerTest {
         val entityId = "$IMAGE_DOMAIN.test"
         mockGetEntity(entityId)
 
-        val actions = createHandler().getActionsForEntity(entityId)
+        val actions = createManager().getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.EntityWidget, EntityAddToAction.CameraWidget), actions.unwrap())
     }
 
     @Test
     fun `Given EntityWidget action when executing then returns NavigateToWidgetConfig with Entity type`() = runTest {
-        val event = createHandler().execute("light.test", EntityAddToAction.EntityWidget)
+        val event = createManager().execute("light.test", EntityAddToAction.EntityWidget)
 
         assertEquals(FrontendEvent.NavigateToWidgetConfig("light.test", WidgetType.Entity), event)
     }
 
     @Test
     fun `Given MediaPlayerWidget action when executing then returns NavigateToWidgetConfig with MediaPlayer type`() = runTest {
-        val event = createHandler().execute("media_player.tv", EntityAddToAction.MediaPlayerWidget)
+        val event = createManager().execute("media_player.tv", EntityAddToAction.MediaPlayerWidget)
 
         assertEquals(FrontendEvent.NavigateToWidgetConfig("media_player.tv", WidgetType.MediaPlayer), event)
     }
 
     @Test
     fun `Given CameraWidget action when executing then returns NavigateToWidgetConfig with Camera type`() = runTest {
-        val event = createHandler().execute("camera.front", EntityAddToAction.CameraWidget)
+        val event = createManager().execute("camera.front", EntityAddToAction.CameraWidget)
 
         assertEquals(FrontendEvent.NavigateToWidgetConfig("camera.front", WidgetType.Camera), event)
     }
 
     @Test
     fun `Given TodoWidget action when executing then returns NavigateToWidgetConfig with Todo type`() = runTest {
-        val event = createHandler().execute("todo.shopping", EntityAddToAction.TodoWidget)
+        val event = createManager().execute("todo.shopping", EntityAddToAction.TodoWidget)
 
         assertEquals(FrontendEvent.NavigateToWidgetConfig("todo.shopping", WidgetType.Todo), event)
     }
 
     @Test
     fun `Given Tile action when executing then returns null`() = runTest {
-        assertNull(createHandler().execute("light.test", EntityAddToAction.Tile))
+        assertNull(createManager().execute("light.test", EntityAddToAction.Tile))
     }
 
     @Test
     fun `Given Shortcut action when executing then returns null`() = runTest {
-        assertNull(createHandler().execute("light.test", EntityAddToAction.Shortcut(enabled = true)))
+        assertNull(createManager().execute("light.test", EntityAddToAction.Shortcut(enabled = true)))
     }
 
     @Test
     fun `Given Watch action when executing then returns null`() = runTest {
-        assertNull(createHandler().execute("light.test", EntityAddToAction.Watch(name = "Pixel Watch", enabled = true)))
+        assertNull(createManager().execute("light.test", EntityAddToAction.Watch(name = "Pixel Watch", enabled = true)))
     }
 
     @ParameterizedTest
@@ -241,7 +241,7 @@ class FrontendEntityAddToHandlerTest {
     fun `Given standard entity on automotive when getting actionsForEntity then returns auto favorite`(isFullFlavor: Boolean, entityId: String) = runTest {
         mockGetEntity(entityId)
 
-        val actions = createHandler(isAutomotive = true, isFullFlavor = isFullFlavor).getActionsForEntity(entityId)
+        val actions = createManager(isAutomotive = true, isFullFlavor = isFullFlavor).getActionsForEntity(entityId)
 
         assertEquals(listOf(EntityAddToAction.AndroidAutoFavorite), actions.unwrap())
     }
@@ -258,7 +258,7 @@ class FrontendEntityAddToHandlerTest {
     fun `Given entity on automotive not vehicle domain when getting actionsForEntity then returns empty list`(entityId: String) = runTest {
         mockGetEntity(entityId)
 
-        val actions = createHandler(isAutomotive = true).getActionsForEntity(entityId)
+        val actions = createManager(isAutomotive = true).getActionsForEntity(entityId)
 
         assertEquals(emptyList<ExternalEntityAddToAction>(), actions)
     }
@@ -277,16 +277,16 @@ class FrontendEntityAddToHandlerTest {
     fun `Given entity on Quest when getting actionsForEntity then returns empty list`(entityId: String) = runTest {
         mockGetEntity(entityId)
 
-        val actions = createHandler(isQuest = true, isFullFlavor = false).getActionsForEntity(entityId)
+        val actions = createManager(isQuest = true, isFullFlavor = false).getActionsForEntity(entityId)
 
         assertEquals(emptyList<ExternalEntityAddToAction>(), actions)
     }
 
-    private fun createHandler(
+    private fun createManager(
         isAutomotive: Boolean = false,
         isQuest: Boolean = false,
         isFullFlavor: Boolean = true,
-    ) = FrontendEntityAddToHandler(
+    ) = FrontendEntityAddToManager(
         context = context,
         serverManager = serverManager,
         prefsRepository = prefsRepository,

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/handler/FrontendMessageHandlerTest.kt
@@ -9,7 +9,7 @@ import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
 import io.homeassistant.companion.android.frontend.EvaluateJavascriptUsage
 import io.homeassistant.companion.android.frontend.WebViewAction
-import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToHandler
+import io.homeassistant.companion.android.frontend.addto.FrontendEntityAddToManager
 import io.homeassistant.companion.android.frontend.download.DownloadResult
 import io.homeassistant.companion.android.frontend.download.FrontendDownloadManager
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
@@ -97,7 +97,7 @@ class FrontendMessageHandlerTest {
     private val sessionManager: ServerSessionManager = mockk(relaxed = true)
     private val downloadManager: FrontendDownloadManager = mockk(relaxed = true)
     private val bluetoothCapabilities: BluetoothCapabilities = BluetoothCapabilities { true }
-    private val entityAddToHandler: FrontendEntityAddToHandler =
+    private val entityAddToManager: FrontendEntityAddToManager =
         mockk(relaxed = true)
     private lateinit var handler: FrontendMessageHandler
 
@@ -119,7 +119,7 @@ class FrontendMessageHandlerTest {
             sessionManager = sessionManager,
             downloadManager = downloadManager,
             bluetoothCapabilities = bluetoothCapabilities,
-            entityAddToHandler = entityAddToHandler,
+            entityAddToManager = entityAddToManager,
             isAutomotive = false,
         )
     }
@@ -196,7 +196,7 @@ class FrontendMessageHandlerTest {
             sessionManager = sessionManager,
             downloadManager = downloadManager,
             bluetoothCapabilities = { true },
-            entityAddToHandler = entityAddToHandler,
+            entityAddToManager = entityAddToManager,
             isAutomotive = false,
         )
 
@@ -237,7 +237,7 @@ class FrontendMessageHandlerTest {
             sessionManager = sessionManager,
             downloadManager = downloadManager,
             bluetoothCapabilities = { false },
-            entityAddToHandler = entityAddToHandler,
+            entityAddToManager = entityAddToManager,
             isAutomotive = false,
         )
 
@@ -555,7 +555,7 @@ class FrontendMessageHandlerTest {
             sessionManager = sessionManager,
             downloadManager = downloadManager,
             bluetoothCapabilities = bluetoothCapabilities,
-            entityAddToHandler = entityAddToHandler,
+            entityAddToManager = entityAddToManager,
             isAutomotive = true,
         )
 
@@ -589,7 +589,7 @@ class FrontendMessageHandlerTest {
             sessionManager = sessionManager,
             downloadManager = downloadManager,
             bluetoothCapabilities = bluetoothCapabilities,
-            entityAddToHandler = entityAddToHandler,
+            entityAddToManager = entityAddToManager,
             isAutomotive = false,
         )
 
@@ -839,7 +839,7 @@ class FrontendMessageHandlerTest {
                 mdiIcon = "mdi:shape",
             ),
         )
-        coEvery { entityAddToHandler.getActionsForEntity("light.living_room") } returns actions
+        coEvery { entityAddToManager.getActionsForEntity("light.living_room") } returns actions
 
         val message = EntityAddToGetActionsMessage(
             id = 20,
@@ -866,7 +866,7 @@ class FrontendMessageHandlerTest {
     fun `Given entity add_to message when messageResults then emits EntityAddToExecuted with event from handler`() = runTest {
         val entityWidgetPayload = Base64.UrlSafe.encode(kotlinJsonMapper.encodeToString<EntityAddToAction>(EntityAddToAction.EntityWidget).encodeToByteArray())
         coEvery {
-            entityAddToHandler.execute("light.living_room", any())
+            entityAddToManager.execute("light.living_room", any())
         } returns FrontendEvent.ShowSnackbar(
             io.homeassistant.companion.android.common.R.string.add_to_android_auto_success,
         )


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While writing the documentation of the new architecture https://github.com/home-assistant/developers.home-assistant/pull/2965 we found some inconsistency in the naming that needs to be addressed. The `EntityAddToHandler` was in fact a Manager since has per definition it doesn't use any other Manager (except the `ServerManager` that is an exception).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.