### PR TITLE
Fix legacy WebView same-origin URL routing

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -653,9 +653,12 @@ class WebViewActivity :
                                     startActivity(intent)
                                 }
                                 return true
-                            } else if (shouldOpenInExternalBrowser(currentUrl = webView.url, targetUrl = it.toUri())) {
+                            }
+
+                            val targetUrl = it.toUri()
+                            if (shouldOpenInExternalBrowser(currentUrl = webView.url, targetUrl = targetUrl)) {
                                 Timber.d("Launching browser")
-                                val browserIntent = Intent(Intent.ACTION_VIEW, it.toUri())
+                                val browserIntent = Intent(Intent.ACTION_VIEW, targetUrl)
                                 startActivity(browserIntent)
                                 return true
                             } else {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -653,7 +653,7 @@ class WebViewActivity :
                                     startActivity(intent)
                                 }
                                 return true
-                            } else if (!webView.url.toString().contains(it)) {
+                            } else if (shouldOpenInExternalBrowser(currentUrl = webView.url, targetUrl = it.toUri())) {
                                 Timber.d("Launching browser")
                                 val browserIntent = Intent(Intent.ACTION_VIEW, it.toUri())
                                 startActivity(browserIntent)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverride.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverride.kt
@@ -4,5 +4,12 @@ import android.net.Uri
 import io.homeassistant.companion.android.util.hasSameOrigin
 
 internal fun shouldOpenInExternalBrowser(currentUrl: String?, targetUrl: Uri): Boolean {
+    if (!targetUrl.isHttpOrHttpsWithHost()) return true
+
     return !targetUrl.hasSameOrigin(currentUrl)
+}
+
+private fun Uri.isHttpOrHttpsWithHost(): Boolean {
+    return host != null &&
+        (scheme.equals("http", ignoreCase = true) || scheme.equals("https", ignoreCase = true))
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverride.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverride.kt
@@ -1,0 +1,8 @@
+package io.homeassistant.companion.android.webview
+
+import android.net.Uri
+import io.homeassistant.companion.android.util.hasSameOrigin
+
+internal fun shouldOpenInExternalBrowser(currentUrl: String?, targetUrl: Uri): Boolean {
+    return !targetUrl.hasSameOrigin(currentUrl)
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverrideTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverrideTest.kt
@@ -1,0 +1,48 @@
+package io.homeassistant.companion.android.webview
+
+import android.net.Uri
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WebViewUrlOverrideTest {
+
+    @Test
+    fun `Given same origin URL with different path then WebView should handle it`() {
+        val targetUrl = Uri.parse("http://homeassistant.local:8123/lovelace/default")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = "http://homeassistant.local:8123/",
+            targetUrl = targetUrl,
+        )
+
+        assertFalse(shouldOpen)
+    }
+
+    @Test
+    fun `Given different origin URL then external browser should handle it`() {
+        val targetUrl = Uri.parse("https://www.home-assistant.io/docs")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = "http://homeassistant.local:8123/",
+            targetUrl = targetUrl,
+        )
+
+        assertTrue(shouldOpen)
+    }
+
+    @Test
+    fun `Given missing current URL then external browser should handle it`() {
+        val targetUrl = Uri.parse("http://homeassistant.local:8123/lovelace/default")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = null,
+            targetUrl = targetUrl,
+        )
+
+        assertTrue(shouldOpen)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverrideTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/webview/WebViewUrlOverrideTest.kt
@@ -1,13 +1,16 @@
 package io.homeassistant.companion.android.webview
 
 import android.net.Uri
+import dagger.hilt.android.testing.HiltTestApplication
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
 class WebViewUrlOverrideTest {
 
     @Test
@@ -40,6 +43,42 @@ class WebViewUrlOverrideTest {
 
         val shouldOpen = shouldOpenInExternalBrowser(
             currentUrl = null,
+            targetUrl = targetUrl,
+        )
+
+        assertTrue(shouldOpen)
+    }
+
+    @Test
+    fun `Given mail URL then external browser should handle it`() {
+        val targetUrl = Uri.parse("mailto:user@example.com")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = "http://homeassistant.local:8123/",
+            targetUrl = targetUrl,
+        )
+
+        assertTrue(shouldOpen)
+    }
+
+    @Test
+    fun `Given telephone URL then external browser should handle it`() {
+        val targetUrl = Uri.parse("tel:+15555555555")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = "http://homeassistant.local:8123/",
+            targetUrl = targetUrl,
+        )
+
+        assertTrue(shouldOpen)
+    }
+
+    @Test
+    fun `Given relative URL then external browser should handle it`() {
+        val targetUrl = Uri.parse("/lovelace/default")
+
+        val shouldOpen = shouldOpenInExternalBrowser(
+            currentUrl = "http://homeassistant.local:8123/",
             targetUrl = targetUrl,
         )
 


### PR DESCRIPTION
## Summary

Potentially addresses part of #7027.

The legacy WebViewActivity URL override path used a substring check against the current WebView URL to decide whether a URL should open externally. That can incorrectly classify same-origin Home Assistant URLs with a different path as external.

This updates the legacy override path to compare origins instead. Same-origin Home Assistant URLs stay in the app, different origins still open externally, and non-HTTP(S)/hostless URLs continue to be handed to Android without calling the origin helper.

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots

Not applicable; this changes URL routing behavior only.

## Any other notes

Verification performed:

- `git diff --check`
- `./gradlew --no-daemon --console=plain :app:testFullDebugUnitTest --tests io.homeassistant.companion.android.webview.WebViewUrlOverrideTest`
- `./gradlew --no-daemon --console=plain :app:ktlintCheck`
