### PR TITLE
Reduce max heap size to 4G for screenshot test

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidComposeConventionPlugin.kt
@@ -35,7 +35,7 @@ class AndroidComposeConventionPlugin : Plugin<Project> {
 
             // Screenshot test worker memory grows with test count. Increase as needed.
             // Tracking: https://issuetracker.google.com/issues/469819154
-            val maxHeapSizeScreenshotTesting = "5g"
+            val maxHeapSizeScreenshotTesting = "4g"
 
             tasks.withType<PreviewScreenshotValidationTask>().configureEach {
                 maxHeapSize = maxHeapSizeScreenshotTesting


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
CI is failing on screenshot testing again, it seems that we are using more RAM that the runner can allow us. This PR tries to reduce the max heap size to 4g instead of 5g. It passes locally let see if it helps on the CI.