### PR TITLE
Improve back behavior of FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -103,7 +103,6 @@ internal const val CUSTOM_VIEW_OVERLAY_TAG = "custom_view_overlay"
  * The WebView is always rendered at the base layer to prevent it to not load the URL.
  * Loading indicators, error screens, and blocking screens are overlaid on top.
  *
- * @param onBackClick Callback when user navigates back
  * @param viewModel The ViewModel providing state and handling actions
  * @param onOpenExternalLink Callback to open external links
  * @param onBlockInsecureHelpClick Callback when user taps help on the insecure screen
@@ -116,7 +115,6 @@ internal const val CUSTOM_VIEW_OVERLAY_TAG = "custom_view_overlay"
  */
 @Composable
 internal fun FrontendScreen(
-    onBackClick: () -> Unit,
     viewModel: FrontendViewModel,
     onOpenExternalLink: suspend (Uri) -> Unit,
     onBlockInsecureHelpClick: suspend () -> Unit,
@@ -158,7 +156,6 @@ internal fun FrontendScreen(
         }
 
     FrontendScreenContent(
-        onBackClick = onBackClick,
         viewState = viewState,
         errorStateProvider = viewModel as FrontendConnectionErrorStateProvider,
         webViewClient = viewModel.webViewClient,
@@ -201,7 +198,6 @@ internal fun FrontendScreen(
 
 @Composable
 internal fun FrontendScreenContent(
-    onBackClick: () -> Unit,
     viewState: FrontendViewState,
     webViewClient: WebViewClient,
     webChromeClient: WebChromeClient,
@@ -242,6 +238,9 @@ internal fun FrontendScreenContent(
 ) {
     var webView by remember { mutableStateOf<WebView?>(null) }
 
+    // Consume back only while the dashboard (Content) is shown and the WebView has history to pop.
+    BackHandler(enabled = (viewState as? FrontendViewState.Content)?.canGoBack == true) { webView?.goBack() }
+
     FrontendScreenEffects(
         webView = webView,
         url = viewState.url,
@@ -260,7 +259,6 @@ internal fun FrontendScreenContent(
     Box(modifier = modifier.fillMaxSize()) {
         // Always render WebView at base layer
         SafeHAWebView(
-            onBackClick = onBackClick,
             onWebViewCreated = { webView = it },
             webViewClient = webViewClient,
             webChromeClient = webChromeClient,
@@ -510,7 +508,6 @@ private fun ErrorOverlay(
  */
 @Composable
 private fun SafeHAWebView(
-    onBackClick: () -> Unit,
     onWebViewCreated: (WebView) -> Unit,
     webViewClient: WebViewClient,
     contentState: FrontendViewState.Content?,
@@ -563,7 +560,6 @@ private fun SafeHAWebView(
                         autoPlayVideoEnabled = autoPlayVideoEnabled,
                     )
                 },
-                onBackPressed = onBackClick,
                 onWebViewCreationFailed = onWebViewCreationFailed,
             )
 
@@ -763,6 +759,11 @@ private fun BoxScope.PipEligibleOverlays(
     CustomViewOverlay(customView = customView)
 }
 
+/**
+ * Renders the WebView's HTML5 fullscreen view (e.g. a fullscreen `<video>`) over the WebView.
+ *
+ * Back handling is intentionally not added here: the WebView owns its fullscreen lifecycle.
+ */
 @Composable
 private fun CustomViewOverlay(customView: View?) {
     val view: View = customView ?: return
@@ -774,6 +775,14 @@ private fun CustomViewOverlay(customView: View?) {
     )
 }
 
+/**
+ * Renders the native ExoPlayer surface over the WebView.
+ *
+ * Back handling is intentionally not added here: the Home Assistant frontend reacts to the back event
+ * itself and closes the player by emitting an external-bus event that collapses
+ * [FrontendViewState.Content.exoPlayerState] (and clears this overlay). An app-side back handler would
+ * pre-empt the frontend and break that flow, so back is left to propagate to the frontend.
+ */
 @Composable
 private fun ExoPlayerOverlay(contentState: FrontendViewState.Content?, onFullscreenChanged: (Boolean) -> Unit) {
     val exoState = contentState?.exoPlayerState ?: return
@@ -824,7 +833,6 @@ private fun FrontendBarcodeOverlay(
 private fun FrontendScreenLoadingPreview() {
     HAThemeForPreview {
         FrontendScreenContent(
-            onBackClick = {},
             viewState = FrontendViewState.Loading(
                 serverId = 1,
                 url = "https://example.com",
@@ -851,7 +859,6 @@ private fun FrontendScreenLoadingPreview() {
 private fun FrontendScreenErrorPreview() {
     HAThemeForPreview {
         FrontendScreenContent(
-            onBackClick = {},
             viewState = FrontendViewState.Error(
                 serverId = 1,
                 url = "https://example.com",
@@ -883,7 +890,6 @@ private fun FrontendScreenErrorPreview() {
 private fun FrontendScreenInsecurePreview() {
     HAThemeForPreview {
         FrontendScreenContent(
-            onBackClick = {},
             viewState = FrontendViewState.Insecure(
                 serverId = 1,
                 missingHomeSetup = true,
@@ -911,7 +917,6 @@ private fun FrontendScreenInsecurePreview() {
 private fun FrontendScreenSecurityLevelRequiredPreview() {
     HAThemeForPreview {
         FrontendScreenContent(
-            onBackClick = {},
             viewState = FrontendViewState.SecurityLevelRequired(
                 serverId = 1,
             ),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -226,6 +226,13 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                 }
             }
         },
+        onCanGoBackChanged = { canGoBack ->
+            // Only meaningful while the dashboard is shown; in any other state the WebView is hidden
+            // behind an overlay, so the flag is dropped with the state.
+            _viewState.update { state ->
+                if (state is FrontendViewState.Content) state.copy(canGoBack = canGoBack) else state
+            }
+        },
     )
 
     /** The current pending file chooser request from the WebView, or null if none. */
@@ -619,6 +626,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private suspend fun handleMessageResult(result: FrontendHandlerEvent) {
         when (result) {
             is FrontendHandlerEvent.Connected -> {
+                val wasLoading = _viewState.value is FrontendViewState.Loading
                 _viewState.update { currentState ->
                     if (currentState is FrontendViewState.Loading) {
                         FrontendViewState.Content(
@@ -628,6 +636,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                     } else {
                         currentState
                     }
+                }
+                if (wasLoading) {
+                    // Remove any previous navigation
+                    _webViewActions.emit(WebViewAction.ClearHistory())
                 }
                 permissionManager.checkNotificationPermission(_viewState.value.serverId)
             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
@@ -57,6 +57,7 @@ sealed interface FrontendViewState {
         val nightModeTheme: NightModeTheme? = null,
         val statusBarColor: Color? = null,
         val backgroundColor: Color? = null,
+        val canGoBack: Boolean = false,
         val exoPlayerState: ExoPlayerUiState? = null,
         val improvUiState: ImprovUIState? = null,
         val barcodeScanner: BarcodeScannerUiState? = null,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
@@ -110,7 +110,6 @@ internal fun NavGraphBuilder.frontendScreen(
             )
 
             FrontendScreen(
-                onBackClick = navController::popBackStack,
                 viewModel = viewModel,
                 onOpenExternalLink = onOpenExternalLink,
                 onBlockInsecureHelpClick = onSecurityLevelHelpClick,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/HAWebViewClient.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/HAWebViewClient.kt
@@ -39,6 +39,8 @@ class HAWebViewClientFactory @Inject constructor(@NamedKeyChain private val keyC
      * @param onPageFinished Optional callback when a page finishes loading.
      * @param onReceivedHttpAuthRequest Optional callback when the server requests HTTP Basic Auth.
      *        Receives the handler, host, the resource URL that triggered the request, and the realm.
+     * @param onCanGoBackChanged Optional callback invoked when the WebView back/forward list changes,
+     *        reporting whether the WebView can currently navigate back.
      */
     fun create(
         currentUrlFlow: StateFlow<String?>,
@@ -54,6 +56,7 @@ class HAWebViewClientFactory @Inject constructor(@NamedKeyChain private val keyC
                 realm: String,
             ) -> Unit
         )? = null,
+        onCanGoBackChanged: ((canGoBack: Boolean) -> Unit)? = null,
     ): HAWebViewClient {
         return HAWebViewClient(
             keyChainRepository = keyChainRepository,
@@ -63,6 +66,7 @@ class HAWebViewClientFactory @Inject constructor(@NamedKeyChain private val keyC
             onUrlIntercepted = onUrlIntercepted,
             onPageFinished = onPageFinished,
             onReceivedHttpAuthRequest = onReceivedHttpAuthRequest,
+            onCanGoBackChanged = onCanGoBackChanged,
         )
     }
 }
@@ -83,6 +87,7 @@ class HAWebViewClient internal constructor(
     private val onReceivedHttpAuthRequest: (
         (handler: HttpAuthHandler, host: String, resource: String, realm: String) -> Unit
     )?,
+    private val onCanGoBackChanged: ((canGoBack: Boolean) -> Unit)? = null,
 ) : TLSWebViewClient(keyChainRepository) {
 
     /** Last resource URL loaded by the WebView, used to identify the resource requesting auth. */
@@ -96,6 +101,11 @@ class HAWebViewClient internal constructor(
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         onPageFinished?.invoke()
+    }
+
+    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+        super.doUpdateVisitedHistory(view, url, isReload)
+        view?.let { onCanGoBackChanged?.invoke(it.canGoBack()) }
     }
 
     override fun onReceivedHttpAuthRequest(view: WebView?, handler: HttpAuthHandler?, host: String?, realm: String?) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HANavHost.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HANavHost.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import androidx.navigation.navOptions
 import io.homeassistant.companion.android.automotive.navigation.carAppActivity
 import io.homeassistant.companion.android.automotive.navigation.navigateToCarAppActivity
 import io.homeassistant.companion.android.common.util.DisabledLocationHandler
@@ -67,10 +68,13 @@ internal fun HANavHost(
                 navController,
                 onShowSnackbar = onShowSnackbar,
                 onOnboardingDone = {
+                    val navOptions = navOptions {
+                        popUpTo<OnboardingRoute> { inclusive = true }
+                    }
                     if (isAutomotive) {
-                        navController.navigateToCarAppActivity()
+                        navController.navigateToCarAppActivity(navOptions)
                     } else {
-                        navController.navigateToFrontend()
+                        navController.navigateToFrontend(navOptions = navOptions)
                     }
                 },
                 urlToOnboard = (startDestination as? OnboardingRoute)?.urlToOnboard,

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenImprovScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenImprovScreenshotTest.kt
@@ -193,7 +193,6 @@ class FrontendScreenImprovScreenshotTest {
         pendingPermissionRequest: PermissionRequest? = null,
     ) {
         FrontendScreenContent(
-            onBackClick = {},
             viewState = FrontendViewState.Content(
                 serverId = 1,
                 url = "https://example.com",

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenScreenshotTest.kt
@@ -25,7 +25,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen LoadServer state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.LoadServer(serverId = 1),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -50,7 +49,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Loading state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Loading(
                     serverId = 1,
                     url = "https://example.com",
@@ -78,7 +76,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen SecurityLevelRequired state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.SecurityLevelRequired(serverId = 1),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -103,7 +100,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Insecure state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Insecure(
                     serverId = 1,
                     missingHomeSetup = true,
@@ -132,7 +128,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Content state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -161,7 +156,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Content with notification permission prompt`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -190,7 +184,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Content with JS confirm dialog`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -223,7 +216,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Error`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Error(
                     serverId = 1,
                     url = "https://example.com",
@@ -256,7 +248,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Content with HTTP auth dialog`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -291,7 +282,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen Content with HTTP auth dialog in error state`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -328,7 +318,6 @@ class FrontendScreenScreenshotTest {
             val context = LocalContext.current
             val view = View(context).apply { setBackgroundColor(AndroidColor.RED) }
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -357,7 +346,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen barcode scanner overlay`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -391,7 +379,6 @@ class FrontendScreenScreenshotTest {
     fun `FrontendScreen barcode scanner notify dialog`() {
         HAThemeForPreview {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendScreenTest.kt
@@ -511,7 +511,6 @@ class FrontendScreenTest {
         setContent {
             val content: @Composable () -> Unit = {
                 FrontendScreenContent(
-                    onBackClick = {},
                     viewState = viewState,
                     webViewClient = WebViewClient(),
                     webChromeClient = WebChromeClient(),
@@ -563,7 +562,6 @@ class FrontendScreenTest {
         setContent {
             CompositionLocalProvider(LocalInspectionMode provides true) {
                 FrontendScreenContent(
-                    onBackClick = {},
                     viewState = FrontendViewState.Content(
                         serverId = 1,
                         url = "https://example.com",
@@ -676,7 +674,6 @@ class FrontendScreenTest {
         composeTestRule.apply {
             setContent {
                 FrontendScreenContent(
-                    onBackClick = {},
                     viewState = FrontendViewState.Error(
                         serverId = 1,
                         url = "https://example.com",
@@ -722,7 +719,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             val context = LocalContext.current
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -767,7 +763,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             val context = androidx.compose.ui.platform.LocalContext.current
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -801,7 +796,6 @@ class FrontendScreenTest {
 
         composeTestRule.setContent {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(
                     serverId = 1,
                     url = "https://example.com",
@@ -834,7 +828,6 @@ class FrontendScreenTest {
         val orientationState = mutableStateOf(ScreenOrientation.SYSTEM)
         composeTestRule.setContent {
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -880,7 +873,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             if (visible.value) {
                 FrontendScreenContent(
-                    onBackClick = {},
                     viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                     webViewClient = WebViewClient(),
                     webChromeClient = WebChromeClient(),
@@ -920,7 +912,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             capturedView = LocalView.current
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -950,7 +941,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             capturedView = LocalView.current
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -984,7 +974,6 @@ class FrontendScreenTest {
         composeTestRule.setContent {
             capturedView = LocalView.current
             FrontendScreenContent(
-                onBackClick = {},
                 viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                 webViewClient = WebViewClient(),
                 webChromeClient = WebChromeClient(),
@@ -1020,7 +1009,6 @@ class FrontendScreenTest {
             capturedView = LocalView.current
             if (visible.value) {
                 FrontendScreenContent(
-                    onBackClick = {},
                     viewState = FrontendViewState.Content(serverId = 1, url = "https://example.com"),
                     webViewClient = WebViewClient(),
                     webChromeClient = WebChromeClient(),

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -1100,9 +1100,10 @@ class FrontendViewModelTest {
                     onUrlIntercepted = any(),
                     onPageFinished = any(),
                     onReceivedHttpAuthRequest = any(),
+                    onCanGoBackChanged = any(),
                 )
             } answers {
-                // onPageFinished is the 5th of the 6 named arguments (zero-based index 4)
+                // onPageFinished is at parameter index 4 in HAWebViewClientFactory.create
                 capturedPageFinished = arg(4)
                 mockk(relaxed = true)
             }
@@ -1199,9 +1200,10 @@ class FrontendViewModelTest {
                     onUrlIntercepted = any(),
                     onPageFinished = any(),
                     onReceivedHttpAuthRequest = any(),
+                    onCanGoBackChanged = any(),
                 )
             } answers {
-                capturedCallback = lastArg()
+                capturedCallback = arg(5)
                 mockk(relaxed = true)
             }
 
@@ -1283,6 +1285,137 @@ class FrontendViewModelTest {
                 assertTrue(event is FrontendEvent.ShowSnackbar)
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+    }
+
+    @Nested
+    inner class BackNavigation {
+
+        private fun createViewModelWithCanGoBackCapture(): Pair<FrontendViewModel, (Boolean) -> Unit> {
+            var capturedCanGoBackChanged: ((Boolean) -> Unit)? = null
+            every {
+                webViewClientFactory.create(
+                    currentUrlFlow = any(),
+                    onFrontendError = any(),
+                    onCrash = any(),
+                    onUrlIntercepted = any(),
+                    onPageFinished = any(),
+                    onReceivedHttpAuthRequest = any(),
+                    onCanGoBackChanged = any(),
+                )
+            } answers {
+                // onCanGoBackChanged is at parameter index 6 in HAWebViewClientFactory.create
+                capturedCanGoBackChanged = arg(6)
+                mockk(relaxed = true)
+            }
+
+            val viewModel = createViewModel()
+            return viewModel to { capturedCanGoBackChanged!!.invoke(it) }
+        }
+
+        /** Reads the back-navigation flag from the current state (only the dashboard carries it). */
+        private fun FrontendViewModel.canGoBack(): Boolean = (viewState.value as? FrontendViewState.Content)?.canGoBack == true
+
+        @Test
+        fun `Given Content state when WebView reports back availability then canGoBack reflects it`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val (viewModel, reportCanGoBack) = createViewModelWithCanGoBackCapture()
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+
+            assertFalse(viewModel.canGoBack())
+
+            reportCanGoBack(true)
+            assertTrue(viewModel.canGoBack())
+
+            reportCanGoBack(false)
+            assertFalse(viewModel.canGoBack())
+        }
+
+        @Test
+        fun `Given WebView covered by an overlay when it can go back then canGoBack is false`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val (viewModel, reportCanGoBack) = createViewModelWithCanGoBackCapture()
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+            reportCanGoBack(true)
+            assertTrue(viewModel.canGoBack())
+
+            // An overlay (here the unrecoverable error screen) now covers the WebView: back must not
+            // drive the hidden WebView's history.
+            viewModel.onWebViewCreationFailed(RuntimeException("WebView unavailable"))
+            advanceUntilIdle()
+
+            assertFalse(viewModel.canGoBack())
+        }
+
+        @Test
+        fun `Given the frontend connects when content is shown then webViewActions emits ClearHistory`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val (viewModel, _) = createViewModelWithCanGoBackCapture()
+
+            viewModel.webViewActions.test {
+                advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+                // Connecting makes the dashboard the current page; clearing history drops the
+                // intermediate about:blank placeholder so it is not a reachable back entry.
+                messageFlow.emit(FrontendHandlerEvent.Connected)
+                advanceUntilIdle()
+
+                assertInstanceOf(WebViewAction.ClearHistory::class.java, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given a connected server with back history when switching servers then history is cleared and canGoBack is false`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(1, any()) } returns flowOf(
+                UrlLoadResult.Success(url = "https://server1.com?external_auth=1", serverId = 1),
+            )
+            every { urlManager.serverUrlFlow(2, any()) } returns flowOf(
+                UrlLoadResult.Success(url = "https://server2.com?external_auth=1", serverId = 2),
+            )
+
+            val (viewModel, reportCanGoBack) = createViewModelWithCanGoBackCapture()
+
+            // Connect to server 1 and let it accrue in-dashboard back history.
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+            reportCanGoBack(true)
+            assertTrue(viewModel.canGoBack())
+
+            viewModel.webViewActions.test {
+                viewModel.switchServer(2)
+                advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+                messageFlow.emit(FrontendHandlerEvent.Connected)
+                advanceUntilIdle()
+
+                // The new server's history is cleared so back cannot return to the previous server.
+                assertInstanceOf(WebViewAction.ClearHistory::class.java, awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+
+            assertEquals(2, viewModel.viewState.value.serverId)
+            assertFalse(viewModel.canGoBack())
         }
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/util/HAWebViewClientTest.kt
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNotNull
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 @ExtendWith(MainDispatcherJUnit5Extension::class)
 class HAWebViewClientTest {
@@ -394,6 +396,29 @@ class HAWebViewClientTest {
         assertEquals("example.com", capturedHost)
         assertEquals("https://example.com/protected", capturedResource)
         assertEquals("myrealm", capturedRealm)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `Given onCanGoBackChanged callback when doUpdateVisitedHistory then reports webView canGoBack`(
+        canGoBack: Boolean,
+    ) {
+        var captured: Boolean? = null
+        val client = HAWebViewClient(
+            keyChainRepository = keyChainRepository,
+            currentUrlFlow = currentUrlFlow,
+            onFrontendError = { capturedError = it },
+            onCrash = null,
+            onUrlIntercepted = null,
+            onPageFinished = null,
+            onReceivedHttpAuthRequest = null,
+            onCanGoBackChanged = { captured = it },
+        )
+        val webView = mockk<WebView> { every { canGoBack() } returns canGoBack }
+
+        client.doUpdateVisitedHistory(webView, "https://example.com", false)
+
+        assertEquals(canGoBack, captured)
     }
 
     @Test


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The back behavior on the `FrontendScreen` was wrong in few places alongside with the clear of the history of the WebView while changing server.

- While coming from the onboarding the onboarding could have still be in the navigation back stack
- Predictive back was not working properly because we were using the navController instead of letting the system handle it
- While on overlay like error screen the back behavior was wrong
- Missing documentation on the overlays on how the back is handled

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I tried to test some scenario that I've think off but I might have missed some.