### PR TITLE
Introduce FrontendTarget and use it instead of WebViewActivity

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterCommissioningActivity.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterCommissioningActivity.kt
@@ -14,10 +14,11 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.gms.home.matter.Matter
 import com.google.android.gms.home.matter.commissioning.SharedDeviceData
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.startLaunchWithNavigateTo
 import io.homeassistant.companion.android.matter.views.MatterCommissioningView
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.enableEdgeToEdgeCompat
-import io.homeassistant.companion.android.webview.WebViewActivity
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -100,7 +101,7 @@ class MatterCommissioningActivity : AppCompatActivity() {
     }
 
     private fun continueToApp(hideTransition: Boolean) {
-        startActivity(WebViewActivity.newInstance(this, null, viewModel.serverId))
+        startLaunchWithNavigateTo(FrontendTarget.Default, viewModel.serverId)
         finish()
         if (hideTransition) { // Disable activity start/stop animation
             overridePendingTransition(0, 0)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/assist/AssistActivity.kt
@@ -22,9 +22,10 @@ import io.homeassistant.companion.android.assist.ui.AssistSheetView
 import io.homeassistant.companion.android.common.assist.AssistViewModelBase
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.SdkVersion
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
-import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
 import kotlinx.coroutines.launch
 
@@ -137,9 +138,9 @@ class AssistActivity : BaseActivity() {
                     if (fromFrontend && viewModel.userCanManagePipelines) {
                         {
                             startActivity(
-                                WebViewActivity.newInstance(
-                                    this,
-                                    "config/voice-assistants/assistants",
+                                intentLaunchWithNavigateTo(
+                                    FrontendTarget.Path("config/voice-assistants/assistants"),
+                                    ServerManager.SERVER_ID_ACTIVE,
                                 ).apply {
                                     flags += Intent.FLAG_ACTIVITY_NEW_TASK // Delivers data in onNewIntent
                                 },

--- a/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControl.kt
@@ -22,24 +22,26 @@ import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.util.SdkVersion
-import io.homeassistant.companion.android.webview.WebViewActivity
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
 
 @RequiresApi(Build.VERSION_CODES.R)
 interface HaControl {
 
     @SuppressLint("ResourceType")
     fun createControl(context: Context, entity: Entity, info: HaControlInfo): Control {
-        val controlPath = "entityId:${info.entityId}"
+        val controlIntent =
+            context.applicationContext.intentLaunchWithNavigate(
+                FrontendTarget.EntityMoreInfo(info.entityId),
+                info.serverId,
+            )
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         val control = Control.StatefulBuilder(
             info.systemId,
             PendingIntent.getActivity(
                 context,
-                controlPath.hashCode(),
-                WebViewActivity.newInstance(
-                    context.applicationContext,
-                    controlPath,
-                    info.serverId,
-                ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+                info.entityId.hashCode(),
+                controlIntent,
                 PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE,
             ),
         )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControl.kt
@@ -23,7 +23,7 @@ import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.integration.isActive
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
-import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 
 @RequiresApi(Build.VERSION_CODES.R)
 interface HaControl {
@@ -31,7 +31,7 @@ interface HaControl {
     @SuppressLint("ResourceType")
     fun createControl(context: Context, entity: Entity, info: HaControlInfo): Control {
         val controlIntent =
-            context.applicationContext.intentLaunchWithNavigate(
+            context.applicationContext.intentLaunchWithNavigateTo(
                 FrontendTarget.EntityMoreInfo(info.entityId),
                 info.serverId,
             )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -28,6 +28,7 @@ import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.servers.ServerManager.Companion.SERVER_ID_ACTIVE
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.webview.WebViewActivity
@@ -73,7 +74,10 @@ class HaControlsPanelActivity : AppCompatActivity() {
                 Timber.d("Launching LaunchActivity…")
                 LaunchActivity.newInstance(
                     context = this@HaControlsPanelActivity,
-                    deepLink = LaunchActivity.DeepLink.NavigateTo(path = path, serverId = serverId ?: SERVER_ID_ACTIVE),
+                    deepLink = LaunchActivity.DeepLink.NavigateTo(
+                        target = FrontendTarget.fromRawPath(path),
+                        serverId = serverId ?: SERVER_ID_ACTIVE,
+                    ),
                     showWhenLocked = true,
                 )
             } else {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/controls/HaControlsPanelActivity.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import io.homeassistant.companion.android.WIPFeature
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
@@ -31,10 +30,8 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager.Comp
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
-import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class HaControlsPanelActivity : AppCompatActivity() {
@@ -70,26 +67,14 @@ class HaControlsPanelActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val serverId = prefsRepository.getControlsPanelServer() ?: serverManager.getServer()?.id
             val path = prefsRepository.getControlsPanelPath()
-            val intent = if (WIPFeature.USE_FRONTEND_V2) {
-                Timber.d("Launching LaunchActivity…")
-                LaunchActivity.newInstance(
-                    context = this@HaControlsPanelActivity,
-                    deepLink = LaunchActivity.DeepLink.NavigateTo(
-                        target = FrontendTarget.fromRawPath(path),
-                        serverId = serverId ?: SERVER_ID_ACTIVE,
-                    ),
-                    showWhenLocked = true,
-                )
-            } else {
-                Timber.d("Launching WebView…")
-                WebViewActivity.newInstance(
-                    context = this@HaControlsPanelActivity,
-                    path = path,
-                    serverId = serverId,
-                ).apply {
-                    putExtra(WebViewActivity.EXTRA_SHOW_WHEN_LOCKED, true)
-                }
-            }
+            val intent = LaunchActivity.newInstance(
+                context = this@HaControlsPanelActivity,
+                deepLink = LaunchActivity.DeepLink.NavigateTo(
+                    target = FrontendTarget.fromRawPath(path),
+                    serverId = serverId ?: SERVER_ID_ACTIVE,
+                ),
+                showWhenLocked = true,
+            )
             startActivity(intent)
             overridePendingTransition(0, 0) // Disable activity start/stop animation
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -290,6 +290,13 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private var zoomObserverJob: Job? = null
 
     /**
+     * Entity whose more-info dialog must be opened via JavaScript once the page finishes loading.
+     * Set for servers older than HA 2025.6 (see [UrlLoadResult.Success.moreInfoEntityId]) and
+     * cleared after it is dispatched in [onPageFinished].
+     */
+    private var pendingMoreInfoEntityId: String? = null
+
+    /**
      * The user's "Autoplay video" preference.
      *
      * Lives outside [FrontendViewState] because the WebView is rendered during `Loading`,
@@ -915,6 +922,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private fun handleUrlResult(result: UrlLoadResult) {
         when (result) {
             is UrlLoadResult.Success -> {
+                pendingMoreInfoEntityId = result.moreInfoEntityId
                 _viewState.update {
                     FrontendViewState.Loading(
                         serverId = result.serverId,
@@ -1088,6 +1096,12 @@ internal class FrontendViewModel @VisibleForTesting constructor(
      * to react to settings changes until the next page load restarts it.
      */
     private fun onPageFinished(url: String?) {
+        // Open the more-info dialog for an older-server deep link now that the frontend has loaded.
+        pendingMoreInfoEntityId?.let { entityId ->
+            pendingMoreInfoEntityId = null
+            viewModelScope.launch { _webViewActions.emit(WebViewAction.OpenMoreInfo(entityId)) }
+        }
+
         zoomObserverJob?.cancel()
         zoomObserverJob = viewModelScope.launch {
             prefsRepository.zoomSettingsFlow().collect { settings ->

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -47,6 +47,7 @@ import io.homeassistant.companion.android.frontend.js.FrontendJsCallback
 import io.homeassistant.companion.android.frontend.matterthread.FrontendMatterThreadHandler
 import io.homeassistant.companion.android.frontend.navigation.FrontendEvent
 import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.permissions.PermissionManager
 import io.homeassistant.companion.android.frontend.url.FrontendUrlManager
 import io.homeassistant.companion.android.frontend.url.UrlLoadResult
@@ -108,7 +109,7 @@ private val FIRST_VIEW_EXCLUDED_URL_REGEX =
 @HiltViewModel
 internal class FrontendViewModel @VisibleForTesting constructor(
     initialServerId: Int,
-    initialPath: String?,
+    initialTarget: FrontendTarget,
     webViewClientFactory: HAWebViewClientFactory,
     private val frontendBusObserver: FrontendBusObserver,
     private val externalBusRepository: FrontendExternalBusRepository,
@@ -155,7 +156,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         @NamedKeyChain keyChainRepository: KeyChainRepository,
     ) : this(
         initialServerId = savedStateHandle.toRoute<FrontendRoute>().serverId,
-        initialPath = savedStateHandle.toRoute<FrontendRoute>().path,
+        initialTarget = savedStateHandle.toRoute<FrontendRoute>().target,
         webViewClientFactory = webViewClientFactory,
         frontendBusObserver = frontendBusObserver,
         externalBusRepository = externalBusRepository,
@@ -213,7 +214,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val _viewState = ViewStateManager(
         FrontendViewState.LoadServer(
             serverId = initialServerId,
-            path = initialPath,
+            target = initialTarget,
         ),
     )
     val viewState: StateFlow<FrontendViewState> = _viewState
@@ -380,7 +381,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                 when (event) {
                     is FrontendImprovHandler.Event.ReloadAtPath -> {
                         _viewState.update {
-                            FrontendViewState.LoadServer(serverId = event.serverId, path = event.path)
+                            FrontendViewState.LoadServer(
+                                serverId = event.serverId,
+                                target = FrontendTarget.Path(event.path),
+                            )
                         }
                     }
                 }
@@ -725,14 +729,14 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         urlFlowJob = viewModelScope.launch {
             permissionManager.checkLocalNetworkPermission()
             val currentState = _viewState.value
-            val path = when (currentState) {
-                is FrontendViewState.LoadServer -> currentState.path
-                is FrontendViewState.Loading -> currentState.path
-                else -> null
+            val target = when (currentState) {
+                is FrontendViewState.LoadServer -> currentState.target
+                is FrontendViewState.Loading -> currentState.target
+                else -> FrontendTarget.Default
             }
             urlManager.serverUrlFlow(
                 serverId = currentState.serverId,
-                path = path,
+                target = target,
             ).collect { result ->
                 handleUrlResult(result)
             }
@@ -915,7 +919,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                     FrontendViewState.Loading(
                         serverId = result.serverId,
                         url = result.url,
-                        path = null,
+                        target = FrontendTarget.Default,
                     )
                 }
             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewState.kt
@@ -7,6 +7,7 @@ import io.homeassistant.companion.android.frontend.error.ErrorAction
 import io.homeassistant.companion.android.frontend.error.FrontendConnectionError
 import io.homeassistant.companion.android.frontend.exoplayer.ExoPlayerUiState
 import io.homeassistant.companion.android.frontend.improv.ImprovUIState
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.util.compose.webview.BLANK_URL
 
 /**
@@ -36,7 +37,8 @@ sealed interface FrontendViewState {
      *
      * The [url] is set to about:blank to clear the webview of any previously loaded URL
      */
-    data class LoadServer(override val serverId: Int, val path: String? = null) : FrontendViewState {
+    data class LoadServer(override val serverId: Int, val target: FrontendTarget = FrontendTarget.Default) :
+        FrontendViewState {
         override val url: String = BLANK_URL
     }
 
@@ -45,8 +47,11 @@ sealed interface FrontendViewState {
      *
      * The connection timeout starts when entering this state.
      */
-    data class Loading(override val serverId: Int, override val url: String, val path: String? = null) :
-        FrontendViewState
+    data class Loading(
+        override val serverId: Int,
+        override val url: String,
+        val target: FrontendTarget = FrontendTarget.Default,
+    ) : FrontendViewState
 
     /**
      * Content state when the WebView is displaying the Home Assistant frontend.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerforme
 import io.homeassistant.companion.android.util.compose.webview.settings
 import io.homeassistant.companion.android.util.sensitive
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.serialization.json.Json
 import timber.log.Timber
 
 /**
@@ -175,6 +176,29 @@ sealed interface WebViewAction {
             // is the only way to adjust these settings at runtime.
             @OptIn(EvaluateJavascriptUsage::class)
             webView.evaluateJavascript(viewportZoomScript(pinchToZoomEnabled)) {}
+        }
+    }
+
+    /**
+     * Opens the more-info dialog for [entityId] by dispatching the frontend's `hass-more-info`
+     * DOM event.
+     *
+     * Fallback for servers older than HA 2025.6, which ignore the `more-info-entity-id` URL query
+     * parameter. There is no external bus message to open more-info on those servers, so dispatching
+     * the frontend DOM event is the only option.
+     */
+    data class OpenMoreInfo(val entityId: String) : WebViewAction {
+        // [entityId] originates from server/registry data, so it is treated as untrusted: it is
+        // JSON-encoded (quotes/backslashes escaped) so it cannot break out of the JS string literal.
+        private fun moreInfoScript(entityId: String): String {
+            val entityIdJson = Json.encodeToString(entityId)
+            return """document.querySelector("home-assistant")""" +
+                """.dispatchEvent(new CustomEvent("hass-more-info", { detail: { entityId: $entityIdJson }}))"""
+        }
+
+        override fun run(webView: WebView) {
+            @OptIn(EvaluateJavascriptUsage::class)
+            webView.evaluateJavascript(moreInfoScript(entityId)) {}
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendNavigation.kt
@@ -22,6 +22,7 @@ import io.homeassistant.companion.android.assist.AssistActivity
 import io.homeassistant.companion.android.common.data.servers.ServerManager.Companion.SERVER_ID_ACTIVE
 import io.homeassistant.companion.android.frontend.FrontendScreen
 import io.homeassistant.companion.android.frontend.FrontendViewModel
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget.Companion.toRawPath
 import io.homeassistant.companion.android.launch.HAStartDestinationRoute
 import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.launch.PipReadiness
@@ -41,15 +42,33 @@ internal data class FrontendActivityRoute(
 )
 
 @Serializable
-internal data class FrontendRoute(val path: String? = null, val serverId: Int = SERVER_ID_ACTIVE) :
-    HAStartDestinationRoute
+internal data class FrontendRoute
+/**
+ * The destination is stored as the raw [rawPath] string rather than a custom-typed field on
+ * purpose: a custom `NavType` for a [FrontendTarget] field would force a `typeOf`/kotlin-reflect
+ * lookup on the main thread during navigation.
+ *
+ * Annotated `@VisibleForTesting` so the linter discourages building a route from a raw path;
+ * production code should use the [FrontendTarget] constructor instead. It remains used by the
+ * generated kotlinx.serialization route serializer.
+ */
+@VisibleForTesting constructor(
+    // TODO make this private when removing FrontendActivityRoute
+    val rawPath: String? = null,
+    val serverId: Int = SERVER_ID_ACTIVE,
+) : HAStartDestinationRoute {
+
+    constructor(target: FrontendTarget, serverId: Int = SERVER_ID_ACTIVE) : this(target.toRawPath(), serverId)
+
+    val target: FrontendTarget get() = FrontendTarget.fromRawPath(rawPath)
+}
 
 internal fun NavController.navigateToFrontend(
-    path: String? = null,
+    target: FrontendTarget = FrontendTarget.Default,
     serverId: Int = SERVER_ID_ACTIVE,
     navOptions: NavOptions? = null,
 ) {
-    navigate(FrontendRoute(path, serverId), navOptions)
+    navigate(FrontendRoute(target, serverId), navOptions)
 }
 
 /**
@@ -158,7 +177,7 @@ internal fun NavGraphBuilder.frontendScreen(
     } else {
         composable<FrontendRoute> {
             val route = it.toRoute<FrontendRoute>()
-            navController.navigate(FrontendActivityRoute(route.serverId, route.path))
+            navController.navigate(FrontendActivityRoute(route.serverId, route.rawPath))
             navController.context.getActivity()?.finish()
         }
 
@@ -214,12 +233,15 @@ internal fun FrontendEventHandler(
                 is FrontendEvent.NavigateToAssistSettings -> onNavigateToSettings(
                     SettingsActivity.Deeplink.AssistSettings,
                 )
+
                 is FrontendEvent.NavigateToAssist ->
                     onNavigateToAssist(event.serverId, event.pipelineId, event.startListening)
+
                 is FrontendEvent.OpenExternalLink -> onOpenExternalLink(event.uri)
                 is FrontendEvent.NavigateToDeveloperSettings -> onNavigateToSettings(
                     SettingsActivity.Deeplink.Developer,
                 )
+
                 is FrontendEvent.ShowServerSwitcher -> onShowServerSwitcher()
                 is FrontendEvent.NavigateToNfcWrite -> onNavigateToNfcWrite(event.messageId, event.tagId)
                 is FrontendEvent.LaunchMatterThreadIntent -> onLaunchMatterThreadIntent(event.intentSender)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
@@ -35,7 +35,7 @@ sealed interface FrontendTarget : Parcelable {
         }
 
         /**
-         * Serializes this target back to the raw path string, persisted
+         * Serializes this target back to the raw path string
          * Returns `null` for [FrontendTarget.Default].
          */
         internal fun FrontendTarget.toRawPath(): String? = when (this) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
@@ -1,0 +1,47 @@
+package io.homeassistant.companion.android.frontend.navigation
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+private const val ENTITY_ID_PREFIX = "entityId:"
+
+/**
+ * A destination within the Home Assistant frontend.
+ */
+sealed interface FrontendTarget : Parcelable {
+
+    /** Open the server's default dashboard with no specific path. */
+    @Parcelize
+    data object Default : FrontendTarget
+
+    /** Navigate to a relative path or URL within the frontend (e.g. `/lovelace/0`). */
+    @Parcelize
+    data class Path(val path: String) : FrontendTarget
+
+    /** Open the more-info dialog for [entityId] (e.g. `light.kitchen`). */
+    @Parcelize
+    data class EntityMoreInfo(val entityId: String) : FrontendTarget
+
+    companion object {
+        /**
+         * Parses a raw path string into a [FrontendTarget].
+         *
+         * A `null` path maps to [Default].
+         */
+        fun fromRawPath(path: String?): FrontendTarget = when {
+            path == null -> Default
+            path.startsWith(ENTITY_ID_PREFIX) -> EntityMoreInfo(path.removePrefix(ENTITY_ID_PREFIX))
+            else -> Path(path)
+        }
+
+        /**
+         * Serializes this target back to the raw path string, persisted
+         * Returns `null` for [FrontendTarget.Default].
+         */
+        internal fun FrontendTarget.toRawPath(): String? = when (this) {
+            Default -> null
+            is Path -> path
+            is EntityMoreInfo -> "$ENTITY_ID_PREFIX$entityId"
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
@@ -106,12 +106,22 @@ class FrontendUrlManager @Inject constructor(
     }
 
     private suspend fun buildUrl(baseUrl: URL?, serverId: Int, target: FrontendTarget): UrlLoadResult {
+        // Set when the more-info dialog must be opened via the `more-info-entity-id` URL parameter
+        // (HA 2025.6+) — added through the query builder below so the entity id is percent-encoded.
+        var moreInfoEntityIdForQuery: String? = null
+        // Set when the more-info dialog must instead be opened via JavaScript after the page loads
+        // (older servers that don't honor the `more-info-entity-id` URL parameter).
+        var moreInfoEntityIdForJs: String? = null
         val urlToLoad = when (target) {
             FrontendTarget.Default -> baseUrl
             is FrontendTarget.Path -> UrlUtil.handle(baseUrl, target.path)
             is FrontendTarget.EntityMoreInfo -> {
-                val moreInfoPath = moreInfoPath(target.entityId, serverId)
-                if (moreInfoPath != null) UrlUtil.handle(baseUrl, moreInfoPath) else baseUrl
+                if (supportsMoreInfoQueryParam(serverId)) {
+                    moreInfoEntityIdForQuery = target.entityId
+                } else {
+                    moreInfoEntityIdForJs = target.entityId
+                }
+                baseUrl
             }
         }
 
@@ -137,28 +147,21 @@ class FrontendUrlManager @Inject constructor(
         }
 
         val urlWithAuth = httpUrl.newBuilder()
+            .apply { moreInfoEntityIdForQuery?.let { addQueryParameter("more-info-entity-id", it) } }
             .addQueryParameter("external_auth", "1")
             .build()
             .toString()
 
         Timber.d("Loading server URL: $urlWithAuth")
-        return UrlLoadResult.Success(url = urlWithAuth, serverId = serverId)
+        return UrlLoadResult.Success(url = urlWithAuth, serverId = serverId, moreInfoEntityId = moreInfoEntityIdForJs)
     }
 
     /**
-     * Resolves the relative path that opens the more-info dialog for [entityId], or `null` when it
-     * cannot be opened via the URL.
-     *
-     * HA 2025.6+ honors the `more-info-entity-id` query parameter directly. Older servers ignore it,
-     * so we fall back to loading the dashboard.
+     * Whether the server honors the `more-info-entity-id` URL query parameter (HA 2025.6+). Older
+     * servers ignore it, so the more-info dialog must be opened via JavaScript after the page loads.
      */
-    private suspend fun moreInfoPath(entityId: String, serverId: Int): String? {
-        return if (serverManager.getServer(serverId)?.version?.isAtLeast(2025, 6, 0) == true) {
-            "/?more-info-entity-id=$entityId"
-        } else {
-            Timber.w("more-info deep link requires HA 2025.6+, loading dashboard instead")
-            null
-        }
+    private suspend fun supportsMoreInfoQueryParam(serverId: Int): Boolean {
+        return serverManager.getServer(serverId)?.version?.isAtLeast(2025, 6, 0) == true
     }
 
     private suspend fun shouldSetSecurityLevel(serverId: Int): Boolean {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.frontend.url
 import dagger.hilt.android.scopes.ViewModelScoped
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.servers.UrlState
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.session.ServerSessionManager
 import io.homeassistant.companion.android.util.UrlUtil
 import java.net.URL
@@ -41,14 +42,14 @@ class FrontendUrlManager @Inject constructor(
     /**
      * Retrieve URL for server. Returns a Flow that emits URL updates when connection state changes.
      *
-     * The path parameter is only applied to the first emission to handle deep links.
-     * Subsequent emissions (e.g., when switching between internal/external URLs) use only the base URL.
+     * The target is only applied to the first emission to handle deep links.
+     * Subsequent emissions (e.g., when switching between internal/external URLs) load only the base URL.
      *
      * @param serverId The server ID to use (can be [ServerManager.SERVER_ID_ACTIVE])
-     * @param path Optional path to append to the initial URL (e.g., deep link path)
+     * @param target The frontend destination to open on the initial URL (e.g., a deep link)
      * @return Flow of [UrlLoadResult] that emits when URL state changes
      */
-    fun serverUrlFlow(serverId: Int, path: String?): Flow<UrlLoadResult> = flow {
+    fun serverUrlFlow(serverId: Int, target: FrontendTarget): Flow<UrlLoadResult> = flow {
         val server = serverManager.getServer(serverId)
         if (server == null) {
             Timber.e("Server not found for id: $serverId")
@@ -65,30 +66,30 @@ class FrontendUrlManager @Inject constructor(
 
         serverManager.activateServer(actualServerId)
 
-        var pathConsumed = false
+        var targetConsumed = false
         serverManager.connectionStateProvider(actualServerId).urlFlow().collect { urlState ->
-            val currentPath = if (pathConsumed) null else path
+            val currentTarget = if (targetConsumed) FrontendTarget.Default else target
 
             val result = handleUrlState(
                 serverId = actualServerId,
                 urlState = urlState,
-                path = currentPath,
+                target = currentTarget,
             )
-            // Only consume the path when a URL was actually loaded with it
+            // Only consume the target when a URL was actually loaded with it
             if (urlState is UrlState.HasUrl) {
-                pathConsumed = true
+                targetConsumed = true
             }
             emit(result)
         }
     }
 
-    private suspend fun handleUrlState(serverId: Int, urlState: UrlState, path: String?): UrlLoadResult {
+    private suspend fun handleUrlState(serverId: Int, urlState: UrlState, target: FrontendTarget): UrlLoadResult {
         return when (urlState) {
             is UrlState.HasUrl -> {
                 buildUrl(
                     baseUrl = urlState.url,
                     serverId = serverId,
-                    path = path,
+                    target = target,
                 )
             }
 
@@ -104,12 +105,14 @@ class FrontendUrlManager @Inject constructor(
         }
     }
 
-    private suspend fun buildUrl(baseUrl: URL?, serverId: Int, path: String?): UrlLoadResult {
-        // Build URL with path (skip path handling if it starts with "entityId:")
-        val urlToLoad = if (path != null && !path.startsWith("entityId:")) {
-            UrlUtil.handle(baseUrl, path)
-        } else {
-            baseUrl
+    private suspend fun buildUrl(baseUrl: URL?, serverId: Int, target: FrontendTarget): UrlLoadResult {
+        val urlToLoad = when (target) {
+            FrontendTarget.Default -> baseUrl
+            is FrontendTarget.Path -> UrlUtil.handle(baseUrl, target.path)
+            is FrontendTarget.EntityMoreInfo -> {
+                val moreInfoPath = moreInfoPath(target.entityId, serverId)
+                if (moreInfoPath != null) UrlUtil.handle(baseUrl, moreInfoPath) else baseUrl
+            }
         }
 
         if (urlToLoad == null) {
@@ -140,6 +143,22 @@ class FrontendUrlManager @Inject constructor(
 
         Timber.d("Loading server URL: $urlWithAuth")
         return UrlLoadResult.Success(url = urlWithAuth, serverId = serverId)
+    }
+
+    /**
+     * Resolves the relative path that opens the more-info dialog for [entityId], or `null` when it
+     * cannot be opened via the URL.
+     *
+     * HA 2025.6+ honors the `more-info-entity-id` query parameter directly. Older servers ignore it,
+     * so we fall back to loading the dashboard.
+     */
+    private suspend fun moreInfoPath(entityId: String, serverId: Int): String? {
+        return if (serverManager.getServer(serverId)?.version?.isAtLeast(2025, 6, 0) == true) {
+            "/?more-info-entity-id=$entityId"
+        } else {
+            Timber.w("more-info deep link requires HA 2025.6+, loading dashboard instead")
+            null
+        }
     }
 
     private suspend fun shouldSetSecurityLevel(serverId: Int): Boolean {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/UrlLoadResult.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/UrlLoadResult.kt
@@ -10,8 +10,12 @@ sealed interface UrlLoadResult {
 
     /**
      * URL ready to load in the WebView.
+     *
+     * @property moreInfoEntityId When non-null, the more-info dialog for this entity must be opened
+     *   via JavaScript once the page has loaded. Used as a fallback for servers older than HA 2025.6,
+     *   which ignore the `more-info-entity-id` URL parameter.
      */
-    data class Success(val url: String, val serverId: Int) : UrlLoadResult
+    data class Success(val url: String, val serverId: Int, val moreInfoEntityId: String? = null) : UrlLoadResult
 
     /**
      * Server not found in the database.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -45,6 +45,7 @@ import io.homeassistant.companion.android.common.compose.theme.HATheme
 import io.homeassistant.companion.android.common.sensors.SensorWorker
 import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissionUseCase
 import io.homeassistant.companion.android.common.util.SdkVersion
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.applock.HazeLockOverlay
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.util.ChangeLog
@@ -124,11 +125,11 @@ class LaunchActivity : AppCompatActivity() {
         data class OpenInvitation(val serverUrl: String) : DeepLink
 
         /**
-         * Navigates to a specific path within the webview.
-         * @property path The path to navigate to within the Home Assistant interface.
+         * Navigates to a specific [target] within the frontend.
+         * @property target The frontend destination to open.
          * @property serverId The ID of the server to use for navigation.
          */
-        data class NavigateTo(val path: String?, val serverId: Int) : DeepLink
+        data class NavigateTo(val target: FrontendTarget, val serverId: Int) : DeepLink
 
         /**
          * Opens the Wear OS device onboarding flow.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivity.kt
@@ -149,7 +149,7 @@ class LaunchActivity : AppCompatActivity() {
          *   apps cannot reach the alias and therefore cannot opt into this behavior.
          */
         fun newInstance(context: Context, deepLink: DeepLink? = null, showWhenLocked: Boolean = false): Intent {
-            return Intent().apply {
+            return Intent(Intent.ACTION_MAIN).apply {
                 component = if (showWhenLocked) {
                     ComponentName(context, LOCK_SCREEN_ALIAS_CLASS)
                 } else {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivityExt.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivityExt.kt
@@ -13,11 +13,11 @@ internal fun Context.startLaunchInvitation(serverUrl: String) {
     )
 }
 
-internal fun Context.intentLaunchWithNavigate(target: FrontendTarget, serverId: Int): Intent =
+internal fun Context.intentLaunchWithNavigateTo(target: FrontendTarget, serverId: Int): Intent =
     LaunchActivity.newInstance(this, LaunchActivity.DeepLink.NavigateTo(target, serverId))
 
 internal fun Context.startLaunchWithNavigateTo(target: FrontendTarget, serverId: Int) {
-    startActivity(intentLaunchWithNavigate(target, serverId))
+    startActivity(intentLaunchWithNavigateTo(target, serverId))
 }
 
 internal fun Context.intentLaunchWearOnboarding(wearName: String, urlToOnboard: String?): Intent {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivityExt.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchActivityExt.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.launch
 
 import android.content.Context
 import android.content.Intent
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 
 internal fun Context.startLaunchInvitation(serverUrl: String) {
     startActivity(
@@ -12,8 +13,11 @@ internal fun Context.startLaunchInvitation(serverUrl: String) {
     )
 }
 
-internal fun Context.startLaunchWithNavigateTo(path: String, serverId: Int) {
-    startActivity(LaunchActivity.newInstance(this, LaunchActivity.DeepLink.NavigateTo(path, serverId)))
+internal fun Context.intentLaunchWithNavigate(target: FrontendTarget, serverId: Int): Intent =
+    LaunchActivity.newInstance(this, LaunchActivity.DeepLink.NavigateTo(target, serverId))
+
+internal fun Context.startLaunchWithNavigateTo(target: FrontendTarget, serverId: Int) {
+    startActivity(intentLaunchWithNavigate(target, serverId))
 }
 
 internal fun Context.intentLaunchWearOnboarding(wearName: String, urlToOnboard: String?): Intent {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/LaunchViewModel.kt
@@ -21,6 +21,7 @@ import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.di.qualifiers.IsAutomotive
 import io.homeassistant.companion.android.di.qualifiers.LocationTrackingSupport
 import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.onboarding.OnboardingRoute
 import io.homeassistant.companion.android.onboarding.WearOnboardingRoute
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -217,18 +218,18 @@ internal class LaunchViewModel @VisibleForTesting constructor(
             )
 
             is LaunchActivity.DeepLink.NavigateTo,
-            -> connectToServer(initialDeepLink.serverId, initialDeepLink.path)
+            -> connectToServer(initialDeepLink.serverId, initialDeepLink.target)
 
             is LaunchActivity.DeepLink.OpenWearOnboarding -> navigateToWearOnboarding(
                 wearName = initialDeepLink.wearName,
                 urlToOnboard = initialDeepLink.urlToOnboard,
             )
 
-            null -> connectToServer(ServerManager.SERVER_ID_ACTIVE, null)
+            null -> connectToServer(ServerManager.SERVER_ID_ACTIVE, FrontendTarget.Default)
         }
     }
 
-    private suspend fun connectToServer(serverId: Int, path: String?) {
+    private suspend fun connectToServer(serverId: Int, target: FrontendTarget) {
         try {
             getServerConnectedAndRegistered(serverId)?.let { server ->
                 Timber.d("Server (id=${server.id}) is connected and registered checking network status")
@@ -236,7 +237,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
                 networkStatusMonitor.observeNetworkStatus(serverManager.connectionStateProvider(server.id))
                     .takeWhile { state ->
                         // Until the network is ready we continue to observe network status changes
-                        !handleNetworkState(state, path, serverId)
+                        !handleNetworkState(state, target, serverId)
                     }.collect()
             } ?: navigateToOnboarding()
         } catch (e: IllegalStateException) {
@@ -303,7 +304,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
             .forEach { serverManager.removeServer(it.id) }
     }
 
-    private fun handleNetworkState(state: NetworkState, path: String?, serverId: Int): Boolean {
+    private fun handleNetworkState(state: NetworkState, target: FrontendTarget, serverId: Int): Boolean {
         Timber.i("Current network state $state")
         return when (state) {
             NetworkState.READY_INTERNAL, NetworkState.READY_NET_VALIDATED, NetworkState.READY_NET_LOCAL -> {
@@ -312,7 +313,7 @@ internal class LaunchViewModel @VisibleForTesting constructor(
                     if (shouldNavigateToAutomotive) {
                         AutomotiveRoute
                     } else {
-                        FrontendRoute(path, serverId)
+                        FrontendRoute(target, serverId)
                     },
                 )
                 true

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
@@ -29,6 +29,7 @@ import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.compose.theme.HATheme
 import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.startLaunchInvitation
 import io.homeassistant.companion.android.launch.startLaunchWithNavigateTo
 import io.homeassistant.companion.android.settings.server.ServerChooser
@@ -83,7 +84,10 @@ class LinkActivity : BaseActivity() {
         when (event) {
             LinkNavigationEvent.Finish -> Unit
             is LinkNavigationEvent.OpenInvitation -> startLaunchInvitation(event.serverUrl)
-            is LinkNavigationEvent.NavigateToWebView -> startLaunchWithNavigateTo(event.path, event.serverId)
+            is LinkNavigationEvent.NavigateToWebView -> startLaunchWithNavigateTo(
+                FrontendTarget.fromRawPath(event.path),
+                event.serverId,
+            )
         }
         finish()
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -83,6 +83,8 @@ import io.homeassistant.companion.android.database.notification.NotificationDao
 import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.sensors.LocationSensorManager
 import io.homeassistant.companion.android.sensors.LocationSensorManager.Companion.setHighAccuracyModeIntervalSetting
 import io.homeassistant.companion.android.sensors.LocationSensorManager.Companion.setHighAccuracyModeSetting
@@ -98,7 +100,6 @@ import io.homeassistant.companion.android.util.UrlUtil
 import io.homeassistant.companion.android.util.sensitive
 import io.homeassistant.companion.android.vehicle.HaCarAppService
 import io.homeassistant.companion.android.websocket.WebsocketManager
-import io.homeassistant.companion.android.webview.WebViewActivity
 import java.io.File
 import java.net.URL
 import java.net.URLDecoder
@@ -1697,7 +1698,7 @@ class MessagingManager @Inject constructor(
         val otherApp = needsPackage || UrlUtil.isAbsoluteUrl(uri) || uri.startsWith(DEEP_LINK_PREFIX)
         val intent = when {
             uri.isBlank() -> {
-                WebViewActivity.newInstance(context, null, serverId)
+                context.intentLaunchWithNavigateTo(FrontendTarget.Default, serverId)
             }
 
             uri.startsWith(APP_PREFIX) -> {
@@ -1717,7 +1718,7 @@ class MessagingManager @Inject constructor(
                 if (uri.substringAfter(SETTINGS_PREFIX) == NOTIFICATION_HISTORY) {
                     SettingsActivity.newInstance(context, SettingsActivity.Deeplink.NotificationHistory)
                 } else {
-                    WebViewActivity.newInstance(context, null, serverId)
+                    context.intentLaunchWithNavigateTo(FrontendTarget.Default, serverId)
                 }
             }
 
@@ -1732,9 +1733,9 @@ class MessagingManager @Inject constructor(
             }
 
             else -> {
-                WebViewActivity.newInstance(context, uri, serverId)
+                context.intentLaunchWithNavigateTo(FrontendTarget.fromRawPath(uri), serverId)
             }
-        } ?: WebViewActivity.newInstance(context, null, serverId)
+        } ?: context.intentLaunchWithNavigateTo(FrontendTarget.Default, serverId)
 
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         if (!otherApp) {
@@ -1999,9 +2000,9 @@ class MessagingManager @Inject constructor(
         try {
             val serverId = data[THIS_SERVER_ID]!!.toInt()
             val intent = if (title.isNullOrEmpty()) {
-                WebViewActivity.newInstance(context, null, serverId)
+                context.intentLaunchWithNavigateTo(FrontendTarget.Default, serverId)
             } else {
-                WebViewActivity.newInstance(context, title, serverId)
+                context.intentLaunchWithNavigateTo(FrontendTarget.fromRawPath(title), serverId)
             }
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
@@ -14,7 +14,7 @@ import io.homeassistant.companion.android.database.qs.TileDao
 import io.homeassistant.companion.android.database.qs.isSetup
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
-import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.qs.ManageTilesViewModel
 import javax.inject.Inject
@@ -63,7 +63,7 @@ class TilePreferenceActivity : BaseActivity() {
             val intent = if (!serverManager.isRegistered()) {
                 Intent(this@TilePreferenceActivity, LaunchActivity::class.java)
             } else if (tileData?.isSetup == true) {
-                this@TilePreferenceActivity.intentLaunchWithNavigate(
+                this@TilePreferenceActivity.intentLaunchWithNavigateTo(
                     target = FrontendTarget.EntityMoreInfo(tileData.entityId),
                     serverId = tileData.serverId,
                 )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/qs/TilePreferenceActivity.kt
@@ -12,10 +12,11 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.qs.TileDao
 import io.homeassistant.companion.android.database.qs.isSetup
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.qs.ManageTilesViewModel
-import io.homeassistant.companion.android.webview.WebViewActivity
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -62,9 +63,8 @@ class TilePreferenceActivity : BaseActivity() {
             val intent = if (!serverManager.isRegistered()) {
                 Intent(this@TilePreferenceActivity, LaunchActivity::class.java)
             } else if (tileData?.isSetup == true) {
-                WebViewActivity.newInstance(
-                    this@TilePreferenceActivity,
-                    path = "entityId:${tileData.entityId}",
+                this@TilePreferenceActivity.intentLaunchWithNavigate(
+                    target = FrontendTarget.EntityMoreInfo(tileData.entityId),
                     serverId = tileData.serverId,
                 )
             } else {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/SettingsFragment.kt
@@ -34,7 +34,9 @@ import io.homeassistant.companion.android.common.util.isAutomotive
 import io.homeassistant.companion.android.common.util.isIgnoringBatteryOptimizations
 import io.homeassistant.companion.android.common.util.maybeAskForIgnoringBatteryOptimizations
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.intentLaunchOnboarding
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.nfc.NfcSetupActivity
 import io.homeassistant.companion.android.settings.assist.AssistSettingsFragment
 import io.homeassistant.companion.android.settings.assist.DefaultAssistantManager
@@ -57,7 +59,6 @@ import io.homeassistant.companion.android.settings.wear.SettingsWearDetection
 import io.homeassistant.companion.android.settings.widgets.ManageWidgetsSettingsFragment
 import io.homeassistant.companion.android.util.QuestUtil
 import io.homeassistant.companion.android.util.applyBottomSafeDrawingInsets
-import io.homeassistant.companion.android.webview.WebViewActivity
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -621,9 +622,10 @@ class SettingsFragment(
             ).apply {
                 if (success && serverId != null) {
                     setAction(commonR.string.activate) {
-                        val intent = WebViewActivity.newInstance(requireContext(), null, serverId).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                        }
+                        val intent = requireContext().intentLaunchWithNavigateTo(
+                            FrontendTarget.Default,
+                            serverId,
+                        ).addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                         requireContext().startActivity(intent)
                     }
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerSettingsFragment.kt
@@ -30,7 +30,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.authenticator.Authenticator.Companion.AuthenticationResult
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.settings.ConnectionSecurityLevelFragment
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.ssid.SsidFragment
@@ -38,7 +40,6 @@ import io.homeassistant.companion.android.settings.url.ExternalUrlFragment
 import io.homeassistant.companion.android.settings.websocket.WebsocketSettingFragment
 import io.homeassistant.companion.android.util.QuestUtil
 import io.homeassistant.companion.android.util.applyBottomSafeDrawingInsets
-import io.homeassistant.companion.android.webview.WebViewActivity
 import java.net.URLEncoder
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -92,9 +93,9 @@ class ServerSettingsFragment :
         lifecycleScope.launch {
             if (presenter.hasMultipleServers()) {
                 val activateClickListener = OnPreferenceClickListener {
-                    val intent = WebViewActivity.newInstance(requireContext(), null, serverId).apply {
-                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    }
+                    val intent = requireContext().intentLaunchWithNavigateTo(FrontendTarget.Default, serverId)
+                        .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+
                     requireContext().startActivity(intent)
                     return@OnPreferenceClickListener true
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
@@ -39,6 +39,8 @@ import androidx.compose.ui.unit.sp
 import com.mikepenz.iconics.compose.IconicsPainter
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.compose.theme.HATheme
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget.Companion.toRawPath
 import io.homeassistant.companion.android.settings.shortcuts.legacy.ManageShortcutsSettingsFragment
 import io.homeassistant.companion.android.settings.shortcuts.legacy.ManageShortcutsViewModel
 import io.homeassistant.companion.android.util.compose.ServerExposedDropdownMenu
@@ -274,9 +276,12 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
                 entityRegistry = viewModel.entityRegistry[shortcut.serverId.value],
                 deviceRegistry = viewModel.deviceRegistry[shortcut.serverId.value],
                 areaRegistry = viewModel.areaRegistry[shortcut.serverId.value],
-                selectedEntityId = viewModel.shortcuts[i].path.value.split(":").getOrNull(1),
+                selectedEntityId = (
+                    FrontendTarget.fromRawPath(viewModel.shortcuts[i].path.value)
+                        as? FrontendTarget.EntityMoreInfo
+                    )?.entityId,
                 onEntitySelectedId = { entityId ->
-                    viewModel.shortcuts[i].path.value = "entityId:$entityId"
+                    viewModel.shortcuts[i].path.value = FrontendTarget.EntityMoreInfo(entityId).toRawPath().orEmpty()
                 },
                 onEntityCleared = {
                     viewModel.shortcuts[i].path.value = ""

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/GlanceExt.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/GlanceExt.kt
@@ -7,6 +7,8 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.glance.LocalContext
 import androidx.glance.action.Action
 import androidx.glance.appwidget.action.actionStartActivity
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.webview.WebViewActivity
 
 @Composable
@@ -19,11 +21,9 @@ fun glanceStringResource(@StringRes id: Int, vararg arguments: Any): String =
  */
 @Composable
 fun actionStartWebView(path: String, serverId: Int): Action {
-    val intent = Intent(
-        WebViewActivity.newInstance(LocalContext.current, path, serverId)
-            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
-    )
+    val intent = LocalContext.current.intentLaunchWithNavigateTo(FrontendTarget.fromRawPath(path), serverId)
     intent.action = path
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
     intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
     intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
     return actionStartActivity(intent)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/GlanceExt.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/GlanceExt.kt
@@ -9,7 +9,6 @@ import androidx.glance.action.Action
 import androidx.glance.appwidget.action.actionStartActivity
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
-import io.homeassistant.companion.android.webview.WebViewActivity
 
 @Composable
 @ReadOnlyComposable
@@ -17,7 +16,7 @@ fun glanceStringResource(@StringRes id: Int, vararg arguments: Any): String =
     LocalContext.current.getString(id, *arguments)
 
 /**
- * Get an Action that will open the [WebViewActivity] for the given [path]
+ * Get an Action that will open the frontend for the given [path]
  */
 @Composable
 fun actionStartWebView(path: String, serverId: Int): Action {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/websocket/WebsocketManager.kt
@@ -32,10 +32,10 @@ import io.homeassistant.companion.android.common.util.CheckLocalNetworkPermissio
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.database.settings.WebsocketSetting
+import io.homeassistant.companion.android.launch.LaunchActivity
 import io.homeassistant.companion.android.notifications.MessagingManager
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.util.hasActiveConnection
-import io.homeassistant.companion.android.webview.WebViewActivity
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -252,7 +252,7 @@ class WebsocketManager(appContext: Context, workerParams: WorkerParameters) :
             notificationManager.createNotificationChannel(notificationChannel)
         }
 
-        val intent = WebViewActivity.newInstance(applicationContext)
+        val intent = LaunchActivity.newInstance(applicationContext)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
         intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -192,6 +192,7 @@ class WebViewActivity :
         private const val INTENT_PREFIX = "intent:"
         private const val MARKET_PREFIX = "https://play.google.com/store/apps/details?id="
 
+        @Deprecated("Use LaunchActivity directly")
         fun newInstance(context: Context, path: String? = null, serverId: Int? = null): Intent {
             return Intent(context, WebViewActivity::class.java).apply {
                 putExtra(EXTRA_PATH, path)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -26,7 +26,7 @@ import io.homeassistant.companion.android.database.widget.CameraWidgetDao
 import io.homeassistant.companion.android.database.widget.CameraWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetTapAction
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
-import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigateTo
 import io.homeassistant.companion.android.util.hasActiveConnection
 import io.homeassistant.companion.android.widgets.ACTION_APPWIDGET_CREATED
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider.Companion.UPDATE_WIDGETS
@@ -187,7 +187,7 @@ class CameraWidget : AppWidgetProvider() {
                     WidgetTapAction.OPEN -> PendingIntent.getActivity(
                         context,
                         appWidgetId,
-                        context.intentLaunchWithNavigate(
+                        context.intentLaunchWithNavigateTo(
                             FrontendTarget.EntityMoreInfo(widget.entityId),
                             widget.serverId,
                         ),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/camera/CameraWidget.kt
@@ -25,8 +25,9 @@ import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.widget.CameraWidgetDao
 import io.homeassistant.companion.android.database.widget.CameraWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetTapAction
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.intentLaunchWithNavigate
 import io.homeassistant.companion.android.util.hasActiveConnection
-import io.homeassistant.companion.android.webview.WebViewActivity
 import io.homeassistant.companion.android.widgets.ACTION_APPWIDGET_CREATED
 import io.homeassistant.companion.android.widgets.BaseWidgetProvider.Companion.UPDATE_WIDGETS
 import io.homeassistant.companion.android.widgets.EXTRA_WIDGET_ENTITY
@@ -186,7 +187,10 @@ class CameraWidget : AppWidgetProvider() {
                     WidgetTapAction.OPEN -> PendingIntent.getActivity(
                         context,
                         appWidgetId,
-                        WebViewActivity.newInstance(context, "entityId:${widget.entityId}", widget.serverId),
+                        context.intentLaunchWithNavigate(
+                            FrontendTarget.EntityMoreInfo(widget.entityId),
+                            widget.serverId,
+                        ),
                         PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
                     )
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -48,6 +48,7 @@ import io.homeassistant.companion.android.frontend.improv.ImprovUIState
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridgeFactory
 import io.homeassistant.companion.android.frontend.matterthread.FrontendMatterThreadHandler
 import io.homeassistant.companion.android.frontend.navigation.FrontendEvent
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.permissions.PermissionManager
 import io.homeassistant.companion.android.frontend.url.FrontendUrlManager
 import io.homeassistant.companion.android.frontend.url.UrlLoadResult
@@ -162,7 +163,7 @@ class FrontendViewModelTest {
     ): FrontendViewModel {
         return FrontendViewModel(
             initialServerId = serverId,
-            initialPath = path,
+            initialTarget = FrontendTarget.fromRawPath(path),
             webViewClientFactory = webViewClientFactory,
             frontendBusObserver = frontendBusObserver,
             externalBusRepository = externalBusRepository,
@@ -342,7 +343,7 @@ class FrontendViewModelTest {
         @Test
         fun `Given url manager returns success with path when initialized then loading state includes path`() = runTest {
             val urlWithPath = "https://example.com/dashboard?external_auth=1"
-            every { urlManager.serverUrlFlow(serverId, "/dashboard") } returns flowOf(
+            every { urlManager.serverUrlFlow(serverId, FrontendTarget.Path("/dashboard")) } returns flowOf(
                 UrlLoadResult.Success(url = urlWithPath, serverId = serverId),
             )
 
@@ -2319,8 +2320,8 @@ class FrontendViewModelTest {
             val state = viewModel.viewState.value
             assertTrue(state is FrontendViewState.LoadServer)
             assertEquals(
-                "/_my_redirect/config_flow_start?domain=acme",
-                (state as FrontendViewState.LoadServer).path,
+                FrontendTarget.Path("/_my_redirect/config_flow_start?domain=acme"),
+                (state as FrontendViewState.LoadServer).target,
             )
         }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -1261,6 +1261,42 @@ class FrontendViewModelTest {
         }
 
         @Test
+        fun `Given older-server more-info deep link when page finishes then OpenMoreInfo is dispatched`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId, moreInfoEntityId = "light.kitchen"),
+            )
+
+            val (viewModel, triggerPageFinished) = createViewModelWithPageFinishedCapture()
+
+            viewModel.webViewActions.test {
+                triggerPageFinished()
+
+                assertEquals(WebViewAction.OpenMoreInfo("light.kitchen"), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given more-info dispatched when page finishes again then OpenMoreInfo is not repeated`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId, moreInfoEntityId = "light.kitchen"),
+            )
+
+            val (viewModel, triggerPageFinished) = createViewModelWithPageFinishedCapture()
+
+            viewModel.webViewActions.test {
+                triggerPageFinished()
+                assertEquals(WebViewAction.OpenMoreInfo("light.kitchen"), awaitItem())
+                awaitItem() // ApplyZoom from the first page load
+
+                triggerPageFinished()
+                // Only the zoom action repeats; the more-info dialog must not be reopened.
+                assertTrue(awaitItem() is WebViewAction.ApplyZoom)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
         fun `Given page loaded when settings change then ApplyZoom action is emitted without page finish`() = runTest {
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
@@ -132,4 +132,30 @@ class WebViewActionTest {
         callbackSlot.captured.onReceiveValue(null)
         assertEquals(null, action.result.await())
     }
+
+    @Test
+    fun `Given OpenMoreInfo when run then it dispatches hass-more-info for the entity`() = runTest {
+        val scriptSlot = slot<String>()
+        every { webView.evaluateJavascript(capture(scriptSlot), any()) } just Runs
+
+        WebViewAction.OpenMoreInfo("light.kitchen").run(webView)
+
+        val script = scriptSlot.captured
+        assertTrue(script.contains("hass-more-info"))
+        assertTrue(script.contains("\"light.kitchen\""))
+    }
+
+    @Test
+    fun `Given OpenMoreInfo with a hostile entity id when run then the value is JSON-escaped and cannot break out`() = runTest {
+        val scriptSlot = slot<String>()
+        every { webView.evaluateJavascript(capture(scriptSlot), any()) } just Runs
+
+        // Crafted to close the string/object and inject code if interpolated raw.
+        WebViewAction.OpenMoreInfo("""x"}});alert(1);//""").run(webView)
+
+        val script = scriptSlot.captured
+        // The embedded double quote must be backslash-escaped (proof of JSON encoding), so the
+        // payload stays inside the entityId string literal instead of becoming executable code.
+        assertTrue(script.contains("\\\""))
+    }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
@@ -1,0 +1,38 @@
+package io.homeassistant.companion.android.frontend.navigation
+
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget.Companion.toRawPath
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class FrontendTargetTest {
+
+    private val samples = listOf(
+        FrontendTarget.Default,
+        FrontendTarget.Path("/lovelace/0"),
+        FrontendTarget.Path("/?more-info-entity-id=light.kitchen&foo=a b"),
+        FrontendTarget.EntityMoreInfo("light.kitchen"),
+    )
+
+    @Test
+    fun `Given legacy paths when fromRawPath then maps to the matching target`() {
+        assertEquals(FrontendTarget.Default, FrontendTarget.fromRawPath(null))
+        assertEquals(FrontendTarget.Path("/lovelace/0"), FrontendTarget.fromRawPath("/lovelace/0"))
+        assertEquals(
+            FrontendTarget.EntityMoreInfo("light.kitchen"),
+            FrontendTarget.fromRawPath("entityId:light.kitchen"),
+        )
+    }
+
+    @Test
+    fun `Given any target when toLegacyPath then round-trips through fromRawPath`() {
+        samples.forEach { target ->
+            assertEquals(target, FrontendTarget.fromRawPath(target.toRawPath()))
+        }
+    }
+
+    @Test
+    fun `Given default target when toLegacyPath then returns null`() {
+        assertNull(FrontendTarget.Default.toRawPath())
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManagerTest.kt
@@ -9,6 +9,7 @@ import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import io.homeassistant.companion.android.database.server.ServerSessionInfo
 import io.homeassistant.companion.android.database.server.ServerUserInfo
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.session.ServerSessionManager
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -45,7 +46,7 @@ class FrontendUrlManagerTest {
     fun `Given server not found when serverUrlFlow then returns ServerNotFound`() = runTest {
         coEvery { serverManager.getServer(1) } returns null
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.ServerNotFound)
             assertEquals(1, (result as UrlLoadResult.ServerNotFound).serverId)
@@ -59,7 +60,7 @@ class FrontendUrlManagerTest {
         coEvery { serverManager.getServer(1) } returns server
         coEvery { sessionManager.isSessionConnected(1) } returns false
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.SessionNotConnected)
             assertEquals(1, (result as UrlLoadResult.SessionNotConnected).serverId)
@@ -78,7 +79,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             val success = result as UrlLoadResult.Success
@@ -99,7 +100,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = "/dashboard").test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Path("/dashboard")).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             val success = result as UrlLoadResult.Success
@@ -109,8 +110,8 @@ class FrontendUrlManagerTest {
     }
 
     @Test
-    fun `Given path with entityId prefix when serverUrlFlow then skips path handling`() = runTest {
-        val server = createTestServer(id = 1, externalUrl = "https://home.example.com")
+    fun `Given EntityMoreInfo on HA 2025_6+ when serverUrlFlow then loads more-info-entity-id query`() = runTest {
+        val server = createTestServer(id = 1, externalUrl = "https://home.example.com", version = "2025.6.0")
         coEvery { serverManager.getServer(1) } returns server
         coEvery { sessionManager.isSessionConnected(1) } returns true
         coEvery { serverManager.activateServer(1) } just runs
@@ -119,11 +120,33 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = "entityId:light.living_room").test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.EntityMoreInfo("light.living_room")).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             val success = result as UrlLoadResult.Success
-            // Should not contain the entityId path in URL
+            assertEquals(
+                "https://home.example.com/?more-info-entity-id=light.living_room&external_auth=1",
+                success.url,
+            )
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Given EntityMoreInfo on HA older than 2025_6 when serverUrlFlow then falls back to dashboard`() = runTest {
+        val server = createTestServer(id = 1, externalUrl = "https://home.example.com", version = "2025.5.0")
+        coEvery { serverManager.getServer(1) } returns server
+        coEvery { sessionManager.isSessionConnected(1) } returns true
+        coEvery { serverManager.activateServer(1) } just runs
+        coEvery { serverManager.connectionStateProvider(1) } returns connectionStateProvider
+        every { connectionStateProvider.urlFlow(null) } returns flowOf(
+            UrlState.HasUrl(URL("https://home.example.com")),
+        )
+
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.EntityMoreInfo("light.living_room")).test {
+            val result = awaitItem()
+            assertTrue(result is UrlLoadResult.Success)
+            val success = result as UrlLoadResult.Success
             assertEquals("https://home.example.com/?external_auth=1", success.url)
             awaitComplete()
         }
@@ -152,7 +175,7 @@ class FrontendUrlManagerTest {
             locationEnabled = locationEnabled,
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.InsecureBlocked)
             val blocked = result as UrlLoadResult.InsecureBlocked
@@ -172,7 +195,7 @@ class FrontendUrlManagerTest {
         coEvery { serverManager.connectionStateProvider(1) } returns connectionStateProvider
         every { connectionStateProvider.urlFlow(null) } returns flowOf(UrlState.HasUrl(null))
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.NoUrlAvailable)
             assertEquals(1, (result as UrlLoadResult.NoUrlAvailable).serverId)
@@ -192,7 +215,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = ServerManager.SERVER_ID_ACTIVE, path = null).test {
+        urlManager.serverUrlFlow(serverId = ServerManager.SERVER_ID_ACTIVE, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             assertEquals(42, (result as UrlLoadResult.Success).serverId)
@@ -218,7 +241,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("http://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.SecurityLevelRequired)
             assertEquals(1, (result as UrlLoadResult.SecurityLevelRequired).serverId)
@@ -243,7 +266,7 @@ class FrontendUrlManagerTest {
 
         urlManager.onSecurityLevelShown(serverId = 1)
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             awaitComplete()
@@ -265,7 +288,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             awaitComplete()
@@ -287,7 +310,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("http://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             awaitComplete()
@@ -312,7 +335,7 @@ class FrontendUrlManagerTest {
             locationEnabled = false,
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = null).test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Default).test {
             val first = awaitItem()
             assertTrue(first is UrlLoadResult.Success)
 
@@ -337,7 +360,7 @@ class FrontendUrlManagerTest {
             UrlState.HasUrl(URL("https://home.example.com")),
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = "/dashboard").test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Path("/dashboard")).test {
             val first = awaitItem() as UrlLoadResult.Success
             assertTrue(first.url.contains("/dashboard"), "First emission should contain path")
 
@@ -364,7 +387,7 @@ class FrontendUrlManagerTest {
             locationEnabled = false,
         )
 
-        urlManager.serverUrlFlow(serverId = 1, path = "/dashboard").test {
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.Path("/dashboard")).test {
             val first = awaitItem()
             assertTrue(first is UrlLoadResult.InsecureBlocked)
 
@@ -378,11 +401,13 @@ class FrontendUrlManagerTest {
         id: Int,
         externalUrl: String = "https://home.example.com",
         connectionInfo: ServerConnectionInfo? = null,
+        version: String? = null,
     ): Server {
         val connection = connectionInfo ?: ServerConnectionInfo(externalUrl = externalUrl)
         return Server(
             id = id,
             _name = "Test Server",
+            _version = version,
             connection = connection,
             session = ServerSessionInfo(),
             user = ServerUserInfo(),

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManagerTest.kt
@@ -128,12 +128,33 @@ class FrontendUrlManagerTest {
                 "https://home.example.com/?more-info-entity-id=light.living_room&external_auth=1",
                 success.url,
             )
+            // The query param opens the dialog, so no JavaScript fallback is needed.
+            assertEquals(null, success.moreInfoEntityId)
             awaitComplete()
         }
     }
 
     @Test
-    fun `Given EntityMoreInfo on HA older than 2025_6 when serverUrlFlow then falls back to dashboard`() = runTest {
+    fun `Given EntityMoreInfo with URL-special chars on HA 2025_6+ then the entity id is percent-encoded`() = runTest {
+        val server = createTestServer(id = 1, externalUrl = "https://home.example.com", version = "2025.6.0")
+        coEvery { serverManager.getServer(1) } returns server
+        coEvery { sessionManager.isSessionConnected(1) } returns true
+        coEvery { serverManager.activateServer(1) } just runs
+        coEvery { serverManager.connectionStateProvider(1) } returns connectionStateProvider
+        every { connectionStateProvider.urlFlow(null) } returns flowOf(
+            UrlState.HasUrl(URL("https://home.example.com")),
+        )
+
+        urlManager.serverUrlFlow(serverId = 1, target = FrontendTarget.EntityMoreInfo("x&admin=1")).test {
+            val success = awaitItem() as UrlLoadResult.Success
+            // The '&' is encoded (%26) so it cannot break out and inject a second query parameter.
+            assertTrue(success.url.contains("more-info-entity-id=x%26"))
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Given EntityMoreInfo on HA older than 2025_6 when serverUrlFlow then signals JS more-info fallback`() = runTest {
         val server = createTestServer(id = 1, externalUrl = "https://home.example.com", version = "2025.5.0")
         coEvery { serverManager.getServer(1) } returns server
         coEvery { sessionManager.isSessionConnected(1) } returns true
@@ -147,7 +168,9 @@ class FrontendUrlManagerTest {
             val result = awaitItem()
             assertTrue(result is UrlLoadResult.Success)
             val success = result as UrlLoadResult.Success
+            // Loads the dashboard (no query param) and signals that the dialog must be opened via JS.
             assertEquals("https://home.example.com/?external_auth=1", success.url)
+            assertEquals("light.living_room", success.moreInfoEntityId)
             awaitComplete()
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchActivityTest.kt
@@ -34,11 +34,12 @@ import io.mockk.unmockkConstructor
 import io.mockk.unmockkObject
 import io.mockk.verify
 import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -152,6 +153,8 @@ class LaunchActivityTest {
     fun `Given showWhenLocked is true when launched then activity is shown over the lock screen`() {
         val intent = LaunchActivity.newInstance(ApplicationProvider.getApplicationContext(), showWhenLocked = true)
 
+        assertEquals(Intent.ACTION_MAIN, intent.action)
+
         ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->
                 assertTrue(shadowOf(activity).showWhenLocked)
@@ -162,6 +165,8 @@ class LaunchActivityTest {
     @Test
     fun `Given showWhenLocked is false when launched then activity is not shown over the lock screen`() {
         val intent = LaunchActivity.newInstance(ApplicationProvider.getApplicationContext(), showWhenLocked = false)
+
+        assertEquals(Intent.ACTION_MAIN, intent.action)
 
         ActivityScenario.launch<LaunchActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/LaunchViewModelTest.kt
@@ -16,6 +16,7 @@ import io.homeassistant.companion.android.database.server.ServerConnectionInfo
 import io.homeassistant.companion.android.database.server.ServerSessionInfo
 import io.homeassistant.companion.android.database.server.ServerUserInfo
 import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.onboarding.OnboardingRoute
 import io.homeassistant.companion.android.onboarding.WearOnboardingRoute
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
@@ -95,7 +96,7 @@ class LaunchViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute(null, ServerManager.SERVER_ID_ACTIVE)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Default, ServerManager.SERVER_ID_ACTIVE)),
             viewModel.uiState.value,
         )
         assertEquals(0, networkStateFlow.subscriptionCount.value)
@@ -159,7 +160,7 @@ class LaunchViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute(null, ServerManager.SERVER_ID_ACTIVE)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Default, ServerManager.SERVER_ID_ACTIVE)),
             viewModel.uiState.value,
         )
         assertEquals(0, networkStateFlow.subscriptionCount.value)
@@ -381,10 +382,10 @@ class LaunchViewModelTest {
         val networkStateFlow = MutableStateFlow(NetworkState.READY_NET_VALIDATED)
         coEvery { networkStatusMonitor.observeNetworkStatus(any()) } returns networkStateFlow
 
-        createViewModel(LaunchActivity.DeepLink.NavigateTo("/path", serverId))
+        createViewModel(LaunchActivity.DeepLink.NavigateTo(FrontendTarget.Path("/path"), serverId))
         advanceUntilIdle()
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute("/path", serverId)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Path("/path"), serverId)),
             viewModel.uiState.value,
         )
     }
@@ -452,7 +453,7 @@ class LaunchViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute(null, ServerManager.SERVER_ID_ACTIVE)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Default, ServerManager.SERVER_ID_ACTIVE)),
             viewModel.uiState.value,
         )
     }
@@ -479,7 +480,7 @@ class LaunchViewModelTest {
         advanceUntilIdle()
 
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute(null, ServerManager.SERVER_ID_ACTIVE)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Default, ServerManager.SERVER_ID_ACTIVE)),
             viewModel.uiState.value,
         )
         assertEquals(0, networkStateFlow.subscriptionCount.value)
@@ -553,11 +554,11 @@ class LaunchViewModelTest {
         val networkStateFlow = MutableStateFlow(NetworkState.READY_NET_VALIDATED)
         coEvery { networkStatusMonitor.observeNetworkStatus(any()) } returns networkStateFlow
 
-        createViewModel(LaunchActivity.DeepLink.NavigateTo(path = null, serverId = serverId))
+        createViewModel(LaunchActivity.DeepLink.NavigateTo(FrontendTarget.Default, serverId))
         advanceUntilIdle()
 
         assertEquals(
-            LaunchUiState.Ready(FrontendRoute(null, serverId)),
+            LaunchUiState.Ready(FrontendRoute(FrontendTarget.Default, serverId)),
             viewModel.uiState.value,
         )
     }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The support for the deep link `more-info` was not complete it was missing the fallback case for old server, in order to make it right I've decided to introduce the `FrontendTarget` sealed interface. I've also replace most of the call to `WebViewActivity.newInstance` it only remains one usage in `ManageShortcutsViewModel` we need to migrate to `LinkActivity` https://github.com/home-assistant/android/issues/7086.

I've also made sure that the given parameter cannot extend more than just the entityID in the URL or JS evaluation.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.