### PR TITLE
Use external/internal URL and optional version for mDNS discovery and add missing tests

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -28,7 +28,7 @@ const val SERVICE_TYPE = "_home-assistant._tcp"
 @VisibleForTesting
 const val LOCK_TAG = "HomeAssistantSearcher_lock"
 
-internal data class HomeAssistantInstance(val name: String, val url: URL, val version: HomeAssistantVersion)
+internal data class HomeAssistantInstance(val name: String, val url: URL, val version: HomeAssistantVersion?)
 
 /**
  * Interface responsible for discovering Home Assistant instances on the local network.
@@ -64,7 +64,8 @@ internal class HomeAssistantSearcherImpl @Inject constructor(
          * (hence its static nature) or unintended multiple concurrent collections of the flow.
          * It ensures that only one collector can be active at any given time.
          */
-        @VisibleForTesting val hasCollector = AtomicBoolean(false)
+        @VisibleForTesting
+        val hasCollector = AtomicBoolean(false)
     }
 
     override fun discoveredInstanceFlow(): Flow<HomeAssistantInstance> {
@@ -242,18 +243,12 @@ private fun NsdServiceInfo.toHomeAssistantInstance(): HomeAssistantInstance? {
         return null
     }
 
-    val versionAttr = attributes?.get("version")?.toString(Charsets.UTF_8)
-    if (versionAttr.isNullOrBlank()) {
-        Timber.w(
-            "Version attribute is missing or empty for service: $serviceName. Cannot create HomeAssistantInstance.",
-        )
-        return null
-    }
-
-    val haVersion = HomeAssistantVersion.fromString(versionAttr)
+    // The version is optional: a discovered instance is still usable without it, the instance might simply be on the
+    // https://github.com/home-assistant/landingpage/.
+    val haVersion = attributes?.get("version")?.toString(Charsets.UTF_8)?.ifEmpty { null }
+        ?.let { HomeAssistantVersion.fromString(it) }
     if (haVersion == null) {
-        Timber.w("Failed to parse version from '$versionAttr' for service: $serviceName. Skipping.")
-        return null
+        Timber.w("Version is missing in NSD attributes for service: $serviceName")
     }
 
     return HomeAssistantInstance(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -22,9 +22,11 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 
-@VisibleForTesting const val SERVICE_TYPE = "_home-assistant._tcp"
+@VisibleForTesting
+const val SERVICE_TYPE = "_home-assistant._tcp"
 
-@VisibleForTesting const val LOCK_TAG = "HomeAssistantSearcher_lock"
+@VisibleForTesting
+const val LOCK_TAG = "HomeAssistantSearcher_lock"
 
 internal data class HomeAssistantInstance(val name: String, val url: URL, val version: HomeAssistantVersion)
 
@@ -227,7 +229,7 @@ private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManag
 }
 
 private fun NsdServiceInfo.toHomeAssistantInstance(): HomeAssistantInstance? {
-    val baseUrlString = attributes?.get("base_url")?.toString(Charsets.UTF_8)
+    val baseUrlString = (attributes?.get("external_url") ?: attributes?.get("internal_url"))?.toString(Charsets.UTF_8)
     if (baseUrlString.isNullOrBlank()) {
         Timber.w("Base URL is missing or empty in NSD attributes for service: $this")
         return null

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -229,31 +229,33 @@ private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManag
     }
 }
 
+private fun NsdServiceInfo.attribute(key: String): String? =
+    attributes?.get(key)?.toString(Charsets.UTF_8)?.ifEmpty { null }
+
 private fun NsdServiceInfo.toHomeAssistantInstance(): HomeAssistantInstance? {
-    val baseUrlString = (attributes?.get("external_url") ?: attributes?.get("internal_url"))?.toString(Charsets.UTF_8)
-    if (baseUrlString.isNullOrBlank()) {
-        Timber.w("Base URL is missing or empty in NSD attributes for service: $this")
+    val urlString = attribute("external_url") ?: attribute("internal_url")
+    if (urlString.isNullOrBlank()) {
+        Timber.w("URL is missing or empty in NSD attributes for service: $this")
         return null
     }
 
-    val baseUrl = try {
-        URL(baseUrlString)
+    val url = try {
+        URL(urlString)
     } catch (e: MalformedURLException) {
-        Timber.w(e, "Invalid base_url format: $baseUrlString for service: $this")
+        Timber.w(e, "Invalid url format: $urlString for service: $this")
         return null
     }
 
     // The version is optional: a discovered instance is still usable without it, the instance might simply be on the
     // https://github.com/home-assistant/landingpage/.
-    val haVersion = attributes?.get("version")?.toString(Charsets.UTF_8)?.ifEmpty { null }
-        ?.let { HomeAssistantVersion.fromString(it) }
+    val haVersion = attribute("version")?.let { HomeAssistantVersion.fromString(it) }
     if (haVersion == null) {
         Timber.w("Version is missing in NSD attributes for service: $serviceName")
     }
 
     return HomeAssistantInstance(
         serviceName,
-        baseUrl,
+        url,
         haVersion,
     )
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcher.kt
@@ -230,7 +230,7 @@ private fun ProducerScope<HomeAssistantInstance>.getResolvedListener(): NsdManag
 }
 
 private fun NsdServiceInfo.attribute(key: String): String? =
-    attributes?.get(key)?.toString(Charsets.UTF_8)?.ifEmpty { null }
+    attributes?.get(key)?.toString(Charsets.UTF_8)?.ifBlank { null }
 
 private fun NsdServiceInfo.toHomeAssistantInstance(): HomeAssistantInstance? {
     val urlString = attribute("external_url") ?: attribute("internal_url")

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModel.kt
@@ -52,7 +52,7 @@ data object NoServerFound : DiscoveryState
 /**
  * The first server has been fully discovered.
  */
-data class ServerDiscovered(val name: String, val url: URL, val version: HomeAssistantVersion) : DiscoveryState
+data class ServerDiscovered(val name: String, val url: URL, val version: HomeAssistantVersion?) : DiscoveryState
 
 /**
  * Multiple server have been fully discovered.

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
@@ -168,11 +168,11 @@ class HomeAssistantSearcherImplTest {
         ],
     )
     fun `Given one discoverable instance with missing or malformed url when discoveredInstanceFlow is called then nothing is emitted`(
-        baseUrl: String?,
+        url: String?,
     ) = runTest {
         val discoveryListener = slot<NsdManager.DiscoveryListener>()
         val resolveListener = slot<NsdManager.ResolveListener>()
-        val serviceInfo = createNsdServiceInfo(externalUrl = baseUrl)
+        val serviceInfo = createNsdServiceInfo(externalUrl = url)
 
         captureListeners(discoveryListener, resolveListener)
 
@@ -259,6 +259,8 @@ class HomeAssistantSearcherImplTest {
             "http://external:8123,null,http://external:8123",
             // internal_url is used as a fallback when external_url is missing
             "null,http://internal:8123,http://internal:8123",
+            // internal_url is used as a fallback when external_url is empty
+            ",http://internal:8123,http://internal:8123",
         ],
     )
     fun `Given external and internal url attributes when discoveredInstanceFlow is called then external url is preferred`(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
@@ -22,6 +22,7 @@ import java.net.URL
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -160,19 +161,18 @@ class HomeAssistantSearcherImplTest {
     @CsvSource(
         nullValues = ["null"],
         value = [
-            "null,null",
-            "http://localhost:8123,null",
-            "http://localhost:8123,wrong_version",
-            "malformed://localhost:8123,null",
+            // No url attribute at all (neither external_url nor internal_url).
+            "null",
+            // Url attribute present but not a parseable URL.
+            "malformed://localhost:8123",
         ],
     )
-    fun `Given one discoverable instance with wrong attributes when discoveredInstanceFlow is called then nothing is emitted`(
+    fun `Given one discoverable instance with missing or malformed url when discoveredInstanceFlow is called then nothing is emitted`(
         baseUrl: String?,
-        version: String?,
     ) = runTest {
         val discoveryListener = slot<NsdManager.DiscoveryListener>()
         val resolveListener = slot<NsdManager.ResolveListener>()
-        val serviceInfo = createNsdServiceInfo(externalUrl = baseUrl, version = version)
+        val serviceInfo = createNsdServiceInfo(externalUrl = baseUrl)
 
         captureListeners(discoveryListener, resolveListener)
 
@@ -180,6 +180,42 @@ class HomeAssistantSearcherImplTest {
             discoveryListener.captured.onServiceFound(serviceInfo)
             resolveListener.captured.onServiceResolved(serviceInfo)
 
+            expectNoEvents()
+        }
+
+        verifyDiscoveryStartedAndStopped(discoveryListener.captured, resolveListener.captured)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        nullValues = ["null"],
+        emptyValue = "",
+        value = [
+            // version attribute absent
+            "null",
+            // version attribute present but empty
+            "''",
+            // version attribute present but not parseable
+            "wrong_version",
+        ],
+    )
+    fun `Given a valid url but missing version when discoveredInstanceFlow is called then emits instance with null version`(
+        version: String?,
+    ) = runTest {
+        val discoveryListener = slot<NsdManager.DiscoveryListener>()
+        val resolveListener = slot<NsdManager.ResolveListener>()
+        // The version is optional, so a resolvable instance is still emitted without a parsed version.
+        val serviceInfo = createNsdServiceInfo(version = version)
+
+        captureListeners(discoveryListener, resolveListener)
+
+        discoveredInstanceFlow {
+            discoveryListener.captured.onServiceFound(serviceInfo)
+            resolveListener.captured.onServiceResolved(serviceInfo)
+
+            val instance = awaitItem()
+            assertEquals(URL("http://localhost:8123"), instance.url)
+            assertNull(instance.version)
             expectNoEvents()
         }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/HomeAssistantSearcherImplTest.kt
@@ -85,7 +85,7 @@ class HomeAssistantSearcherImplTest {
         val resolveListener = slot<NsdManager.ResolveListener>()
         val wifiLock = mockk<WifiManager.MulticastLock>(relaxed = true)
         val serviceInfo = createNsdServiceInfo()
-        val serviceInfo2 = createNsdServiceInfo(baseUrl = "https://helloworld.org")
+        val serviceInfo2 = createNsdServiceInfo(externalUrl = "https://helloworld.org")
 
         captureListeners(discoveryListener, resolveListener)
         every { wifiManager.createMulticastLock(LOCK_TAG) } returns wifiLock
@@ -172,7 +172,7 @@ class HomeAssistantSearcherImplTest {
     ) = runTest {
         val discoveryListener = slot<NsdManager.DiscoveryListener>()
         val resolveListener = slot<NsdManager.ResolveListener>()
-        val serviceInfo = createNsdServiceInfo(baseUrl, version)
+        val serviceInfo = createNsdServiceInfo(externalUrl = baseUrl, version = version)
 
         captureListeners(discoveryListener, resolveListener)
 
@@ -180,6 +180,67 @@ class HomeAssistantSearcherImplTest {
             discoveryListener.captured.onServiceFound(serviceInfo)
             resolveListener.captured.onServiceResolved(serviceInfo)
 
+            expectNoEvents()
+        }
+
+        verifyDiscoveryStartedAndStopped(discoveryListener.captured, resolveListener.captured)
+    }
+
+    /**
+     * The Home Assistant landing page advertises itself over NSD with the placeholder version
+     * "0000.0.0". This test ensures we recognize it as a valid instance so it is discoverable
+     * during onboarding.
+     *
+     * See https://github.com/home-assistant/landingpage/pull/195
+     */
+    @Test
+    fun `Given one discoverable instance with version 0000_0_0 when discoveredInstanceFlow is called then should emit instance`() = runTest {
+        val discoveryListener = slot<NsdManager.DiscoveryListener>()
+        val resolveListener = slot<NsdManager.ResolveListener>()
+        // "0000.0.0" still matches the version pattern, so it is a valid (lower-bound) version.
+        val serviceInfo = createNsdServiceInfo(version = "0000.0.0")
+
+        captureListeners(discoveryListener, resolveListener)
+
+        discoveredInstanceFlow {
+            discoveryListener.captured.onServiceFound(serviceInfo)
+            resolveListener.captured.onServiceResolved(serviceInfo)
+
+            assertEquals(HomeAssistantVersion(year = 0, month = 0, release = 0), awaitItem().version)
+            expectNoEvents()
+        }
+
+        verifyDiscoveryStartedAndStopped(discoveryListener.captured, resolveListener.captured)
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        nullValues = ["null"],
+        value = [
+            // external_url is preferred when present, even if internal_url is also set
+            "http://external:8123,http://internal:8123,http://external:8123",
+            // external_url alone is used
+            "http://external:8123,null,http://external:8123",
+            // internal_url is used as a fallback when external_url is missing
+            "null,http://internal:8123,http://internal:8123",
+        ],
+    )
+    fun `Given external and internal url attributes when discoveredInstanceFlow is called then external url is preferred`(
+        externalUrl: String?,
+        internalUrl: String?,
+        expectedUrl: String,
+    ) = runTest {
+        val discoveryListener = slot<NsdManager.DiscoveryListener>()
+        val resolveListener = slot<NsdManager.ResolveListener>()
+        val serviceInfo = createNsdServiceInfo(externalUrl = externalUrl, internalUrl = internalUrl)
+
+        captureListeners(discoveryListener, resolveListener)
+
+        discoveredInstanceFlow {
+            discoveryListener.captured.onServiceFound(serviceInfo)
+            resolveListener.captured.onServiceResolved(serviceInfo)
+
+            assertEquals(URL(expectedUrl), awaitItem().url)
             expectNoEvents()
         }
 
@@ -283,11 +344,18 @@ class HomeAssistantSearcherImplTest {
     }
 }
 
-private fun createNsdServiceInfo(baseUrl: String? = "http://localhost:8123", version: String? = "2025.8.0"): NsdServiceInfo {
+private fun createNsdServiceInfo(
+    externalUrl: String? = "http://localhost:8123",
+    internalUrl: String? = null,
+    version: String? = "2025.8.0",
+): NsdServiceInfo {
     return mockk<NsdServiceInfo>().apply {
         val attributes = mutableMapOf<String, ByteArray>()
-        baseUrl?.let {
-            attributes["base_url"] = it.toByteArray(Charsets.UTF_8)
+        externalUrl?.let {
+            attributes["external_url"] = it.toByteArray(Charsets.UTF_8)
+        }
+        internalUrl?.let {
+            attributes["internal_url"] = it.toByteArray(Charsets.UTF_8)
         }
         version?.let {
             attributes["version"] = it.toByteArray(Charsets.UTF_8)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/serverdiscovery/ServerDiscoveryViewModelTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -190,6 +191,27 @@ private class ServerDiscoveryViewModelTest {
             assertEquals(instance1.name, discoveredState.servers[0].name)
             assertEquals(instance2.name, discoveredState.servers[1].name)
 
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given a discovered instance without a version when collecting from discoveryFlow then emits ServerDiscovered with a null version`() = runTest {
+        createViewModel()
+        // An instance whose version could not be resolved (e.g. the Home Assistant landing page) is
+        // still surfaced rather than dropped.
+        val instance = HomeAssistantInstance("Server 1", URL("http://server1.local:8123"), version = null)
+
+        viewModel.discoveryFlow.test {
+            assertEquals(Started, awaitItem())
+
+            discoveredInstanceFlow.emit(instance)
+            runCurrent()
+
+            val discoveredState = awaitItem()
+            assertTrue(discoveredState is ServerDiscovered)
+            assertEquals(instance.name, (discoveredState as ServerDiscovered).name)
+            assertNull(discoveredState.version)
             expectNoEvents()
         }
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR changes the fields that we are reading from mDNS for the instance discovery to use the `external/internal` URLs available to match the current logic of core and make version optional. See https://github.com/home-assistant/developers.home-assistant/pull/3130#discussion_r3358143525 for more details. Core implementation https://github.com/home-assistant/core/blob/d9a89beb3daaf68e3716f5f6e00cd22eed16e2eb/homeassistant/components/zeroconf/__init__.py#L273

I've also added missing test especially to make sure the version returned by the landing page is supported by the searcher.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.