### PR TITLE
Force Kotlin version for AbiValidationCompatClasspath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
 
+val kotlinVersion = libs.versions.kotlin.get()
+
 plugins {
     alias(libs.plugins.ktlint)
 
@@ -19,6 +21,29 @@ plugins {
 
 allprojects {
     apply(plugin = rootProject.libs.plugins.ktlint.get().pluginId)
+
+    configurations.matching { it.name == "kotlinAbiValidationCompatClasspath" }.configureEach {
+        resolutionStrategy.eachDependency {
+            if (
+                requested.group == "org.jetbrains.kotlin" &&
+                requested.name in setOf(
+                    "kotlin-build-tools-api",
+                    "kotlin-build-tools-cri-impl",
+                    "kotlin-build-tools-impl",
+                    "kotlin-compiler-embeddable",
+                    "kotlin-compiler-runner",
+                    "kotlin-daemon-client",
+                    "kotlin-daemon-embeddable",
+                    "kotlin-script-runtime",
+                    "kotlin-stdlib",
+                    "kotlin-tooling-core",
+                )
+            ) {
+                useVersion(kotlinVersion)
+                because("Keep Kotlin ABI validation tooling aligned with the configured Kotlin version.")
+            }
+        }
+    }
 
     ktlint {
         android.set(true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 allprojects {
     apply(plugin = rootProject.libs.plugins.ktlint.get().pluginId)
 
+    // TODO this has been added until https://youtrack.jetbrains.com/issue/KT-87220/Kotlin-Gradle-plugin-resolves-kotlinAbiValidationCompatClasspath-to-newer-beta-Kotlin-artifacts-during-dependency-locking is addressed
     configurations.matching { it.name == "kotlinAbiValidationCompatClasspath" }.configureEach {
         resolutionStrategy.eachDependency {
             if (


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We started to see failure on CI because lockfile were not updated and the `lockfile` job detected it. It seems something in Kotlin deps changed and we got 
<img width="1445" height="468" alt="image" src="https://github.com/user-attachments/assets/d727b192-5064-4e08-8e79-bf193b8abfb8" />

This is not something we want we want a fixed version of Kotlin. This PR with the help of codex is addressing this by ensuring we use the right version of Kotlin for the task kotlinAbiValidationCompatClasspath.
