### PR TITLE
Intercept URI in FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.frontend
 
+import android.net.Uri
 import android.view.View
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
@@ -43,6 +44,7 @@ import io.homeassistant.companion.android.frontend.url.UrlLoadResult
 import io.homeassistant.companion.android.util.HAWebChromeClient
 import io.homeassistant.companion.android.util.HAWebViewClient
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
+import io.homeassistant.companion.android.util.hasSameOrigin
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
@@ -70,6 +72,9 @@ import timber.log.Timber
 /** Maximum time to wait for the frontend to load before showing a timeout error. */
 @VisibleForTesting
 val CONNECTION_TIMEOUT = 10.seconds
+
+private const val APP_PREFIX = "app://"
+private const val INTENT_PREFIX = "intent:"
 
 /**
  * ViewModel for frontend screen.
@@ -217,6 +222,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         onFrontendError = ::onError,
         onCrash = ::onRetry,
         onPageFinished = ::onPageFinished,
+        onUrlIntercepted = { uri, _ -> onUrlIntercepted(uri) },
         onReceivedHttpAuthRequest = { handler, host, resource, realm ->
             viewModelScope.launch {
                 if (httpAuthHandler.handleAuthRequest(handler, host = host, resource = resource, realm = realm) ==
@@ -820,6 +826,37 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
             is DownloadResult.Error -> {
                 _events.emit(FrontendEvent.ShowSnackbar(result.messageResId))
+            }
+        }
+    }
+
+    /**
+     * Handles a URL the WebView is about to load.
+     *
+     * Custom schemes (`app://`, `intent:`) and URLs that do not match the current server origin are
+     * routed to the host through [FrontendEvent]s, while same-origin URLs are left for the WebView.
+     * The origin comparison uses scheme, host and port (see [hasSameOrigin]).
+     *
+     * @return `true` when the URL was intercepted (the host will handle it), `false` to let the WebView load it.
+     */
+    private fun onUrlIntercepted(uri: Uri): Boolean {
+        val rawUrl = uri.toString()
+        return when {
+            rawUrl.startsWith(APP_PREFIX) -> {
+                _events.tryEmit(FrontendEvent.LaunchApp(rawUrl.substringAfter(APP_PREFIX)))
+                true
+            }
+
+            rawUrl.startsWith(INTENT_PREFIX) -> {
+                _events.tryEmit(FrontendEvent.LaunchIntent(rawUrl))
+                true
+            }
+
+            uri.hasSameOrigin(urlFlow.value) -> false
+
+            else -> {
+                _events.tryEmit(FrontendEvent.OpenExternalLink(uri))
+                true
             }
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEvent.kt
@@ -34,6 +34,22 @@ sealed interface FrontendEvent {
     /** Open a URI externally using the host-provided external link handler. */
     data class OpenExternalLink(val uri: Uri) : FrontendEvent
 
+    /**
+     * Launch an installed app by its [packageName].
+     *
+     * The host is responsible for opening the app store when no app with this package is installed.
+     */
+    data class LaunchApp(val packageName: String) : FrontendEvent
+
+    /**
+     * Parse and launch an Android `intent:` URI.
+     *
+     * The host is responsible for opening the app store when the intent targets a package that is not installed.
+     *
+     * @param intentUri The raw `intent:` URI as provided by the frontend.
+     */
+    data class LaunchIntent(val intentUri: String) : FrontendEvent
+
     /** Navigate to the developer tools settings screen */
     data object NavigateToDeveloperSettings : FrontendEvent
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
@@ -18,6 +18,8 @@ import io.homeassistant.companion.android.assist.AssistActivity
 import io.homeassistant.companion.android.common.data.servers.ServerManager.Companion.SERVER_ID_ACTIVE
 import io.homeassistant.companion.android.frontend.FrontendScreen
 import io.homeassistant.companion.android.frontend.FrontendViewModel
+import io.homeassistant.companion.android.frontend.url.launchAppOrStore
+import io.homeassistant.companion.android.frontend.url.launchIntentUri
 import io.homeassistant.companion.android.launch.HAStartDestinationRoute
 import io.homeassistant.companion.android.launch.PipReadiness
 import io.homeassistant.companion.android.nfc.WriteNfcTag
@@ -107,6 +109,8 @@ internal fun NavGraphBuilder.frontendScreen(
                     val context = navController.context
                     context.startActivity(widgetType.toConfigureIntent(context, entityId))
                 },
+                onLaunchApp = { packageName -> navController.context.launchAppOrStore(packageName) },
+                onLaunchIntent = { intentUri -> navController.context.launchIntentUri(intentUri) },
             )
 
             FrontendScreen(
@@ -152,6 +156,8 @@ internal fun FrontendEventHandler(
     onNavigateToNfcWrite: (messageId: Int, tagId: String?) -> Unit,
     onRequestFullscreen: (Boolean) -> Unit,
     onNavigateToWidgetConfig: (entityId: String, widgetType: WidgetType) -> Unit,
+    onLaunchApp: (packageName: String) -> Unit = {},
+    onLaunchIntent: (intentUri: String) -> Unit = {},
 ) {
     val resources = LocalResources.current
     LaunchedEffect(Unit) {
@@ -175,6 +181,14 @@ internal fun FrontendEventHandler(
 
                 is FrontendEvent.OpenExternalLink -> {
                     onOpenExternalLink(event.uri)
+                }
+
+                is FrontendEvent.LaunchApp -> {
+                    onLaunchApp(event.packageName)
+                }
+
+                is FrontendEvent.LaunchIntent -> {
+                    onLaunchIntent(event.intentUri)
                 }
 
                 is FrontendEvent.NavigateToDeveloperSettings -> {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 import io.homeassistant.companion.android.common.util.parseExternalIntentUri
+import java.net.URISyntaxException
 import timber.log.Timber
 
 private const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
@@ -37,7 +38,7 @@ fun Context.launchAppOrStore(packageName: String) {
 fun Context.launchIntentUri(intentUri: String) {
     val intent = try {
         parseExternalIntentUri(intentUri)
-    } catch (e: java.net.URISyntaxException) {
+    } catch (e: URISyntaxException) {
         Timber.e(e, "Unable to parse intent URI")
         return
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
@@ -1,0 +1,61 @@
+package io.homeassistant.companion.android.frontend.url
+
+import android.content.ActivityNotFoundException
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import io.homeassistant.companion.android.common.util.parseExternalIntentUri
+import timber.log.Timber
+
+private const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
+
+/**
+ * Launches the installed app identified by [packageName].
+ *
+ * When no app with the given package is installed, the Play Store listing for that package is opened instead.
+ * Failures to start any activity (e.g. no app able to handle the store URL) are logged and swallowed so a
+ * malformed link from the frontend cannot crash the app.
+ */
+fun Context.launchAppOrStore(packageName: String) {
+    val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+    val intent = if (launchIntent != null) {
+        launchIntent.apply { flags = Intent.FLAG_ACTIVITY_NEW_TASK }
+    } else {
+        Timber.w("No launch intent for package, opening app store")
+        Intent(Intent.ACTION_VIEW, (MARKET_PREFIX + packageName).toUri())
+    }
+    startActivityCatching(intent)
+}
+
+/**
+ * Parses [intentUri] as an Android `intent:` URI and launches it.
+ *
+ * When the parsed intent targets a package that is not installed, the Play Store listing for that package is
+ * opened instead. Parsing and launch failures are logged and swallowed so a malformed link from the frontend
+ * cannot crash the app.
+ */
+fun Context.launchIntentUri(intentUri: String) {
+    val intent = try {
+        parseExternalIntentUri(intentUri)
+    } catch (e: java.net.URISyntaxException) {
+        Timber.e(e, "Unable to parse intent URI")
+        return
+    }
+
+    val targetPackage = intent.`package`
+    val isPackageInstalled = targetPackage?.let { packageManager.getLaunchIntentForPackage(it) } != null
+    if (!isPackageInstalled && !targetPackage.isNullOrEmpty()) {
+        Timber.w("No app found for intent, opening app store")
+        startActivityCatching(Intent(Intent.ACTION_VIEW, (MARKET_PREFIX + targetPackage).toUri()))
+    } else {
+        startActivityCatching(intent)
+    }
+}
+
+private fun Context.startActivityCatching(intent: Intent) {
+    try {
+        startActivity(intent)
+    } catch (e: ActivityNotFoundException) {
+        Timber.e(e, "No activity found to handle intent")
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendExternalAppLauncher.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.frontend.url
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.util.AndroidRuntimeException
 import androidx.core.net.toUri
 import io.homeassistant.companion.android.common.util.parseExternalIntentUri
 import java.net.URISyntaxException
@@ -58,5 +59,11 @@ private fun Context.startActivityCatching(intent: Intent) {
         startActivity(intent)
     } catch (e: ActivityNotFoundException) {
         Timber.e(e, "No activity found to handle intent")
+    } catch (e: SecurityException) {
+        // The resolved activity requires a permission we were not granted to launch it.
+        Timber.e(e, "Not allowed to launch intent")
+    } catch (e: AndroidRuntimeException) {
+        // e.g. launching without FLAG_ACTIVITY_NEW_TASK from a non-Activity context.
+        Timber.e(e, "Unable to launch intent")
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -47,13 +47,16 @@ import io.homeassistant.companion.android.frontend.url.UrlLoadResult
 import io.homeassistant.companion.android.testing.unit.FakeClock
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
 import io.homeassistant.companion.android.util.HAWebViewClientFactory
+import io.homeassistant.companion.android.util.hasSameOrigin
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.runs
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -163,6 +166,109 @@ class FrontendViewModelTest {
             improvHandler = improvHandler,
             barcodeScannerHandler = FrontendBarcodeScannerHandler(externalBusRepository, dialogManager),
         )
+    }
+
+    @Nested
+    inner class UrlInterception {
+
+        /**
+         * Captures the `onUrlIntercepted` callback the ViewModel wires into the WebView client and returns a
+         * lambda that drives it (the `false` TLS-client-auth flag is irrelevant to scheme handling).
+         *
+         * The external/same-origin branch relies on [hasSameOrigin], which parses URLs via real
+         * `android.net.Uri` (unavailable on the plain JVM these tests run on); tests covering that branch
+         * mock [hasSameOrigin] directly. The origin parsing itself is covered by `UrlUtilTest`.
+         */
+        private fun createViewModelWithUrlInterceptCapture(): Pair<FrontendViewModel, (Uri) -> Boolean> {
+            var capturedCallback: ((Uri, Boolean) -> Boolean)? = null
+            every {
+                webViewClientFactory.create(
+                    currentUrlFlow = any(),
+                    onFrontendError = any(),
+                    onCrash = any(),
+                    onUrlIntercepted = any(),
+                    onPageFinished = any(),
+                    onReceivedHttpAuthRequest = any(),
+                )
+            } answers {
+                // onUrlIntercepted is the 4th of the 6 named arguments (zero-based index 3)
+                capturedCallback = arg(3)
+                mockk(relaxed = true)
+            }
+
+            val viewModel = createViewModel()
+            return viewModel to { uri -> capturedCallback!!.invoke(uri, false) }
+        }
+
+        private fun uri(value: String): Uri = mockk {
+            every { this@mockk.toString() } returns value
+        }
+
+        @Test
+        fun `Given app scheme url when intercepted then emits LaunchApp event and intercepts`() = runTest {
+            val (viewModel, intercept) = createViewModelWithUrlInterceptCapture()
+
+            viewModel.events.test {
+                val handled = intercept(uri("app://com.example.app"))
+
+                assertTrue(handled)
+                assertEquals(FrontendEvent.LaunchApp("com.example.app"), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given intent scheme url when intercepted then emits LaunchIntent event and intercepts`() = runTest {
+            val intentUri = "intent://scan/#Intent;scheme=zxing;package=com.google.zxing;end"
+            val (viewModel, intercept) = createViewModelWithUrlInterceptCapture()
+
+            viewModel.events.test {
+                val handled = intercept(uri(intentUri))
+
+                assertTrue(handled)
+                assertEquals(FrontendEvent.LaunchIntent(intentUri), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given external url not matching server origin when intercepted then emits OpenExternalLink and intercepts`() = runTest {
+            mockkStatic("io.homeassistant.companion.android.util.UrlUtilKt")
+            try {
+                every { any<Uri>().hasSameOrigin(any<String>()) } returns false
+                val externalUri = uri("https://external.example.org/page")
+                val (viewModel, intercept) = createViewModelWithUrlInterceptCapture()
+
+                viewModel.events.test {
+                    val handled = intercept(externalUri)
+
+                    assertTrue(handled)
+                    assertEquals(FrontendEvent.OpenExternalLink(externalUri), awaitItem())
+                    cancelAndIgnoreRemainingEvents()
+                }
+            } finally {
+                unmockkStatic("io.homeassistant.companion.android.util.UrlUtilKt")
+            }
+        }
+
+        @Test
+        fun `Given url matching server origin when intercepted then emits no event and lets WebView load`() = runTest {
+            mockkStatic("io.homeassistant.companion.android.util.UrlUtilKt")
+            try {
+                every { any<Uri>().hasSameOrigin(any<String>()) } returns true
+                val (viewModel, intercept) = createViewModelWithUrlInterceptCapture()
+
+                viewModel.events.test {
+                    val handled = intercept(uri("https://example.com/lovelace/0"))
+
+                    assertFalse(handled)
+                    expectNoEvents()
+                    cancelAndIgnoreRemainingEvents()
+                }
+            } finally {
+                unmockkStatic("io.homeassistant.companion.android.util.UrlUtilKt")
+            }
+        }
     }
 
     @Nested

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendEventHandlerTest.kt
@@ -189,6 +189,60 @@ class FrontendEventHandlerTest {
     }
 
     @Test
+    fun `Given LaunchApp event then onLaunchApp is called with the package name`() {
+        var capturedPackageName: String? = null
+        val events = TestSharedFlow<FrontendEvent>()
+
+        composeTestRule.setContent {
+            FrontendEventHandler(
+                events = events,
+                onShowSnackbar = { _, _ -> false },
+                onNavigateToSettings = {},
+                onNavigateToAssist = { _, _, _ -> },
+                onOpenExternalLink = {},
+                onShowServerSwitcher = {},
+                onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
+                onNavigateToWidgetConfig = { _, _ -> },
+                onLaunchApp = { packageName -> capturedPackageName = packageName },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        events.emit(FrontendEvent.LaunchApp(packageName = "com.example.app"))
+        composeTestRule.waitForIdle()
+
+        assertEquals("com.example.app", capturedPackageName)
+    }
+
+    @Test
+    fun `Given LaunchIntent event then onLaunchIntent is called with the intent uri`() {
+        var capturedIntentUri: String? = null
+        val events = TestSharedFlow<FrontendEvent>()
+
+        composeTestRule.setContent {
+            FrontendEventHandler(
+                events = events,
+                onShowSnackbar = { _, _ -> false },
+                onNavigateToSettings = {},
+                onNavigateToAssist = { _, _, _ -> },
+                onOpenExternalLink = {},
+                onShowServerSwitcher = {},
+                onNavigateToNfcWrite = { _, _ -> },
+                onRequestFullscreen = {},
+                onNavigateToWidgetConfig = { _, _ -> },
+                onLaunchIntent = { intentUri -> capturedIntentUri = intentUri },
+            )
+        }
+
+        composeTestRule.waitForIdle()
+        events.emit(FrontendEvent.LaunchIntent(intentUri = "intent://scan#Intent;end"))
+        composeTestRule.waitForIdle()
+
+        assertEquals("intent://scan#Intent;end", capturedIntentUri)
+    }
+
+    @Test
     fun `Given ShowServerSwitcher event then onShowServerSwitcher is called`() {
         var serverSwitcherShown = false
         val events = TestSharedFlow<FrontendEvent>()

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
@@ -131,6 +131,9 @@ fun Context.openSystemAppSettings() {
  * sanitization can never be forgotten at a call site.
  *
  * @return the parsed and sanitized [Intent]
+ * @throws java.net.URISyntaxException if the basic URI syntax
+ * it bad (as parsed by the Uri class) or the Intent data within the
+ * URI is invalid.
  */
 fun Context.parseExternalIntentUri(uri: String): Intent =
     Intent.parseUri(uri, Intent.URI_INTENT_SCHEME).stripSelfNonExportedTarget(this)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/ContextExt.kt
@@ -132,7 +132,7 @@ fun Context.openSystemAppSettings() {
  *
  * @return the parsed and sanitized [Intent]
  * @throws java.net.URISyntaxException if the basic URI syntax
- * it bad (as parsed by the Uri class) or the Intent data within the
+ * is bad (as parsed by the Uri class) or the Intent data within the
  * URI is invalid.
  */
 fun Context.parseExternalIntentUri(uri: String): Intent =

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.util
 
 import android.net.Uri
+import androidx.core.net.toUri
 import io.homeassistant.companion.android.common.BuildConfig
 import io.homeassistant.companion.android.common.data.MalformedHttpUrlException
 import io.homeassistant.companion.android.common.data.authentication.impl.AuthenticationService
@@ -216,6 +217,18 @@ fun Uri.hasSameOrigin(other: Uri?): Boolean {
         host.equals(other.host, ignoreCase = true) &&
         effectivePort == other.effectivePort
 }
+
+/**
+ * Checks if this Uri has the same origin (scheme, host, and port) as the [other] URL string.
+ * Default ports (443 for HTTPS, 80 for HTTP) are normalized for comparison.
+ *
+ * Convenience overload for callers that hold the other side as a raw URL string; the string is parsed
+ * into a [Uri] before comparison.
+ *
+ * @param other the URL string to compare against; a `null` or unparsable value never matches
+ * @return `true` if both origins share the same scheme, host, and port
+ */
+fun Uri.hasSameOrigin(other: String?): Boolean = hasSameOrigin(other?.toUri())
 
 private val Uri.effectivePort: Int
     get() = when {

--- a/common/src/test/kotlin/io/homeassistant/companion/android/util/UriExtensionsTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/util/UriExtensionsTest.kt
@@ -42,7 +42,21 @@ class UriExtensionsTest {
     @Test
     fun `hasSameOrigin returns false when other is null`() {
         val uri = Uri.parse("https://example.com")
-        assertFalse(uri.hasSameOrigin(null))
+        assertFalse(uri.hasSameOrigin(null as Uri?))
+    }
+
+    @Test
+    fun `hasSameOrigin with string overload returns expected value`() {
+        val uri = Uri.parse("https://example.com:8123")
+        assertEquals(true, uri.hasSameOrigin("https://example.com:8123/lovelace/0"))
+        assertEquals(false, uri.hasSameOrigin("https://other.com"))
+        assertEquals(false, uri.hasSameOrigin("http://example.com:8123"))
+    }
+
+    @Test
+    fun `hasSameOrigin with string overload returns false when other is null`() {
+        val uri = Uri.parse("https://example.com")
+        assertFalse(uri.hasSameOrigin(null as String?))
     }
 
     @Test


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Add URL interception logic to the FrontendScreen to properly handle `app://` and `intent://` from the WebView. 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
The PR is based on #6994 