### PR TITLE
Accept notification_icon_color as preferred alias to color

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
@@ -39,6 +39,7 @@ object NotificationData {
     const val CHANNEL = "channel"
     const val IMPORTANCE = "importance"
     const val LED_COLOR = "ledColor"
+    const val COLOR = "color"
     const val VIBRATION_PATTERN = "vibrationPattern"
     const val NOTIFICATION_ICON = "notification_icon"
     const val NOTIFICATION_ICON_COLOR = "notification_icon_color"
@@ -247,7 +248,7 @@ fun prepareText(text: String): Spanned {
 }
 
 fun handleColor(context: Context, builder: NotificationCompat.Builder, data: Map<String, String>) {
-    val colorString = data[NotificationData.NOTIFICATION_ICON_COLOR] ?: data["color"]
+    val colorString = data[NotificationData.NOTIFICATION_ICON_COLOR] ?: data[NotificationData.COLOR]
     val color = parseColor(context, colorString, R.color.colorPrimary)
     builder.color = color
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
@@ -41,6 +41,7 @@ object NotificationData {
     const val LED_COLOR = "ledColor"
     const val VIBRATION_PATTERN = "vibrationPattern"
     const val NOTIFICATION_ICON = "notification_icon"
+    const val NOTIFICATION_ICON_COLOR = "notification_icon_color"
     const val ALERT_ONCE = "alert_once"
     const val COMMAND = "command"
 
@@ -246,7 +247,7 @@ fun prepareText(text: String): Spanned {
 }
 
 fun handleColor(context: Context, builder: NotificationCompat.Builder, data: Map<String, String>) {
-    val colorString = data["notification_icon_color"] ?: data["color"]
+    val colorString = data[NotificationData.NOTIFICATION_ICON_COLOR] ?: data["color"]
     val color = parseColor(context, colorString, R.color.colorPrimary)
     builder.color = color
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
@@ -246,7 +246,7 @@ fun prepareText(text: String): Spanned {
 }
 
 fun handleColor(context: Context, builder: NotificationCompat.Builder, data: Map<String, String>) {
-    val colorString = data["color"]
+    val colorString = data["notification_icon_color"] ?: data["color"]
     val color = parseColor(context, colorString, R.color.colorPrimary)
     builder.color = color
 }


### PR DESCRIPTION


<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Accept `notification_icon_color` as preferred alias to `color` in notification data.
The iOS app now uses `notification_icon_color` to specify the notification icon color, as `color` is not preferred due to other color attributes existing too. 

This change supports the `notification_icon_color` parameter alongside the old `color` parameter.
If both parameters are present, `color` will be ignored.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.


## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Requires update to Firebase Cloud Messaging to support the new key on Android. https://github.com/home-assistant/mobile-apps-fcm-push/pull/328

Documentation PR: https://github.com/home-assistant/companion.home-assistant/pull/1362