### PR TITLE
Capture schema/port redirection in ConnectionScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -812,7 +812,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
      * navigations can reset the viewport meta tag). The collection then stays active
      * to react to settings changes until the next page load restarts it.
      */
-    private fun onPageFinished() {
+    private fun onPageFinished(url: String?) {
         zoomObserverJob?.cancel()
         zoomObserverJob = viewModelScope.launch {
             prefsRepository.zoomSettingsFlow().collect { settings ->

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -211,7 +211,15 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         if (navigated.host != initial.host) return
         if (navigated.scheme == initial.scheme && navigated.port == initial.port) return
 
-        val newOrigin = "${navigated.scheme}://${navigated.host}:${navigated.port}"
+        // Rebuild from the initial URL, swapping only scheme/port. HttpUrl handles IPv6 bracketing and
+        // drops the scheme's default port; the trailing slash it always appends is removed to keep the
+        // same no-trailing-slash form as the URL used to open the screen.
+        val newOrigin = initial.newBuilder()
+            .scheme(navigated.scheme)
+            .port(navigated.port)
+            .build()
+            .toString()
+            .removeSuffix("/")
         if (newOrigin != effectiveUrl.value) {
             Timber.d("Onboarding redirected to a new origin on the same host, updating stored URL")
             effectiveUrl.value = newOrigin

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -2,7 +2,6 @@ package io.homeassistant.companion.android.onboarding.connection
 
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
-import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -31,6 +30,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 
 /**
@@ -86,7 +86,23 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         fileChooserManager,
     )
 
-    private val rawUri: Uri by lazy { rawUrl.toUri() }
+    /**
+     * The origin (scheme/host/port) of the URL used to open this screen.
+     *
+     * Used both to detect redirects to a new port/scheme and to tell apart links that belong to the
+     * server (same host) from external links that should open in a browser.
+     */
+    private val rawHttpUrl: HttpUrl? = rawUrl.toHttpUrlOrNull()
+
+    /**
+     * The base URL the app should store for this server.
+     *
+     * Starts as the URL used to open the screen and is updated to a new origin when the WebView is
+     * redirected to the same host on a different scheme/port (e.g. the landing page on `:8123`
+     * handing over to the freshly installed core on `:80`). A redirect to a different host is
+     * ignored, so the initial URL is kept.
+     */
+    private val effectiveUrl = MutableStateFlow(rawUrl)
 
     private val _navigationEventsFlow = MutableSharedFlow<ConnectionNavigationEvent>(replay = 1)
     val navigationEventsFlow = _navigationEventsFlow.asSharedFlow()
@@ -112,7 +128,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     override fun runConnectivityChecks() {
         connectivityCheckJob?.cancel()
         connectivityCheckJob = viewModelScope.launch {
-            connectivityCheckRepository.runChecks(rawUrl).collect { state ->
+            connectivityCheckRepository.runChecks(effectiveUrl.value).collect { state ->
                 _connectivityCheckState.value = state
             }
         }
@@ -122,7 +138,10 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         currentUrlFlow = urlFlow,
         onFrontendError = ::onError,
         onUrlIntercepted = ::interceptRedirectIfRequired,
-        onPageFinished = { _isLoadingFlow.update { false } },
+        onPageFinished = { url ->
+            _isLoadingFlow.update { false }
+            updateEffectiveBaseUrl(url)
+        },
     )
 
     /**
@@ -177,6 +196,28 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         }
     }
 
+    /**
+     * Tracks the origin the WebView ends up on after each page load during onboarding.
+     *
+     * The WebView's `onPageFinished` reports the final URL once any redirect chain (e.g. the landing page on
+     * `:8123` handing over to the freshly installed core on `:80`) has resolved. When that origin
+     * is on the same host as the initial URL but a different scheme or port, [effectiveUrl] is
+     * updated so the correct URL is stored once authentication completes. Navigations to a different
+     * host are ignored, keeping the initial URL.
+     */
+    private fun updateEffectiveBaseUrl(url: String?) {
+        val navigated = url?.toHttpUrlOrNull() ?: return
+        val initial = rawHttpUrl ?: return
+        if (navigated.host != initial.host) return
+        if (navigated.scheme == initial.scheme && navigated.port == initial.port) return
+
+        val newOrigin = "${navigated.scheme}://${navigated.host}:${navigated.port}"
+        if (newOrigin != effectiveUrl.value) {
+            Timber.d("Onboarding redirected to a new origin on the same host, updating stored URL")
+            effectiveUrl.value = newOrigin
+        }
+    }
+
     private fun interceptRedirectIfRequired(url: Uri, isTLSClientAuthNeeded: Boolean): Boolean {
         return if (url.isOpaque) {
             false // Not intercepted: opaque is not handled by app
@@ -186,7 +227,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                 viewModelScope.launch {
                     _navigationEventsFlow.emit(
                         ConnectionNavigationEvent.Authenticated(
-                            url = rawUrl,
+                            url = effectiveUrl.value,
                             authCode = code,
                             requiredMTLS = isTLSClientAuthNeeded,
                         ),
@@ -197,7 +238,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                 Timber.w("Auth code is missing from the auth callback")
                 false // Not intercepted: Auth code missing
             }
-        } else if (url.host != rawUri.host) {
+        } else if (url.host != rawHttpUrl?.host) {
             Timber.d("$url is not from the server, opening it on external browser.")
             viewModelScope.launch {
                 _navigationEventsFlow.emit(ConnectionNavigationEvent.OpenExternalLink(url))

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -245,7 +245,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
                 false // Not intercepted: Auth code missing
             }
         } else if (url.host != rawHttpUrl?.host) {
-            Timber.d("$url is not from the server, opening it on external browser.")
+            Timber.d("$url is not from the server, opening it in an external browser")
             viewModelScope.launch {
                 _navigationEventsFlow.emit(ConnectionNavigationEvent.OpenExternalLink(url))
             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -95,14 +95,15 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
     private val rawHttpUrl: HttpUrl? = rawUrl.toHttpUrlOrNull()
 
     /**
-     * The base URL the app should store for this server.
+     * The base URL the app should store for this server, normalized to its origin
+     * (`scheme://host:port`, no path/query/fragment).
      *
-     * Starts as the URL used to open the screen and is updated to a new origin when the WebView is
-     * redirected to the same host on a different scheme/port (e.g. the landing page on `:8123`
-     * handing over to the freshly installed core on `:80`). A redirect to a different host is
-     * ignored, so the initial URL is kept.
+     * Starts as the origin of the URL used to open the screen and is updated to a new origin when
+     * the WebView is redirected to the same host on a different scheme/port (e.g. the landing page on
+     * `:8123` handing over to the freshly installed core on `:80`). A redirect to a different host is
+     * ignored, so the initial origin is kept. Falls back to the raw URL if it cannot be parsed.
      */
-    private val effectiveUrl = MutableStateFlow(rawUrl)
+    private val effectiveUrl = MutableStateFlow(rawHttpUrl?.toBaseUrl() ?: rawUrl)
 
     private val _navigationEventsFlow = MutableSharedFlow<ConnectionNavigationEvent>(replay = 1)
     val navigationEventsFlow = _navigationEventsFlow.asSharedFlow()
@@ -211,15 +212,7 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         if (navigated.host != initial.host) return
         if (navigated.scheme == initial.scheme && navigated.port == initial.port) return
 
-        // Rebuild from the initial URL, swapping only scheme/port. HttpUrl handles IPv6 bracketing and
-        // drops the scheme's default port; the trailing slash it always appends is removed to keep the
-        // same no-trailing-slash form as the URL used to open the screen.
-        val newOrigin = initial.newBuilder()
-            .scheme(navigated.scheme)
-            .port(navigated.port)
-            .build()
-            .toString()
-            .removeSuffix("/")
+        val newOrigin = navigated.toBaseUrl()
         if (newOrigin != effectiveUrl.value) {
             Timber.d("Onboarding redirected to a new origin on the same host, updating stored URL")
             effectiveUrl.value = newOrigin
@@ -278,3 +271,18 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         runConnectivityChecks()
     }
 }
+
+/**
+ * The origin (`scheme://host:port`) of this URL as a string, with path, query and fragment removed.
+ *
+ * Delegating to [HttpUrl] keeps the formatting correct: IPv6 literal hosts stay bracketed (e.g.
+ * `http://[::1]:8123`) and the scheme's default port is dropped. The trailing slash that [HttpUrl]
+ * always appends is removed so the result has the same shape as a bare base URL.
+ */
+private fun HttpUrl.toBaseUrl(): String = newBuilder()
+    .encodedPath("/")
+    .encodedQuery(null)
+    .encodedFragment(null)
+    .build()
+    .toString()
+    .removeSuffix("/")

--- a/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModel.kt
@@ -210,11 +210,16 @@ internal class ConnectionViewModel @VisibleForTesting constructor(
         val navigated = url?.toHttpUrlOrNull() ?: return
         val initial = rawHttpUrl ?: return
         if (navigated.host != initial.host) return
-        if (navigated.scheme == initial.scheme && navigated.port == initial.port) return
+        // Never downgrade a secure connection: if the screen was opened on https, ignore a redirect to
+        // http and keep the original URL rather than silently storing a plaintext origin.
+        if (initial.isHttps && !navigated.isHttps) {
+            Timber.w("Ignoring an https to http downgrade during onboarding, keeping the original URL")
+            return
+        }
 
         val newOrigin = navigated.toBaseUrl()
         if (newOrigin != effectiveUrl.value) {
-            Timber.d("Onboarding redirected to a new origin on the same host, updating stored URL")
+            Timber.d("Onboarding navigated to a new origin on the same host, updating stored URL")
             effectiveUrl.value = newOrigin
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/HAWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/HAWebViewClient.kt
@@ -36,7 +36,8 @@ class HAWebViewClientFactory @Inject constructor(@NamedKeyChain private val keyC
      * @param onUrlIntercepted Optional callback to intercept URL navigation.
      *        Receives the URI and whether TLS client auth was required.
      *        Return `true` to prevent WebView from loading the URL.
-     * @param onPageFinished Optional callback when a page finishes loading.
+     * @param onPageFinished Optional callback when a page finishes loading, with the final URL
+     *        (after any redirects have resolved).
      * @param onReceivedHttpAuthRequest Optional callback when the server requests HTTP Basic Auth.
      *        Receives the handler, host, the resource URL that triggered the request, and the realm.
      */
@@ -45,7 +46,7 @@ class HAWebViewClientFactory @Inject constructor(@NamedKeyChain private val keyC
         onFrontendError: (FrontendConnectionError) -> Unit,
         onCrash: (() -> Unit)? = null,
         onUrlIntercepted: ((uri: Uri, isTLSClientAuthNeeded: Boolean) -> Boolean)? = null,
-        onPageFinished: (() -> Unit)? = null,
+        onPageFinished: ((url: String?) -> Unit)? = null,
         onReceivedHttpAuthRequest: (
             (
                 handler: HttpAuthHandler,
@@ -79,7 +80,7 @@ class HAWebViewClient internal constructor(
     private val onFrontendError: (FrontendConnectionError) -> Unit,
     private val onCrash: (() -> Unit)?,
     private val onUrlIntercepted: ((uri: Uri, isTLSClientAuthNeeded: Boolean) -> Boolean)?,
-    private val onPageFinished: (() -> Unit)?,
+    private val onPageFinished: ((url: String?) -> Unit)?,
     private val onReceivedHttpAuthRequest: (
         (handler: HttpAuthHandler, host: String, resource: String, realm: String) -> Unit
     )?,
@@ -95,7 +96,7 @@ class HAWebViewClient internal constructor(
 
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
-        onPageFinished?.invoke()
+        onPageFinished?.invoke(url)
     }
 
     override fun onReceivedHttpAuthRequest(view: WebView?, handler: HttpAuthHandler?, host: String?, realm: String?) {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -996,7 +996,7 @@ class FrontendViewModelTest {
     inner class Zoom {
 
         private fun createViewModelWithPageFinishedCapture(): Pair<FrontendViewModel, () -> Unit> {
-            var capturedPageFinished: (() -> Unit)? = null
+            var capturedPageFinished: ((String?) -> Unit)? = null
             every {
                 webViewClientFactory.create(
                     currentUrlFlow = any(),
@@ -1013,7 +1013,7 @@ class FrontendViewModelTest {
             }
 
             val viewModel = createViewModel()
-            return viewModel to { capturedPageFinished!!.invoke() }
+            return viewModel to { capturedPageFinished!!.invoke(null) }
         }
 
         @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -205,7 +205,8 @@ class ConnectionViewModelTest {
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
 
-            // Landing page redirects the WebView to the core on a new port, same host
+            // Landing page redirects the WebView to the core on a new port, same host.
+            // Port 80 is http's default, so the normalized stored URL drops it.
             viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:80/onboarding")
 
             val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
@@ -213,7 +214,33 @@ class ConnectionViewModelTest {
             assertTrue(result)
             val event = navigationEventsFlow.awaitItem()
             assertTrue(event is ConnectionNavigationEvent.Authenticated)
-            assertEquals("http://homeassistant.local:80", (event as ConnectionNavigationEvent.Authenticated).url)
+            assertEquals("http://homeassistant.local", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given same-host IPv6 redirect to a new port when auth completes then Authenticated url keeps the host bracketed`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://[::1]:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // Same IPv6 host, new port: the produced origin must keep the brackets to stay a valid URL
+            viewModel.webViewClient.onPageFinished(null, "http://[::1]:80/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("http://[::1]", (event as ConnectionNavigationEvent.Authenticated).url)
         }
     }
 
@@ -281,16 +308,17 @@ class ConnectionViewModelTest {
         turbineScope {
             val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
 
-            // Several hops on the same host; the last one wins
+            // Several hops on the same host; the last one wins. The final port is non-default,
+            // so it is kept explicitly in the stored URL.
             viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:8123/")
-            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:8080/onboarding")
             viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:80/onboarding")
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:8080/onboarding")
 
             val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
 
             assertTrue(result)
             val event = navigationEventsFlow.awaitItem()
-            assertEquals("http://homeassistant.local:80", (event as ConnectionNavigationEvent.Authenticated).url)
+            assertEquals("http://homeassistant.local:8080", (event as ConnectionNavigationEvent.Authenticated).url)
         }
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -191,6 +191,110 @@ class ConnectionViewModelTest {
     }
 
     @Test
+    fun `Given same-host redirect to a new port when auth completes then Authenticated url uses the new origin`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // Landing page redirects the WebView to the core on a new port, same host
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:80/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertTrue(event is ConnectionNavigationEvent.Authenticated)
+            assertEquals("http://homeassistant.local:80", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given redirect to a different host when auth completes then Authenticated url stays the initial url`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // A redirect to a different host must NOT change the stored URL
+            viewModel.webViewClient.onPageFinished(null, "http://other.local:80/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("http://homeassistant.local:8123", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given no redirect when auth completes then Authenticated url stays the initial url`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("http://homeassistant.local:8123", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given multiple same-host redirects when auth completes then Authenticated url uses the last origin`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // Several hops on the same host; the last one wins
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:8123/")
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:8080/onboarding")
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:80/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("http://homeassistant.local:80", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
     fun `Given auth callback uri without code when shouldRedirect then no event and returns false`() = runTest {
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = null)
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -250,7 +250,7 @@ class ConnectionViewModelTest {
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
 
         val viewModel = ConnectionViewModel(
-            "http://homeassistant.local:8123",
+            "http://homeassistant.local:8123/lovelace?foo=bar#baz",
             webViewClientFactory,
             connectivityCheckRepository,
             fileChooserManager,
@@ -289,6 +289,30 @@ class ConnectionViewModelTest {
 
             assertTrue(result)
             val event = navigationEventsFlow.awaitItem()
+            assertEquals("http://homeassistant.local:8123", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given an initial url with a path and query when auth completes then Authenticated url is the bare origin`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123/lovelace?foo=bar#baz",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            // The stored server URL is the bare origin, not the onboarding path/query
             assertEquals("http://homeassistant.local:8123", (event as ConnectionNavigationEvent.Authenticated).url)
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/onboarding/connection/ConnectionViewModelTest.kt
@@ -245,6 +245,58 @@ class ConnectionViewModelTest {
     }
 
     @Test
+    fun `Given a same-host redirect that downgrades https to http when auth completes then Authenticated url keeps the original https url`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "https://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // A redirect that downgrades https -> http on the same host must be ignored
+            viewModel.webViewClient.onPageFinished(null, "http://homeassistant.local:80/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("https://homeassistant.local:8123", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
+    fun `Given a same-host redirect that upgrades http to https when auth completes then Authenticated url uses the https origin`() = runTest {
+        val authCode = "test_auth_code"
+        val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
+
+        val viewModel = ConnectionViewModel(
+            "http://homeassistant.local:8123",
+            webViewClientFactory,
+            connectivityCheckRepository,
+            fileChooserManager,
+        )
+
+        turbineScope {
+            val navigationEventsFlow = viewModel.navigationEventsFlow.testIn(backgroundScope)
+
+            // An upgrade http -> https on the same host is allowed and adopted
+            viewModel.webViewClient.onPageFinished(null, "https://homeassistant.local/onboarding")
+
+            val result = viewModel.webViewClient.shouldOverrideUrlLoading(null, stringUri)
+
+            assertTrue(result)
+            val event = navigationEventsFlow.awaitItem()
+            assertEquals("https://homeassistant.local", (event as ConnectionNavigationEvent.Authenticated).url)
+        }
+    }
+
+    @Test
     fun `Given redirect to a different host when auth completes then Authenticated url stays the initial url`() = runTest {
         val authCode = "test_auth_code"
         val stringUri = mockAuthCodeUri(scheme = "homeassistant", host = "auth-callback", authCode = authCode)
@@ -598,7 +650,7 @@ class ConnectionViewModelTest {
         assertTrue(handled)
         val pending = viewModel.pendingFileChooser.value
         assertNotNull(pending)
-        assertTrue(pending!!.fileChooserParams === fileChooserParams)
+        assertTrue(pending.fileChooserParams === fileChooserParams)
     }
 
     @Test
@@ -622,7 +674,7 @@ class ConnectionViewModelTest {
         val pending = viewModel.pendingFileChooser.value
         assertNotNull(pending)
         val uris = arrayOf(mockk<Uri>())
-        pending!!.onResult(uris)
+        pending.onResult(uris)
         advanceUntilIdle()
 
         verify { filePathCallback.onReceiveValue(uris) }
@@ -649,7 +701,7 @@ class ConnectionViewModelTest {
 
         val pending = viewModel.pendingFileChooser.value
         assertNotNull(pending)
-        pending!!.onResult(null)
+        pending.onResult(null)
         advanceUntilIdle()
 
         verify { filePathCallback.onReceiveValue(null) }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
@@ -53,6 +53,24 @@ class HAWebViewClientTest {
     }
 
     @Test
+    fun `Given onPageFinished callback when onPageFinished then invokes callback with final url`() {
+        var finishedUrl: String? = null
+        val client = HAWebViewClient(
+            keyChainRepository = keyChainRepository,
+            currentUrlFlow = currentUrlFlow,
+            onFrontendError = { capturedError = it },
+            onCrash = null,
+            onUrlIntercepted = null,
+            onPageFinished = { finishedUrl = it },
+            onReceivedHttpAuthRequest = null,
+        )
+
+        client.onPageFinished(null, "http://homeassistant.local:80/onboarding")
+
+        assertEquals("http://homeassistant.local:80/onboarding", finishedUrl)
+    }
+
+    @Test
     fun `Given SSL_DATE_INVALID error when onReceivedSslError then emits AuthenticationError`() {
         testSslError(SslError.SSL_DATE_INVALID, commonR.string.webview_error_SSL_DATE_INVALID)
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We are in the discussion of having the default port changed from 8123 to 80 for core, but this comes with some issues with the [landing page ](https://github.com/home-assistant/landingpage/) that is going to expose mDNS external URL with port 8123. We decided that core is going to handle the redirection from 8123 to 80 but on the mobile app we will need to detect this redirection so that we store the right port, since core is going then to remove this redirection. To do so the `ConnectionViewModel` is keeping track of the URL returned by the WebView and detect any changes of schema/port and persist this change before navigating away from the screen.

This is not yet implemented in core but we need to be ready and this deploy ASAP so that when it is release the app is already ready for this behavior. Otherwise user might experience a full onboarding and end up into an unreachable dashboard and they would need to onboard again or manually change the port in the external URL setting.

Closes #6991 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## To test
I simply spawn a nginx docker that do a redirection to my instance like this 

```
http {
    server {
        listen 8111;

        # Dumb landing-page simulation: redirect everything to the real Home Assistant
        # on its real port. $request_uri keeps the path + query string, so the auth flow
        # (/auth/authorize?...) continues seamlessly on the new port.
        #
        # 302 (temporary) on purpose: it is a server-side redirect (the case the app must
        # detect via onPageFinished) and it is not cached by the WebView.
        location / {
            return 302 http://server_ip:8123/$request_uri;
        }
    }
}
```

The external IP should have the port 8123 while you've entered the port 8111 manually.