### PR TITLE
DispatchKeyDown now uses body documentElement or document for events

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
@@ -124,7 +124,7 @@ class FrontendGestureManager @Inject constructor(
                 bubbles: true,
                 cancelable: true
             });
-            document.body.dispatchEvent(event);
+             (document.body || document.documentElement || document).dispatchEvent(event);
         """.trimIndent()
         externalBusRepository.evaluateScript(script)
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/gesture/FrontendGestureManager.kt
@@ -124,7 +124,7 @@ class FrontendGestureManager @Inject constructor(
                 bubbles: true,
                 cancelable: true
             });
-            document.dispatchEvent(event);
+            document.body.dispatchEvent(event);
         """.trimIndent()
         externalBusRepository.evaluateScript(script)
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -2219,7 +2219,7 @@ class WebViewActivity :
             bubbles: true,
             cancelable: true
         });
-        document.dispatchEvent(event);
+        document.body.dispatchEvent(event);
         """.trimIndent()
         // Opts into [EvaluateJavascriptUsage] to simulate a keyboard input, which is an
         // interaction the frontend already handles through its normal DOM event listeners — no

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -2219,7 +2219,7 @@ class WebViewActivity :
             bubbles: true,
             cancelable: true
         });
-        document.body.dispatchEvent(event);
+         (document.body || document.documentElement || document).dispatchEvent(event);
         """.trimIndent()
         // Opts into [EvaluateJavascriptUsage] to simulate a keyboard input, which is an
         // interaction the frontend already handles through its normal DOM event listeners — no


### PR DESCRIPTION
## Summary
This PR makes synthetic keyboard events be dispatched on `document.body` instead of `document` due to a bug in the `tinykeys` library used in the HA frontend. This fixes search gestures (any everything else that would dispatch keyboard events).

Fixes https://github.com/home-assistant/android/issues/6952

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
  - I did *not* compile and test the app due to lack of a development environment.
  - Since this change only changes JavaScript that is run in the HA frontend, I have run these in a browser console in my HA instance:
    - `document.dispatchEvent(new KeyboardEvent('keydown', {key: 'd', code: 'KeyD', keyCode: 68, which: 68, ctrlKey: false, bubbles: true, cancelable: true}))` → crashes
    - `document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'd', code: 'KeyD', keyCode: 68, which: 68, ctrlKey: false, bubbles: true, cancelable: true}))` → works
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.