### PR TITLE
Bring back multi_json in ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,5 @@ source "https://rubygems.org"
 
 gem "ostruct"
 gem "fastlane"
+gem "multi_json" # Added since it was missing from fastlane after merging https://github.com/home-assistant/android/pull/6983
 gem "fastlane-plugin-amazon_app_submission"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
     logger (1.7.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
+    multi_json (1.21.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
     nanaimo (0.4.0)
@@ -237,6 +238,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-amazon_app_submission
+  multi_json
   ostruct
 
 CHECKSUMS
@@ -304,6 +306,7 @@ CHECKSUMS
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   nanaimo (0.4.0) sha256=faf069551bab17f15169c1f74a1c73c220657e71b6e900919897a10d991d0723
@@ -339,4 +342,4 @@ CHECKSUMS
   xcpretty-travis-formatter (1.0.1) sha256=aacc332f17cb7b2cba222994e2adc74223db88724fe76341483ad3098e232f93
 
 BUNDLED WITH
-  4.0.3
+  4.0.10


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
After merging https://github.com/home-assistant/android/pull/6983 CI started to fail with missing deps on `multi_json`. this PR adds back the missing deps. It should be remove in the future when it is not needed anymore, since it should come with `fastlane` directly if it is required.