### PR TITLE
Avoid failing InstrumentationTest when Pull request workflow fail

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -18,8 +18,7 @@ jobs:
     environment: ui-test
     if: >
       github.event.workflow_run.event == 'pull_request'
-      && github.event.workflow_run.conclusion != 'cancelled'
-      && github.event.workflow_run.conclusion != 'skipped'
+      && github.event.workflow_run.conclusion == 'success'
     permissions:
       id-token: write  # Needed for OIDC authentication
       actions: read  # Needed for retrieving artifacts
@@ -87,17 +86,6 @@ jobs:
             echo "job_url=$JOB_URL"
           } >> "$GITHUB_OUTPUT"
 
-      # Halt before spending any emulator.wtf credits if the triggering Pull Request
-      # workflow did not succeed (publish_test_results still runs afterward to
-      # aggregate whatever results pr.yml produced).
-      - name: Halt if triggering workflow did not succeed
-        if: github.event.workflow_run.conclusion != 'success'
-        env:
-          CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-        run: |
-          echo "::error::Triggering 'Pull Request' workflow concluded as '$CONCLUSION'; skipping emulator.wtf to save resources"
-          exit 1
-
       - name: Download emulator.wtf inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -164,7 +152,7 @@ jobs:
           name: Instrumentation Test app reports
           path: build/test-results/**
 
-      # job.status reflects everything above (halt, downloads, test runs) and is
+      # job.status reflects everything above (downloads, test runs) and is
       # one of success/failure/cancelled, all valid check-run conclusions.
       # We re-send the same output.summary link so the completed check page
       # keeps the deep-link to the emulator.wtf job logs (see the Create step
@@ -207,11 +195,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-artifacts
 
-      # If emulator_wtf halted or failed before running tests, it uploads no
-      # results artifact, and downloading it by name errors. Tolerate that so we
-      # still publish the pr.yml results below. We cannot gate on
-      # needs.emulator_wtf.result because a real test failure also fails the job
-      # yet does produce this artifact, which we must still publish.
+      # If emulator_wtf was skipped (triggering workflow did not succeed) or
+      # failed before running tests, it uploads no results artifact, and
+      # downloading it by name errors. Tolerate that so we still publish the
+      # pr.yml results below. We cannot gate on needs.emulator_wtf.result because
+      # a real test failure also fails the job yet does produce this artifact,
+      # which we must still publish.
       - name: Download emulator.wtf results from this run
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -152,7 +152,7 @@ jobs:
           name: Instrumentation Test app reports
           path: build/test-results/**
 
-      # job.status reflects everything above (downloads, test runs) and is
+      # job.status reflects everything above (check creation, downloads, test runs) and is
       # one of success/failure/cancelled, all valid check-run conclusions.
       # We re-send the same output.summary link so the completed check page
       # keeps the deep-link to the emulator.wtf job logs (see the Create step
@@ -195,8 +195,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-artifacts
 
-      # If emulator_wtf was skipped (triggering workflow did not succeed) or
-      # failed before running tests, it uploads no results artifact, and
+      # If emulator_wtf was skipped (non-PR trigger or triggering workflow did not succeed) or
+      # cancelled/failed before running tests, it uploads no results artifact, and
       # downloading it by name errors. Tolerate that so we still publish the
       # pr.yml results below. We cannot gate on needs.emulator_wtf.result because
       # a real test failure also fails the job yet does produce this artifact,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Today when the Pull Request workflow fail we fail the Instrumentation Test job. This is annoying because we get two notification (email for instance) for one failure. This PR simply skip the Instrumentation Test job if the workflow failed. 
The downside is that the check is not going to be created but it's fine since the workflow failed anyway. It might just leave the yellow dot on the PR instead of a cross (to be checked).