### PR TITLE
Test widget background type mapping

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureActivity.kt
@@ -342,6 +342,9 @@ class EntityWidgetConfigureActivity : BaseWidgetConfigureActivity<StaticWidgetEn
             throw IllegalStateException("Selected entity is unknown on server")
         }
 
+        val selectedBackgroundOption = binding.backgroundType.selectedItem as String? ?: ""
+        val selectedBackgroundType = WidgetUtils.getWidgetBackgroundType(this, selectedBackgroundOption)
+
         return StaticWidgetEntity(
             id = appWidgetId,
             serverId = serverId,
@@ -363,14 +366,8 @@ class EntityWidgetConfigureActivity : BaseWidgetConfigureActivity<StaticWidgetEn
                 0 -> WidgetTapAction.TOGGLE
                 else -> WidgetTapAction.REFRESH
             },
-            backgroundType = when (binding.backgroundType.selectedItem as String?) {
-                getString(commonR.string.widget_background_type_dynamiccolor) -> WidgetBackgroundType.DYNAMICCOLOR
-                getString(commonR.string.widget_background_type_transparent) -> WidgetBackgroundType.TRANSPARENT
-                else -> WidgetBackgroundType.DAYNIGHT
-            },
-            textColor = if (binding.backgroundType.selectedItem as String? ==
-                getString(commonR.string.widget_background_type_transparent)
-            ) {
+            backgroundType = selectedBackgroundType,
+            textColor = if (selectedBackgroundType == WidgetBackgroundType.TRANSPARENT) {
                 getHexForColor(
                     if (binding.textColorWhite.isChecked) {
                         android.R.color.white

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/common/WidgetUtilsTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/common/WidgetUtilsTest.kt
@@ -1,0 +1,55 @@
+package io.homeassistant.companion.android.widgets.common
+
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class WidgetUtilsTest {
+    private val context = ApplicationProvider.getApplicationContext<HiltTestApplication>()
+
+    @Test
+    fun `Given dynamic color background option when getting widget background type then returns dynamic color`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_dynamiccolor),
+            WidgetBackgroundType.DYNAMICCOLOR,
+        )
+    }
+
+    @Test
+    fun `Given transparent background option when getting widget background type then returns transparent`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_transparent),
+            WidgetBackgroundType.TRANSPARENT,
+        )
+    }
+
+    @Test
+    fun `Given day night background option when getting widget background type then returns day night`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_daynight),
+            WidgetBackgroundType.DAYNIGHT,
+        )
+    }
+
+    @Test
+    fun `Given unknown background option when getting widget background type then returns day night`() {
+        assertWidgetBackgroundType("unknown", WidgetBackgroundType.DAYNIGHT)
+    }
+
+    private fun assertWidgetBackgroundType(
+        selectedOption: String,
+        expectedType: WidgetBackgroundType,
+    ) {
+        val result = WidgetUtils.getWidgetBackgroundType(context, selectedOption)
+
+        assertEquals(expectedType, result)
+    }
+}


### PR DESCRIPTION
## Summary
- Add tests for `WidgetUtils.getWidgetBackgroundType()`.
- Reuse that helper when saving the entity widget background type.
- Prep for the entity widget XML-to-Compose migration by covering the shared background type mapping.

Refs #6307.

## Testing
- `./gradlew :app:testFullDebugUnitTest --tests '*WidgetUtilsTest*'`
- `./gradlew :app:ktlintCheck`
- `./gradlew :app:assembleFullDebug`
- Manually launched `EntityWidgetConfigureActivity` on `Pixel_8_API_35` and verified the theme dropdown behavior.

<details>
<summary>Manual verification screenshots</summary>

Captured from `Pixel_8_API_35`.

| Default | Theme menu | Transparent | Light/dark |
| --- | --- | --- | --- |
| ![Default widget configuration](https://github.com/user-attachments/assets/d4b672d5-a7cb-4c41-a5eb-78cf7e66816d) | ![Theme dropdown](https://github.com/user-attachments/assets/e28f06e8-f112-40e8-959f-258c00ccd4f2) | ![Transparent theme selected](https://github.com/user-attachments/assets/608f7899-7db6-4e14-8a0f-650f57b2a215) | ![Light/dark theme selected](https://github.com/user-attachments/assets/1267fab8-4830-439d-ab09-3473090e6676) |

https://github.com/user-attachments/assets/54fd7a20-3e41-4912-b8c9-50458e89e7ae

</details>