### PR TITLE
Restore fullscreen in focus change for FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -337,9 +337,11 @@ private fun FullscreenEffect(isFullScreen: Boolean) {
                 applyFullscreen()
             }
         }
-        view.viewTreeObserver.addOnWindowFocusChangeListener(focusListener)
+        val viewTreeObserver = view.viewTreeObserver
+
+        viewTreeObserver.addOnWindowFocusChangeListener(focusListener)
         onDispose {
-            view.viewTreeObserver.removeOnWindowFocusChangeListener(focusListener)
+            viewTreeObserver.removeOnWindowFocusChangeListener(focusListener)
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
+import android.view.ViewTreeObserver
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -16,6 +17,7 @@ import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult.ActionPerformed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -308,14 +310,36 @@ private fun AppLockEffect(isAppLocked: Boolean, onAuthSucceeded: () -> Unit) {
 private fun FullscreenEffect(isFullScreen: Boolean) {
     val view = LocalView.current
     val window = LocalActivity.current?.window ?: return
-    LaunchedEffect(isFullScreen) {
-        val controller = WindowInsetsControllerCompat(window, view)
-        if (isFullScreen) {
-            controller.systemBarsBehavior =
-                WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            controller.hide(systemBars())
-        } else {
-            controller.show(systemBars())
+    val controller = remember(window, view) { WindowInsetsControllerCompat(window, view) }
+
+    // Applies the state immediately (the effect re-runs whenever [isFullScreen] changes) and,
+    // while fullscreen, re-applies it every time the window regains focus. The system can
+    // transiently restore the system bars when focus is lost — a dialog, the notification
+    // shade, or the recents switcher — so re-hiding on focus regain keeps the frontend in
+    // fullscreen.
+    DisposableEffect(view, isFullScreen) {
+        fun applyFullscreen() {
+            if (isFullScreen) {
+                controller.systemBarsBehavior =
+                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                controller.hide(systemBars())
+            } else {
+                controller.show(systemBars())
+            }
+        }
+
+        applyFullscreen()
+
+        val focusListener = ViewTreeObserver.OnWindowFocusChangeListener { hasFocus ->
+            // Only re-hide on focus regain while fullscreen. Outside fullscreen the bars are
+            // already shown, so reacting to every focus change here would be redundant work.
+            if (hasFocus && isFullScreen) {
+                applyFullscreen()
+            }
+        }
+        view.viewTreeObserver.addOnWindowFocusChangeListener(focusListener)
+        onDispose {
+            view.viewTreeObserver.removeOnWindowFocusChangeListener(focusListener)
         }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The `WebViewActivity` was restoring the fullscreen using a focus change listener. This PR does change how we apply the full screen mode to replicate this behavior.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I kept AI generated comment to give more details about why we do these extra checks and why we go this on change focus way rather than the initial one I did.