### PR TITLE
Improve UX when 'Sensor detail' dialog has many entries

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -34,6 +34,7 @@ import io.homeassistant.companion.android.database.settings.SensorUpdateFrequenc
 import io.homeassistant.companion.android.database.settings.SettingsDao
 import io.homeassistant.companion.android.sensors.LastAppSensorManager
 import io.homeassistant.companion.android.sensors.SensorReceiver
+import java.util.Locale
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.Dispatchers
@@ -480,10 +481,10 @@ class SensorDetailViewModel @Inject constructor(
                             packageManager.getApplicationLabel(it).let { label ->
                                 when {
                                     label.isBlank() -> it.packageName
-                                    label != it.packageName -> "$label\n(${it.packageName}"
+                                    label != it.packageName -> "$label\n(${it.packageName})"
                                     else -> label.toString()
                                 }
-                            }.lowercase()
+                            }.lowercase(Locale.ROOT)
                         }
                         .map { it.packageName }
                 }
@@ -531,7 +532,7 @@ class SensorDetailViewModel @Inject constructor(
                                     label.toString()
                             }
                         }
-                        .sortedBy { it.lowercase() }
+                        .sortedBy { it.lowercase(Locale.ROOT) }
                 }
             }
             SensorSettingType.LIST_BLUETOOTH -> {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -316,30 +316,15 @@ class SensorDetailViewModel @Inject constructor(
         val state = SettingDialogState(
             setting = setting,
             loading = false,
-            entries = sortEntriesSelectedFirst(setting, entries, entriesSelected),
+            entries = sortEntriesSelectedFirst(
+                entries = entries,
+                entriesSelected = entriesSelected,
+                singleSelect = setting.valueType == SensorSettingType.LIST,
+            ),
             entriesSelected = entriesSelected,
         )
         dialogLoadingJob.cancel()
         sensorSettingsDialog = state
-    }
-
-    /**
-     * Moves the entries that are currently selected to the front of the list, so users can review
-     * their existing selection without hunting through the full list. The relative order within
-     * the selected and unselected groups is preserved. This is only applied when building the
-     * dialog state, so toggling entries while the dialog is open does not reorder the list.
-     */
-    private fun sortEntriesSelectedFirst(
-        setting: SensorSetting,
-        entries: List<Pair<String, String>>,
-        entriesSelected: List<String>,
-    ): List<Pair<String, String>> {
-        // Single-select lists (radio buttons) keep their fixed order as it can be meaningful
-        if (setting.valueType == SensorSettingType.LIST || entriesSelected.isEmpty()) return entries
-
-        val selected = entriesSelected.toSet()
-        val (checked, unchecked) = entries.partition { (id, _) -> id in selected }
-        return checked + unchecked
     }
 
     fun cancelSettingWithDialog() {
@@ -653,4 +638,24 @@ class SensorDetailViewModel @Inject constructor(
         }
         return state
     }
+}
+
+/**
+ * Moves the entries (ID to label pairs) that are currently selected to the front of the list, so
+ * users can review their existing selection without hunting through the full list. The relative
+ * order within the selected and unselected groups is preserved. This should only be applied when
+ * building the dialog state, so toggling entries while the dialog is open does not reorder the
+ * list. When [singleSelect] is true the entries are returned unchanged, since the fixed order of
+ * a single-select (radio button) list can be meaningful.
+ */
+internal fun sortEntriesSelectedFirst(
+    entries: List<Pair<String, String>>,
+    entriesSelected: List<String>,
+    singleSelect: Boolean,
+): List<Pair<String, String>> {
+    if (singleSelect || entriesSelected.isEmpty()) return entries
+
+    val selected = entriesSelected.toSet()
+    val (checked, unchecked) = entries.partition { (id, _) -> id in selected }
+    return checked + unchecked
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -36,6 +36,7 @@ import io.homeassistant.companion.android.sensors.LastAppSensorManager
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -53,6 +54,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 @HiltViewModel
@@ -462,19 +464,23 @@ class SensorDetailViewModel @Inject constructor(
             SensorSettingType.LIST ->
                 setting.entries
             SensorSettingType.LIST_APPS -> {
-                val packageManager = getApplication<Application>().packageManager
-                getApplicationInfoForEntries(null)
-                    .filterNotNull()
-                    .sortedBy {
-                        packageManager.getApplicationLabel(it).let { label ->
-                            when {
-                                label.isBlank() -> it.packageName
-                                label != it.packageName -> "$label\n(${it.packageName}"
-                                else -> label.toString()
-                            }
-                        }.lowercase()
-                    }
-                    .map { it.packageName }
+                // Enumerating and sorting all installed packages is expensive on devices with many
+                // apps, so this must not run on the main thread.
+                withContext(Dispatchers.Default) {
+                    val packageManager = getApplication<Application>().packageManager
+                    getApplicationInfoForEntries(null)
+                        .filterNotNull()
+                        .sortedBy {
+                            packageManager.getApplicationLabel(it).let { label ->
+                                when {
+                                    label.isBlank() -> it.packageName
+                                    label != it.packageName -> "$label\n(${it.packageName}"
+                                    else -> label.toString()
+                                }
+                            }.lowercase()
+                        }
+                        .map { it.packageName }
+                }
             }
             SensorSettingType.LIST_BLUETOOTH ->
                 BluetoothUtils.getBluetoothDevices(getApplication()).map { it.address }
@@ -497,22 +503,30 @@ class SensorDetailViewModel @Inject constructor(
             SensorSettingType.LIST ->
                 getSettingTranslatedEntries(setting.name, entries ?: setting.entries)
             SensorSettingType.LIST_APPS -> {
-                val packageManager = getApplication<Application>().packageManager
-                val apps = getApplicationInfoForEntries(entries)
-                apps
-                    .mapIndexed { index, info ->
-                        if (info == null) return@mapIndexed entries?.get(index) ?: ""
-                        val label = packageManager.getApplicationLabel(info)
-                        when {
-                            label.isBlank() ->
-                                info.packageName
-                            label != info.packageName ->
-                                if (entries?.isNotEmpty() == true) label.toString() else "$label\n(${info.packageName})"
-                            else ->
-                                label.toString()
+                // Enumerating and sorting all installed packages is expensive on devices with many
+                // apps, so this must not run on the main thread.
+                withContext(Dispatchers.Default) {
+                    val packageManager = getApplication<Application>().packageManager
+                    val apps = getApplicationInfoForEntries(entries)
+                    apps
+                        .mapIndexed { index, info ->
+                            if (info == null) return@mapIndexed entries?.get(index) ?: ""
+                            val label = packageManager.getApplicationLabel(info)
+                            when {
+                                label.isBlank() ->
+                                    info.packageName
+                                label != info.packageName ->
+                                    if (entries?.isNotEmpty() == true) {
+                                        label.toString()
+                                    } else {
+                                        "$label\n(${info.packageName})"
+                                    }
+                                else ->
+                                    label.toString()
+                            }
                         }
-                    }
-                    .sortedBy { it.lowercase() }
+                        .sortedBy { it.lowercase() }
+                }
             }
             SensorSettingType.LIST_BLUETOOTH -> {
                 val devices = BluetoothUtils.getBluetoothDevices(getApplication())

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/SensorDetailViewModel.kt
@@ -287,38 +287,59 @@ class SensorDetailViewModel @Inject constructor(
 
         val listKeys = getSettingKeys(setting)
         val listEntries = getSettingEntries(setting, null)
+        val entries = when {
+            setting.valueType == SensorSettingType.LIST ||
+                setting.valueType == SensorSettingType.LIST_APPS ||
+                setting.valueType == SensorSettingType.LIST_BLUETOOTH ||
+                setting.valueType == SensorSettingType.LIST_ZONES ->
+                listKeys.zip(listEntries)
+
+            setting.valueType.listType ->
+                listEntries.map { it to it }
+
+            else ->
+                emptyList()
+        }
+        val entriesSelected = when {
+            setting.valueType == SensorSettingType.LIST ||
+                setting.valueType == SensorSettingType.LIST_APPS ||
+                setting.valueType == SensorSettingType.LIST_BLUETOOTH ||
+                setting.valueType == SensorSettingType.LIST_ZONES ->
+                setting.value.split(", ").filter { listKeys.contains(it) }
+
+            setting.valueType.listType ->
+                setting.value.split(", ").filter { listEntries.contains(it) }
+
+            else ->
+                emptyList()
+        }
         val state = SettingDialogState(
             setting = setting,
             loading = false,
-            entries = when {
-                setting.valueType == SensorSettingType.LIST ||
-                    setting.valueType == SensorSettingType.LIST_APPS ||
-                    setting.valueType == SensorSettingType.LIST_BLUETOOTH ||
-                    setting.valueType == SensorSettingType.LIST_ZONES ->
-                    listKeys.zip(listEntries)
-
-                setting.valueType.listType ->
-                    listEntries.map { it to it }
-
-                else ->
-                    emptyList()
-            },
-            entriesSelected = when {
-                setting.valueType == SensorSettingType.LIST ||
-                    setting.valueType == SensorSettingType.LIST_APPS ||
-                    setting.valueType == SensorSettingType.LIST_BLUETOOTH ||
-                    setting.valueType == SensorSettingType.LIST_ZONES ->
-                    setting.value.split(", ").filter { listKeys.contains(it) }
-
-                setting.valueType.listType ->
-                    setting.value.split(", ").filter { listEntries.contains(it) }
-
-                else ->
-                    emptyList()
-            },
+            entries = sortEntriesSelectedFirst(setting, entries, entriesSelected),
+            entriesSelected = entriesSelected,
         )
         dialogLoadingJob.cancel()
         sensorSettingsDialog = state
+    }
+
+    /**
+     * Moves the entries that are currently selected to the front of the list, so users can review
+     * their existing selection without hunting through the full list. The relative order within
+     * the selected and unselected groups is preserved. This is only applied when building the
+     * dialog state, so toggling entries while the dialog is open does not reorder the list.
+     */
+    private fun sortEntriesSelectedFirst(
+        setting: SensorSetting,
+        entries: List<Pair<String, String>>,
+        entriesSelected: List<String>,
+    ): List<Pair<String, String>> {
+        // Single-select lists (radio buttons) keep their fixed order as it can be meaningful
+        if (setting.valueType == SensorSettingType.LIST || entriesSelected.isEmpty()) return entries
+
+        val selected = entriesSelected.toSet()
+        val (checked, unchecked) = entries.partition { (id, _) -> id in selected }
+        return checked + unchecked
     }
 
     fun cancelSettingWithDialog() {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -96,6 +96,23 @@ import kotlinx.coroutines.flow.onEach
 /** Splits a setting dialog search query into its space-separated search terms. */
 private val WHITESPACE_REGEX = Regex("\\s+")
 
+/**
+ * Filters list setting dialog entries (ID to label pairs) against a free-text search query.
+ *
+ * The query is split on whitespace and an entry matches only if its label contains every term
+ * (case-insensitive), so `google maps` matches "Google Maps" but not other Google apps. A blank
+ * query returns [entries] unchanged.
+ */
+internal fun filterSettingEntries(entries: List<Pair<String, String>>, query: String): List<Pair<String, String>> {
+    val searchTerms = query.trim().lowercase().split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
+    if (searchTerms.isEmpty()) return entries
+
+    return entries.filter { (_, label) ->
+        val lowercaseLabel = label.lowercase()
+        searchTerms.all { term -> lowercaseLabel.contains(term) }
+    }
+}
+
 @Composable
 fun SensorDetailView(
     viewModel: SensorDetailViewModel,
@@ -600,15 +617,7 @@ fun SensorDetailSettingDialog(
         remember(state.loading) { mutableStateListOf<String>().also { it.addAll(state.entriesSelected) } }
     var searchQuery by remember(state.loading) { mutableStateOf("") }
     val filteredEntries = remember(state.entries, searchQuery) {
-        val searchTerms = searchQuery.trim().lowercase().split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
-        if (searchTerms.isEmpty()) {
-            state.entries
-        } else {
-            state.entries.filter { (_, label) ->
-                val lowercaseLabel = label.lowercase()
-                searchTerms.all { term -> lowercaseLabel.contains(term) }
-            }
-        }
+        filterSettingEntries(entries = state.entries, query = searchQuery)
     }
 
     MdcAlertDialog(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -90,6 +90,7 @@ import io.homeassistant.companion.android.util.compose.MdcAlertDialog
 import io.homeassistant.companion.android.util.compose.TransparentChip
 import io.homeassistant.companion.android.util.safeBottomPaddingValues
 import io.homeassistant.companion.android.util.safeBottomWindowInsets
+import java.util.Locale
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -110,11 +111,11 @@ private const val MIN_ENTRIES_FOR_SEARCH = 10
  * query returns [entries] unchanged.
  */
 internal fun filterSettingEntries(entries: List<Pair<String, String>>, query: String): List<Pair<String, String>> {
-    val searchTerms = query.trim().lowercase().split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
+    val searchTerms = query.trim().lowercase(Locale.ROOT).split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
     if (searchTerms.isEmpty()) return entries
 
     return entries.filter { (_, label) ->
-        val lowercaseLabel = label.lowercase()
+        val lowercaseLabel = label.lowercase(Locale.ROOT)
         searchTerms.all { term -> lowercaseLabel.contains(term) }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -97,6 +97,12 @@ import kotlinx.coroutines.flow.onEach
 private val WHITESPACE_REGEX = Regex("\\s+")
 
 /**
+ * Minimum number of entries in a list setting dialog before the search field is shown. Short lists,
+ * such as the single-select option pickers used by some sensors, are quicker to scan than to filter.
+ */
+private const val MIN_ENTRIES_FOR_SEARCH = 10
+
+/**
  * Filters list setting dialog entries (ID to label pairs) against a free-text search query.
  *
  * The query is split on whitespace and an entry matches only if its label contains every term
@@ -636,30 +642,32 @@ fun SensorDetailSettingDialog(
                 }
             } else if (listSettingDialog) {
                 Column(modifier = Modifier.fillMaxHeight()) {
-                    TextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp),
-                        singleLine = true,
-                        placeholder = { Text(stringResource(commonR.string.search)) },
-                        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
-                        trailingIcon = if (searchQuery.isNotBlank()) {
-                            {
-                                IconButton(onClick = { searchQuery = "" }) {
-                                    Icon(
-                                        Icons.Filled.Clear,
-                                        contentDescription = stringResource(commonR.string.clear_search),
-                                    )
+                    if (state.entries.size >= MIN_ENTRIES_FOR_SEARCH) {
+                        TextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp),
+                            singleLine = true,
+                            placeholder = { Text(stringResource(commonR.string.search)) },
+                            leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+                            trailingIcon = if (searchQuery.isNotBlank()) {
+                                {
+                                    IconButton(onClick = { searchQuery = "" }) {
+                                        Icon(
+                                            Icons.Filled.Clear,
+                                            contentDescription = stringResource(commonR.string.clear_search),
+                                        )
+                                    }
                                 }
-                            }
-                        } else {
-                            null
-                        },
-                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                        keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
-                    )
+                            } else {
+                                null
+                            },
+                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                            keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
+                        )
+                    }
                     LazyColumn(modifier = Modifier.weight(1f)) {
                         items(filteredEntries, key = { (id) -> id }) { (id, entry) ->
                             SensorDetailSettingRow(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/sensor/views/SensorDetailView.kt
@@ -28,6 +28,8 @@ import androidx.compose.material.Checkbox
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.LocalContentAlpha
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.RadioButton
@@ -40,6 +42,9 @@ import androidx.compose.material.SwitchDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.material.contentColorFor
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -87,6 +92,9 @@ import io.homeassistant.companion.android.util.safeBottomPaddingValues
 import io.homeassistant.companion.android.util.safeBottomWindowInsets
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+
+/** Splits a setting dialog search query into its space-separated search terms. */
+private val WHITESPACE_REGEX = Regex("\\s+")
 
 @Composable
 fun SensorDetailView(
@@ -590,6 +598,18 @@ fun SensorDetailSettingDialog(
     val inputValue = remember(state.loading) { mutableStateOf(state.setting.value) }
     val checkedValue =
         remember(state.loading) { mutableStateListOf<String>().also { it.addAll(state.entriesSelected) } }
+    var searchQuery by remember(state.loading) { mutableStateOf("") }
+    val filteredEntries = remember(state.entries, searchQuery) {
+        val searchTerms = searchQuery.trim().lowercase().split(WHITESPACE_REGEX).filter { it.isNotEmpty() }
+        if (searchTerms.isEmpty()) {
+            state.entries
+        } else {
+            state.entries.filter { (_, label) ->
+                val lowercaseLabel = label.lowercase()
+                searchTerms.all { term -> lowercaseLabel.contains(term) }
+            }
+        }
+    }
 
     MdcAlertDialog(
         modifier = modifier,
@@ -606,31 +626,57 @@ fun SensorDetailSettingDialog(
                     CircularProgressIndicator()
                 }
             } else if (listSettingDialog) {
-                LazyColumn {
-                    items(state.entries, key = { (id) -> id }) { (id, entry) ->
-                        SensorDetailSettingRow(
-                            label = entry,
-                            checked = if (state.setting.valueType ==
-                                SensorSettingType.LIST
-                            ) {
-                                inputValue.value == id
-                            } else {
-                                checkedValue.contains(id)
-                            },
-                            multiple = state.setting.valueType != SensorSettingType.LIST,
-                            onClick = { isChecked ->
-                                if (state.setting.valueType == SensorSettingType.LIST) {
-                                    inputValue.value = id
-                                    onSubmit(state.copy(setting = state.setting.copy(value = inputValue.value)))
-                                } else {
-                                    if (checkedValue.contains(id) && !isChecked) {
-                                        checkedValue.remove(id)
-                                    } else if (!checkedValue.contains(id) && isChecked) {
-                                        checkedValue.add(id)
-                                    }
+                Column(modifier = Modifier.fillMaxHeight()) {
+                    TextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp),
+                        singleLine = true,
+                        placeholder = { Text(stringResource(commonR.string.search)) },
+                        leadingIcon = { Icon(Icons.Filled.Search, contentDescription = null) },
+                        trailingIcon = if (searchQuery.isNotBlank()) {
+                            {
+                                IconButton(onClick = { searchQuery = "" }) {
+                                    Icon(
+                                        Icons.Filled.Clear,
+                                        contentDescription = stringResource(commonR.string.clear_search),
+                                    )
                                 }
-                            },
-                        )
+                            }
+                        } else {
+                            null
+                        },
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
+                    )
+                    LazyColumn(modifier = Modifier.weight(1f)) {
+                        items(filteredEntries, key = { (id) -> id }) { (id, entry) ->
+                            SensorDetailSettingRow(
+                                label = entry,
+                                checked = if (state.setting.valueType ==
+                                    SensorSettingType.LIST
+                                ) {
+                                    inputValue.value == id
+                                } else {
+                                    checkedValue.contains(id)
+                                },
+                                multiple = state.setting.valueType != SensorSettingType.LIST,
+                                onClick = { isChecked ->
+                                    if (state.setting.valueType == SensorSettingType.LIST) {
+                                        inputValue.value = id
+                                        onSubmit(state.copy(setting = state.setting.copy(value = inputValue.value)))
+                                    } else {
+                                        if (checkedValue.contains(id) && !isChecked) {
+                                            checkedValue.remove(id)
+                                        } else if (!checkedValue.contains(id) && isChecked) {
+                                            checkedValue.add(id)
+                                        }
+                                    }
+                                },
+                            )
+                        }
                     }
                 }
             } else {

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,7 @@
     tools:ignore="MissingDefaultResource">
     <release version="2026.7.1 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
+        <change>Sensor app allow list: added a loading indicator and search</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.1 - Wear" versioncode="2">

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,7 +3,7 @@
     tools:ignore="MissingDefaultResource">
     <release version="2026.7.1 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
-        <change>Sensor app allow list: added a loading indicator and search</change>
+        <change>Sensor app allow list: added a loading indicator and search, selected apps are listed first</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.1 - Wear" versioncode="2">

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/sensor/SortEntriesSelectedFirstTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/sensor/SortEntriesSelectedFirstTest.kt
@@ -1,0 +1,79 @@
+package io.homeassistant.companion.android.settings.sensor
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SortEntriesSelectedFirstTest {
+
+    private val alpha = "com.example.alpha" to "Alpha"
+    private val bravo = "com.example.bravo" to "Bravo"
+    private val charlie = "com.example.charlie" to "Charlie"
+    private val delta = "com.example.delta" to "Delta"
+    private val entries = listOf(alpha, bravo, charlie, delta)
+
+    @Test
+    fun `Given selected entries when sorting then they are moved to the front keeping order within groups`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = listOf(delta.first, bravo.first),
+            singleSelect = false,
+        )
+
+        assertEquals(listOf(bravo, delta, alpha, charlie), result)
+    }
+
+    @Test
+    fun `Given no selected entries when sorting then the list is unchanged`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = emptyList(),
+            singleSelect = false,
+        )
+
+        assertEquals(entries, result)
+    }
+
+    @Test
+    fun `Given all entries selected when sorting then the list is unchanged`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = entries.map { it.first },
+            singleSelect = false,
+        )
+
+        assertEquals(entries, result)
+    }
+
+    @Test
+    fun `Given a single-select list when sorting then the list is unchanged even with a selection`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = listOf(charlie.first),
+            singleSelect = true,
+        )
+
+        assertEquals(entries, result)
+    }
+
+    @Test
+    fun `Given selected IDs not present in the entries when sorting then they are ignored`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = listOf("com.example.unknown", charlie.first),
+            singleSelect = false,
+        )
+
+        assertEquals(listOf(charlie, alpha, bravo, delta), result)
+    }
+
+    @Test
+    fun `Given a selection when sorting then matching is done on entry ID and not on label`() {
+        val result = sortEntriesSelectedFirst(
+            entries = entries,
+            entriesSelected = listOf("Bravo"),
+            singleSelect = false,
+        )
+
+        assertEquals(entries, result)
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/sensor/views/FilterSettingEntriesTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/sensor/views/FilterSettingEntriesTest.kt
@@ -1,0 +1,64 @@
+package io.homeassistant.companion.android.settings.sensor.views
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class FilterSettingEntriesTest {
+
+    private val entries = listOf(
+        "com.google.android.apps.maps" to "Google Maps\n(com.google.android.apps.maps)",
+        "com.google.android.calendar" to "Google Calendar\n(com.google.android.calendar)",
+        "com.coloros.alarmclock" to "Clock\n(com.coloros.alarmclock)",
+        "org.mozilla.firefox" to "Firefox\n(org.mozilla.firefox)",
+    )
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", " ", "   ", "\t"])
+    fun `Given a blank query when filtering then all entries are returned`(query: String) {
+        assertEquals(entries, filterSettingEntries(entries = entries, query = query))
+    }
+
+    @Test
+    fun `Given a single term when filtering then labels are matched case-insensitively`() {
+        val result = filterSettingEntries(entries = entries, query = "FIREFOX")
+
+        assertEquals(listOf(entries[3]), result)
+    }
+
+    @Test
+    fun `Given multiple terms when filtering then only entries matching every term are returned`() {
+        val result = filterSettingEntries(entries = entries, query = "google maps")
+
+        assertEquals(listOf(entries[0]), result)
+    }
+
+    @Test
+    fun `Given multiple terms when filtering then term order does not matter`() {
+        val result = filterSettingEntries(entries = entries, query = "maps goo")
+
+        assertEquals(listOf(entries[0]), result)
+    }
+
+    @Test
+    fun `Given surrounding and repeated whitespace when filtering then terms are still applied`() {
+        val result = filterSettingEntries(entries = entries, query = "  google   maps ")
+
+        assertEquals(listOf(entries[0]), result)
+    }
+
+    @Test
+    fun `Given a term matching several labels when filtering then all matching entries are returned in order`() {
+        val result = filterSettingEntries(entries = entries, query = "google")
+
+        assertEquals(listOf(entries[0], entries[1]), result)
+    }
+
+    @Test
+    fun `Given a term without matches when filtering then no entries are returned`() {
+        val result = filterSettingEntries(entries = entries, query = "does not exist")
+
+        assertEquals(emptyList<Pair<String, String>>(), result)
+    }
+}


### PR DESCRIPTION
## Summary

Quality-of-life improvements to the shared sensor list setting dialog — the picker used by the **Next Alarm** allow list (Settings → Sensors → Next Alarm), the notification sensors' allow list, and the Location/Bluetooth sensor pickers. They matter most when the list is large (the app allow list has hundreds of entries).

## What it does

- **No freeze on open.** The dialog used to block the UI for several seconds while building the app list. It now opens instantly and shows a loading spinner until the list is ready.
- **Searchable.** A search box filters the list as you type (multi-word, order-independent, case-insensitive).
- **Selections first.** Entries you've already selected are shown at the top when the dialog opens, so you don't have to hunt for them.
- **Search only when useful.** The search box appears only for lists long enough to need it, so short option pickers stay uncluttered.

## Scope & safety

The dialog is shared, so this applies to every list setting (allow lists, Bluetooth devices, zones, beacons, single-select option pickers). The changes are additive and low-risk:

- Existing alphabetical sorting is unchanged.
- Single-select (radio) pickers keep their fixed order; only multi-select lists reorder.
- The background-loading change touches only the app-list code path; other list types are untouched.
- The filter and ordering logic are extracted into pure functions covered by unit tests.

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots

Next Alarm allow list dialog with the search filter active, light and dark mode:

| Light | Dark |
| --- | --- |
| ![Allow list dialog, light mode](https://github.com/user-attachments/assets/929aa81f-1d4b-4427-827d-712601843b47) | ![Allow list dialog, dark mode](https://github.com/user-attachments/assets/714bb678-cfa7-4bd5-a834-e396feb0fd78) |

## Any other notes

- Manually tested on a physical device (Oppo Find X9 Pro, ColorOS, Android 16) across the Next Alarm allow list, the notification allow list, and a Bluetooth device list.
- No new strings — reuses the existing `search` / `clear_search` resources.
- `:app:compileFullDebugKotlin`, `:app:ktlintCheck` and the unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
