### PR TITLE
Implement command_volume_level_step notification command for relative volume adjustments

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/ApplicationModule.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/ApplicationModule.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android
 
 import android.app.DownloadManager
 import android.content.Context
+import android.media.AudioManager
 import androidx.core.content.getSystemService
 import androidx.work.WorkManager
 import dagger.Module
@@ -73,5 +74,11 @@ object ApplicationModule {
     @Singleton
     fun providesDownloadManager(@ApplicationContext context: Context): DownloadManager? {
         return context.getSystemService<DownloadManager>()
+    }
+
+    @Provides
+    @Singleton
+    fun providesAudioManager(@ApplicationContext context: Context): AudioManager? {
+        return context.getSystemService<AudioManager>()
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -178,6 +178,7 @@ class MessagingManager @Inject constructor(
         const val COMMAND_RINGER_MODE = "command_ringer_mode"
         const val COMMAND_BROADCAST_INTENT = "command_broadcast_intent"
         const val COMMAND_VOLUME_LEVEL = "command_volume_level"
+        const val COMMAND_VOLUME_LEVEL_STEP = "command_volume_level_step"
         const val COMMAND_BLUETOOTH = "command_bluetooth"
         const val COMMAND_SCREEN_ON = "command_screen_on"
         const val COMMAND_MEDIA = "command_media"
@@ -234,6 +235,7 @@ class MessagingManager @Inject constructor(
             COMMAND_RINGER_MODE,
             COMMAND_BROADCAST_INTENT,
             COMMAND_VOLUME_LEVEL,
+            COMMAND_VOLUME_LEVEL_STEP,
             COMMAND_BLUETOOTH,
             DeviceCommandData.COMMAND_BLE_TRANSMITTER,
             DeviceCommandData.COMMAND_BEACON_MONITOR,
@@ -418,7 +420,8 @@ class MessagingManager @Inject constructor(
                             }
                         }
 
-                        COMMAND_VOLUME_LEVEL -> {
+                        COMMAND_VOLUME_LEVEL,
+                        COMMAND_VOLUME_LEVEL_STEP -> {
                             if (!jsonData[NotificationData.MEDIA_STREAM].isNullOrEmpty() &&
                                 jsonData[NotificationData.MEDIA_STREAM] in CHANNEL_VOLUME_STREAM &&
                                 !jsonData[NotificationData.COMMAND].isNullOrEmpty() &&
@@ -730,15 +733,18 @@ class MessagingManager @Inject constructor(
                 }
             }
 
-            COMMAND_VOLUME_LEVEL -> {
+            COMMAND_VOLUME_LEVEL,
+            COMMAND_VOLUME_LEVEL_STEP -> {
                 val notificationManager = context.getSystemService<NotificationManager>()
                 if (notificationManager?.isNotificationPolicyAccessGranted == false) {
                     notifyMissingPermission(message, serverId)
                 } else {
                     processStreamVolume(
-                        data[NotificationData.MEDIA_STREAM].toString(),
-                        command!!.toInt(),
-                        serverId,
+                        stream = data[NotificationData.MEDIA_STREAM].toString(),
+                        volume = command!!.toInt(),
+                        step = message == COMMAND_VOLUME_LEVEL_STEP,
+                        serverId = serverId ,
+                        message = message,
                     )
                 }
             }
@@ -1900,7 +1906,13 @@ class MessagingManager @Inject constructor(
         }
     }
 
-    private suspend fun processStreamVolume(stream: String, volume: Int, serverId: String) {
+    private suspend fun processStreamVolume(
+        stream: String,
+        volume: Int,
+        step: Boolean,
+        serverId: String,
+        message: String,
+    ) {
         val streamType = when (stream) {
             NotificationData.ALARM_STREAM -> AudioManager.STREAM_ALARM
             NotificationData.MUSIC_STREAM -> AudioManager.STREAM_MUSIC
@@ -1912,7 +1924,7 @@ class MessagingManager @Inject constructor(
             NotificationData.ASSISTANT_STREAM -> if (SdkVersion.isAtLeast(Build.VERSION_CODES.CINNAMON_BUN)) {
                 if (!defaultAssistantManager.isDefaultAssistant()) {
                     Timber.w("Cannot control assistant volume: app is not the default assistant")
-                    notifyDefaultAssistant(command = "$COMMAND_VOLUME_LEVEL($stream)", serverId = serverId)
+                    notifyDefaultAssistant(command = "$message($stream)", serverId = serverId)
                     return
                 }
                 AudioManager.STREAM_ASSISTANT
@@ -1926,20 +1938,31 @@ class MessagingManager @Inject constructor(
             }
         }
 
-        adjustVolumeStream(streamType, volume)
+        if (step) {
+            stepStreamVolume(streamType = streamType, volumeDelta = volume)
+        } else {
+            setStreamVolume(streamType = streamType, volume = volume)
+        }
     }
 
-    private fun adjustVolumeStream(stream: Int, volume: Int) {
+    private fun stepStreamVolume(streamType: Int, volumeDelta: Int) {
         val audioManager = context.getSystemService<AudioManager>()!!
-        var volumeLevel = volume
-        if (volumeLevel > audioManager.getStreamMaxVolume(stream)) {
-            volumeLevel = audioManager.getStreamMaxVolume(stream)
-        } else if (volumeLevel < 0) {
-            volumeLevel = 0
-        }
+
+        val currentVolume = audioManager.getStreamVolume(streamType)
+        val newVolume = currentVolume + volumeDelta
+
+        setStreamVolume(streamType = streamType, volume = newVolume)
+    }
+
+    private fun setStreamVolume(streamType: Int, volume: Int) {
+        val audioManager = context.getSystemService<AudioManager>()!!
+
+        val maxVolume = audioManager.getStreamMaxVolume(streamType)
+        val clampedVolume = volume.coerceIn(0, maxVolume)
+
         audioManager.setStreamVolume(
-            stream,
-            volumeLevel,
+            streamType,
+            clampedVolume,
             AudioManager.FLAG_SHOW_UI,
         )
     }
@@ -2125,7 +2148,7 @@ class MessagingManager @Inject constructor(
                         when (type) {
                             COMMAND_WEBVIEW, COMMAND_ACTIVITY, COMMAND_LAUNCH_APP -> requestSystemAlertPermission()
 
-                            COMMAND_RINGER_MODE, COMMAND_DND, COMMAND_VOLUME_LEVEL -> requestDNDPermission()
+                            COMMAND_RINGER_MODE, COMMAND_DND, COMMAND_VOLUME_LEVEL, COMMAND_VOLUME_LEVEL_STEP -> requestDNDPermission()
 
                             COMMAND_MEDIA -> requestNotificationPermission()
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -422,7 +422,8 @@ class MessagingManager @Inject constructor(
                         }
 
                         COMMAND_VOLUME_LEVEL,
-                        COMMAND_VOLUME_LEVEL_STEP -> {
+                        COMMAND_VOLUME_LEVEL_STEP,
+                        -> {
                             if (!jsonData[NotificationData.MEDIA_STREAM].isNullOrEmpty() &&
                                 jsonData[NotificationData.MEDIA_STREAM] in CHANNEL_VOLUME_STREAM &&
                                 !jsonData[NotificationData.COMMAND].isNullOrEmpty() &&
@@ -734,7 +735,8 @@ class MessagingManager @Inject constructor(
             }
 
             COMMAND_VOLUME_LEVEL,
-            COMMAND_VOLUME_LEVEL_STEP -> {
+            COMMAND_VOLUME_LEVEL_STEP,
+            -> {
                 val notificationManager = context.getSystemService<NotificationManager>()
                 if (notificationManager?.isNotificationPolicyAccessGranted == false) {
                     notifyMissingPermission(message, serverId)
@@ -743,7 +745,7 @@ class MessagingManager @Inject constructor(
                         stream = data[NotificationData.MEDIA_STREAM].toString(),
                         volume = command!!.toInt(),
                         step = message == COMMAND_VOLUME_LEVEL_STEP,
-                        serverId = serverId ,
+                        serverId = serverId,
                         message = message,
                     )
                 }
@@ -1932,6 +1934,7 @@ class MessagingManager @Inject constructor(
                 Timber.w("Cannot control assistant volume: Not supported by the current version of Android")
                 return
             }
+
             else -> {
                 Timber.d("Skipping command due to invalid channel stream ($stream)")
                 return
@@ -2144,7 +2147,11 @@ class MessagingManager @Inject constructor(
                         when (type) {
                             COMMAND_WEBVIEW, COMMAND_ACTIVITY, COMMAND_LAUNCH_APP -> requestSystemAlertPermission()
 
-                            COMMAND_RINGER_MODE, COMMAND_DND, COMMAND_VOLUME_LEVEL, COMMAND_VOLUME_LEVEL_STEP -> requestDNDPermission()
+                            COMMAND_RINGER_MODE,
+                            COMMAND_DND,
+                            COMMAND_VOLUME_LEVEL,
+                            COMMAND_VOLUME_LEVEL_STEP,
+                            -> requestDNDPermission()
 
                             COMMAND_MEDIA -> requestNotificationPermission()
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -129,6 +129,7 @@ class MessagingManager @Inject constructor(
     private val permissionRequestMediator: PermissionRequestMediator,
     private val assistConfigManager: AssistConfigManager,
     private val defaultAssistantManager: DefaultAssistantManager,
+    private val audioManager: AudioManager?,
 ) {
     companion object {
         const val APP_PREFIX = "app://"
@@ -696,7 +697,6 @@ class MessagingManager @Inject constructor(
             }
 
             COMMAND_RINGER_MODE -> {
-                val audioManager = context.getSystemService<AudioManager>()
                 val notificationManager =
                     context.getSystemService<NotificationManager>()
                 if (notificationManager?.isNotificationPolicyAccessGranted == false) {
@@ -1946,18 +1946,14 @@ class MessagingManager @Inject constructor(
     }
 
     private fun stepStreamVolume(streamType: Int, volumeDelta: Int) {
-        val audioManager = context.getSystemService<AudioManager>()!!
-
-        val currentVolume = audioManager.getStreamVolume(streamType)
+        val currentVolume = audioManager!!.getStreamVolume(streamType)
         val newVolume = currentVolume + volumeDelta
 
         setStreamVolume(streamType = streamType, volume = newVolume)
     }
 
     private fun setStreamVolume(streamType: Int, volume: Int) {
-        val audioManager = context.getSystemService<AudioManager>()!!
-
-        val maxVolume = audioManager.getStreamMaxVolume(streamType)
+        val maxVolume = audioManager!!.getStreamMaxVolume(streamType)
         val clampedVolume = volume.coerceIn(0, maxVolume)
 
         audioManager.setStreamVolume(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -1901,27 +1901,32 @@ class MessagingManager @Inject constructor(
     }
 
     private suspend fun processStreamVolume(stream: String, volume: Int, serverId: String) {
-        when (stream) {
-            NotificationData.ALARM_STREAM -> adjustVolumeStream(AudioManager.STREAM_ALARM, volume)
-            NotificationData.MUSIC_STREAM -> adjustVolumeStream(AudioManager.STREAM_MUSIC, volume)
-            NotificationData.NOTIFICATION_STREAM -> adjustVolumeStream(AudioManager.STREAM_NOTIFICATION, volume)
-            NotificationData.RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume)
-            NotificationData.CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume)
-            NotificationData.SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume)
-            NotificationData.DTMF_STREAM -> adjustVolumeStream(AudioManager.STREAM_DTMF, volume)
+        val streamType = when (stream) {
+            NotificationData.ALARM_STREAM -> AudioManager.STREAM_ALARM
+            NotificationData.MUSIC_STREAM -> AudioManager.STREAM_MUSIC
+            NotificationData.NOTIFICATION_STREAM -> AudioManager.STREAM_NOTIFICATION
+            NotificationData.RING_STREAM -> AudioManager.STREAM_RING
+            NotificationData.CALL_STREAM -> AudioManager.STREAM_VOICE_CALL
+            NotificationData.SYSTEM_STREAM -> AudioManager.STREAM_SYSTEM
+            NotificationData.DTMF_STREAM -> AudioManager.STREAM_DTMF
             NotificationData.ASSISTANT_STREAM -> if (SdkVersion.isAtLeast(Build.VERSION_CODES.CINNAMON_BUN)) {
                 if (!defaultAssistantManager.isDefaultAssistant()) {
                     Timber.w("Cannot control assistant volume: app is not the default assistant")
                     notifyDefaultAssistant(command = "$COMMAND_VOLUME_LEVEL($stream)", serverId = serverId)
                     return
                 }
-                adjustVolumeStream(AudioManager.STREAM_ASSISTANT, volume)
+                AudioManager.STREAM_ASSISTANT
             } else {
                 Timber.w("Cannot control assistant volume: Not supported by the current version of Android")
+                return
             }
-
-            else -> Timber.d("Skipping command due to invalid channel stream ($stream)")
+            else -> {
+                Timber.d("Skipping command due to invalid channel stream ($stream)")
+                return
+            }
         }
+
+        adjustVolumeStream(streamType, volume)
     }
 
     private fun adjustVolumeStream(stream: Int, volume: Int) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/notifications/MessagingManager.kt
@@ -731,14 +731,11 @@ class MessagingManager @Inject constructor(
             }
 
             COMMAND_VOLUME_LEVEL -> {
-                val audioManager =
-                    context.getSystemService<AudioManager>()
                 val notificationManager = context.getSystemService<NotificationManager>()
                 if (notificationManager?.isNotificationPolicyAccessGranted == false) {
                     notifyMissingPermission(message, serverId)
                 } else {
                     processStreamVolume(
-                        audioManager!!,
                         data[NotificationData.MEDIA_STREAM].toString(),
                         command!!.toInt(),
                         serverId,
@@ -1903,27 +1900,22 @@ class MessagingManager @Inject constructor(
         }
     }
 
-    private suspend fun processStreamVolume(audioManager: AudioManager, stream: String, volume: Int, serverId: String) {
+    private suspend fun processStreamVolume(stream: String, volume: Int, serverId: String) {
         when (stream) {
-            NotificationData.ALARM_STREAM -> adjustVolumeStream(AudioManager.STREAM_ALARM, volume, audioManager)
-            NotificationData.MUSIC_STREAM -> adjustVolumeStream(AudioManager.STREAM_MUSIC, volume, audioManager)
-            NotificationData.NOTIFICATION_STREAM -> adjustVolumeStream(
-                AudioManager.STREAM_NOTIFICATION,
-                volume,
-                audioManager,
-            )
-
-            NotificationData.RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume, audioManager)
-            NotificationData.CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume, audioManager)
-            NotificationData.SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume, audioManager)
-            NotificationData.DTMF_STREAM -> adjustVolumeStream(AudioManager.STREAM_DTMF, volume, audioManager)
+            NotificationData.ALARM_STREAM -> adjustVolumeStream(AudioManager.STREAM_ALARM, volume)
+            NotificationData.MUSIC_STREAM -> adjustVolumeStream(AudioManager.STREAM_MUSIC, volume)
+            NotificationData.NOTIFICATION_STREAM -> adjustVolumeStream(AudioManager.STREAM_NOTIFICATION, volume)
+            NotificationData.RING_STREAM -> adjustVolumeStream(AudioManager.STREAM_RING, volume)
+            NotificationData.CALL_STREAM -> adjustVolumeStream(AudioManager.STREAM_VOICE_CALL, volume)
+            NotificationData.SYSTEM_STREAM -> adjustVolumeStream(AudioManager.STREAM_SYSTEM, volume)
+            NotificationData.DTMF_STREAM -> adjustVolumeStream(AudioManager.STREAM_DTMF, volume)
             NotificationData.ASSISTANT_STREAM -> if (SdkVersion.isAtLeast(Build.VERSION_CODES.CINNAMON_BUN)) {
                 if (!defaultAssistantManager.isDefaultAssistant()) {
                     Timber.w("Cannot control assistant volume: app is not the default assistant")
                     notifyDefaultAssistant(command = "$COMMAND_VOLUME_LEVEL($stream)", serverId = serverId)
                     return
                 }
-                adjustVolumeStream(AudioManager.STREAM_ASSISTANT, volume, audioManager)
+                adjustVolumeStream(AudioManager.STREAM_ASSISTANT, volume)
             } else {
                 Timber.w("Cannot control assistant volume: Not supported by the current version of Android")
             }
@@ -1932,7 +1924,8 @@ class MessagingManager @Inject constructor(
         }
     }
 
-    private fun adjustVolumeStream(stream: Int, volume: Int, audioManager: AudioManager) {
+    private fun adjustVolumeStream(stream: Int, volume: Int) {
+        val audioManager = context.getSystemService<AudioManager>()!!
         var volumeLevel = volume
         if (volumeLevel > audioManager.getStreamMaxVolume(stream)) {
             volumeLevel = audioManager.getStreamMaxVolume(stream)

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -2,6 +2,7 @@
 <changelog xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="MissingDefaultResource">
     <release version="2026.7.1 - Main" versioncode="3">
+        <change>Added command_volume_level_step notification command for relative volume adjustments</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.1 - Wear" versioncode="2">


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
This PR adds a new `command_volume_level_step` notification command (alongside the existing `command_volume_level`) to add support for relative volume adjustments. It enables users to create responsive volume up/down control automations, for example for physical media control buttons through HA (eg. [this Zigbee device](https://www.zigbee2mqtt.io/devices/E2123.html)). Currently the best option for implementing such automation is to first read the current state of the music volume sensor, then add/subtract the desired adjustment value, and then fire a `command_volume_level` notification command to set the new volume. The problem with this approach is slowness. Quick successive button presses would result in most of the button presses to be seemingly ignored, because the music volume sensor doesn't update quickly enough.

The parameters of the new command are exactly the same as for `command_volume_level`. The only difference is in behavior of the `command` key. Here's an example service call YAML to decrease music volume by 2 steps:

```yaml
service: notify.mobile_app_<device_name>
data:
  message: command_volume_level_step
  data:
    media_stream: music_stream
    command: -2
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] ~~New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).~~
  - No, as `MessagingManager` didn't have any unit tests to begin with.
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
Documentation: home-assistant/companion.home-assistant#

**I'll open the doc update PR and the PR for adding the new notification command in the [mobile-apps-fcm-push](https://github.com/home-assistant/mobile-apps-fcm-push) repo when this PR is getting close to be merged :hourglass_flowing_sand:**

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
This is a reworked & rethought version of a PR I opened (and abandoned) a while ago: #4056 (closed without merging)
In that PR, I implemented the same functionality with a different approach: I extended the existing `command_volume_level` notification command with a `relative: true/false` property. Now I changed my mind, because I think adding a separate notification command feels cleaner, expresses the distinction more clearly, and is more similar to existing patterns in HA, like the `brightness_step` key for the `light.turn_on` command.