### PR TITLE
Make Sensor immutable

### DIFF
--- a/common/lint-baseline.xml
+++ b/common/lint-baseline.xml
@@ -118,7 +118,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdater.kt"
-            line="370"
+            line="421"
             column="9"/>
     </issue>
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdater.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdater.kt
@@ -251,6 +251,8 @@ class SensorUpdater @VisibleForTesting internal constructor(
                         registerSensor(fullSensor, basicSensor)
                         fullSensor =
                             fullSensor.copy(sensor = persistRegistration(sensor.copy(registered = sensor.enabled)))
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e, "Issue registering sensor ${basicSensor.id}")
                     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdater.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdater.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
 import android.os.Build
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.content.getSystemService
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -19,6 +20,7 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ge
 import io.homeassistant.companion.android.common.util.AppVersionProvider
 import io.homeassistant.companion.android.common.util.CHANNEL_SENSOR_SYNC
 import io.homeassistant.companion.android.common.util.SdkVersion
+import io.homeassistant.companion.android.database.sensor.Sensor
 import io.homeassistant.companion.android.database.sensor.SensorWithAttributes
 import io.homeassistant.companion.android.database.sensor.toSensorWithAttributes
 import io.homeassistant.companion.android.database.sensor.toSensorsWithAttributes
@@ -56,14 +58,33 @@ fun interface SensorSettingsIntentProvider {
  * Runs sensor updates and reconciles sensor registrations with each configured server.
  */
 @Singleton
-class SensorUpdater @Inject constructor(
-    @ApplicationContext private val context: Context,
+class SensorUpdater @VisibleForTesting internal constructor(
+    private val context: Context,
     private val serverManager: ServerManager,
     private val sensorRepository: SensorRepository,
     private val appVersionProvider: AppVersionProvider,
     private val managers: Set<@JvmSuppressWildcards SensorManager>,
     private val sensorSettingsIntentProvider: SensorSettingsIntentProvider,
+    private val notificationManager: NotificationManager?,
 ) {
+
+    @Inject
+    constructor(
+        @ApplicationContext context: Context,
+        serverManager: ServerManager,
+        sensorRepository: SensorRepository,
+        appVersionProvider: AppVersionProvider,
+        managers: Set<@JvmSuppressWildcards SensorManager>,
+        sensorSettingsIntentProvider: SensorSettingsIntentProvider,
+    ) : this(
+        context,
+        serverManager,
+        sensorRepository,
+        appVersionProvider,
+        managers,
+        sensorSettingsIntentProvider,
+        context.getSystemService(),
+    )
 
     /**
      * Requests an update from every manager that has a sensor and then syncs all servers in
@@ -176,6 +197,13 @@ class SensorUpdater @Inject constructor(
         val currentHAversion = integrationRepository.getHomeAssistantVersion()
         val supportsDisabledSensors = integrationRepository.isHomeAssistantVersionAtLeast(2022, 6, 0)
         val serverIsTrusted = integrationRepository.isTrusted()
+
+        suspend fun persistRegistration(updated: Sensor): Sensor {
+            val persisted = updated.copy(coreRegistration = currentHAversion, appRegistration = appVersion)
+            sensorRepository.update(persisted)
+            return persisted
+        }
+
         val coreSensorStatus: Map<String, Boolean>? =
             if (supportsDisabledSensors && (serverIsTrusted || sensorRepository.getEnabledCount() > 0)) {
                 config.entities
@@ -194,21 +222,14 @@ class SensorUpdater @Inject constructor(
             val hasSensor = manager.hasSensor()
 
             manager.getAvailableSensors().forEach sensorForEach@{ basicSensor ->
-                val fullSensor = sensorRepository.getFull(basicSensor.id, server.id).toSensorWithAttributes()
-                val sensor = fullSensor?.sensor ?: return@sensorForEach
+                val hasPermission = manager.checkPermission(basicSensor.id)
+                var fullSensor = loadSensorReconcilingPermission(basicSensor, server, hasPermission)
+                    ?: return@sensorForEach
+                val sensor = fullSensor.sensor
                 val sensorCoreEnabled = coreSensorStatus?.get(basicSensor.id)
                 val canBeRegistered = hasSensor &&
                     basicSensor.type.isNotBlank() &&
                     basicSensor.statelessIcon.isNotBlank()
-                val hasPermission = manager.checkPermission(basicSensor.id)
-
-                // A sensor enabled in the database but missing its runtime permission isn't really
-                // enabled. Persist that so the reconciliation below unregisters it on the server instead
-                // of leaving a stale entity behind.
-                if (sensor.enabled && !hasPermission) {
-                    sensor.enabled = false
-                    sensorRepository.update(sensor)
-                }
 
                 // Register sensor and/or update the sensor enabled state. Priority is:
                 // 1. There is a new sensor or change in enabled state according to the app
@@ -228,10 +249,8 @@ class SensorUpdater @Inject constructor(
                     // - sensor is registered according to database, but core >=2022.6 doesn't know about it
                     try {
                         registerSensor(fullSensor, basicSensor)
-                        sensor.registered = sensor.enabled
-                        sensor.coreRegistration = currentHAversion
-                        sensor.appRegistration = appVersion
-                        sensorRepository.update(sensor)
+                        fullSensor =
+                            fullSensor.copy(sensor = persistRegistration(sensor.copy(registered = sensor.enabled)))
                     } catch (e: Exception) {
                         Timber.e(e, "Issue registering sensor ${basicSensor.id}")
                     }
@@ -245,17 +264,21 @@ class SensorUpdater @Inject constructor(
                     // the app, if the sensor can be registered, on core >= 2022.6 and server trusted.
                     // If the server isn't trusted, update registered state to match app.
                     try {
-                        if (!serverIsTrusted) { // Core changed, but app doesn't trust server so 'override'
+                        // Core changed, but app doesn't trust server so 'override'
+                        val sensorUpdated = if (!serverIsTrusted) {
                             registerSensor(fullSensor, basicSensor)
+                            sensor
                         } else if (sensorCoreEnabled) { // App disabled, should enable
                             if (hasPermission) {
-                                sensor.enabled = true
-                                sensor.registered = true
+                                sensor.copy(
+                                    enabled = true,
+                                    registered = true,
+                                )
                             } else {
                                 // Can't enable due to missing permission(s), 'override' core and notify user
                                 registerSensor(fullSensor, basicSensor)
 
-                                context.getSystemService<NotificationManager>()?.let { notificationManager ->
+                                notificationManager?.let { notificationManager ->
                                     createNotificationChannel()
                                     val notificationId = "$CHANNEL_SENSOR_SYNC-${basicSensor.id}".hashCode()
                                     val notificationIntent =
@@ -271,15 +294,16 @@ class SensorUpdater @Inject constructor(
                                         .build()
                                     notificationManager.notify(notificationId, notification)
                                 }
+                                sensor
                             }
                         } else { // App enabled, should disable
-                            sensor.enabled = false
-                            sensor.registered = false
+                            sensor.copy(
+                                enabled = false,
+                                registered = false,
+                            )
                         }
 
-                        sensor.coreRegistration = currentHAversion
-                        sensor.appRegistration = appVersion
-                        sensorRepository.update(sensor)
+                        fullSensor = fullSensor.copy(sensor = persistRegistration(sensorUpdated))
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -295,10 +319,8 @@ class SensorUpdater @Inject constructor(
                     // core >= 2022.6, and app or core version change is detected
                     try {
                         registerSensor(fullSensor, basicSensor)
-                        sensor.registered = sensor.enabled
-                        sensor.coreRegistration = currentHAversion
-                        sensor.appRegistration = appVersion
-                        sensorRepository.update(sensor)
+                        fullSensor =
+                            fullSensor.copy(sensor = persistRegistration(sensor.copy(registered = sensor.enabled)))
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -314,10 +336,16 @@ class SensorUpdater @Inject constructor(
                     }
                 }
 
+                // Read from the (possibly re-registered) fullSensor so a sensor registered/enabled above
+                // has its fresh state sent in this same pass rather than being deferred to the next one.
+                val reconciledSensor = fullSensor.sensor
                 if (canBeRegistered &&
-                    sensor.enabled &&
-                    sensor.registered != null &&
-                    (sensor.state != sensor.lastSentState || sensor.icon != sensor.lastSentIcon)
+                    reconciledSensor.enabled &&
+                    reconciledSensor.registered != null &&
+                    (
+                        reconciledSensor.state != reconciledSensor.lastSentState ||
+                            reconciledSensor.icon != reconciledSensor.lastSentIcon
+                        )
                 ) {
                     enabledRegistrations.add(fullSensor.toSensorRegistration(basicSensor))
                 }
@@ -351,10 +379,13 @@ class SensorUpdater @Inject constructor(
                 enabledRegistrations.forEach {
                     val sensor = sensorRepository.get(it.uniqueId, it.serverId)
                     if (sensor != null) {
-                        sensor.registered = null
-                        sensor.lastSentState = null
-                        sensor.lastSentIcon = null
-                        sensorRepository.update(sensor)
+                        sensorRepository.update(
+                            sensor.copy(
+                                registered = null,
+                                lastSentState = null,
+                                lastSentIcon = null,
+                            ),
+                        )
                     }
                 }
             }
@@ -362,6 +393,24 @@ class SensorUpdater @Inject constructor(
             Timber.d("Nothing to update for server ${server.id} (${server.friendlyName})")
         }
         return success
+    }
+
+    private suspend fun loadSensorReconcilingPermission(
+        basicSensor: SensorManager.BasicSensor,
+        server: Server,
+        hasPermission: Boolean,
+    ): SensorWithAttributes? {
+        val fullSensor = sensorRepository.getFull(basicSensor.id, server.id).toSensorWithAttributes() ?: return null
+
+        // A sensor enabled in the database but missing its runtime permission isn't really
+        // enabled. Persist that so the reconciliation below unregisters it on the server instead
+        // of leaving a stale entity behind.
+        if (fullSensor.sensor.enabled && !hasPermission) {
+            val disabled = fullSensor.copy(sensor = fullSensor.sensor.copy(enabled = false))
+            sensorRepository.update(disabled.sensor)
+            return disabled
+        }
+        return fullSensor
     }
 
     private suspend fun registerSensor(fullSensor: SensorWithAttributes, basicSensor: SensorManager.BasicSensor) {
@@ -375,14 +424,14 @@ class SensorUpdater @Inject constructor(
 
     private fun createNotificationChannel() {
         if (SdkVersion.isAtLeast(Build.VERSION_CODES.O)) {
-            val notificationManager = context.getSystemService<NotificationManager>() ?: return
-            if (notificationManager.getNotificationChannel(CHANNEL_SENSOR_SYNC) == null) {
+            val manager = notificationManager ?: return
+            if (manager.getNotificationChannel(CHANNEL_SENSOR_SYNC) == null) {
                 val notificationChannel = NotificationChannel(
                     CHANNEL_SENSOR_SYNC,
                     CHANNEL_SENSOR_SYNC,
                     NotificationManager.IMPORTANCE_DEFAULT,
                 )
-                notificationManager.createNotificationChannel(notificationChannel)
+                manager.createNotificationChannel(notificationChannel)
             }
         }
     }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/sensor/Sensor.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/sensor/Sensor.kt
@@ -10,15 +10,15 @@ data class Sensor(
     @ColumnInfo(name = "server_id", defaultValue = "0")
     val serverId: Int,
     @ColumnInfo(name = "enabled")
-    var enabled: Boolean,
+    val enabled: Boolean,
     @ColumnInfo(name = "registered", defaultValue = "NULL")
-    var registered: Boolean? = null,
+    val registered: Boolean? = null,
     @ColumnInfo(name = "state")
     val state: String,
     @ColumnInfo(name = "last_sent_state", defaultValue = "NULL")
-    var lastSentState: String? = null,
+    val lastSentState: String? = null,
     @ColumnInfo(name = "last_sent_icon", defaultValue = "NULL")
-    var lastSentIcon: String? = null,
+    val lastSentIcon: String? = null,
     @ColumnInfo(name = "state_type")
     val stateType: String = "",
     @ColumnInfo(name = "type")
@@ -36,7 +36,7 @@ data class Sensor(
     @ColumnInfo(name = "entity_category")
     val entityCategory: String? = null,
     @ColumnInfo(name = "core_registration")
-    var coreRegistration: String? = null,
+    val coreRegistration: String? = null,
     @ColumnInfo(name = "app_registration")
-    var appRegistration: String? = null,
+    val appRegistration: String? = null,
 )

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdaterNotificationTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdaterNotificationTest.kt
@@ -1,0 +1,120 @@
+package io.homeassistant.companion.android.common.sensors
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetConfigResponse
+import io.homeassistant.companion.android.common.util.AppVersion
+import io.homeassistant.companion.android.common.util.AppVersionProvider
+import io.homeassistant.companion.android.database.sensor.Sensor
+import io.homeassistant.companion.android.database.server.Server
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * Covers the missing-permission notification branch of [SensorUpdater]. It lives in its own Robolectric
+ * test because building the [androidx.core.app.NotificationCompat] notification needs a real Android
+ * runtime, which the plain JVM [SensorUpdaterTest] doesn't provide.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class SensorUpdaterNotificationTest {
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val sensorRepository = mockk<SensorRepository>(relaxed = true)
+    private val appVersion = AppVersion.from("1.0", 1)
+    private val appVersionProvider = AppVersionProvider { appVersion }
+    private val settingsIntentProvider = SensorSettingsIntentProvider { _, _, _, _ -> null }
+
+    private val haVersion = "2022.6.0"
+    private val serverId = 0
+    private val basicSensor = SensorManager.BasicSensor(
+        id = "test_sensor",
+        type = "sensor",
+        statelessIcon = "mdi:test",
+    )
+
+    @Test
+    fun `Given a sensor enabled on core but missing permission when updateSensors then core is overridden and the user is notified`() = runTest {
+        val sensor = disabledUnregisteredSensor()
+        val integrationRepository = stubbedIntegrationRepository(coreEntities(disabled = false))
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = false)
+        val notificationManager = mockk<NotificationManager>(relaxed = true)
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        SensorUpdater(
+            context,
+            serverManager,
+            sensorRepository,
+            appVersionProvider,
+            setOf(manager),
+            settingsIntentProvider,
+            notificationManager,
+        ).updateSensors()
+
+        // Core wants it enabled but the runtime permission is missing: re-register to override core...
+        coVerify(exactly = 1) { integrationRepository.registerSensor(any()) }
+        // ...and notify the user so they can grant the permission.
+        verify { notificationManager.notify(any<Int>(), any()) }
+    }
+
+    private fun registeredServerManager(integrationRepository: IntegrationRepository) = mockk<ServerManager> {
+        coEvery { isRegistered() } returns true
+        coEvery { servers() } returns listOf(mockk<Server>(relaxed = true) { every { id } returns serverId })
+        coEvery { integrationRepository(serverId) } returns integrationRepository
+    }
+
+    private fun stubbedIntegrationRepository(entities: Map<String, Map<String, Any>>) = mockk<IntegrationRepository>(relaxed = true) {
+        coEvery { getConfig() } returns config(entities)
+        coEvery { getHomeAssistantVersion() } returns haVersion
+        coEvery { isHomeAssistantVersionAtLeast(any(), any(), any()) } returns true
+        coEvery { isTrusted() } returns true
+    }
+
+    private fun sensorManager(hasPermission: Boolean) = mockk<SensorManager>(relaxed = true) {
+        every { name } returns commonR.string.sensor
+        every { hasSensor() } returns true
+        coEvery { getAvailableSensors() } returns listOf(basicSensor)
+        coEvery { checkPermission(basicSensor.id) } returns hasPermission
+    }
+
+    private fun coreEntities(disabled: Boolean) = mapOf(basicSensor.id to mapOf<String, Any>("disabled" to disabled))
+
+    // Known to the app but disabled and not registered, so a core-driven enable reaches the branch.
+    private fun disabledUnregisteredSensor() = Sensor(
+        id = basicSensor.id,
+        serverId = serverId,
+        enabled = false,
+        registered = false,
+        state = "",
+        lastSentState = "",
+        lastSentIcon = "",
+        appRegistration = appVersion.value,
+        coreRegistration = haVersion,
+    )
+
+    private fun config(entities: Map<String, Map<String, Any>>) = GetConfigResponse(
+        latitude = 0.0,
+        longitude = 0.0,
+        elevation = 0.0,
+        unitSystem = emptyMap(),
+        locationName = "",
+        timeZone = "",
+        components = emptyList(),
+        version = haVersion,
+        entities = entities,
+    )
+}

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdaterTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/sensors/SensorUpdaterTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.common.sensors
 
+import android.app.NotificationManager
 import android.content.Context
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
@@ -16,7 +17,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
@@ -36,7 +36,19 @@ class SensorUpdaterTest {
         statelessIcon = "mdi:test",
     )
 
-    private fun updater(serverManager: ServerManager, managers: Set<SensorManager>) = SensorUpdater(context, serverManager, sensorRepository, appVersionProvider, managers, settingsIntentProvider)
+    private fun updater(
+        serverManager: ServerManager,
+        managers: Set<SensorManager>,
+        notificationManager: NotificationManager = mockk(relaxed = true),
+    ) = SensorUpdater(
+        context,
+        serverManager,
+        sensorRepository,
+        appVersionProvider,
+        managers,
+        settingsIntentProvider,
+        notificationManager,
+    )
 
     @Test
     fun `Given device not registered when updateSensors then no manager is asked to update`() = runTest {
@@ -76,8 +88,9 @@ class SensorUpdaterTest {
         updater(serverManager, setOf(manager)).updateSensors()
 
         // The missing permission is persisted as disabled.
-        assertFalse(sensor.enabled)
-        coVerify { sensorRepository.update(sensor) }
+        val sensorUpdateCaptured = mutableListOf<Sensor>()
+        coVerify { sensorRepository.update(capture(sensorUpdateCaptured)) }
+        assertTrue(sensorUpdateCaptured.any { !it.enabled })
 
         // The server is told the sensor is now disabled.
         val registration = slot<SensorRegistration<Any>>()
@@ -100,19 +113,111 @@ class SensorUpdaterTest {
         coVerify(exactly = 0) { integrationRepository.registerSensor(any()) }
     }
 
+    @Test
+    fun `Given a new enabled sensor with a changed state when updateSensors runs then its state is sent to the server in the same pass`() = runTest {
+        val sensor = newEnabledSensor()
+        val integrationRepository = stubbedIntegrationRepository()
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = true)
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        updater(serverManager, setOf(manager)).updateSensors()
+
+        // The sensor is registered with core...
+        coVerify(exactly = 1) { integrationRepository.registerSensor(any()) }
+        // ...and its state is sent in the same pass, because the just-registered state is visible downstream.
+        coVerify(exactly = 1) { integrationRepository.updateSensors(any()) }
+    }
+
+    @Test
+    fun `Given a disabled sensor enabled on core with permission when updateSensors then it is enabled and registered locally`() = runTest {
+        val sensor = disabledUnregisteredSensor()
+        val integrationRepository = stubbedIntegrationRepository(config(entities = coreEntities(disabled = false)))
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = true)
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        updater(serverManager, setOf(manager)).updateSensors()
+
+        val sensorUpdateCaptured = mutableListOf<Sensor>()
+        coVerify { sensorRepository.update(capture(sensorUpdateCaptured)) }
+        assertTrue(sensorUpdateCaptured.any { it.enabled && it.registered == true })
+        // App state now matches core directly, so there is no need to re-register/override on the server.
+        coVerify(exactly = 0) { integrationRepository.registerSensor(any()) }
+    }
+
+    @Test
+    fun `Given an enabled sensor disabled on core when updateSensors then it is disabled locally`() = runTest {
+        val sensor = enabledRegisteredSensor()
+        val integrationRepository = stubbedIntegrationRepository(config(entities = coreEntities(disabled = true)))
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = true)
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        updater(serverManager, setOf(manager)).updateSensors()
+
+        val sensorUpdateCaptured = mutableListOf<Sensor>()
+        coVerify { sensorRepository.update(capture(sensorUpdateCaptured)) }
+        assertTrue(sensorUpdateCaptured.any { !it.enabled && it.registered == false })
+        coVerify(exactly = 0) { integrationRepository.registerSensor(any()) }
+    }
+
+    @Test
+    fun `Given core enables a sensor but the server is untrusted when updateSensors then the app state is kept and core is overridden`() = runTest {
+        val sensor = disabledUnregisteredSensor()
+        val integrationRepository = stubbedIntegrationRepository(config(entities = coreEntities(disabled = false)), trusted = false)
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = true)
+        // Untrusted servers only reach the reconciliation branch when at least one sensor is enabled.
+        coEvery { sensorRepository.getEnabledCount() } returns 1
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        updater(serverManager, setOf(manager)).updateSensors()
+
+        // The app doesn't trust the server to flip the state, so it re-registers to override core...
+        coVerify(exactly = 1) { integrationRepository.registerSensor(any()) }
+        // ...and keeps the sensor disabled locally instead of enabling it to match core.
+        val sensorUpdateCaptured = mutableListOf<Sensor>()
+        coVerify { sensorRepository.update(capture(sensorUpdateCaptured)) }
+        assertTrue(sensorUpdateCaptured.any { !it.enabled && it.registered == false })
+    }
+
+    @Test
+    fun `Given core disables a sensor but the server is untrusted when updateSensors then the app state is kept and core is overridden`() = runTest {
+        val sensor = enabledRegisteredSensor()
+        val integrationRepository = stubbedIntegrationRepository(config(entities = coreEntities(disabled = true)), trusted = false)
+        val serverManager = registeredServerManager(integrationRepository)
+        val manager = sensorManager(hasPermission = true)
+        coEvery { sensorRepository.getEnabledCount() } returns 1
+        coEvery { sensorRepository.getFull(basicSensor.id, serverId) } returns mapOf(sensor to emptyList())
+
+        updater(serverManager, setOf(manager)).updateSensors()
+
+        // The app doesn't trust the server to flip the state, so it re-registers to override core...
+        coVerify(exactly = 1) { integrationRepository.registerSensor(any()) }
+        // ...and keeps the sensor enabled locally instead of disabling it to match core.
+        val sensorUpdateCaptured = mutableListOf<Sensor>()
+        coVerify { sensorRepository.update(capture(sensorUpdateCaptured)) }
+        assertTrue(sensorUpdateCaptured.any { it.enabled && it.registered == true })
+    }
+
     private fun registeredServerManager(integrationRepository: IntegrationRepository) = mockk<ServerManager> {
         coEvery { isRegistered() } returns true
         coEvery { servers() } returns listOf(mockk<Server>(relaxed = true) { every { id } returns serverId })
         coEvery { integrationRepository(serverId) } returns integrationRepository
     }
 
-    // Core >= 2022.6 (supports disabled sensors) and trusted, with no per-entity disabled state
-    // reported, so the core-driven reconciliation branch stays out of the way.
-    private fun stubbedIntegrationRepository() = mockk<IntegrationRepository>(relaxed = true) {
-        coEvery { getConfig() } returns config()
+    // Core >= 2022.6 (supports disabled sensors) and trusted by default. No per-entity disabled state is
+    // reported unless a [config] with entities is passed; set [trusted] to false to simulate a server that
+    // isn't allowed to remotely control the app.
+    private fun stubbedIntegrationRepository(
+        config: GetConfigResponse = config(),
+        trusted: Boolean = true,
+    ) = mockk<IntegrationRepository>(relaxed = true) {
+        coEvery { getConfig() } returns config
         coEvery { getHomeAssistantVersion() } returns haVersion
         coEvery { isHomeAssistantVersionAtLeast(any(), any(), any()) } returns true
-        coEvery { isTrusted() } returns true
+        coEvery { isTrusted() } returns trusted
     }
 
     private fun sensorManager(hasPermission: Boolean) = mockk<SensorManager>(relaxed = true) {
@@ -135,7 +240,20 @@ class SensorUpdaterTest {
         coreRegistration = haVersion,
     )
 
-    private fun config() = GetConfigResponse(
+    // Newly discovered sensor, enabled by the user but not yet registered, with a state that hasn't been sent.
+    private fun newEnabledSensor() = Sensor(
+        id = basicSensor.id,
+        serverId = serverId,
+        enabled = true,
+        registered = null,
+        state = "on",
+        lastSentState = null,
+        lastSentIcon = null,
+        appRegistration = appVersion.value,
+        coreRegistration = haVersion,
+    )
+
+    private fun config(entities: Map<String, Map<String, Any>>? = null) = GetConfigResponse(
         latitude = 0.0,
         longitude = 0.0,
         elevation = 0.0,
@@ -144,6 +262,22 @@ class SensorUpdaterTest {
         timeZone = "",
         components = emptyList(),
         version = haVersion,
-        entities = null,
+        entities = entities,
+    )
+
+    // Mimics core reporting a per-entity disabled flag, which drives the core-state reconciliation branch.
+    private fun coreEntities(disabled: Boolean) = mapOf(basicSensor.id to mapOf<String, Any>("disabled" to disabled))
+
+    // Known to the app but disabled and not registered, so a core-driven enable can reconcile it.
+    private fun disabledUnregisteredSensor() = Sensor(
+        id = basicSensor.id,
+        serverId = serverId,
+        enabled = false,
+        registered = false,
+        state = "",
+        lastSentState = "",
+        lastSentIcon = "",
+        appRegistration = appVersion.value,
+        coreRegistration = haVersion,
     )
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The `Sensor` data class should be immutable since it comes directly from the repository, if we want to modify it we should make a copy of the object. This PR replace the `var` with `val` in the class.

It is based on #7107 