### PR TITLE
Add tests for media player widget configuration

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivity.kt
@@ -19,16 +19,13 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationDom
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetDao
 import io.homeassistant.companion.android.database.widget.MediaPlayerControlsWidgetEntity
-import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
 import io.homeassistant.companion.android.databinding.WidgetMediaControlsConfigureBinding
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsViewModel
 import io.homeassistant.companion.android.util.applySafeDrawingInsets
 import io.homeassistant.companion.android.widgets.BaseWidgetConfigureActivity
 import io.homeassistant.companion.android.widgets.common.SingleItemArrayAdapter
 import io.homeassistant.companion.android.widgets.common.WidgetUtils
-import java.util.LinkedList
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 // TODO Migrate to compose https://github.com/home-assistant/android/issues/6308
@@ -57,7 +54,6 @@ class MediaPlayerControlsWidgetConfigureActivity :
         get() = binding.serverSelectList
 
     private var entities = mutableMapOf<Int, List<Entity>>()
-    private var selectedEntities: LinkedList<Entity?> = LinkedList()
 
     private var entityAdapter: SingleItemArrayAdapter<Entity>? = null
 
@@ -136,24 +132,18 @@ class MediaPlayerControlsWidgetConfigureActivity :
                         backgroundTypeValues,
                     ),
                 )
-                val entities = runBlocking {
-                    try {
-                        mediaPlayerWidget.entityId.split(",").map { s ->
-                            serverManager.integrationRepository(mediaPlayerWidget.serverId).getEntity(s.trim())
-                        }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Unable to get entity information")
-                        Toast.makeText(
-                            applicationContext,
-                            commonR.string.widget_entity_fetch_error,
-                            Toast.LENGTH_LONG,
-                        )
-                            .show()
-                        null
+                try {
+                    mediaPlayerWidget.entityId.split(",").forEach { s ->
+                        serverManager.integrationRepository(mediaPlayerWidget.serverId).getEntity(s.trim())
                     }
-                }
-                if (entities != null) {
-                    selectedEntities.addAll(entities)
+                } catch (e: Exception) {
+                    Timber.e(e, "Unable to get entity information")
+                    Toast.makeText(
+                        applicationContext,
+                        commonR.string.widget_entity_fetch_error,
+                        Toast.LENGTH_LONG,
+                    )
+                        .show()
                 }
                 binding.addButton.setText(commonR.string.update_widget)
             }
@@ -191,7 +181,6 @@ class MediaPlayerControlsWidgetConfigureActivity :
     }
 
     override fun onServerSelected(serverId: Int) {
-        selectedEntities.clear()
         binding.widgetTextConfigEntityId.setText("")
         setAdapterEntities(serverId)
     }
@@ -209,14 +198,10 @@ class MediaPlayerControlsWidgetConfigureActivity :
 
     override suspend fun getPendingDaoEntity(): MediaPlayerControlsWidgetEntity {
         val serverId = checkNotNull(selectedServerId) { "Selected server ID is null" }
-        selectedEntities = LinkedList()
-        val se = binding.widgetTextConfigEntityId.text.split(",")
-        se.forEach {
-            val entity = entities[serverId]?.firstOrNull { e -> e.entityId == it.trim() }
-            if (entity != null) selectedEntities.add(entity)
-        }
-
-        val entitySelection = selectedEntities.map { e -> e?.entityId }.reduceOrNull { a, b -> "$a,$b" }
+        val entitySelection = getSelectedMediaPlayerEntityIds(
+            binding.widgetTextConfigEntityId.text,
+            entities[serverId].orEmpty(),
+        )
 
         if (entitySelection == null) {
             throw IllegalStateException("No valid entities selected")
@@ -231,13 +216,27 @@ class MediaPlayerControlsWidgetConfigureActivity :
             showSkip = binding.widgetShowSkipButtonsCheckbox.isChecked,
             showSeek = binding.widgetShowSeekButtonsCheckbox.isChecked,
             showSource = binding.widgetShowMediaPlayerSource.isChecked,
-            backgroundType = when (binding.backgroundType.selectedItem as String?) {
-                getString(commonR.string.widget_background_type_dynamiccolor) -> WidgetBackgroundType.DYNAMICCOLOR
-                getString(commonR.string.widget_background_type_transparent) -> WidgetBackgroundType.TRANSPARENT
-                else -> WidgetBackgroundType.DAYNIGHT
-            },
+            backgroundType = WidgetUtils.getWidgetBackgroundType(
+                this,
+                binding.backgroundType.selectedItem?.toString().orEmpty(),
+            ),
         )
     }
 
     override val widgetClass: Class<*> = MediaPlayerControlsWidget::class.java
+}
+
+internal fun getSelectedMediaPlayerEntityIds(
+    selectedEntityText: CharSequence,
+    availableEntities: List<Entity>,
+): String? {
+    val availableEntityIds = availableEntities.map { it.entityId }.toSet()
+    val selectedEntityIds = selectedEntityText.toString()
+        .split(",")
+        .mapNotNull { selectedEntityId ->
+            val entityId = selectedEntityId.trim()
+            entityId.takeIf { it in availableEntityIds }
+        }
+
+    return selectedEntityIds.joinToString(",").ifEmpty { null }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/common/WidgetUtilsTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/common/WidgetUtilsTest.kt
@@ -1,0 +1,56 @@
+package io.homeassistant.companion.android.widgets.common
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class WidgetUtilsTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @Test
+    fun `Given dynamic color background option when getting widget background type then returns dynamic color`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_dynamiccolor),
+            WidgetBackgroundType.DYNAMICCOLOR,
+        )
+    }
+
+    @Test
+    fun `Given transparent background option when getting widget background type then returns transparent`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_transparent),
+            WidgetBackgroundType.TRANSPARENT,
+        )
+    }
+
+    @Test
+    fun `Given day night background option when getting widget background type then returns day night`() {
+        assertWidgetBackgroundType(
+            context.getString(R.string.widget_background_type_daynight),
+            WidgetBackgroundType.DAYNIGHT,
+        )
+    }
+
+    @Test
+    fun `Given unknown background option when getting widget background type then returns day night`() {
+        assertWidgetBackgroundType("unknown", WidgetBackgroundType.DAYNIGHT)
+    }
+
+    private fun assertWidgetBackgroundType(
+        selectedOption: String,
+        expectedType: WidgetBackgroundType,
+    ) {
+        val result = WidgetUtils.getWidgetBackgroundType(context, selectedOption)
+
+        assertEquals(expectedType, result)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivityTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureActivityTest.kt
@@ -1,0 +1,63 @@
+package io.homeassistant.companion.android.widgets.mediaplayer
+
+import io.homeassistant.companion.android.common.data.integration.Entity
+import java.time.LocalDateTime
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class MediaPlayerControlsWidgetConfigureActivityTest {
+    @Test
+    fun `Given selected entity ids when getting selected media player entity ids then returns valid ids in selection order`() {
+        val result = getSelectedMediaPlayerEntityIds(
+            " media_player.living_room , media_player.kitchen ",
+            listOf(
+                entity("media_player.kitchen"),
+                entity("media_player.living_room"),
+            ),
+        )
+
+        assertEquals("media_player.living_room,media_player.kitchen", result)
+    }
+
+    @Test
+    fun `Given selected entity ids with unknown entries when getting selected media player entity ids then ignores unknown entries`() {
+        val result = getSelectedMediaPlayerEntityIds(
+            "media_player.living_room, light.kitchen, media_player.kitchen",
+            listOf(
+                entity("media_player.living_room"),
+                entity("media_player.kitchen"),
+            ),
+        )
+
+        assertEquals("media_player.living_room,media_player.kitchen", result)
+    }
+
+    @Test
+    fun `Given no matching selected entity ids when getting selected media player entity ids then returns null`() {
+        val result = getSelectedMediaPlayerEntityIds(
+            "light.kitchen, switch.fan",
+            listOf(entity("media_player.living_room")),
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `Given empty selected entity ids when getting selected media player entity ids then returns null`() {
+        val result = getSelectedMediaPlayerEntityIds(
+            " , ",
+            listOf(entity("media_player.living_room")),
+        )
+
+        assertNull(result)
+    }
+
+    private fun entity(entityId: String) = Entity(
+        entityId = entityId,
+        state = "playing",
+        attributes = emptyMap(),
+        lastChanged = LocalDateTime.MIN,
+        lastUpdated = LocalDateTime.MIN,
+    )
+}


### PR DESCRIPTION
## Summary
This PR adds tests for media player widget configuration entity selection and `WidgetUtils.getWidgetBackgroundType()` to help prepare for home-assistant/android#6308.

It also reuses the shared background type helper when saving media player widget configuration.

The media player entity fetch now keeps the existing error handling side effect without storing the unused `selectedEntities` list.

## Checklist
- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

<details>
<summary>Testing</summary>

- `./gradlew :app:testFullDebugUnitTest --tests '*MediaPlayerControlsWidgetConfigureActivityTest*' --tests '*WidgetUtilsTest*'`
- `./gradlew :app:ktlintCheck`
- `./gradlew :app:assembleFullDebug`

</details>

<details>
<summary>Manual testing</summary>

- Verified the real Launcher media player widget add/configure/save flow.
- Selected `media_player.kitchen,media_player.living_room` and added the widget.
- Verified the widget remained hosted by AppWidgetManager and the configuration row persisted.

https://github.com/user-attachments/assets/886bad75-efe1-491c-a292-e689f63502a1

</details>
