### PR TITLE
Introduce HaShortcutManager and migration to deep link storage

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/HomeAssistantApplication.kt
@@ -33,6 +33,7 @@ import io.homeassistant.companion.android.database.settings.SensorUpdateFrequenc
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.settings.language.LanguagesManager
+import io.homeassistant.companion.android.settings.shortcuts.HaShortcutManager
 import io.homeassistant.companion.android.themes.NightModeManager
 import io.homeassistant.companion.android.util.LifecycleHandler
 import io.homeassistant.companion.android.util.QuestUtil
@@ -81,6 +82,9 @@ open class HomeAssistantApplication : Application() {
     @Inject
     lateinit var settingsDao: SettingsDao
 
+    @Inject
+    lateinit var shortcutManager: HaShortcutManager
+
     override fun onCreate() {
         // We should initialize the logger as early as possible in the lifecycle of the application
         Timber.plant(Timber.DebugTree())
@@ -124,6 +128,7 @@ open class HomeAssistantApplication : Application() {
 
             languagesManager.applyCurrentLang()
             nightModeManager.applyCurrentNightMode()
+            shortcutManager.migrateLegacyShortcuts()
         }
 
         configureComposeDiagnosticStackTrace(isDebug = BuildConfig.DEBUG)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkActivity.kt
@@ -84,10 +84,7 @@ class LinkActivity : BaseActivity() {
         when (event) {
             LinkNavigationEvent.Finish -> Unit
             is LinkNavigationEvent.OpenInvitation -> startLaunchInvitation(event.serverUrl)
-            is LinkNavigationEvent.NavigateToWebView -> startLaunchWithNavigateTo(
-                FrontendTarget.fromRawPath(event.path),
-                event.serverId,
-            )
+            is LinkNavigationEvent.NavigateToWebView -> startLaunchWithNavigateTo(event.target, event.serverId)
         }
         finish()
     }
@@ -131,7 +128,7 @@ private fun LinkActivityScreenPreview() {
                     ServerChooserItem(serverId = 1, userName = "Alice Smith", serverName = "Home"),
                     ServerChooserItem(serverId = 2, userName = "Bob", serverName = "Friends home"),
                 ),
-                path = "/lovelace",
+                target = FrontendTarget.Path("/lovelace"),
             ),
             onServerSelected = {},
             onServerChooserDismissed = {},

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
@@ -5,6 +5,7 @@ import androidx.core.net.toUri
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import javax.inject.Inject
 import timber.log.Timber
 
@@ -15,12 +16,33 @@ private const val NAVIGATE_URL_PATH = "/navigate/"
 private const val MY_BASE_DOMAIN = "my.home-assistant.io"
 private const val BASE_MY_REDIRECT_URL = "https://$MY_BASE_DOMAIN$REDIRECT_URL_PATH"
 
-private const val DEEP_LINK_SCHEME = "homeassistant"
+internal const val HA_DEEP_LINK_SCHEME = "homeassistant"
 
 private const val INTERNAL_MY_REDIRECT_PREFIX = "_my_redirect/"
 
 private const val MOBILE_PARAM = "mobile"
 private const val MOBILE_VALUE = "1"
+
+private const val SERVER_PARAM = "server"
+private const val SERVER_ID_PARAM = "server_id"
+private const val MORE_INFO_ENTITY_ID_PARAM = "more-info-entity-id"
+
+/**
+ * Builds the `homeassistant://navigate` deep link that [LinkHandler] resolves back to [target] on
+ * the server identified by [serverId]. Used for persisted intents (e.g. shortcuts) so they target
+ * the stable, exported [LinkActivity] entry point rather than an internal activity.
+ */
+internal fun navigateDeepLinkUri(target: FrontendTarget, serverId: Int): Uri {
+    val builder = Uri.Builder()
+        .scheme(HA_DEEP_LINK_SCHEME)
+        .authority(NAVIGATE_URL_PATH.removeSurrounding("/"))
+    when (target) {
+        is FrontendTarget.EntityMoreInfo -> builder.appendQueryParameter(MORE_INFO_ENTITY_ID_PARAM, target.entityId)
+        is FrontendTarget.Path -> builder.path(target.path)
+        FrontendTarget.Default -> Unit
+    }
+    return builder.appendQueryParameter(SERVER_ID_PARAM, serverId.toString()).build()
+}
 
 /**
  * Sealed class that represents the destination of a link.
@@ -33,14 +55,14 @@ sealed interface LinkDestination {
     data class Onboarding(val serverUrl: String) : LinkDestination
 
     /**
-     * Open a WebView with the given [path] and an optional [serverId].
+     * Open the frontend at [target] on the server identified by [serverId].
      */
-    data class Webview(val path: String, val serverId: Int) : LinkDestination
+    data class Webview(val target: FrontendTarget, val serverId: Int) : LinkDestination
 
     /**
-     * Let the user pick one of the registered [servers] before opening the WebView at [path].
+     * Let the user pick one of the registered [servers] before opening the frontend at [target].
      */
-    data class ServerPicker(val path: String, val servers: List<Server>) : LinkDestination
+    data class ServerPicker(val target: FrontendTarget, val servers: List<Server>) : LinkDestination
 
     /**
      * Nowhere to go from this link.
@@ -68,7 +90,7 @@ class LinkHandlerImpl @Inject constructor(private val serverManager: ServerManag
     override suspend fun handleLink(uri: Uri): LinkDestination {
         return when (uri.scheme) {
             "https" -> handleUniversalLink(uri)
-            DEEP_LINK_SCHEME -> handleDeepLink(uri)
+            HA_DEEP_LINK_SCHEME -> handleDeepLink(uri)
             else -> {
                 FailFast.fail {
                     "Invalid link scheme: $uri"
@@ -78,16 +100,16 @@ class LinkHandlerImpl @Inject constructor(private val serverManager: ServerManag
         }
     }
 
-    private suspend fun webviewDestination(path: String, serverId: Int? = null): LinkDestination {
+    private suspend fun webviewDestination(target: FrontendTarget, serverId: Int? = null): LinkDestination {
         if (serverId != null) {
-            return LinkDestination.Webview(path, serverId)
+            return LinkDestination.Webview(target, serverId)
         }
 
         val servers = serverManager.servers()
         return if (servers.size <= 1) {
-            LinkDestination.Webview(path, ServerManager.SERVER_ID_ACTIVE)
+            LinkDestination.Webview(target, ServerManager.SERVER_ID_ACTIVE)
         } else {
-            LinkDestination.ServerPicker(path, servers)
+            LinkDestination.ServerPicker(target, servers)
         }
     }
 
@@ -181,36 +203,56 @@ class LinkHandlerImpl @Inject constructor(private val serverManager: ServerManag
             .build().toString()
             .replaceFirst(BASE_MY_REDIRECT_URL, INTERNAL_MY_REDIRECT_PREFIX)
 
-        return webviewDestination(path)
+        return webviewDestination(FrontendTarget.Path(path))
     }
 
     /**
      * Handles navigate deep links from `homeassistant://navigate/...`.
      *
-     * Supports server selection via the `server` query parameter:
-     * - No parameter or `server=default`: Uses the default server
+     * Server selection (in order of precedence):
+     * - `server_id=<id>`: Uses the server with that stable id
      * - `server=<name>`: Searches for a server with matching friendly name (case-insensitive)
+     * - No parameter or `server=default`: Uses the active server
+     *
+     * A root-level `more-info-entity-id=<entity>` opens that entity's more-info dialog.
      *
      * @param uri The navigate URI to process.
-     * @return [LinkDestination.Webview] with the full URI and resolved serverId, or [LinkDestination.NoDestination]
-     *         if no server is registered.
+     * @return [LinkDestination.Webview] with the resolved target and serverId, or
+     *         [LinkDestination.NoDestination] if no server is registered.
      */
     private suspend fun handleNavigateLink(uri: Uri): LinkDestination {
         if (!requireServerRegistered()) {
             return LinkDestination.NoDestination
         }
 
-        val serverName = uri.getQueryParameter("server").takeIf { !it.isNullOrBlank() }
-        val serverId = when (serverName) {
-            "default", null -> serverManager.getServer()?.id
-            else -> serverManager.servers().find {
-                it.friendlyName.equals(serverName, ignoreCase = true)
-            }?.id
-        }
+        val serverId = resolveNavigateServerId(uri)
 
-        val path = uri.toString()
-        return webviewDestination(path, serverId)
+        // A root-level `more-info-entity-id` maps to FrontendTarget.EntityMoreInfo, which keeps the
+        // server-version handling (URL query parameter on HA 2025.6+, JavaScript dispatch on older
+        // servers). Anything else is a plain path/URL.
+        val moreInfoEntityId = uri.getQueryParameter(MORE_INFO_ENTITY_ID_PARAM)?.takeIf { it.isNotBlank() }
+        val target = if (moreInfoEntityId != null && uri.isNavigateRoot()) {
+            FrontendTarget.EntityMoreInfo(moreInfoEntityId)
+        } else {
+            FrontendTarget.Path(uri.toString())
+        }
+        return webviewDestination(target, serverId)
     }
+
+    /**
+     * Resolves the target server for a navigate link: a stable `server_id` takes precedence,
+     * otherwise the `server` friendly-name lookup (`default`/absent uses the active server).
+     */
+    private suspend fun resolveNavigateServerId(uri: Uri): Int? {
+        uri.getQueryParameter(SERVER_ID_PARAM)?.toIntOrNull()?.let { return it }
+        val serverName = uri.getQueryParameter(SERVER_PARAM).takeIf { !it.isNullOrBlank() }
+        return when (serverName) {
+            "default", null -> serverManager.getServer()?.id
+            else -> serverManager.servers().find { it.friendlyName.equals(serverName, ignoreCase = true) }?.id
+        }
+    }
+
+    private fun Uri.isNavigateRoot(): Boolean = path.isNullOrEmpty() || path == "/"
 
     private suspend fun requireServerRegistered(): Boolean {
         return serverManager.isRegistered().also { registered ->

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkNavigationEvent.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkNavigationEvent.kt
@@ -1,5 +1,7 @@
 package io.homeassistant.companion.android.launch.link
 
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+
 /**
  * One-shot navigation events.
  */
@@ -10,6 +12,6 @@ sealed interface LinkNavigationEvent {
     /** Start the server onboarding flow for [serverUrl]. */
     data class OpenInvitation(val serverUrl: String) : LinkNavigationEvent
 
-    /** Navigate the WebView at [path] on the server identified by [serverId]. */
-    data class NavigateToWebView(val path: String, val serverId: Int) : LinkNavigationEvent
+    /** Open the frontend at [target] on the server identified by [serverId]. */
+    data class NavigateToWebView(val target: FrontendTarget, val serverId: Int) : LinkNavigationEvent
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkUiState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkUiState.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.launch.link
 
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.settings.server.ServerChooserItem
 
 /**
@@ -13,8 +14,8 @@ sealed interface LinkUiState {
     data object Loading : LinkUiState
 
     /**
-     * More than one server is registered: the user must pick one of [items] before the WebView
-     * is opened at [path].
+     * More than one server is registered: the user must pick one of [items] before the frontend
+     * is opened at [target].
      */
-    data class ChoosingServer(val items: List<ServerChooserItem>, val path: String) : LinkUiState
+    data class ChoosingServer(val items: List<ServerChooserItem>, val target: FrontendTarget) : LinkUiState
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkViewModel.kt
@@ -55,13 +55,13 @@ class LinkViewModel @Inject constructor(
                     _navigationEvents.trySend(LinkNavigationEvent.OpenInvitation(destination.serverUrl))
                 is LinkDestination.Webview ->
                     _navigationEvents.trySend(
-                        LinkNavigationEvent.NavigateToWebView(destination.path, destination.serverId),
+                        LinkNavigationEvent.NavigateToWebView(destination.target, destination.serverId),
                     )
                 is LinkDestination.ServerPicker ->
                     serverChooserItemsUseCase(destination.servers).collect { items ->
                         _uiState.value = LinkUiState.ChoosingServer(
                             items = items,
-                            path = destination.path,
+                            target = destination.target,
                         )
                     }
             }
@@ -70,7 +70,7 @@ class LinkViewModel @Inject constructor(
 
     fun onServerSelected(serverId: Int) {
         val state = _uiState.value as? LinkUiState.ChoosingServer ?: return
-        _navigationEvents.trySend(LinkNavigationEvent.NavigateToWebView(path = state.path, serverId = serverId))
+        _navigationEvents.trySend(LinkNavigationEvent.NavigateToWebView(target = state.target, serverId = serverId))
     }
 
     fun onServerChooserDismissed() {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManager.kt
@@ -1,0 +1,213 @@
+package io.homeassistant.companion.android.settings.shortcuts
+
+import android.content.Context
+import android.content.Intent
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
+import android.os.Build
+import android.util.NoSuchPropertyException
+import android.util.TypedValue
+import androidx.core.content.ContextCompat
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.core.graphics.createBitmap
+import androidx.core.graphics.drawable.IconCompat
+import com.mikepenz.iconics.IconicsColor
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.IconicsSize
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import com.mikepenz.iconics.utils.backgroundColor
+import com.mikepenz.iconics.utils.size
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.util.SdkVersion
+import io.homeassistant.companion.android.database.IconDialogCompat
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.launch.link.HA_DEEP_LINK_SCHEME
+import io.homeassistant.companion.android.launch.link.LinkActivity
+import io.homeassistant.companion.android.launch.link.navigateDeepLinkUri
+import io.homeassistant.companion.android.util.icondialog.getIconByMdiName
+import io.homeassistant.companion.android.util.icondialog.mdiName
+import io.homeassistant.companion.android.widgets.assist.AssistShortcutActivity
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Key used by WebViewActivity to store the server used in the shortcut within the Intent.
+ * The value need to stay the same otherwise it's going to break shortcuts.
+ */
+internal const val SHORTCUT_EXTRA_SERVER = "server"
+
+/**
+ * Key used by WebViewActivity to store the path used in the shortcut within the Intent.
+ * The value need to stay the same otherwise it's going to break shortcuts.
+ */
+internal const val SHORTCUT_EXTRA_PATH = "path"
+private const val SHORTCUT_EXTRA_ICON_NAME = "iconName"
+private const val SHORTCUT_EXTRA_ICON_ID = "iconId"
+
+/**
+ * Manage Shortcuts.
+ *
+ * Shortcuts launch through the stable, exported [LinkActivity] via a `homeassistant://navigate`
+ * deep link. Older app versions launched `WebViewActivity` directly; [migrateLegacyShortcuts]
+ * rewrites those to the current format so they keep working once `WebViewActivity` is removed.
+ */
+@Singleton
+class HaShortcutManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val iconDialogCompat: IconDialogCompat,
+) {
+
+    /**
+     * Builds a [ShortcutInfoCompat] that launches [path] on [serverId] through [LinkActivity].
+     *
+     * The launch destination lives in the intent data URI; `ShortcutInfo` serializes only the extras
+     * into a [android.os.PersistableBundle], so the server id and raw path are kept as primitive
+     * extras (used to repopulate the edit form).
+     */
+    fun buildShortcutInfo(
+        shortcutId: String,
+        serverId: Int,
+        label: String,
+        longLabel: String,
+        path: String,
+        icon: IIcon?,
+    ): ShortcutInfoCompat {
+        val intent = Intent(
+            Intent.ACTION_VIEW,
+            navigateDeepLinkUri(FrontendTarget.fromRawPath(path), serverId),
+        ).apply {
+            // Scope to our app rather than hard-coding the activity: the persisted shortcut then
+            // resolves to whichever activity handles homeassistant://navigate (currently
+            // LinkActivity), so it survives internal navigation refactors, while the package scope
+            // still prevents another app registering the scheme from intercepting it.
+            setPackage(context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
+            addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            putExtra(SHORTCUT_EXTRA_SERVER, serverId)
+            putExtra(SHORTCUT_EXTRA_PATH, path)
+            icon?.let { putExtra(SHORTCUT_EXTRA_ICON_NAME, it.mdiName) }
+        }
+        return ShortcutInfoCompat.Builder(context, shortcutId)
+            .setShortLabel(label)
+            .setLongLabel(longLabel)
+            .setIcon(
+                // Fall back to the launcher icon (an AdaptiveIcon) so it gets themed by the system.
+                icon?.toAdaptiveIcon() ?: IconCompat.createWithResource(context, R.mipmap.ic_launcher),
+            )
+            .setIntent(intent)
+            .build()
+    }
+
+    /**
+     * Resolves the [IIcon] stored on a shortcut intent via its `iconName`/`iconId` extras, or `null`
+     * if none is present.
+     */
+    suspend fun resolveIconFromIntent(intent: Intent): IIcon? = withContext(Dispatchers.IO) {
+        val extras = intent.extras ?: return@withContext null
+        return@withContext when {
+            extras.containsKey(SHORTCUT_EXTRA_ICON_NAME) -> extras.getString(SHORTCUT_EXTRA_ICON_NAME)?.let {
+                CommunityMaterial.getIconByMdiName(it)
+            }
+
+            extras.containsKey(SHORTCUT_EXTRA_ICON_ID) -> {
+                extras.getInt(SHORTCUT_EXTRA_ICON_ID).takeIf { it != 0 }?.let { iconId ->
+                    try {
+                        CommunityMaterial.getIconByMdiName("mdi:${iconDialogCompat.streamingIconLookup(iconId)}")
+                    } catch (e: NoSuchPropertyException) {
+                        Timber.w(e, "Unknown shortcut iconId=$iconId, falling back to default icon")
+                        null
+                    }
+                }
+            }
+
+            else -> null
+        }
+    }
+
+    /**
+     * Migrates shortcuts created by older app versions (which launched `WebViewActivity` directly)
+     * to the current [LinkActivity] deep-link format, updating dynamic and pinned shortcuts in place
+     * while preserving their label, icon and target.
+     *
+     * Best-effort and idempotent: shortcuts already pointing at the `homeassistant://` deep link are
+     * skipped, so re-running does nothing. Safe to call on any API level (no-op below N_MR1).
+     */
+    suspend fun migrateLegacyShortcuts() {
+        if (!SdkVersion.isAtLeast(Build.VERSION_CODES.N_MR1)) return
+
+        val legacyShortcuts = ShortcutManagerCompat.getShortcuts(
+            context,
+            ShortcutManagerCompat.FLAG_MATCH_DYNAMIC or ShortcutManagerCompat.FLAG_MATCH_PINNED,
+        ).filter {
+            !it.id.startsWith(AssistShortcutActivity.SHORTCUT_PREFIX) &&
+                it.intent.data?.scheme != HA_DEEP_LINK_SCHEME &&
+                it.intent.hasExtra(SHORTCUT_EXTRA_PATH)
+        }
+        if (legacyShortcuts.isEmpty()) return
+        Timber.d("Shortcut to migrate ${legacyShortcuts.map { it.id }}")
+
+        val migrated = legacyShortcuts.mapNotNull { old ->
+            val oldIntent = old.intent
+            // The filter above only keeps shortcuts carrying the "path" extra, so it is normally
+            // present; bail defensively if it is somehow missing rather than guessing a target.
+            val path = oldIntent.getStringExtra(SHORTCUT_EXTRA_PATH) ?: return@mapNotNull null
+            buildShortcutInfo(
+                shortcutId = old.id,
+                serverId = oldIntent.getIntExtra(SHORTCUT_EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE),
+                label = old.shortLabel.toString(),
+                longLabel = old.longLabel?.toString().orEmpty(),
+                path = path,
+                icon = resolveIconFromIntent(oldIntent),
+            )
+        }
+
+        try {
+            ShortcutManagerCompat.updateShortcuts(context, migrated)
+            Timber.d("Migrated ${migrated.size} legacy shortcut(s) to deep link")
+        } catch (e: IllegalStateException) {
+            Timber.e(e, "Failed to migrate legacy shortcuts")
+        }
+    }
+
+    /**
+     * Replicates an AdaptiveIcon from an [IIcon] by drawing it centered on a themed launcher-colored
+     * background, returned as an [IconCompat] flagged as an AdaptiveIcon.
+     */
+    private fun IIcon.toAdaptiveIcon(): IconCompat {
+        val iconDrawable = IconicsDrawable(context, this).apply {
+            size = IconicsSize.dp(48)
+            colorFilter = PorterDuffColorFilter(
+                ContextCompat.getColor(context, commonR.color.colorAccent),
+                PorterDuff.Mode.SRC_IN,
+            )
+            backgroundColor = IconicsColor.colorInt(Color.TRANSPARENT)
+        }
+
+        val adaptiveIconSize = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            108f,
+            context.resources.displayMetrics,
+        ).toInt()
+        val adaptiveBitmap = createBitmap(adaptiveIconSize, adaptiveIconSize)
+        val canvas = Canvas(adaptiveBitmap)
+        // Use the same color as the foreground of the launcher as background
+        canvas.drawColor(ContextCompat.getColor(context, R.color.ic_launcher_foreground))
+        val x = (canvas.width - iconDrawable.intrinsicWidth) / 2f
+        val y = (canvas.height - iconDrawable.intrinsicHeight) / 2f
+        canvas.translate(x, y)
+        iconDrawable.draw(canvas)
+
+        return IconCompat.createWithAdaptiveBitmap(adaptiveBitmap)
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManager.kt
@@ -42,13 +42,13 @@ import timber.log.Timber
 
 /**
  * Key used by WebViewActivity to store the server used in the shortcut within the Intent.
- * The value need to stay the same otherwise it's going to break shortcuts.
+ * This value cannot be changed, otherwise it's going to break shortcuts.
  */
 internal const val SHORTCUT_EXTRA_SERVER = "server"
 
 /**
  * Key used by WebViewActivity to store the path used in the shortcut within the Intent.
- * The value need to stay the same otherwise it's going to break shortcuts.
+ * This value cannot be changed, otherwise it's going to break shortcuts.
  */
 internal const val SHORTCUT_EXTRA_PATH = "path"
 private const val SHORTCUT_EXTRA_ICON_NAME = "iconName"
@@ -68,7 +68,8 @@ class HaShortcutManager @Inject constructor(
 ) {
 
     /**
-     * Builds a [ShortcutInfoCompat] that launches [path] on [serverId] through [LinkActivity].
+     * Builds a [ShortcutInfoCompat] that launches [path] on [serverId] through a
+     * `homeassistant://navigate` deep link.
      *
      * The launch destination lives in the intent data URI; `ShortcutInfo` serializes only the extras
      * into a [android.os.PersistableBundle], so the server id and raw path are kept as primitive
@@ -137,8 +138,8 @@ class HaShortcutManager @Inject constructor(
 
     /**
      * Migrates shortcuts created by older app versions (which launched `WebViewActivity` directly)
-     * to the current [LinkActivity] deep-link format, updating dynamic and pinned shortcuts in place
-     * while preserving their label, icon and target.
+     * to the current deep link format, updating dynamic and pinned shortcuts in place while
+     * preserving their label, icon and target.
      *
      * Best-effort and idempotent: shortcuts already pointing at the `homeassistant://` deep link are
      * skipped, so re-running does nothing. Safe to call on any API level (no-op below N_MR1).

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
@@ -1,14 +1,7 @@
 package io.homeassistant.companion.android.settings.shortcuts.legacy
 
 import android.app.Application
-import android.content.Intent
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.PorterDuff
-import android.graphics.PorterDuffColorFilter
-import android.graphics.drawable.AdaptiveIconDrawable
 import android.os.Build
-import android.util.TypedValue
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.MutableState
@@ -18,22 +11,12 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
-import androidx.core.graphics.createBitmap
-import androidx.core.graphics.drawable.IconCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.mikepenz.iconics.IconicsColor
-import com.mikepenz.iconics.IconicsDrawable
-import com.mikepenz.iconics.IconicsSize
 import com.mikepenz.iconics.typeface.IIcon
-import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
-import com.mikepenz.iconics.utils.backgroundColor
-import com.mikepenz.iconics.utils.size
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.servers.ServerManager
@@ -41,23 +24,18 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.Ar
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.common.util.SdkVersion
-import io.homeassistant.companion.android.database.IconDialogCompat
 import io.homeassistant.companion.android.database.server.Server
-import io.homeassistant.companion.android.util.icondialog.getIconByMdiName
-import io.homeassistant.companion.android.util.icondialog.mdiName
-import io.homeassistant.companion.android.webview.WebViewActivity
 import io.homeassistant.companion.android.widgets.assist.AssistShortcutActivity
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @RequiresApi(Build.VERSION_CODES.N_MR1)
 @HiltViewModel
 class ManageShortcutsViewModel @Inject constructor(
     private val serverManager: ServerManager,
+    private val shortcutManager: HaShortcutManager,
     application: Application,
 ) : AndroidViewModel(application) {
 
@@ -84,8 +62,6 @@ class ManageShortcutsViewModel @Inject constructor(
         private set
 
     private suspend fun currentServerId() = serverManager.getServer()?.id ?: 0
-
-    private val iconIdToName: Map<Int, String> by lazy { IconDialogCompat(app.assets).loadAllIcons() }
 
     data class Shortcut(
         var id: MutableState<String?>,
@@ -192,26 +168,14 @@ class ManageShortcutsViewModel @Inject constructor(
         icon: IIcon?,
     ) {
         Timber.d("Attempt to add shortcut $shortcutId")
-        val intent = Intent(
-            WebViewActivity.newInstance(app, shortcutPath, serverId).addFlags(
-                Intent.FLAG_ACTIVITY_NEW_TASK,
-            ),
+        val shortcut = shortcutManager.buildShortcutInfo(
+            shortcutId = shortcutId,
+            serverId = serverId,
+            label = shortcutLabel,
+            longLabel = shortcutDesc,
+            path = shortcutPath,
+            icon = icon,
         )
-        intent.action = shortcutPath
-        intent.addFlags(Intent.FLAG_ACTIVITY_MULTIPLE_TASK)
-        intent.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
-        icon?.let { intent.putExtra("iconName", icon.mdiName) }
-
-        val shortcut = ShortcutInfoCompat.Builder(app, shortcutId)
-            .setShortLabel(shortcutLabel)
-            .setLongLabel(shortcutDesc)
-            .setIcon(
-                icon?.toAdaptiveIcon()
-                    ?: // Use launcher icon that is an AdaptiveIcon so it gets themed properly by the system
-                    IconCompat.createWithResource(app, R.mipmap.ic_launcher),
-            )
-            .setIntent(intent)
-            .build()
 
         if (shortcutId.startsWith("shortcut")) {
             ShortcutManagerCompat.addDynamicShortcuts(app, listOf(shortcut))
@@ -250,41 +214,6 @@ class ManageShortcutsViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Replicate an AdaptiveIcon from a [IIcon] by applying the right measure.
-     * It will output an [IconCompat] created with [IconCompat.createWithAdaptiveBitmap] to flag the [android.graphics.Bitmap]
-     * as AdaptiveIcon.
-     *
-     * @see [AdaptiveIconDrawable] for more the details.
-     */
-    private fun IIcon.toAdaptiveIcon(): IconCompat {
-        val iconDrawable = IconicsDrawable(app, this).apply {
-            size = IconicsSize.dp(48)
-            colorFilter = PorterDuffColorFilter(
-                ContextCompat.getColor(app, commonR.color.colorAccent),
-                PorterDuff.Mode.SRC_IN,
-            )
-            backgroundColor = IconicsColor.colorInt(Color.TRANSPARENT)
-        }
-
-        val adaptiveIconSize = TypedValue.applyDimension(
-            TypedValue.COMPLEX_UNIT_DIP,
-            108f,
-            app.resources.displayMetrics,
-        ).toInt()
-        val adaptiveBitmap = createBitmap(adaptiveIconSize, adaptiveIconSize)
-        val canvas = Canvas(adaptiveBitmap)
-        // Use the same color as the foreground of the launcher as background
-        canvas.drawColor(ContextCompat.getColor(app, R.color.ic_launcher_foreground))
-        // Calculate the position to draw the icon in the center
-        val x = (canvas.width - iconDrawable.intrinsicWidth) / 2f
-        val y = (canvas.height - iconDrawable.intrinsicHeight) / 2f
-        canvas.translate(x, y)
-        iconDrawable.draw(canvas)
-
-        return IconCompat.createWithAdaptiveBitmap(adaptiveBitmap)
-    }
-
     private fun updateDynamicShortcuts() {
         dynamicShortcuts =
             ShortcutManagerCompat.getShortcuts(app, ShortcutManagerCompat.FLAG_MATCH_DYNAMIC).sortedBy {
@@ -305,21 +234,11 @@ class ManageShortcutsViewModel @Inject constructor(
 
     private suspend fun Shortcut.setData(item: ShortcutInfoCompat) {
         val currentServerId = currentServerId()
-        serverId.value = item.intent.extras?.getInt("server", currentServerId) ?: currentServerId
+        serverId.value = item.intent.extras?.getInt(SHORTCUT_EXTRA_SERVER, currentServerId) ?: currentServerId
         label.value = item.shortLabel.toString()
         desc.value = item.longLabel.toString()
-        path.value = item.intent.action.toString()
-        selectedIcon.value = if (item.intent.extras?.containsKey("iconName") == true) {
-            item.intent.extras?.getString("iconName")?.let { CommunityMaterial.getIconByMdiName(it) }
-        } else if (item.intent.extras?.containsKey("iconId") == true) {
-            withContext(Dispatchers.IO) {
-                item.intent.extras?.getInt("iconId")?.takeIf { it != 0 }?.let {
-                    CommunityMaterial.getIconByMdiName("mdi:${iconIdToName.getValue(it)}")
-                }
-            }
-        } else {
-            null
-        }
+        path.value = item.intent.getStringExtra(SHORTCUT_EXTRA_PATH).orEmpty()
+        selectedIcon.value = shortcutManager.resolveIconFromIntent(item.intent)
         if (path.value.startsWith("entityId:")) {
             type.value = "entityId"
         } else {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
@@ -25,6 +25,9 @@ import io.homeassistant.companion.android.common.data.websocket.impl.entities.De
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.settings.shortcuts.HaShortcutManager
+import io.homeassistant.companion.android.settings.shortcuts.SHORTCUT_EXTRA_PATH
+import io.homeassistant.companion.android.settings.shortcuts.SHORTCUT_EXTRA_SERVER
 import io.homeassistant.companion.android.widgets.assist.AssistShortcutActivity
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -86,6 +86,7 @@ import androidx.webkit.WebViewFeature
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.BaseActivity
 import io.homeassistant.companion.android.R
+import io.homeassistant.companion.android.WIPFeature
 import io.homeassistant.companion.android.assist.AssistActivity
 import io.homeassistant.companion.android.authenticator.Authenticator
 import io.homeassistant.companion.android.authenticator.Authenticator.Companion.AuthenticationResult
@@ -132,15 +133,16 @@ import io.homeassistant.companion.android.frontend.js.FrontendJsBridge.Companion
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge.Companion.externalBusCallback
 import io.homeassistant.companion.android.frontend.js.FrontendJsBridge.Companion.isServerSupportingExternalAppV2
 import io.homeassistant.companion.android.frontend.navigation.FrontendEvent
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.improv.ui.ImprovPermissionDialog
 import io.homeassistant.companion.android.improv.ui.ImprovSetupDialog
 import io.homeassistant.companion.android.launch.LaunchActivity
+import io.homeassistant.companion.android.launch.startLaunchWithNavigateTo
 import io.homeassistant.companion.android.nfc.WriteNfcTag
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.settings.ConnectionSecurityLevelFragment
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.server.ServerChooserFragment
-import io.homeassistant.companion.android.settings.shortcuts.HaShortcutManager
 import io.homeassistant.companion.android.themes.NightModeManager
 import io.homeassistant.companion.android.util.ChangeLog
 import io.homeassistant.companion.android.util.CheckLocationDisabledUseCase
@@ -291,9 +293,6 @@ class WebViewActivity :
     @Inject
     lateinit var dataSourceFactoryProvider: SuspendProvider<DataSource.Factory>
 
-    @Inject
-    lateinit var shortcutManager: HaShortcutManager
-
     private lateinit var webView: WebView
     private var loadedUrl: Uri? = null
     private lateinit var decor: FrameLayout
@@ -384,12 +383,18 @@ class WebViewActivity :
 
         super.onCreate(savedInstanceState)
 
-        // Old shortcuts launch this activity directly, so migrate them to the LinkActivity deep-link
-        // format on use (a safety net alongside the startup migration in HomeAssistantApplication).
-        // KEEP this trigger when migrating away from WebViewActivity: whatever component replaces it
-        // as the legacy shortcut target must keep migrating those shortcuts, otherwise they break.
-        lifecycleScope.launch(Dispatchers.IO) {
-            shortcutManager.migrateLegacyShortcuts()
+        // Legacy shortcuts launch this activity directly with a path and/or server extra. Under the
+        // V2 frontend, redirect them to the navigate deep link so they open in FrontendScreen, then
+        // close this activity. The shortcuts themselves are rewritten to the deep-link format by the
+        // startup migration in HomeAssistantApplication; this only covers a direct launch that slips
+        // through. KEEP this redirect when migrating away from WebViewActivity: whatever component
+        // replaces it as the legacy shortcut target must keep doing this, otherwise shortcuts break.
+        if (WIPFeature.USE_FRONTEND_V2 && (intent.hasExtra(EXTRA_PATH) || intent.hasExtra(EXTRA_SERVER))) {
+            val target = intent.getStringExtra(EXTRA_PATH)?.let(FrontendTarget::fromRawPath) ?: FrontendTarget.Default
+            val serverId = intent.getIntExtra(EXTRA_SERVER, ServerManager.SERVER_ID_ACTIVE)
+            startLaunchWithNavigateTo(target, serverId)
+            finish()
+            return
         }
 
         maybeRequestLocalNetworkPermission()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/webview/WebViewActivity.kt
@@ -140,6 +140,7 @@ import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.settings.ConnectionSecurityLevelFragment
 import io.homeassistant.companion.android.settings.SettingsActivity
 import io.homeassistant.companion.android.settings.server.ServerChooserFragment
+import io.homeassistant.companion.android.settings.shortcuts.HaShortcutManager
 import io.homeassistant.companion.android.themes.NightModeManager
 import io.homeassistant.companion.android.util.ChangeLog
 import io.homeassistant.companion.android.util.CheckLocationDisabledUseCase
@@ -290,6 +291,9 @@ class WebViewActivity :
     @Inject
     lateinit var dataSourceFactoryProvider: SuspendProvider<DataSource.Factory>
 
+    @Inject
+    lateinit var shortcutManager: HaShortcutManager
+
     private lateinit var webView: WebView
     private var loadedUrl: Uri? = null
     private lateinit var decor: FrameLayout
@@ -379,6 +383,14 @@ class WebViewActivity :
         }
 
         super.onCreate(savedInstanceState)
+
+        // Old shortcuts launch this activity directly, so migrate them to the LinkActivity deep-link
+        // format on use (a safety net alongside the startup migration in HomeAssistantApplication).
+        // KEEP this trigger when migrating away from WebViewActivity: whatever component replaces it
+        // as the legacy shortcut target must keep migrating those shortcuts, otherwise they break.
+        lifecycleScope.launch(Dispatchers.IO) {
+            shortcutManager.migrateLegacyShortcuts()
+        }
 
         maybeRequestLocalNetworkPermission()
 

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/launch/link/LinkActivityScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/launch/link/LinkActivityScreenshotTest.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.launch.link
 import androidx.compose.runtime.Composable
 import com.android.tools.screenshot.PreviewTest
 import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.settings.server.ServerChooserItem
 import io.homeassistant.companion.android.util.compose.HAPreviews
 
@@ -32,7 +33,7 @@ class LinkActivityScreenshotTest {
                         ServerChooserItem(serverId = 1, userName = "Alice Smith", serverName = "Home"),
                         ServerChooserItem(serverId = 2, userName = "Bob", serverName = "Friends home", isActive = true),
                     ),
-                    path = "/lovelace",
+                    target = FrontendTarget.Path("/lovelace"),
                 ),
                 onServerSelected = {},
                 onServerChooserDismissed = {},

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkActivityScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkActivityScreenTest.kt
@@ -8,6 +8,7 @@ import dagger.hilt.android.testing.HiltAndroidTest
 import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.HiltComponentActivity
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.settings.server.ServerChooserItem
 import io.homeassistant.companion.android.testing.unit.stringResource
 import org.junit.Assert.assertEquals
@@ -39,7 +40,7 @@ class LinkActivityScreenTest {
         composeTestRule.apply {
             setContent {
                 LinkActivityScreen(
-                    uiState = LinkUiState.ChoosingServer(items = items, path = "/lovelace"),
+                    uiState = LinkUiState.ChoosingServer(items = items, target = FrontendTarget.Path("/lovelace")),
                     onServerSelected = {},
                     onServerChooserDismissed = {},
                 )
@@ -60,7 +61,7 @@ class LinkActivityScreenTest {
         composeTestRule.apply {
             setContent {
                 LinkActivityScreen(
-                    uiState = LinkUiState.ChoosingServer(items = items, path = "/lovelace"),
+                    uiState = LinkUiState.ChoosingServer(items = items, target = FrontendTarget.Path("/lovelace")),
                     onServerSelected = { selectedServerId = it },
                     onServerChooserDismissed = {},
                 )
@@ -96,7 +97,7 @@ class LinkActivityScreenTest {
         composeTestRule.apply {
             setContent {
                 LinkActivityScreen(
-                    uiState = LinkUiState.ChoosingServer(items = items, path = "/lovelace"),
+                    uiState = LinkUiState.ChoosingServer(items = items, target = FrontendTarget.Path("/lovelace")),
                     onServerSelected = { selectedServerId = it },
                     onServerChooserDismissed = {},
                 )

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
@@ -5,6 +5,7 @@ import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
@@ -144,7 +145,7 @@ class LinkHandlerTest {
         val uri = "https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fandroid%2F".toUri()
 
         val result = handler.handleLink(uri)
-        assertEquals(LinkDestination.Webview("_my_redirect/supervisor_add_addon_repository?repository_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fandroid%2F&mobile=1", ServerManager.SERVER_ID_ACTIVE), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("_my_redirect/supervisor_add_addon_repository?repository_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fandroid%2F&mobile=1"), ServerManager.SERVER_ID_ACTIVE), result)
     }
 
     @Test
@@ -190,7 +191,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard", 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard"), 1), result)
     }
 
     @Test
@@ -203,7 +204,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=default".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard?server=default", 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=default"), 1), result)
     }
 
     @Test
@@ -216,7 +217,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard?server=", 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server="), 1), result)
     }
 
     @Test
@@ -236,7 +237,37 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=Office".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard?server=Office", 2), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=Office"), 2), result)
+    }
+
+    @Test
+    fun `Given navigate deep link with server_id param when invoking handleLink then returns Webview with that server`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = "homeassistant://navigate/lovelace/dashboard?server_id=2".toUri()
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server_id=2"), 2), result)
+    }
+
+    @Test
+    fun `Given navigate deep link with root more-info-entity-id when invoking handleLink then returns the entity target`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = "homeassistant://navigate/?more-info-entity-id=light.kitchen&server_id=2".toUri()
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.EntityMoreInfo("light.kitchen"), 2), result)
+    }
+
+    @Test
+    fun `Given a navigate deep link built for an entity when invoking handleLink then it round-trips to the entity target`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = navigateDeepLinkUri(FrontendTarget.EntityMoreInfo("light.kitchen"), serverId = 2)
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.EntityMoreInfo("light.kitchen"), 2), result)
     }
 
     @Test
@@ -256,7 +287,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=office".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard?server=office", 2), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=office"), 2), result)
     }
 
     @Test
@@ -272,7 +303,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=NonExisting".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview("homeassistant://navigate/lovelace/dashboard?server=NonExisting", ServerManager.SERVER_ID_ACTIVE), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=NonExisting"), ServerManager.SERVER_ID_ACTIVE), result)
     }
 
     /*
@@ -298,7 +329,9 @@ class LinkHandlerTest {
 
         assertEquals(
             LinkDestination.ServerPicker(
-                "_my_redirect/supervisor_add_addon_repository?repository_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fandroid%2F&mobile=1",
+                FrontendTarget.Path(
+                    "_my_redirect/supervisor_add_addon_repository?repository_url=https%3A%2F%2Fgithub.com%2Fhome-assistant%2Fandroid%2F&mobile=1",
+                ),
                 servers,
             ),
             result,
@@ -324,7 +357,7 @@ class LinkHandlerTest {
         val result = handler.handleLink(uri)
 
         assertEquals(
-            LinkDestination.ServerPicker("homeassistant://navigate/lovelace/dashboard?server=NonExisting", servers),
+            LinkDestination.ServerPicker(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=NonExisting"), servers),
             result,
         )
     }
@@ -348,6 +381,6 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.ServerPicker("homeassistant://navigate/lovelace/dashboard", servers), result)
+        assertEquals(LinkDestination.ServerPicker(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard"), servers), result)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkViewModelTest.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import app.cash.turbine.test
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.settings.server.ServerChooserItem
 import io.homeassistant.companion.android.settings.server.ServerChooserItemsUseCase
 import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit5Extension
@@ -39,25 +40,25 @@ class LinkViewModelTest {
             ServerChooserItem(serverId = 1, userName = "Alice", serverName = "Home"),
             ServerChooserItem(serverId = 2, userName = "Bob", serverName = "Office"),
         )
-        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.ServerPicker("/lovelace", servers)
+        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.ServerPicker(FrontendTarget.Path("/lovelace"), servers)
         every { serverChooserItems(servers) } returns flowOf(items)
 
         val viewModel = createViewModel()
         viewModel.uiState.test {
             assertEquals(LinkUiState.Loading, awaitItem())
             viewModel.onLinkReceived(uri())
-            assertEquals(LinkUiState.ChoosingServer(items = items, path = "/lovelace"), awaitItem())
+            assertEquals(LinkUiState.ChoosingServer(items = items, target = FrontendTarget.Path("/lovelace")), awaitItem())
         }
     }
 
     @Test
     fun `Given Webview destination when onLinkReceived then NavigateToWebView event is emitted`() = runTest {
-        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.Webview("/lovelace", serverId = 3)
+        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.Webview(FrontendTarget.Path("/lovelace"), serverId = 3)
 
         val viewModel = createViewModel()
         viewModel.navigationEvents.test {
             viewModel.onLinkReceived(uri())
-            assertEquals(LinkNavigationEvent.NavigateToWebView(path = "/lovelace", serverId = 3), awaitItem())
+            assertEquals(LinkNavigationEvent.NavigateToWebView(target = FrontendTarget.Path("/lovelace"), serverId = 3), awaitItem())
         }
     }
 
@@ -99,7 +100,7 @@ class LinkViewModelTest {
     @Test
     fun `Given ChoosingServer state when onServerSelected then NavigateToWebView event carries the path and id`() = runTest {
         val servers = listOf<Server>(mockk { every { id } returns 1 }, mockk { every { id } returns 2 })
-        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.ServerPicker("/lovelace", servers)
+        coEvery { linkHandler.handleLink(any()) } returns LinkDestination.ServerPicker(FrontendTarget.Path("/lovelace"), servers)
         every { serverChooserItems(servers) } returns flowOf(
             listOf(
                 ServerChooserItem(serverId = 1, userName = "Alice", serverName = "Home"),
@@ -113,7 +114,7 @@ class LinkViewModelTest {
 
         viewModel.navigationEvents.test {
             viewModel.onServerSelected(serverId = 2)
-            assertEquals(LinkNavigationEvent.NavigateToWebView(path = "/lovelace", serverId = 2), awaitItem())
+            assertEquals(LinkNavigationEvent.NavigateToWebView(target = FrontendTarget.Path("/lovelace"), serverId = 2), awaitItem())
         }
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/HaShortcutManagerTest.kt
@@ -1,0 +1,115 @@
+package io.homeassistant.companion.android.settings.shortcuts
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.database.IconDialogCompat
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class HaShortcutManagerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val manager = HaShortcutManager(context, IconDialogCompat(context.assets))
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `Given an entity path when buildShortcutInfo then it produces a package-scoped navigate intent`() {
+        val info = manager.buildShortcutInfo(
+            shortcutId = "shortcut_1",
+            serverId = 2,
+            label = "Label",
+            longLabel = "Description",
+            path = "entityId:light.kitchen",
+            icon = null,
+        )
+
+        val intent = info.intent
+        assertEquals(Intent.ACTION_VIEW, intent.action)
+        // Scoped to our app rather than a hard-coded component.
+        assertEquals(context.packageName, intent.`package`)
+        assertNull(intent.component)
+        assertEquals("homeassistant", intent.data?.scheme)
+        assertEquals("navigate", intent.data?.host)
+        assertEquals("light.kitchen", intent.data?.getQueryParameter("more-info-entity-id"))
+        assertEquals("2", intent.data?.getQueryParameter("server_id"))
+        // Primitive extras for the edit-form round-trip.
+        assertEquals(2, intent.getIntExtra("server", -1))
+        assertEquals("entityId:light.kitchen", intent.getStringExtra("path"))
+    }
+
+    @Test
+    fun `Given an intent without icon extras when resolveIconFromIntent then returns null`() = runTest {
+        assertNull(manager.resolveIconFromIntent(Intent()))
+    }
+
+    @Test
+    fun `Given an unknown legacy iconId when resolveIconFromIntent then returns null instead of throwing`() = runTest {
+        val intent = Intent().putExtra("iconId", Int.MAX_VALUE)
+        assertNull(manager.resolveIconFromIntent(intent))
+    }
+
+    @Test
+    fun `Given a legacy WebViewActivity shortcut when migrateLegacyShortcuts then it is rewritten to a navigate intent`() = runTest {
+        mockkStatic(ShortcutManagerCompat::class)
+        // Legacy shortcuts set the action to the path and stored path/server as extras.
+        val legacyIntent = Intent("entityId:light.kitchen").apply {
+            putExtra("server", 2)
+            putExtra("path", "entityId:light.kitchen")
+        }
+        val legacy = ShortcutInfoCompat.Builder(context, "shortcut_1")
+            .setShortLabel("Label")
+            .setLongLabel("Description")
+            .setIntent(legacyIntent)
+            .build()
+        every { ShortcutManagerCompat.getShortcuts(any(), any()) } returns listOf(legacy)
+        val updated = slot<List<ShortcutInfoCompat>>()
+        every { ShortcutManagerCompat.updateShortcuts(any(), capture(updated)) } returns true
+
+        manager.migrateLegacyShortcuts()
+
+        val migrated = updated.captured.single().intent
+        assertEquals(Intent.ACTION_VIEW, migrated.action)
+        assertEquals(context.packageName, migrated.`package`)
+        assertEquals("light.kitchen", migrated.data?.getQueryParameter("more-info-entity-id"))
+        assertEquals(2, migrated.getIntExtra("server", -1))
+    }
+
+    @Test
+    fun `Given a shortcut already on the navigate format when migrateLegacyShortcuts then it is not updated`() = runTest {
+        mockkStatic(ShortcutManagerCompat::class)
+        val current = manager.buildShortcutInfo(
+            shortcutId = "shortcut_1",
+            serverId = 2,
+            label = "Label",
+            longLabel = "Description",
+            path = "entityId:light.kitchen",
+            icon = null,
+        )
+        every { ShortcutManagerCompat.getShortcuts(any(), any()) } returns listOf(current)
+
+        manager.migrateLegacyShortcuts()
+
+        verify(exactly = 0) { ShortcutManagerCompat.updateShortcuts(any(), any()) }
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/util/UtilModule.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/util/UtilModule.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.util
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.content.res.AssetManager
 import android.media.AudioManager
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -22,6 +23,9 @@ object UtilModule {
     @Provides
     @Singleton
     fun provideVoiceAudioRecorder(): VoiceAudioRecorder = VoiceAudioRecorder()
+
+    @Provides
+    fun provideAssetManager(@ApplicationContext context: Context): AssetManager = context.assets
 
     @Provides
     fun provideNotificationStatusProvider(@ApplicationContext context: Context): NotificationStatusProvider =


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Closes #7086, by introducing a small manager that handle the creation/migration of the shortcut. In order to make them as much as possible agnostic I've decided to use the deep link path and migrating the Intent to an action + URI that we need to maintain in all case.

I've added also a migration path from the Application class.
I've added also a handling in the WebViewActivity that would only trigger one time then after the shortcut is going to be migrated.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I've tested the migration and it works, but I might have missed some cases.