### PR TITLE
Make WearPrefs init non blocking

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImpl.kt
@@ -3,21 +3,16 @@ package io.homeassistant.companion.android.common.data.prefs
 import androidx.annotation.VisibleForTesting
 import io.homeassistant.companion.android.common.data.LocalStorage
 import io.homeassistant.companion.android.common.data.integration.ControlsAuthRequiredSetting
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl.Companion.MIGRATION_PREF
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl.Companion.MIGRATION_VERSION
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.HAGesture
 import io.homeassistant.companion.android.di.qualifiers.NamedIntegrationStorage
 import io.homeassistant.companion.android.di.qualifiers.NamedThemesStorage
-import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-
-@VisibleForTesting
-const val MIGRATION_PREF = "migration"
-
-@VisibleForTesting
-const val MIGRATION_VERSION = 1
 
 private const val PREF_VER = "version"
 private const val PREF_NIGHT_MODE_THEME = "theme"
@@ -57,12 +52,14 @@ private class LocalStorageWithMigration(
     private val localStorage: LocalStorage,
     private val integrationStorage: LocalStorage,
 ) {
-    private val migrationChecked = AtomicBoolean(false)
+    @Volatile
+    private var migrationChecked = false
     private val migrationMutex = Mutex()
 
     private suspend fun checkMigration() {
+        if (migrationChecked) return
         migrationMutex.withLock {
-            if (!migrationChecked.get()) {
+            if (!migrationChecked) {
                 val currentVersion = localStorage.getInt(MIGRATION_PREF)
                 if (currentVersion == null || currentVersion < 1) {
                     integrationStorage.getString(PREF_CONTROLS_AUTH_REQUIRED)?.let {
@@ -92,7 +89,7 @@ private class LocalStorageWithMigration(
 
                     localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
                 }
-                migrationChecked.set(true)
+                migrationChecked = true
             }
         }
     }
@@ -108,7 +105,16 @@ internal class PrefsRepositoryImpl @Inject constructor(
     @NamedIntegrationStorage integrationStorage: LocalStorage,
 ) : PrefsRepository {
 
-    private val localStorage = LocalStorageWithMigration(localStorage, integrationStorage)
+    companion object {
+        @VisibleForTesting
+        const val MIGRATION_PREF = "migration"
+
+        @VisibleForTesting
+        const val MIGRATION_VERSION = 1
+    }
+
+    private val localStorage =
+        LocalStorageWithMigration(localStorage = localStorage, integrationStorage = integrationStorage)
 
     override suspend fun getAppVersion(): String? {
         return localStorage().getString(PREF_VER)

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
@@ -62,10 +62,7 @@ private class WearLocalStorageWithMigration(
                         localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, it)
                     }
 
-                    localStorage.putInt(
-                        MIGRATION_PREF,
-                        MIGRATION_VERSION,
-                    )
+                    localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
                 }
 
                 if (currentVersion == null || currentVersion < 2) {
@@ -91,10 +88,7 @@ private class WearLocalStorageWithMigration(
                     localStorage.remove(legacyPrefTileTemplate)
                     localStorage.remove(legacyPrefTileTemplateRefreshInterval)
 
-                    localStorage.putInt(
-                        MIGRATION_PREF,
-                        MIGRATION_VERSION,
-                    )
+                    localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
                 }
             }
             migrationChecked = true

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
@@ -62,7 +62,7 @@ private class WearLocalStorageWithMigration(
                         localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, it)
                     }
 
-                    localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
+                    localStorage.putInt(MIGRATION_PREF, 1)
                 }
 
                 if (currentVersion == null || currentVersion < 2) {

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImpl.kt
@@ -2,6 +2,9 @@ package io.homeassistant.companion.android.common.data.prefs
 
 import androidx.annotation.VisibleForTesting
 import io.homeassistant.companion.android.common.data.LocalStorage
+import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryImpl.Companion.MIGRATION_PREF
+import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryImpl.Companion.MIGRATION_VERSION
+import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryImpl.Companion.PREF_TILE_TEMPLATES
 import io.homeassistant.companion.android.common.data.prefs.impl.entities.TemplateTileConfig
 import io.homeassistant.companion.android.common.util.jsonArrayOrNull
 import io.homeassistant.companion.android.common.util.kotlinJsonMapper
@@ -11,12 +14,102 @@ import io.homeassistant.companion.android.common.util.toStringList
 import io.homeassistant.companion.android.di.qualifiers.NamedIntegrationStorage
 import io.homeassistant.companion.android.di.qualifiers.NamedWearStorage
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.Json
 
+private const val PREF_TILE_SHORTCUTS = "tile_shortcuts_list"
+private const val PREF_SHOW_TILE_SHORTCUTS_TEXT = "show_tile_shortcuts_text"
+private const val PREF_WEAR_HAPTIC_FEEDBACK = "wear_haptic_feedback"
+private const val PREF_WEAR_TOAST_CONFIRMATION = "wear_toast_confirmation"
+private const val PREF_WEAR_FAVORITES_ONLY = "wear_favorites_only"
+
+private const val UNKNOWN_TEMPLATE_TILE_ID = -1
+
+private class WearLocalStorageWithMigration(
+    private val localStorage: LocalStorage,
+    private val integrationStorage: LocalStorage,
+) {
+    @Volatile
+    private var migrationChecked = false
+    private val migrationMutex = Mutex()
+
+    private suspend fun checkMigration() {
+        if (migrationChecked) return
+        migrationMutex.withLock {
+            if (!migrationChecked) {
+                val legacyPrefTileTemplate = "tile_template"
+                val legacyPrefTileTemplateRefreshInterval = "tile_template_refresh_interval"
+
+                val currentVersion = localStorage.getInt(MIGRATION_PREF)
+                if (currentVersion == null || currentVersion < 1) {
+                    integrationStorage.getString(PREF_TILE_SHORTCUTS)?.let {
+                        localStorage.putString(PREF_TILE_SHORTCUTS, it)
+                    }
+                    integrationStorage.getBooleanOrNull(PREF_SHOW_TILE_SHORTCUTS_TEXT)?.let {
+                        localStorage.putBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT, it)
+                    }
+                    integrationStorage.getString(legacyPrefTileTemplate)?.let {
+                        localStorage.putString(legacyPrefTileTemplate, it)
+                    }
+                    integrationStorage.getInt(legacyPrefTileTemplateRefreshInterval)?.let {
+                        localStorage.putInt(legacyPrefTileTemplateRefreshInterval, it)
+                    }
+                    integrationStorage.getBooleanOrNull(PREF_WEAR_HAPTIC_FEEDBACK)?.let {
+                        localStorage.putBoolean(PREF_WEAR_HAPTIC_FEEDBACK, it)
+                    }
+                    integrationStorage.getBooleanOrNull(PREF_WEAR_TOAST_CONFIRMATION)?.let {
+                        localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, it)
+                    }
+
+                    localStorage.putInt(
+                        MIGRATION_PREF,
+                        MIGRATION_VERSION,
+                    )
+                }
+
+                if (currentVersion == null || currentVersion < 2) {
+                    val template = localStorage.getString(legacyPrefTileTemplate)
+                    val templateRefreshInterval = localStorage.getInt(
+                        legacyPrefTileTemplateRefreshInterval,
+                    )
+
+                    if (template != null && templateRefreshInterval != null) {
+                        val templates = mapOf(
+                            UNKNOWN_TEMPLATE_TILE_ID.toString() to
+                                kotlinJsonMapper.encodeToString(
+                                    TemplateTileConfig(
+                                        template,
+                                        templateRefreshInterval,
+                                    ),
+                                ),
+                        )
+
+                        localStorage.putString(PREF_TILE_TEMPLATES, templates.toJsonObject().toString())
+                    }
+
+                    localStorage.remove(legacyPrefTileTemplate)
+                    localStorage.remove(legacyPrefTileTemplateRefreshInterval)
+
+                    localStorage.putInt(
+                        MIGRATION_PREF,
+                        MIGRATION_VERSION,
+                    )
+                }
+            }
+            migrationChecked = true
+        }
+    }
+
+    suspend operator fun invoke(): LocalStorage {
+        checkMigration()
+        return localStorage
+    }
+}
+
 internal class WearPrefsRepositoryImpl @Inject constructor(
-    @NamedWearStorage private val localStorage: LocalStorage,
-    @NamedIntegrationStorage private val integrationStorage: LocalStorage,
+    @NamedWearStorage localStorage: LocalStorage,
+    @NamedIntegrationStorage integrationStorage: LocalStorage,
 ) : WearPrefsRepository {
 
     companion object {
@@ -26,69 +119,12 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
         @VisibleForTesting
         const val MIGRATION_VERSION = 2
 
-        private const val PREF_TILE_SHORTCUTS = "tile_shortcuts_list"
-        private const val PREF_SHOW_TILE_SHORTCUTS_TEXT = "show_tile_shortcuts_text"
-
         @VisibleForTesting
         const val PREF_TILE_TEMPLATES = "tile_templates"
-        private const val PREF_WEAR_HAPTIC_FEEDBACK = "wear_haptic_feedback"
-        private const val PREF_WEAR_TOAST_CONFIRMATION = "wear_toast_confirmation"
-        private const val PREF_WEAR_FAVORITES_ONLY = "wear_favorites_only"
-
-        private const val UNKNOWN_TEMPLATE_TILE_ID = -1
     }
 
-    init {
-        runBlocking {
-            val legacyPrefTileTemplate = "tile_template"
-            val legacyPrefTileTemplateRefreshInterval = "tile_template_refresh_interval"
-
-            val currentVersion = localStorage.getInt(MIGRATION_PREF)
-            if (currentVersion == null || currentVersion < 1) {
-                integrationStorage.getString(PREF_TILE_SHORTCUTS)?.let {
-                    localStorage.putString(PREF_TILE_SHORTCUTS, it)
-                }
-                integrationStorage.getBooleanOrNull(PREF_SHOW_TILE_SHORTCUTS_TEXT)?.let {
-                    localStorage.putBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT, it)
-                }
-                integrationStorage.getString(legacyPrefTileTemplate)?.let {
-                    localStorage.putString(legacyPrefTileTemplate, it)
-                }
-                integrationStorage.getInt(legacyPrefTileTemplateRefreshInterval)?.let {
-                    localStorage.putInt(legacyPrefTileTemplateRefreshInterval, it)
-                }
-                integrationStorage.getBooleanOrNull(PREF_WEAR_HAPTIC_FEEDBACK)?.let {
-                    localStorage.putBoolean(PREF_WEAR_HAPTIC_FEEDBACK, it)
-                }
-                integrationStorage.getBooleanOrNull(PREF_WEAR_TOAST_CONFIRMATION)?.let {
-                    localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, it)
-                }
-
-                localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
-            }
-
-            if (currentVersion == null || currentVersion < 2) {
-                val template = localStorage.getString(legacyPrefTileTemplate)
-                val templateRefreshInterval = localStorage.getInt(
-                    legacyPrefTileTemplateRefreshInterval,
-                )
-
-                if (template != null && templateRefreshInterval != null) {
-                    val templates = mapOf(
-                        UNKNOWN_TEMPLATE_TILE_ID.toString() to
-                            kotlinJsonMapper.encodeToString(TemplateTileConfig(template, templateRefreshInterval)),
-                    )
-
-                    localStorage.putString(PREF_TILE_TEMPLATES, templates.toJsonObject().toString())
-                }
-
-                localStorage.remove(legacyPrefTileTemplate)
-                localStorage.remove(legacyPrefTileTemplateRefreshInterval)
-
-                localStorage.putInt(MIGRATION_PREF, MIGRATION_VERSION)
-            }
-        }
-    }
+    private val localStorage =
+        WearLocalStorageWithMigration(localStorage = localStorage, integrationStorage = integrationStorage)
 
     override suspend fun getTileShortcutsAndSaveTileId(tileId: Int): List<String> {
         val tileIdToShortcutsMap = getAllTileShortcuts()
@@ -108,7 +144,7 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getAllTileShortcuts(): Map<Int?, List<String>> {
-        return localStorage.getString(PREF_TILE_SHORTCUTS)?.let { jsonStr ->
+        return localStorage().getString(PREF_TILE_SHORTCUTS)?.let { jsonStr ->
             runCatching {
                 jsonStr.toJsonObjectOrNull()
             }.fold(
@@ -144,7 +180,7 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
 
     private suspend fun setTileShortcuts(map: Map<Int?, List<String>>) {
         val jsonStr = Json.encodeToString(map)
-        localStorage.putString(PREF_TILE_SHORTCUTS, jsonStr)
+        localStorage().putString(PREF_TILE_SHORTCUTS, jsonStr)
     }
 
     override suspend fun removeTileShortcuts(tileId: Int?): List<String>? {
@@ -155,15 +191,15 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getShowShortcutText(): Boolean {
-        return localStorage.getBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT)
+        return localStorage().getBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT)
     }
 
     override suspend fun setShowShortcutTextEnabled(enabled: Boolean) {
-        localStorage.putBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT, enabled)
+        localStorage().putBoolean(PREF_SHOW_TILE_SHORTCUTS_TEXT, enabled)
     }
 
     override suspend fun getAllTemplateTiles(): Map<Int, TemplateTileConfig> {
-        return localStorage.getString(PREF_TILE_TEMPLATES)?.let { jsonStr ->
+        return localStorage().getString(PREF_TILE_TEMPLATES)?.let { jsonStr ->
             kotlinJsonMapper.decodeFromString<Map<String, TemplateTileConfig>>(jsonStr)
                 .mapKeys { it.key.toInt() }
         } ?: emptyMap()
@@ -188,7 +224,7 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
 
     override suspend fun setAllTemplateTiles(templateTiles: Map<Int, TemplateTileConfig>) {
         val jsonStr = kotlinJsonMapper.encodeToString(templateTiles.mapKeys { it.key.toString() })
-        localStorage.putString(PREF_TILE_TEMPLATES, jsonStr)
+        localStorage().putString(PREF_TILE_TEMPLATES, jsonStr)
     }
 
     override suspend fun setTemplateTile(tileId: Int, content: String, refreshInterval: Int): TemplateTileConfig {
@@ -206,26 +242,26 @@ internal class WearPrefsRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getWearHapticFeedback(): Boolean {
-        return localStorage.getBoolean(PREF_WEAR_HAPTIC_FEEDBACK)
+        return localStorage().getBoolean(PREF_WEAR_HAPTIC_FEEDBACK)
     }
 
     override suspend fun setWearHapticFeedback(enabled: Boolean) {
-        localStorage.putBoolean(PREF_WEAR_HAPTIC_FEEDBACK, enabled)
+        localStorage().putBoolean(PREF_WEAR_HAPTIC_FEEDBACK, enabled)
     }
 
     override suspend fun getWearToastConfirmation(): Boolean {
-        return localStorage.getBoolean(PREF_WEAR_TOAST_CONFIRMATION)
+        return localStorage().getBoolean(PREF_WEAR_TOAST_CONFIRMATION)
     }
 
     override suspend fun setWearToastConfirmation(enabled: Boolean) {
-        localStorage.putBoolean(PREF_WEAR_TOAST_CONFIRMATION, enabled)
+        localStorage().putBoolean(PREF_WEAR_TOAST_CONFIRMATION, enabled)
     }
 
     override suspend fun getWearFavoritesOnly(): Boolean {
-        return localStorage.getBoolean(PREF_WEAR_FAVORITES_ONLY)
+        return localStorage().getBoolean(PREF_WEAR_FAVORITES_ONLY)
     }
 
     override suspend fun setWearFavoritesOnly(enabled: Boolean) {
-        localStorage.putBoolean(PREF_WEAR_FAVORITES_ONLY, enabled)
+        localStorage().putBoolean(PREF_WEAR_FAVORITES_ONLY, enabled)
     }
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/PrefsRepositoryImplTest.kt
@@ -2,6 +2,8 @@ package io.homeassistant.companion.android.common.data.prefs
 
 import app.cash.turbine.test
 import io.homeassistant.companion.android.common.data.LocalStorage
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl.Companion.MIGRATION_PREF
+import io.homeassistant.companion.android.common.data.prefs.PrefsRepositoryImpl.Companion.MIGRATION_VERSION
 import io.homeassistant.companion.android.common.util.GestureAction
 import io.homeassistant.companion.android.common.util.HAGesture
 import io.mockk.coEvery

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImplTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/prefs/WearPrefsRepositoryImplTest.kt
@@ -7,6 +7,7 @@ import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepositoryI
 import io.homeassistant.companion.android.common.data.prefs.impl.entities.TemplateTileConfig
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
@@ -53,5 +54,22 @@ class WearPrefsRepositoryImplTest {
             ),
             result,
         )
+    }
+
+    @Test
+    fun `Given migration already at current version when accessing prefs multiple times then migration check only runs once`() = runTest {
+        // Migration is already current: the lazy check should run once on first access and never
+        // touch the integration storage, and subsequent accesses must skip it via the fast path.
+        initRepository(version = MIGRATION_VERSION)
+        coEvery { localStorage.getBoolean(any()) } returns true
+
+        repository.getShowShortcutText()
+        repository.getWearHapticFeedback()
+        repository.getWearToastConfirmation()
+
+        // The migration version is read only on the first access, not on every call.
+        coVerify(exactly = 1) { localStorage.getInt(MIGRATION_PREF) }
+        // No migration was needed, so the integration storage was never consulted.
+        coVerify(exactly = 0) { integrationStorage.getString(any()) }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
WearPrefsRepository had a migration happening at init time using `runBlocking` we should never do that, especially when injected in DI because it blocks the DI to continue its work. This PR address that to reflect how we handle migration in `PrefsRepository`.

I've also replaced the Mutex with a volatile double-checked locking that avoid useless lock acquirement.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.