### PR TITLE
Rename HttpAuthManager to FrontendHttpAuthHandler

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -13,7 +13,7 @@ import io.homeassistant.companion.android.common.data.connectivity.ConnectivityC
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.ScreenOrientation
 import io.homeassistant.companion.android.common.util.GestureDirection
-import io.homeassistant.companion.android.frontend.auth.HttpAuthManager
+import io.homeassistant.companion.android.frontend.auth.FrontendHttpAuthHandler
 import io.homeassistant.companion.android.frontend.auth.HttpAuthResult
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
 import io.homeassistant.companion.android.frontend.download.DownloadResult
@@ -92,7 +92,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val prefsRepository: PrefsRepository,
     private val dialogManager: FrontendDialogManager,
     private val fileChooserManager: FileChooserManager,
-    private val httpAuthManager: HttpAuthManager,
+    private val httpAuthHandler: FrontendHttpAuthHandler,
     private val exoPlayerManager: FrontendExoPlayerManager,
 ) : ViewModel(),
     FrontendConnectionErrorStateProvider {
@@ -112,7 +112,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         prefsRepository: PrefsRepository,
         dialogManager: FrontendDialogManager,
         fileChooserManager: FileChooserManager,
-        httpAuthManager: HttpAuthManager,
+        httpAuthHandler: FrontendHttpAuthHandler,
         exoPlayerManager: FrontendExoPlayerManager,
     ) : this(
         initialServerId = savedStateHandle.toRoute<FrontendRoute>().serverId,
@@ -129,7 +129,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         prefsRepository = prefsRepository,
         dialogManager = dialogManager,
         fileChooserManager = fileChooserManager,
-        httpAuthManager = httpAuthManager,
+        httpAuthHandler = httpAuthHandler,
         exoPlayerManager = exoPlayerManager,
     )
 
@@ -210,7 +210,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         onPageFinished = ::onPageFinished,
         onReceivedHttpAuthRequest = { handler, host, resource, realm ->
             viewModelScope.launch {
-                if (httpAuthManager.handleAuthRequest(handler, host = host, resource = resource, realm = realm) ==
+                if (httpAuthHandler.handleAuthRequest(handler, host = host, resource = resource, realm = realm) ==
                     HttpAuthResult.Cancelled
                 ) {
                     _events.tryEmit(FrontendEvent.ShowSnackbar(commonR.string.auth_cancel))

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/auth/FrontendHttpAuthHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/auth/FrontendHttpAuthHandler.kt
@@ -32,7 +32,7 @@ internal sealed interface HttpAuthResult {
 }
 
 /**
- * Handles HTTP Basic Auth requests from the WebView end-to-end.
+ * Manages HTTP Basic Auth requests from the WebView end-to-end.
  *
  * Looks up stored credentials from [AuthenticationDao] and auto-proceeds when possible. Otherwise
  * shows a credential dialog through [FrontendDialogManager], suspends until the user responds,
@@ -52,7 +52,7 @@ internal sealed interface HttpAuthResult {
  */
 @OptIn(ExperimentalTime::class)
 @ViewModelScoped
-internal class HttpAuthManager @Inject constructor(
+internal class FrontendHttpAuthHandler @Inject constructor(
     private val authenticationDao: AuthenticationDao,
     private val clock: Clock,
     private val dialogManager: FrontendDialogManager,

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -19,7 +19,7 @@ import io.homeassistant.companion.android.common.data.prefs.ZoomSettings
 import io.homeassistant.companion.android.common.util.GestureDirection
 import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.authentication.AuthenticationDao
-import io.homeassistant.companion.android.frontend.auth.HttpAuthManager
+import io.homeassistant.companion.android.frontend.auth.FrontendHttpAuthHandler
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialog
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
 import io.homeassistant.companion.android.frontend.download.DownloadResult
@@ -123,7 +123,7 @@ class FrontendViewModelTest {
         path: String? = null,
         dialogManager: FrontendDialogManager = FrontendDialogManager(),
         fileChooserManager: FileChooserManager = FileChooserManager(),
-        httpAuthManager: HttpAuthManager = HttpAuthManager(
+        httpAuthHandler: FrontendHttpAuthHandler = FrontendHttpAuthHandler(
             authenticationDao = mockk(relaxed = true),
             clock = FakeClock(),
             dialogManager = dialogManager,
@@ -144,7 +144,7 @@ class FrontendViewModelTest {
             prefsRepository = prefsRepository,
             dialogManager = dialogManager,
             fileChooserManager = fileChooserManager,
-            httpAuthManager = httpAuthManager,
+            httpAuthHandler = httpAuthHandler,
             exoPlayerManager = exoPlayerManager,
         )
     }
@@ -1075,7 +1075,7 @@ class FrontendViewModelTest {
 
         private val authenticationDao: AuthenticationDao = mockk(relaxed = true)
         private val dialogManager = FrontendDialogManager()
-        private val httpAuthManager = HttpAuthManager(
+        private val httpAuthHandler = FrontendHttpAuthHandler(
             authenticationDao = authenticationDao,
             clock = FakeClock(),
             dialogManager = dialogManager,
@@ -1097,7 +1097,7 @@ class FrontendViewModelTest {
                 mockk(relaxed = true)
             }
 
-            val viewModel = createViewModel(httpAuthManager = httpAuthManager, dialogManager = dialogManager)
+            val viewModel = createViewModel(httpAuthHandler = httpAuthHandler, dialogManager = dialogManager)
             return viewModel to capturedCallback!!
         }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/auth/FrontendHttpAuthHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/auth/FrontendHttpAuthHandlerTest.kt
@@ -26,18 +26,18 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @OptIn(ExperimentalTime::class, ExperimentalCoroutinesApi::class)
-class HttpAuthManagerTest {
+class FrontendHttpAuthHandlerTest {
 
     private val authenticationDao: AuthenticationDao = mockk(relaxed = true)
     private val clock = FakeClock()
     private val dialogManager = FrontendDialogManager()
-    private val manager = HttpAuthManager(
+    private val handler = FrontendHttpAuthHandler(
         authenticationDao = authenticationDao,
         clock = clock,
         dialogManager = dialogManager,
     )
 
-    private val handler: HttpAuthHandler = mockk(relaxed = true)
+    private val httpAuthHandler: HttpAuthHandler = mockk(relaxed = true)
 
     private fun pendingHttpAuthDialog(): FrontendDialog.HttpAuth {
         return dialogManager.pendingDialog.value as FrontendDialog.HttpAuth
@@ -54,15 +54,15 @@ class HttpAuthManagerTest {
                 password = "pass",
             )
 
-            val result = manager.handleAuthRequest(
-                handler = handler,
+            val result = handler.handleAuthRequest(
+                handler = httpAuthHandler,
                 host = "example.com",
                 resource = "https://example.com/",
                 realm = "testrealm",
             )
 
             assertEquals(HttpAuthResult.AutoProceeded, result)
-            verify { handler.proceed("user", "pass") }
+            verify { httpAuthHandler.proceed("user", "pass") }
         }
 
         @Test
@@ -70,8 +70,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "testrealm",
@@ -80,7 +80,7 @@ class HttpAuthManagerTest {
             advanceUntilIdle()
 
             assertInstanceOf(FrontendDialog.HttpAuth::class.java, dialogManager.pendingDialog.value)
-            verify(exactly = 0) { handler.proceed(any(), any()) }
+            verify(exactly = 0) { httpAuthHandler.proceed(any(), any()) }
 
             // Tidy up so the suspend returns and async doesn't leak
             pendingHttpAuthDialog().onCancel()
@@ -102,8 +102,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns storedAuth
 
             // First request: auto-proceeds
-            manager.handleAuthRequest(
-                handler = handler,
+            handler.handleAuthRequest(
+                handler = httpAuthHandler,
                 host = "example.com",
                 resource = "https://example.com/",
                 realm = "testrealm",
@@ -113,8 +113,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 200.milliseconds
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "testrealm",
@@ -135,8 +135,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -157,8 +157,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val firstRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -175,8 +175,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 200.milliseconds
 
             val secondRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -198,8 +198,8 @@ class HttpAuthManagerTest {
 
             // Resource A: user proceeds with credentials
             val firstRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "a.example.com",
                     resource = "https://a.example.com/",
                     realm = "realm",
@@ -214,8 +214,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 100.milliseconds
 
             val secondRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "b.example.com",
                     resource = "https://b.example.com/",
                     realm = "realm",
@@ -240,8 +240,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns storedAuth
 
             // First request: auto-proceeds
-            manager.handleAuthRequest(
-                handler = handler,
+            handler.handleAuthRequest(
+                handler = httpAuthHandler,
                 host = "example.com",
                 resource = "https://example.com/",
                 realm = "testrealm",
@@ -250,8 +250,8 @@ class HttpAuthManagerTest {
             // Second request after 500ms: not rapid reauth
             clock.currentInstant += 1.seconds
 
-            val result = manager.handleAuthRequest(
-                handler = handler,
+            val result = handler.handleAuthRequest(
+                handler = httpAuthHandler,
                 host = "example.com",
                 resource = "https://example.com/",
                 realm = "testrealm",
@@ -268,8 +268,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val firstRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -283,8 +283,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 10.seconds
 
             val secondRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -306,8 +306,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val firstRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -322,8 +322,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 100.milliseconds
 
             val secondRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -347,8 +347,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -359,7 +359,7 @@ class HttpAuthManagerTest {
             advanceUntilIdle()
 
             assertEquals(HttpAuthResult.Proceeded, result.await())
-            verify { handler.proceed("user", "pass") }
+            verify { httpAuthHandler.proceed("user", "pass") }
             coVerify { authenticationDao.insert(Authentication("https://example.com/realm", "user", "pass")) }
             coVerify(exactly = 0) { authenticationDao.update(any()) }
         }
@@ -372,8 +372,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val firstRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -388,8 +388,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 20.milliseconds
 
             val secondRequest = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -410,14 +410,14 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns storedAuth
 
             // First request: auto-proceeds
-            manager.handleAuthRequest(handler = handler, host = "example.com", resource = "https://example.com/", realm = "realm")
+            handler.handleAuthRequest(handler = httpAuthHandler, host = "example.com", resource = "https://example.com/", realm = "realm")
 
             // Second request within 500ms: rapid reauth
             clock.currentInstant += 200.milliseconds
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -437,8 +437,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -461,8 +461,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns storedAuth
 
             // First request: auto-proceeds with the stored (wrong) credentials.
-            manager.handleAuthRequest(
-                handler = handler,
+            handler.handleAuthRequest(
+                handler = httpAuthHandler,
                 host = "example.com",
                 resource = "https://example.com/",
                 realm = "realm",
@@ -472,8 +472,8 @@ class HttpAuthManagerTest {
             clock.currentInstant += 200.milliseconds
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -493,8 +493,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -505,7 +505,7 @@ class HttpAuthManagerTest {
             advanceUntilIdle()
 
             assertEquals(HttpAuthResult.Cancelled, result.await())
-            verify { handler.cancel() }
+            verify { httpAuthHandler.cancel() }
         }
     }
 
@@ -527,8 +527,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "https://example.com/",
                     realm = "realm",
@@ -550,8 +550,8 @@ class HttpAuthManagerTest {
             coEvery { authenticationDao.get(any()) } returns null
 
             val result = async {
-                manager.handleAuthRequest(
-                    handler = handler,
+                handler.handleAuthRequest(
+                    handler = httpAuthHandler,
                     host = "example.com",
                     resource = "http://example.com/",
                     realm = "realm",


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While writing the documentation of the new architecture https://github.com/home-assistant/developers.home-assistant/pull/2965 we found some inconsistency in the naming that needs to be addressed. The `FrontendHttpAuthHandler` was in fact a Handler since has per definition depending on other Manager also conflicting with `android.webkit.HttpAuthHandler`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.