### PR TITLE
Move Emoji.parseToUnicode to Dispatcher.IO

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1311,7 +1311,7 @@ class MessagingManager @Inject constructor(
         builder.setAutoCancel(!sticky)
     }
 
-    private fun handleSubject(builder: NotificationCompat.Builder, data: Map<String, String>) {
+    private suspend fun handleSubject(builder: NotificationCompat.Builder, data: Map<String, String>) {
         val subject = data[SUBJECT]
         if (!subject.isNullOrBlank()) {
             builder.setContentText(prepareText(subject))

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/notifications/NotificationFunctions.kt
@@ -28,6 +28,8 @@ import io.homeassistant.companion.android.common.util.CHANNEL_GENERAL
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.common.util.cancel
 import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 object NotificationData {
@@ -216,7 +218,7 @@ fun handleSmallIcon(context: Context, builder: NotificationCompat.Builder, data:
     }
 }
 
-fun getGroupNotificationBuilder(
+suspend fun getGroupNotificationBuilder(
     context: Context,
     channelId: String,
     group: String,
@@ -240,11 +242,12 @@ fun getGroupNotificationBuilder(
     return groupNotificationBuilder
 }
 
-fun prepareText(text: String): Spanned {
+// Emoji parser can trigger a read from the disk so it needs to happen on IO
+suspend fun prepareText(text: String): Spanned = withContext(Dispatchers.IO) {
     // Replace control char \r\n, \r, \n and also \r\n, \r, \n as text literals in strings to <br>
     val brText = text.replace("(\r\n|\r|\n)|(\\\\r\\\\n|\\\\r|\\\\n)".toRegex(), "<br>")
     val emojiParsedText = EmojiParser.parseToUnicode(brText)
-    return HtmlCompat.fromHtml(emojiParsedText, HtmlCompat.FROM_HTML_MODE_LEGACY)
+    return@withContext HtmlCompat.fromHtml(emojiParsedText, HtmlCompat.FROM_HTML_MODE_LEGACY)
 }
 
 fun handleColor(context: Context, builder: NotificationCompat.Builder, data: Map<String, String>) {
@@ -253,7 +256,7 @@ fun handleColor(context: Context, builder: NotificationCompat.Builder, data: Map
     builder.color = color
 }
 
-fun handleText(builder: NotificationCompat.Builder, data: Map<String, String>) {
+suspend fun handleText(builder: NotificationCompat.Builder, data: Map<String, String>) {
     data[NotificationData.TITLE]?.let {
         builder.setContentTitle(prepareText(it))
     }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -107,7 +107,7 @@ class MessagingManager @Inject constructor(
     }
 
     @SuppressLint("MissingPermission")
-    private fun sendNotification(data: Map<String, String>, received: Long? = null) {
+    private suspend fun sendNotification(data: Map<String, String>, received: Long? = null) {
         val notificationManagerCompat = NotificationManagerCompat.from(context)
 
         val tag = data["tag"].takeIf { !it.isNullOrBlank() }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR fix a StrictMode issue we have when parsing emoji
```
2026-06-30 15:24:00.710 19767-19903 CrashFailFastHandler    io....stant.companion.android.debug  E  ██████████████████████
!!! CRITICAL FAILURE: FAIL-FAST !!!
██████████████████████

An unrecoverable error has occurred, and the FailFast mechanism
has been triggered. The application cannot continue and will now exit.

ACTION REQUIRED: This error must be investigated and resolved.
Review the accompanying stack trace for details.
----------------------------------------------------------------


android.os.strictmode.DiskReadViolation
	at android.os.StrictMode$AndroidBlockGuardPolicy.onReadFromDisk(StrictMode.java:1837)
	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:269)
	at libcore.io.ForwardingOs.open(ForwardingOs.java:579)
	at android.app.AndroidForwardingOs.open(AndroidForwardingOs.java:120)
	at libcore.io.IoBridge.open(IoBridge.java:560)
	at java.io.RandomAccessFile.<init>(RandomAccessFile.java:307)
	at java.util.zip.ZipFile$Source.<init>(ZipFile.java:1643)
	at java.util.zip.ZipFile$Source.get(ZipFile.java:1599)
	at java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:797)
	at java.util.zip.ZipFile.<init>(ZipFile.java:299)
	at java.util.zip.ZipFile.<init>(ZipFile.java:261)
	at java.util.jar.JarFile.<init>(JarFile.java:183)
	at java.util.jar.JarFile.<init>(JarFile.java:176)
	at libcore.io.ClassPathURLStreamHandler.<init>(ClassPathURLStreamHandler.java:52)
	at dalvik.system.DexPathList$Element.maybeInit(DexPathList.java:752)
	at dalvik.system.DexPathList$Element.findResource(DexPathList.java:780)
	at dalvik.system.DexPathList.findResource(DexPathList.java:554)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:313)
	at java.lang.ClassLoader.getResource(ClassLoader.java:1397)
	at dalvik.system.BaseDexClassLoader.findResource(BaseDexClassLoader.java:307)
	at java.lang.ClassLoader.getResource(ClassLoader.java:1397)
	at java.lang.ClassLoader.getResourceAsStream(ClassLoader.java:1711)
	at java.lang.Class.getResourceAsStream(Class.java:3120)
	at com.vdurmont.emoji.EmojiManager.<clinit>(EmojiManager.java:30)
	at com.vdurmont.emoji.EmojiParser.getAliasAt(EmojiParser.java:152)
	at com.vdurmont.emoji.EmojiParser.parseToUnicode(EmojiParser.java:117)
	at io.homeassistant.companion.android.common.notifications.NotificationFunctionsKt.prepareText(NotificationFunctions.kt:246)
	at io.homeassistant.companion.android.common.notifications.NotificationFunctionsKt.handleText(NotificationFunctions.kt:261)
	at io.homeassistant.companion.android.notifications.MessagingManager.sendNotification(MessagingManager.kt:1072)
	at io.homeassistant.companion.android.notifications.MessagingManager.access$sendNotification(MessagingManager.kt:119)
	at io.homeassistant.companion.android.notifications.MessagingManager$handleMessage$1.invokeSuspend(MessagingManager.kt:642)
	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
	at android.os.Handler.handleCallback(Handler.java:1095)
	at android.os.Handler.dispatchMessageImpl(Handler.java:135)
	at android.os.Handler.dispatchMessage(Handler.java:125)
	at android.os.Looper.loopOnce(Looper.java:296)
	at android.os.Looper.loop(Looper.java:397)
	at android.app.ActivityThread.main(ActivityThread.java:9537)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:575)
	at com.android.internal.os.WrapperInit.main(WrapperInit.java:94)
	at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
	at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:367)
```

The parsing might read from the disk so it needs to happen on the IO dispatcher.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
