### PR TITLE
Introduce RoomEntityMutablePropertiesIssue lint rule

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -481,7 +481,7 @@
         errorLine2="                ^">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="157"
+            line="162"
             column="17"/>
     </issue>
 
@@ -668,7 +668,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="118"
+            line="123"
             column="17"/>
     </issue>
 
@@ -679,7 +679,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="119"
+            line="124"
             column="17"/>
     </issue>
 
@@ -690,7 +690,7 @@
         errorLine2="                                     ~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt"
-            line="371"
+            line="385"
             column="38"/>
     </issue>
 

--- a/automotive/lint-baseline.xml
+++ b/automotive/lint-baseline.xml
@@ -426,7 +426,7 @@
         errorLine2="                ^">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="157"
+            line="162"
             column="17"/>
     </issue>
 
@@ -624,7 +624,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="118"
+            line="123"
             column="17"/>
     </issue>
 
@@ -635,7 +635,7 @@
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt"
-            line="119"
+            line="124"
             column="17"/>
     </issue>
 
@@ -646,7 +646,7 @@
         errorLine2="                                     ~~~~~~~~~~~~~">
         <location
             file="${:automotive*fullDebug*MAIN*sourceProvider*0*javaDir*5}/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt"
-            line="371"
+            line="385"
             column="38"/>
     </issue>
 

--- a/lint/build.gradle.kts
+++ b/lint/build.gradle.kts
@@ -35,9 +35,15 @@ dependencies {
     compileOnly(libs.kotlin.stdlib)
     compileOnly(libs.lint.api)
     testImplementation(platform(libs.junit.bom))
-    testImplementation(libs.junit.vintage.engine)
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit.jupiter.params)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.lint.tests)
     testImplementation(libs.lint.checks)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }
 
 dependencyLocking {

--- a/lint/src/main/kotlin/io/homeassistant/lint/LintRegistry.kt
+++ b/lint/src/main/kotlin/io/homeassistant/lint/LintRegistry.kt
@@ -7,6 +7,7 @@ import com.android.tools.lint.detector.api.Issue
 import io.homeassistant.lint.annotation.NamedAnnotationDetector
 import io.homeassistant.lint.annotation.ProvidesSensorMissingDetector
 import io.homeassistant.lint.room.CoroutineDaoFunctionsIssue
+import io.homeassistant.lint.room.RoomEntityMutablePropertiesIssue
 import io.homeassistant.lint.sdkversion.SdkVersionDetector
 import io.homeassistant.lint.serialization.MissingSerializableAnnotationIssue
 import io.homeassistant.lint.webview.EvaluateJavascriptDetector
@@ -16,6 +17,7 @@ class LintRegistry : IssueRegistry() {
         MissingSerializableAnnotationIssue.ISSUE,
         MissingSerializableAnnotationIssue.RECOMMENDATION,
         CoroutineDaoFunctionsIssue.ISSUE,
+        RoomEntityMutablePropertiesIssue.ISSUE,
         NamedAnnotationDetector.ISSUE,
         EvaluateJavascriptDetector.ISSUE,
         SdkVersionDetector.ISSUE,

--- a/lint/src/main/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssue.kt
+++ b/lint/src/main/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssue.kt
@@ -1,0 +1,80 @@
+package io.homeassistant.lint.room
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.uast.UClass
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.kotlin.getKotlinMemberOrigin
+
+private val ROOM_ENTITY_ANNOTATIONS = listOf(
+    "androidx.room.Entity",
+    "androidx.room.DatabaseView",
+    "androidx.room3.Entity",
+    "androidx.room3.DatabaseView",
+)
+
+object RoomEntityMutablePropertiesIssue {
+
+    @JvmField
+    val ISSUE = Issue.create(
+        id = "RoomEntityMutableProperty",
+        briefDescription = "Room entity properties should be immutable",
+        explanation = """
+            Room entity classes should use immutable properties to avoid mutating persisted state in place.
+            Use `val` properties and create updated copies instead.
+        """.trimIndent(),
+        category = Category.CORRECTNESS,
+        severity = Severity.ERROR,
+        priority = 10,
+        implementation = Implementation(
+            IssueDetector::class.java,
+            Scope.JAVA_FILE_SCOPE,
+        ),
+    )
+
+    class IssueDetector :
+        Detector(),
+        SourceCodeScanner {
+        override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+        override fun createUastHandler(context: JavaContext): UElementHandler {
+            return object : UElementHandler() {
+                override fun visitClass(node: UClass) {
+                    if (node.isEntity()) {
+                        node.fields
+                            .filter { it.isMutableKotlinProperty() }
+                            .forEach { field ->
+                                context.report(
+                                    ISSUE,
+                                    field,
+                                    context.getNameLocation(field),
+                                    "Room entity properties should be immutable. Use `val` instead of `var`.",
+                                )
+                            }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun UClass.isEntity(): Boolean {
+    return ROOM_ENTITY_ANNOTATIONS.any(::hasAnnotation)
+}
+
+private fun UField.isMutableKotlinProperty(): Boolean {
+    return when (val origin = javaPsi?.originalElement?.let(::getKotlinMemberOrigin)) {
+        is KtProperty -> origin.isVar
+        is KtParameter -> origin.isMutable
+        else -> false
+    }
+}

--- a/lint/src/main/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssue.kt
+++ b/lint/src/main/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssue.kt
@@ -27,10 +27,10 @@ object RoomEntityMutablePropertiesIssue {
     @JvmField
     val ISSUE = Issue.create(
         id = "RoomEntityMutableProperty",
-        briefDescription = "Room entity properties should be immutable",
+        briefDescription = "Room entity/view properties should be immutable",
         explanation = """
-            Room entity classes should use immutable properties to avoid mutating persisted state in place.
-            Use `val` properties and create updated copies instead.
+            Room entity and view classes should use immutable properties to avoid mutating persisted state
+            in place. Use `val` properties and create updated copies instead.
         """.trimIndent(),
         category = Category.CORRECTNESS,
         severity = Severity.ERROR,
@@ -57,7 +57,7 @@ object RoomEntityMutablePropertiesIssue {
                                     ISSUE,
                                     field,
                                     context.getNameLocation(field),
-                                    "Room entity properties should be immutable. Use `val` instead of `var`.",
+                                    "Room entity/view properties should be immutable. Use `val` instead of `var`.",
                                 )
                             }
                     }

--- a/lint/src/test/kotlin/io/homeassistant/lint/annotation/NamedAnnotationDetectorTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/annotation/NamedAnnotationDetectorTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.lint.annotation
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NamedAnnotationDetectorTest {
 

--- a/lint/src/test/kotlin/io/homeassistant/lint/annotation/ProvidesSensorMissingDetectorTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/annotation/ProvidesSensorMissingDetectorTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.lint.annotation
 
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ProvidesSensorMissingDetectorTest {
 

--- a/lint/src/test/kotlin/io/homeassistant/lint/room/CoroutineDaoFunctionsIssueTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/room/CoroutineDaoFunctionsIssueTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.lint.room
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CoroutineDaoFunctionsIssueTest {
     private val roomAnnotation = kotlin(

--- a/lint/src/test/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssueTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssueTest.kt
@@ -1,0 +1,164 @@
+package io.homeassistant.lint.room
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+/**
+ * Runs a parameterized test once for the `androidx.room` package and once for the `androidx.room3`
+ * package, injecting the package name as the test argument.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@ParameterizedTest
+@ValueSource(strings = ["androidx.room", "androidx.room3"])
+private annotation class RoomPackageTest
+
+class RoomEntityMutablePropertiesIssueTest {
+    private fun roomAnnotations(packageName: String) = kotlin(
+        """
+        package $packageName
+
+        @Target(AnnotationTarget.CLASS)
+        @Retention(AnnotationRetention.BINARY)
+        annotation class Entity(val tableName: String = "")
+
+        @Target(AnnotationTarget.CLASS)
+        @Retention(AnnotationRetention.BINARY)
+        annotation class DatabaseView(val value: String = "", val viewName: String = "")
+
+        """,
+    ).indented()
+
+    @RoomPackageTest
+    fun `Given a Room entity when constructor property is var then RoomEntityMutableProperty issue is raised`(roomPackage: String) {
+        lint().issues(RoomEntityMutablePropertiesIssue.ISSUE)
+            .allowMissingSdk()
+            .files(
+                roomAnnotations(roomPackage),
+                kotlin(
+                    """
+                    package io.homeassistant
+
+                    import $roomPackage.Entity
+
+                    @Entity(tableName = "homes")
+                    data class Home(
+                        val id: Int,
+                        var name: String,
+                    )
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """src/io/homeassistant/Home.kt:8: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+    var name: String,
+        ~~~~
+1 error""",
+            )
+    }
+
+    @RoomPackageTest
+    fun `Given a Room database view when constructor property is var then RoomEntityMutableProperty issue is raised`(roomPackage: String) {
+        lint().issues(RoomEntityMutablePropertiesIssue.ISSUE)
+            .allowMissingSdk()
+            .files(
+                roomAnnotations(roomPackage),
+                kotlin(
+                    """
+                    package io.homeassistant
+
+                    import $roomPackage.DatabaseView
+
+                    @DatabaseView("SELECT id, name FROM homes")
+                    data class HomeView(
+                        val id: Int,
+                        var name: String,
+                    )
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """src/io/homeassistant/HomeView.kt:8: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+    var name: String,
+        ~~~~
+1 error""",
+            )
+    }
+
+    @RoomPackageTest
+    fun `Given a Room entity when body property is var then RoomEntityMutableProperty issue is raised`(roomPackage: String) {
+        lint().issues(RoomEntityMutablePropertiesIssue.ISSUE)
+            .allowMissingSdk()
+            .files(
+                roomAnnotations(roomPackage),
+                kotlin(
+                    """
+                    package io.homeassistant
+
+                    import $roomPackage.Entity
+
+                    @Entity
+                    class Home {
+                        var name: String = ""
+                    }
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expect(
+                """src/io/homeassistant/Home.kt:7: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+    var name: String = ""
+        ~~~~
+1 error""",
+            )
+    }
+
+    @RoomPackageTest
+    fun `Given a Room entity when properties are val then no issues`(roomPackage: String) {
+        lint().issues(RoomEntityMutablePropertiesIssue.ISSUE)
+            .allowMissingSdk()
+            .files(
+                roomAnnotations(roomPackage),
+                kotlin(
+                    """
+                    package io.homeassistant
+
+                    import $roomPackage.Entity
+
+                    @Entity
+                    data class Home(
+                        val id: Int,
+                        val name: String,
+                    )
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+
+    @RoomPackageTest
+    fun `Given a non Room entity class when constructor property is var then no issues`(roomPackage: String) {
+        lint().issues(RoomEntityMutablePropertiesIssue.ISSUE)
+            .allowMissingSdk()
+            .files(
+                roomAnnotations(roomPackage),
+                kotlin(
+                    """
+                    package io.homeassistant
+
+                    data class Home(
+                        val id: Int,
+                        var name: String,
+                    )
+                    """,
+                ).indented(),
+            )
+            .run()
+            .expectClean()
+    }
+}

--- a/lint/src/test/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssueTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/room/RoomEntityMutablePropertiesIssueTest.kt
@@ -53,7 +53,7 @@ class RoomEntityMutablePropertiesIssueTest {
             )
             .run()
             .expect(
-                """src/io/homeassistant/Home.kt:8: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+                """src/io/homeassistant/Home.kt:8: Error: Room entity/view properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
     var name: String,
         ~~~~
 1 error""",
@@ -82,7 +82,7 @@ class RoomEntityMutablePropertiesIssueTest {
             )
             .run()
             .expect(
-                """src/io/homeassistant/HomeView.kt:8: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+                """src/io/homeassistant/HomeView.kt:8: Error: Room entity/view properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
     var name: String,
         ~~~~
 1 error""",
@@ -110,7 +110,7 @@ class RoomEntityMutablePropertiesIssueTest {
             )
             .run()
             .expect(
-                """src/io/homeassistant/Home.kt:7: Error: Room entity properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
+                """src/io/homeassistant/Home.kt:7: Error: Room entity/view properties should be immutable. Use val instead of var. [RoomEntityMutableProperty]
     var name: String = ""
         ~~~~
 1 error""",

--- a/lint/src/test/kotlin/io/homeassistant/lint/sdkversion/SdkVersionDetectorTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/sdkversion/SdkVersionDetectorTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.lint.sdkversion
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class SdkVersionDetectorTest {
 

--- a/lint/src/test/kotlin/io/homeassistant/lint/serialization/MissingSerializableAnnotationIssueTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/serialization/MissingSerializableAnnotationIssueTest.kt
@@ -1,8 +1,8 @@
 package io.homeassistant.lint.serialization
 
-import com.android.tools.lint.checks.infrastructure.LintDetectorTest.kotlin
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MissingSerializableAnnotationIssueTest {
     private val issuesToUse = arrayOf(

--- a/lint/src/test/kotlin/io/homeassistant/lint/webview/EvaluateJavascriptDetectorTest.kt
+++ b/lint/src/test/kotlin/io/homeassistant/lint/webview/EvaluateJavascriptDetectorTest.kt
@@ -2,7 +2,7 @@ package io.homeassistant.lint.webview
 
 import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
 import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class EvaluateJavascriptDetectorTest {
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR introduce a new lint rules that forbid the usage of `var` within Room Entity and View. It is ready for the Room3 that just got released.

This PR does not address the actual issue we have in the code base but ignore then. Most of them are going to be addressed in follow up PRs.

I wanted to make parametrized test and found out that the lint test API now supports Jupiter so I've migrated to it so I can write the parametrized tests.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.