### PR TITLE
Apply keep_screen_on change immediately while a dashboard is showing

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -184,6 +184,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND_ACTIVITY = "command_activity"
         const val COMMAND_WEBVIEW = "command_webview"
         const val COMMAND_KEEP_SCREEN_ON = "keep_screen_on"
+        const val ACTION_KEEP_SCREEN_ON_CHANGED = "io.homeassistant.companion.android.KEEP_SCREEN_ON_CHANGED"
         const val COMMAND_LAUNCH_APP = "command_launch_app"
         const val COMMAND_APP_LOCK = "command_app_lock"
         const val COMMAND_PERSISTENT_CONNECTION = "command_persistent_connection"
@@ -815,6 +816,9 @@ class MessagingManager @Inject constructor(
                 if (!command.isNullOrEmpty()) {
                     prefsRepository.setKeepScreenOnEnabled(
                         command == COMMAND_KEEP_SCREEN_ON,
+                    )
+                    context.sendBroadcast(
+                        Intent(ACTION_KEEP_SCREEN_ON_CHANGED).setPackage(context.packageName),
                     )
                 }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -4,8 +4,10 @@ import android.annotation.SuppressLint
 import android.app.DownloadManager
 import android.app.PictureInPictureParams
 import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Rect
 import android.net.Uri
@@ -134,6 +136,7 @@ import io.homeassistant.companion.android.improv.ui.ImprovPermissionDialog
 import io.homeassistant.companion.android.improv.ui.ImprovSetupDialog
 import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.nfc.WriteNfcTag
+import io.homeassistant.companion.android.notifications.MessagingManager
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.sensors.SensorWorker
 import io.homeassistant.companion.android.settings.ConnectionSecurityLevelFragment
@@ -350,6 +353,12 @@ class WebViewActivity :
     private var downloadFileContentDisposition = ""
     private var downloadFileMimetype = ""
     private var serverHandleInsets = mutableStateOf(false)
+    private var isKeepScreenOnReceiverRegistered = false
+    private val keepScreenOnReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            applyKeepScreenOn()
+        }
+    }
 
     private val snackbarHostState = SnackbarHostState()
 
@@ -809,11 +818,9 @@ class WebViewActivity :
             }
         }
 
-        lifecycleScope.launch {
-            if (presenter.isKeepScreenOnEnabled()) {
-                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            }
+        applyKeepScreenOn()
 
+        lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 presenter.getMatterThreadStepFlow().collect {
                     Timber.d("Matter/Thread step changed to $it")
@@ -1394,8 +1401,42 @@ class WebViewActivity :
         requestLocalNetworkPermission.launch(android.Manifest.permission.ACCESS_LOCAL_NETWORK)
     }
 
+    private fun registerKeepScreenOnReceiver() {
+        if (isKeepScreenOnReceiverRegistered) return
+        ContextCompat.registerReceiver(
+            this,
+            keepScreenOnReceiver,
+            IntentFilter(MessagingManager.ACTION_KEEP_SCREEN_ON_CHANGED),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        isKeepScreenOnReceiverRegistered = true
+    }
+
+    private fun unregisterKeepScreenOnReceiver() {
+        if (!isKeepScreenOnReceiverRegistered) return
+        isKeepScreenOnReceiverRegistered = false
+        try {
+            unregisterReceiver(keepScreenOnReceiver)
+        } catch (e: IllegalArgumentException) {
+            Timber.w(e, "Keep screen on receiver was already unregistered")
+        }
+    }
+
+    private fun applyKeepScreenOn() {
+        lifecycleScope.launch {
+            if (presenter.isKeepScreenOnEnabled()) {
+                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            } else {
+                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+            }
+        }
+    }
+
     override fun onResume() {
         super.onResume()
+        registerKeepScreenOnReceiver()
+        applyKeepScreenOn()
+
         lifecycleScope.launch {
             // if null it means that the settings were not yet read so we should not recreate
             if (currentAutoplay != null && currentAutoplay != presenter.isAutoPlayVideoEnabled()) {
@@ -1413,12 +1454,6 @@ class WebViewActivity :
             WebsocketManager.start(this@WebViewActivity)
 
             requestedOrientation = presenter.getScreenOrientation().activityInfo
-
-            if (presenter.isKeepScreenOnEnabled()) {
-                window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            } else {
-                window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            }
 
             checkLocationDisabled()
             changeLog.showChangeLog(this@WebViewActivity, false)
@@ -1438,6 +1473,7 @@ class WebViewActivity :
 
     override fun onPause() {
         super.onPause()
+        unregisterKeepScreenOnReceiver()
         lifecycleScope.launch {
             presenter.setAppActive(false)
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

Fixes #6829.

When a `command_screen_on` notification carries a `command` payload, `MessagingManager` persists the "Keep screen on" preference via `prefsRepository.setKeepScreenOnEnabled(...)`. As diagnosed in the issue, if a `WebViewActivity` dashboard is already in the foreground the new value is never applied to the live window: turning the setting **on** appears to work because acquiring the wake lock lights the screen anyway, but turning it **off** does not clear `FLAG_KEEP_SCREEN_ON` until the activity is recreated. The result is the asymmetry the reporter confirmed: enabling is immediate, disabling is not.

This wires the persisted change through to a live dashboard:

* `MessagingManager` sends an app-internal, package-scoped broadcast (`ACTION_KEEP_SCREEN_ON_CHANGED`) right after it persists the preference in the `COMMAND_SCREEN_ON` branch (only when a command string is present, so the no-command "just wake the screen" path is unchanged).
* `WebViewActivity` registers a non-exported `BroadcastReceiver` (via `ContextCompat.registerReceiver(..., RECEIVER_NOT_EXPORTED)`, matching the existing receiver convention) while it is in the foreground and re-applies/clears `FLAG_KEEP_SCREEN_ON` from the fresh preference value. The flag apply/clear logic is consolidated into a single `applyKeepScreenOn()` helper reused by `onCreate`, `onResume`, and the receiver. The receiver is registered in `onResume` and unregistered in `onPause` (guarded so an unmatched unregister never throws), so nothing leaks while the activity is backgrounded.

Impact: disabling "Keep screen on" via a notification command now takes effect immediately on an open dashboard, with no activity recreation and no behavior change to the wake-lock-only path.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

There is no visible UI change to screenshot: this fix only re-applies the existing `FLAG_KEEP_SCREEN_ON` window flag to a live dashboard, so its effect is whether the screen stays on, not a rendered surface.

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

The behavior was verified by reasoning through the issue's four scenarios (open dashboard + enable, open dashboard + disable, no-command wake-only, no foreground activity). I was unable to compile or run the Android test suite locally to add a new automated test, as there is no existing focused JVM/Robolectric harness around `MessagingManager`/`WebViewActivity` to extend without new test infrastructure; the change reuses the same `presenter.isKeepScreenOnEnabled()` flag-apply path that already runs on activity recreation.
