### PR TITLE
Log WebView version at application startup

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -13,6 +13,7 @@ import android.os.PowerManager
 import android.telephony.TelephonyManager
 import android.webkit.WebView
 import androidx.core.content.ContextCompat
+import androidx.webkit.WebViewCompat
 import coil3.ImageLoader
 import coil3.PlatformContext
 import coil3.SingletonImageLoader
@@ -108,11 +109,7 @@ open class HomeAssistantApplication :
             )
             initCrashSaving(applicationContext)
 
-            val webViewDebug = BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled()
-            withContext(Dispatchers.Main) {
-                // Release builds require calling this on the main thread
-                WebView.setWebContentsDebuggingEnabled(webViewDebug)
-            }
+            configureWebViewDebugging(enabled = BuildConfig.DEBUG || prefsRepository.isWebViewDebugEnabled())
 
             languagesManager.applyCurrentLang()
             nightModeManager.applyCurrentNightMode()
@@ -382,4 +379,20 @@ open class HomeAssistantApplication :
             )
         }
         .build()
+
+    /**
+     * Enables WebView contents debugging and logs the current WebView package.
+     *
+     * Runs on the main thread because [WebView.setWebContentsDebuggingEnabled] requires it in
+     * release builds.
+     */
+    private suspend fun configureWebViewDebugging(enabled: Boolean) = withContext(Dispatchers.Main) {
+        WebView.setWebContentsDebuggingEnabled(enabled)
+        if (SdkVersion.isAtLeast(Build.VERSION_CODES.O)) {
+            val webviewPackage = WebViewCompat.getCurrentWebViewPackage(this@HomeAssistantApplication)
+            Timber.d(
+                "Current webview package ${webviewPackage?.packageName} and version ${webviewPackage?.versionName}",
+            )
+        }
+    }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -784,13 +784,6 @@ class WebViewActivity :
             }
         }
 
-        if (SdkVersion.isAtLeast(Build.VERSION_CODES.O)) {
-            val webviewPackage = WebViewCompat.getCurrentWebViewPackage(this)
-            Timber.d(
-                "Current webview package ${webviewPackage?.packageName} and version ${webviewPackage?.versionName}",
-            )
-        }
-
         lifecycleScope.launch {
             if (presenter.isKeepScreenOnEnabled()) {
                 window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This move the log of the WebView package information into the `HomeAssistantApp` to log only once and also be visible when not opening the `WebViewActivity` like for the `FrontendScreen` or the `ConnectionScreen`

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.