### PR TITLE
Forbid external URI to use not exported app components

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -72,6 +72,7 @@ import io.homeassistant.companion.android.common.util.createSystemAppSettingsInt
 import io.homeassistant.companion.android.common.util.getActiveNotification
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import io.homeassistant.companion.android.common.util.parseExternalIntentUri
 import io.homeassistant.companion.android.common.util.toJsonObject
 import io.homeassistant.companion.android.common.util.tts.TextToSpeechClient
 import io.homeassistant.companion.android.common.util.tts.TextToSpeechData
@@ -1696,7 +1697,7 @@ class MessagingManager @Inject constructor(
 
             uri.startsWith(INTENT_PREFIX) -> {
                 try {
-                    Intent.parseUri(uri, Intent.URI_INTENT_SCHEME)
+                    context.parseExternalIntentUri(uri)
                 } catch (e: Exception) {
                     Timber.e(e, "Unable to parse intent URI")
                     null

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -111,6 +111,7 @@ import io.homeassistant.companion.android.common.util.getStringOrNull
 import io.homeassistant.companion.android.common.util.initializePlayer
 import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.jsonObjectOrNull
+import io.homeassistant.companion.android.common.util.parseExternalIntentUri
 import io.homeassistant.companion.android.common.util.runFragmentTransactionIfStateSafe
 import io.homeassistant.companion.android.common.util.toJsonObject
 import io.homeassistant.companion.android.common.util.toJsonObjectOrNull
@@ -636,8 +637,7 @@ class WebViewActivity :
                                 return true
                             } else if (it.startsWith(INTENT_PREFIX)) {
                                 Timber.d("Launching the intent")
-                                val intent =
-                                    Intent.parseUri(it, Intent.URI_INTENT_SCHEME)
+                                val intent = parseExternalIntentUri(it)
                                 val intentPackage = intent.`package`?.let { it1 ->
                                     packageManager.getLaunchIntentForPackage(
                                         it1,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
@@ -121,3 +121,16 @@ fun Context.openSystemAppSettings() {
         createSystemAppSettingsIntent(),
     )
 }
+
+/**
+ * Parses an `intent:` URI coming from an untrusted source (for example a link in the web
+ * frontend or a server-sent notification) into a launchable [Intent], neutralizing intent
+ * redirection in the process (see [Intent.stripSelfNonExportedTarget]).
+ *
+ * Use this instead of [Intent.parseUri] for any URI we do not fully control, so the
+ * sanitization can never be forgotten at a call site.
+ *
+ * @return the parsed and sanitized [Intent]
+ */
+fun Context.parseExternalIntentUri(uri: String): Intent =
+    Intent.parseUri(uri, Intent.URI_INTENT_SCHEME).stripSelfNonExportedTarget(this)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/IntentExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/IntentExt.kt
@@ -1,0 +1,35 @@
+package io.homeassistant.companion.android.common.util
+
+import android.content.Context
+import android.content.Intent
+
+/**
+ * Neutralizes intent redirection on an [Intent] parsed from an untrusted `intent:` URI.
+ *
+ * A crafted `intent:` URI can embed an explicit component or selector. Android already
+ * prevents an app from launching another app's non-exported components, so the only
+ * redirection risk is a URI that explicitly targets one of *our own* non-exported
+ * components to invoke it with attacker-chosen extras. When that is detected, the explicit
+ * targeting is stripped so the intent can no longer reach the internal component.
+ *
+ * Launches of other apps and of our own exported components are left untouched, so
+ * legitimate `intent:` deep links keep working.
+ *
+ * Prefer [Context.parseExternalIntentUri], which parses and sanitizes in a single call.
+ *
+ * A redirection here always signals either a tampered URI or a bug in our own code, since
+ * we never legitimately target our internal components this way. It is therefore reported
+ * through [FailFast].
+ *
+ * @return the same instance, mutated in place, for call chaining
+ */
+fun Intent.stripSelfNonExportedTarget(context: Context): Intent = apply {
+    val target = resolveActivityInfo(context.packageManager, 0)
+    if (target != null && target.packageName == context.packageName && !target.exported) {
+        FailFast.fail {
+            "Blocked intent redirection to our own non-exported component ${component?.flattenToShortString()}"
+        }
+        component = null
+        selector = null
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/IntentExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/IntentExt.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.util
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 
@@ -23,6 +24,12 @@ import android.content.Intent
  *
  * @return the same instance, mutated in place, for call chaining
  */
+/*
+ * Suppressing QueryPermissionsNeeded: this only resolves the intent to detect whether it targets one of
+ * our own components, and an app can always see itself regardless of Android 11 package visibility, so no
+ * <queries> declaration is required.
+ */
+@SuppressLint("QueryPermissionsNeeded")
 fun Intent.stripSelfNonExportedTarget(context: Context): Intent = apply {
     val target = resolveActivityInfo(context.packageManager, 0)
     if (target != null && target.packageName == context.packageName && !target.exported) {

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/IntentExtTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/IntentExtTest.kt
@@ -1,0 +1,113 @@
+package io.homeassistant.companion.android.common.util
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.ActivityInfo
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertNotNull
+import org.junit.jupiter.api.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+
+private const val OTHER_PACKAGE = "com.example.other"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class IntentExtTest {
+
+    private lateinit var context: Context
+    private lateinit var selfPackage: String
+    private var failFastThrowable: Throwable? = null
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        selfPackage = context.packageName
+        // Capture FailFast instead of crashing the (debug) test JVM when a redirection is detected.
+        FailFast.setHandler { throwable, _ -> failFastThrowable = throwable }
+    }
+
+    private fun registerActivity(packageName: String, className: String, exported: Boolean) {
+        val info = ActivityInfo().apply {
+            this.packageName = packageName
+            this.name = className
+            this.exported = exported
+        }
+        shadowOf(context.packageManager).addOrUpdateActivity(info)
+    }
+
+    @Test
+    fun `Given intent targeting our own non-exported component when stripped then explicit targeting is removed`() {
+        val className = "$selfPackage.SecretActivity"
+        registerActivity(selfPackage, className, exported = false)
+        val intent = Intent().setComponent(ComponentName(selfPackage, className))
+
+        intent.stripSelfNonExportedTarget(context)
+
+        assertNull(intent.component)
+        assertNull(intent.selector)
+        assertNotNull(failFastThrowable, "redirection should be reported through FailFast")
+    }
+
+    @Test
+    fun `Given intent targeting our own exported component when stripped then component is kept`() {
+        val className = "$selfPackage.PublicActivity"
+        registerActivity(selfPackage, className, exported = true)
+        val component = ComponentName(selfPackage, className)
+        val intent = Intent().setComponent(component)
+
+        intent.stripSelfNonExportedTarget(context)
+
+        assertEquals(component, intent.component)
+        assertNull(failFastThrowable, "no redirection so FailFast must not fire")
+    }
+
+    @Test
+    fun `Given intent targeting another app non-exported component when stripped then component is kept`() {
+        // Android already blocks launching another app's non-exported component, so we must not
+        // interfere with cross-app intents here.
+        val className = "$OTHER_PACKAGE.OtherActivity"
+        registerActivity(OTHER_PACKAGE, className, exported = false)
+        val component = ComponentName(OTHER_PACKAGE, className)
+        val intent = Intent().setComponent(component)
+
+        intent.stripSelfNonExportedTarget(context)
+
+        assertEquals(component, intent.component)
+        assertNull(failFastThrowable, "no redirection so FailFast must not fire")
+    }
+
+    @Test
+    fun `Given intent with an unresolvable component when stripped then intent is left untouched`() {
+        val component = ComponentName(selfPackage, "$selfPackage.DoesNotExist")
+        val intent = Intent().setComponent(component)
+
+        intent.stripSelfNonExportedTarget(context)
+
+        assertEquals(component, intent.component)
+        assertNull(failFastThrowable, "no redirection so FailFast must not fire")
+    }
+
+    @Test
+    fun `Given an intent URI targeting our own non-exported component when parsed then redirection is neutralized`() {
+        val className = "$selfPackage.SecretActivity"
+        registerActivity(selfPackage, className, exported = false)
+        val uri = Intent()
+            .setComponent(ComponentName(selfPackage, className))
+            .putExtra("attacker", "value")
+            .toUri(Intent.URI_INTENT_SCHEME)
+
+        val result = context.parseExternalIntentUri(uri)
+
+        assertNull(result.component)
+        assertNull(result.selector)
+        assertNotNull(failFastThrowable, "redirection should be reported through FailFast")
+    }
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/util/IntentExtTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/util/IntentExtTest.kt
@@ -70,7 +70,7 @@ class IntentExtTest {
     }
 
     @Test
-    fun `Given intent targeting another app non-exported component when stripped then component is kept`() {
+    fun `Given intent targeting another app non-exported component when stripped then intent is left untouched`() {
         // Android already blocks launching another app's non-exported component, so we must not
         // interfere with cross-app intents here.
         val className = "$OTHER_PACKAGE.OtherActivity"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We don't want to allow an external URI to use any of our non exposed components. This PR provided 2 extension to handle this.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.