### PR TITLE
Make a context extension to openSystemAppSettings

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
@@ -4,7 +4,6 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings
 import androidx.activity.addCallback
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -13,7 +12,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -23,6 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.barcode.view.BarcodeScannerView
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.util.openAppSettings
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import java.util.Locale
 import kotlinx.coroutines.launch
@@ -133,7 +132,7 @@ class BarcodeScannerActivity : BaseActivity() {
         if (inContext) {
             cameraPermission.launch(Manifest.permission.CAMERA)
         } else {
-            startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS, "package:$packageName".toUri()))
+            openAppSettings()
             requestSilently = true // Reset state to trigger new in context dialog/check when resumed
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/barcode/BarcodeScannerActivity.kt
@@ -21,7 +21,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.barcode.view.BarcodeScannerView
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.util.openAppSettings
+import io.homeassistant.companion.android.common.util.openSystemAppSettings
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import java.util.Locale
 import kotlinx.coroutines.launch
@@ -132,7 +132,7 @@ class BarcodeScannerActivity : BaseActivity() {
         if (inContext) {
             cameraPermission.launch(Manifest.permission.CAMERA)
         } else {
-            openAppSettings()
+            openSystemAppSettings()
             requestSilently = true // Reset state to trigger new in context dialog/check when resumed
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -68,7 +68,7 @@ import io.homeassistant.companion.android.common.notifications.parseVibrationPat
 import io.homeassistant.companion.android.common.notifications.prepareText
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
-import io.homeassistant.companion.android.common.util.createAppSettingsIntent
+import io.homeassistant.companion.android.common.util.createSystemAppSettingsIntent
 import io.homeassistant.companion.android.common.util.getActiveNotification
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
@@ -1797,7 +1797,7 @@ class MessagingManager @Inject constructor(
     }
 
     private fun navigateAppDetails() {
-        val intent = context.createAppSettingsIntent()
+        val intent = context.createSystemAppSettingsIntent()
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(intent)
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -68,6 +68,7 @@ import io.homeassistant.companion.android.common.notifications.parseVibrationPat
 import io.homeassistant.companion.android.common.notifications.prepareText
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.common.util.cancelGroupIfNeeded
+import io.homeassistant.companion.android.common.util.createAppSettingsIntent
 import io.homeassistant.companion.android.common.util.getActiveNotification
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
@@ -1796,10 +1797,7 @@ class MessagingManager @Inject constructor(
     }
 
     private fun navigateAppDetails() {
-        val intent = Intent(
-            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-            "package:${context.packageName}".toUri(),
-        )
+        val intent = context.createAppSettingsIntent()
         intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
         context.startActivity(intent)
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
@@ -66,7 +66,7 @@ import io.homeassistant.companion.android.common.compose.theme.HARadius
 import io.homeassistant.companion.android.common.compose.theme.HATextStyle
 import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
 import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
-import io.homeassistant.companion.android.common.util.openAppSettings
+import io.homeassistant.companion.android.common.util.openSystemAppSettings
 import io.homeassistant.companion.android.util.plus
 import io.homeassistant.companion.android.util.safeBottomPaddingValues
 import kotlinx.coroutines.launch
@@ -93,7 +93,7 @@ private fun rememberRecordAudioPermissionState(
                     duration = SnackbarDuration.Long,
                 )
                 if (result == SnackbarResult.ActionPerformed) {
-                    context.openAppSettings()
+                    context.openSystemAppSettings()
                 }
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/assist/AssistSettingsScreen.kt
@@ -1,9 +1,6 @@
 package io.homeassistant.companion.android.settings.assist
 
 import android.Manifest
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedVisibility
@@ -69,6 +66,7 @@ import io.homeassistant.companion.android.common.compose.theme.HARadius
 import io.homeassistant.companion.android.common.compose.theme.HATextStyle
 import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
 import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
+import io.homeassistant.companion.android.common.util.openAppSettings
 import io.homeassistant.companion.android.util.plus
 import io.homeassistant.companion.android.util.safeBottomPaddingValues
 import kotlinx.coroutines.launch
@@ -95,12 +93,7 @@ private fun rememberRecordAudioPermissionState(
                     duration = SnackbarDuration.Long,
                 )
                 if (result == SnackbarResult.ActionPerformed) {
-                    context.startActivity(
-                        Intent(
-                            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                            Uri.fromParts("package", context.packageName, null),
-                        ),
-                    )
+                    context.openAppSettings()
                 }
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -1,7 +1,5 @@
 package io.homeassistant.companion.android.settings.sensor.views
 
-import android.content.Intent
-import android.provider.Settings
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
@@ -67,7 +65,6 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
@@ -75,6 +72,7 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.compose.composable.HAHint
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import io.homeassistant.companion.android.common.util.openAppSettings
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.database.sensor.SensorWithAttributes
@@ -127,12 +125,7 @@ fun SensorDetailView(
                                 context.startActivity(intent)
                             }
                         } else {
-                            context.startActivity(
-                                Intent(
-                                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                                    "package:${context.packageName}".toUri(),
-                                ),
-                            )
+                            context.openAppSettings()
                         }
                     } else {
                         onSetEnabled(true, it.serverId)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -72,7 +72,7 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.compose.composable.HAHint
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
-import io.homeassistant.companion.android.common.util.openAppSettings
+import io.homeassistant.companion.android.common.util.openSystemAppSettings
 import io.homeassistant.companion.android.database.sensor.SensorSetting
 import io.homeassistant.companion.android.database.sensor.SensorSettingType
 import io.homeassistant.companion.android.database.sensor.SensorWithAttributes
@@ -125,7 +125,7 @@ fun SensorDetailView(
                                 context.startActivity(intent)
                             }
                         } else {
-                            context.openAppSettings()
+                            context.openSystemAppSettings()
                         }
                     } else {
                         onSetEnabled(true, it.serverId)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
+import android.net.Uri
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.compose.ui.platform.AndroidUriHandler
@@ -100,4 +101,23 @@ suspend fun Context.openUri(uri: String, onShowSnackbar: suspend (message: Strin
         Timber.e(e.takeIf { BuildConfig.DEBUG }, "Failed to navigate open uri")
         onShowSnackbar(getString(R.string.fail_to_navigate_to_uri, uri), null)
     }
+}
+
+/**
+ * Builds an [Intent] that opens this app's "App info" page in the system Settings.
+ */
+fun Context.createAppSettingsIntent(): Intent {
+    return Intent(
+        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        Uri.fromParts("package", packageName, null),
+    )
+}
+
+/**
+ * Opens this app's "App info" page in the system Settings.
+ */
+fun Context.openAppSettings() {
+    startActivity(
+        createAppSettingsIntent(),
+    )
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
@@ -106,7 +106,7 @@ suspend fun Context.openUri(uri: String, onShowSnackbar: suspend (message: Strin
 /**
  * Builds an [Intent] that opens this app's "App info" page in the system Settings.
  */
-fun Context.createAppSettingsIntent(): Intent {
+fun Context.createSystemAppSettingsIntent(): Intent {
     return Intent(
         Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
         Uri.fromParts("package", packageName, null),
@@ -116,8 +116,8 @@ fun Context.createAppSettingsIntent(): Intent {
 /**
  * Opens this app's "App info" page in the system Settings.
  */
-fun Context.openAppSettings() {
+fun Context.openSystemAppSettings() {
     startActivity(
-        createAppSettingsIntent(),
+        createSystemAppSettingsIntent(),
     )
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In order to centralize the logic to open the app settings I've made a Context extension for it.