### PR TITLE
Introduce GetEntitiesForDisplayUseCase

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/HomeAssistantVersion.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/HomeAssistantVersion.kt
@@ -22,4 +22,7 @@ data class HomeAssistantVersion(val year: Int, val month: Int, val release: Int)
 
     fun isAtLeast(minYear: Int, minMonth: Int, minRelease: Int = 0): Boolean =
         year > minYear || (year == minYear && (month > minMonth || (month == minMonth && release >= minRelease)))
+
+    fun isAtLeast(min: HomeAssistantVersion): Boolean =
+        isAtLeast(minYear = min.year, minMonth = min.month, minRelease = min.release)
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
@@ -1,0 +1,69 @@
+package io.homeassistant.companion.android.common.data.integration.display
+
+import android.content.Context
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.LayoutDirection
+import com.mikepenz.iconics.typeface.IIcon
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.getIcon
+
+private const val CATEGORY_CONFIG = "config"
+private const val CATEGORY_DIAGNOSTIC = "diagnostic"
+
+/**
+ * Category of an entity in the entity registry, used to separate primary entities from
+ * configuration/diagnostic ones.
+ */
+enum class EntityCategory {
+    CONFIG,
+    DIAGNOSTIC,
+    ;
+
+    companion object {
+        /** Maps the registry string value (`config`/`diagnostic`) to an [EntityCategory], or null. */
+        internal fun fromString(value: String?): EntityCategory? = when (value) {
+            CATEGORY_CONFIG -> CONFIG
+            CATEGORY_DIAGNOSTIC -> DIAGNOSTIC
+            else -> null
+        }
+    }
+}
+
+/** Fully resolved display information for an entity. */
+@Immutable
+data class EntityDisplayItem(
+    val entityId: String,
+    val name: String,
+    val icon: IIcon,
+    val areaName: String? = null,
+    val floorName: String? = null,
+    val deviceName: String? = null,
+    val isHidden: Boolean = false,
+    val entityCategory: EntityCategory? = null,
+    val displayPrecision: Int? = null,
+    val labels: List<String> = emptyList(),
+) {
+    val domain: String get() = entityId.substringBefore('.')
+
+    /**
+     * Formatted subtitle combining area and device name, adapting the separator to the
+     * layout direction. Null if the item has neither.
+     */
+    fun subtitle(layoutDirection: LayoutDirection): String? = listOfNotNull(areaName, deviceName)
+        .takeIf { it.isNotEmpty() }
+        ?.joinToString(if (layoutDirection == LayoutDirection.Ltr) " ▸ " else " ◂ ")
+
+    companion object {
+        /**
+         * Builds an item from an [Entity] alone, without any registry metadata (no
+         * area/floor/device names). Meant for callers that cannot reach the websocket API,
+         * such as the Wear favorites settings screen, and for previews.
+         */
+        fun from(entity: Entity, context: Context): EntityDisplayItem = EntityDisplayItem(
+            entityId = entity.entityId,
+            name = entity.friendlyName,
+            icon = entity.getIcon(context),
+        )
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
@@ -11,10 +11,6 @@ import io.homeassistant.companion.android.common.data.integration.getIcon
 private const val CATEGORY_CONFIG = "config"
 private const val CATEGORY_DIAGNOSTIC = "diagnostic"
 
-/**
- * Category of an entity in the entity registry, used to separate primary entities from
- * configuration/diagnostic ones.
- */
 enum class EntityCategory {
     CONFIG,
     DIAGNOSTIC,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayState.kt
@@ -1,0 +1,18 @@
+package io.homeassistant.companion.android.common.data.integration.display
+
+import androidx.compose.runtime.Immutable
+
+/**
+ * State of the entity display resolution.
+ */
+@Immutable
+sealed interface EntityDisplayState {
+    /** The entities are being retrieved. */
+    data object Loading : EntityDisplayState
+
+    /** The entities could not be retrieved at all (for example the server is unreachable). */
+    data object Error : EntityDisplayState
+
+    /** The entities are resolved and ready to be displayed. */
+    data class Loaded(val entities: List<EntityDisplayItem>) : EntityDisplayState
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
@@ -147,7 +147,6 @@ class GetEntitiesForDisplayUseCase @Inject constructor(
         val classicEntry = snapshot.classicEntries?.get(entity.entityId)
 
         val device = (displayEntry?.deviceId ?: classicEntry?.deviceId)?.let { snapshot.devices[it] }
-        // The area set on the entity itself wins over the area inherited from its device
         val areaId = displayEntry?.areaId ?: classicEntry?.areaId ?: device?.areaId
         val area = areaId?.let { snapshot.areas[it] }
         val floor = area?.floorId?.let { snapshot.floors[it] }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
@@ -55,7 +55,7 @@ private data class RegistrySnapshot(
 )
 
 /**
- * Adapter that resolves the display information (name, area, floor, device, icon, hidden,
+ * Use case that resolves the display information (name, area, floor, device, icon, hidden,
  * category, precision, labels) for the given entities, fetching the data from the right
  * source depending on the server version:
  * - servers >= 2024.10 use the bandwidth-efficient `config/entity_registry/list_for_display`

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
@@ -1,0 +1,226 @@
+package io.homeassistant.companion.android.common.data.integration.display
+
+import android.content.Context
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.IIcon
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.homeassistant.companion.android.common.data.HomeAssistantVersion
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayEntry
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.FloorRegistryResponse
+import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import timber.log.Timber
+
+/**
+ * Minimum server version to use `config/entity_registry/list_for_display` as the source of
+ * entity display data.
+ *
+ * The command itself exists since 2023.3, but only since 2024.10 (https://github.com/home-assistant/core/pull/125832)
+ * is the `en` field the server-resolved display name (`name or original_name`) and the `hn`
+ * (`has_entity_name`) flag present. Before 2024.10, `en` was only sent for entities with
+ * `has_entity_name` and no user-set name, so it cannot be trusted as the display name. Older
+ * servers use the classic registry path instead, which matches the app's behavior before the
+ * introduction of this adapter.
+ */
+private val MIN_VERSION_ENTITY_REGISTRY_DISPLAY = HomeAssistantVersion(year = 2024, month = 10, release = 0)
+
+/** Minimum server version of the `config/floor_registry/list` command (https://github.com/home-assistant/core/pull/110741). */
+private val MIN_VERSION_FLOOR_REGISTRY = HomeAssistantVersion(year = 2024, month = 3, release = 0)
+
+private const val MDI_PREFIX = "mdi:"
+
+/**
+ * Registry data fetched once per resolution, indexed by id for the merge.
+ */
+private data class RegistrySnapshot(
+    val displayEntries: Map<String, EntityRegistryDisplayEntry>? = null,
+    val entityCategories: Map<Int, String> = emptyMap(),
+    val classicEntries: Map<String, EntityRegistryResponse>? = null,
+    val devices: Map<String, DeviceRegistryResponse> = emptyMap(),
+    val areas: Map<String, AreaRegistryResponse> = emptyMap(),
+    val floors: Map<String, FloorRegistryResponse> = emptyMap(),
+)
+
+/**
+ * Adapter that resolves the display information (name, area, floor, device, icon, hidden,
+ * category, precision, labels) for the given entities, fetching the data from the right
+ * source depending on the server version:
+ * - servers >= 2024.10 use the bandwidth-efficient `config/entity_registry/list_for_display`
+ *   command (see [MIN_VERSION_ENTITY_REGISTRY_DISPLAY] for the rationale)
+ * - older servers use the classic entity registry
+ *
+ * Both variants return a cold [Flow] that emits [EntityDisplayState.Loading] first and
+ * completes with a terminal state, so consumers can render loading and error indicators.
+ * Registry failures never produce [EntityDisplayState.Error]: the affected metadata degrades
+ * to null and the entities are still returned, one item per input entity, in the same order.
+ * The whole resolution runs on [Dispatchers.Default], making collection main thread safe.
+ */
+class GetEntitiesForDisplayUseCase @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val serverManager: ServerManager,
+) {
+
+    /**
+     * Variant that retrieves all entities of the server itself before resolving them,
+     * keeping only the ones matching [filter] (which receives the raw [Entity] so it can
+     * inspect attributes, like domain based or capability based filtering).
+     *
+     * Prefer the [invoke] overload taking an entity list when the caller already has the
+     * entities for other purposes. When the entities cannot be retrieved the flow completes
+     * with [EntityDisplayState.Error].
+     */
+    operator fun invoke(serverId: Int, filter: (Entity) -> Boolean = { true }): Flow<EntityDisplayState> = flow {
+        emit(EntityDisplayState.Loading)
+        val entities = fetchOrNull("entities") {
+            serverManager.integrationRepository(serverId).getEntities()
+        }
+        if (entities == null) {
+            emit(EntityDisplayState.Error)
+        } else {
+            emit(resolveState(serverId = serverId, entities = entities.filter(filter)))
+        }
+    }.flowOn(Dispatchers.Default)
+
+    /**
+     * Resolves the display information of the given [entities], for callers that already
+     * have the entity list (for example to filter on data only available on [Entity]).
+     *
+     * The flow always completes with [EntityDisplayState.Loaded] containing one item per
+     * input entity in the same order; missing registry data degrades to null metadata.
+     */
+    operator fun invoke(serverId: Int, entities: List<Entity>): Flow<EntityDisplayState> = flow {
+        emit(EntityDisplayState.Loading)
+        emit(resolveState(serverId = serverId, entities = entities))
+    }.flowOn(Dispatchers.Default)
+
+    private suspend fun resolveState(serverId: Int, entities: List<Entity>): EntityDisplayState.Loaded {
+        if (entities.isEmpty()) return EntityDisplayState.Loaded(emptyList())
+
+        val version = serverManager.getServer(serverId)?.version
+        val snapshot = fetchRegistrySnapshot(serverId, version)
+
+        return EntityDisplayState.Loaded(resolveEntityDisplayItems(entities = entities, snapshot = snapshot))
+    }
+
+    /**
+     * Merges entities with the registry snapshot into fully resolved [EntityDisplayItem]s,
+     * returning one item per input entity in the same order.
+     *
+     * Each field is resolved from the registry entry of the entity (the display entry on
+     * servers >= 2024.10, the classic entry otherwise, [RegistrySnapshot] carries only one
+     * of the two) with the following precedence, stopping at the first available value:
+     * - name: the registry display name (`en`), the `friendly_name` state attribute, the
+     *   entity id
+     * - icon: the custom icon of the registry entry (`ic`), the icon derived from the entity
+     *   state attributes or its domain
+     * - device name: the name given by the user to the device of the entity, the name
+     *   provided by its integration
+     * - area: the area assigned to the entity itself, the area of the device the entity
+     *   belongs to
+     * - floor: the floor of the resolved area, so a device-inherited area also resolves its
+     *   floor
+     * - hidden: the `hb` flag (display), a non null `hidden_by` (classic)
+     * - category: the `ec` index decoded through the response categories mapping (display),
+     *   the raw category string (classic)
+     * - display precision: the server-computed `dp` (display); the user-configured precision,
+     *   the integration-suggested precision (classic)
+     * - labels: only available from the display entry, empty otherwise
+     */
+    private fun resolveEntityDisplayItems(
+        entities: List<Entity>,
+        snapshot: RegistrySnapshot,
+    ): List<EntityDisplayItem> = entities.map { entity ->
+        val displayEntry = snapshot.displayEntries?.get(entity.entityId)
+        val classicEntry = snapshot.classicEntries?.get(entity.entityId)
+
+        val device = (displayEntry?.deviceId ?: classicEntry?.deviceId)?.let { snapshot.devices[it] }
+        // The area set on the entity itself wins over the area inherited from its device
+        val areaId = displayEntry?.areaId ?: classicEntry?.areaId ?: device?.areaId
+        val area = areaId?.let { snapshot.areas[it] }
+        val floor = area?.floorId?.let { snapshot.floors[it] }
+
+        EntityDisplayItem(
+            entityId = entity.entityId,
+            name = displayEntry?.name ?: entity.friendlyName,
+            icon = resolveIcon(entity, displayEntry?.icon),
+            areaName = area?.name,
+            floorName = floor?.name,
+            deviceName = device?.nameByUser ?: device?.name,
+            isHidden = displayEntry?.hidden ?: (classicEntry?.hiddenBy != null),
+            entityCategory = displayEntry?.entityCategory
+                ?.let { EntityCategory.fromString(snapshot.entityCategories[it]) }
+                ?: EntityCategory.fromString(classicEntry?.entityCategory),
+            displayPrecision = displayEntry?.displayPrecision
+                ?: classicEntry?.options?.sensor?.let { it.displayPrecision ?: it.suggestedDisplayPrecision },
+            labels = displayEntry?.labels.orEmpty(),
+        )
+    }
+
+    private suspend fun fetchRegistrySnapshot(serverId: Int, version: HomeAssistantVersion?): RegistrySnapshot =
+        coroutineScope {
+            val webSocketRepository = serverManager.webSocketRepository(serverId)
+            val devices = async {
+                fetchOrNull("device") { webSocketRepository.getDeviceRegistry() }
+            }
+            val areas = async {
+                fetchOrNull("area") { webSocketRepository.getAreaRegistry() }
+            }
+            val floors = async {
+                if (version?.isAtLeast(MIN_VERSION_FLOOR_REGISTRY) == true) {
+                    fetchOrNull("floor") { webSocketRepository.getFloorRegistry() }
+                } else {
+                    null
+                }
+            }
+
+            val displayResponse = if (version?.isAtLeast(MIN_VERSION_ENTITY_REGISTRY_DISPLAY) == true) {
+                fetchOrNull("entity display") { webSocketRepository.getEntityRegistryDisplay() }
+            } else {
+                null
+            }
+            // Fall back to the classic registry when the display command is unavailable or failed
+            val classicEntries = if (displayResponse == null) {
+                fetchOrNull("entity") { webSocketRepository.getEntityRegistry() }
+            } else {
+                null
+            }
+
+            RegistrySnapshot(
+                displayEntries = displayResponse?.entities?.associateBy { it.entityId },
+                entityCategories = displayResponse?.entityCategories.orEmpty(),
+                classicEntries = classicEntries?.associateBy { it.entityId },
+                devices = devices.await().orEmpty().associateBy { it.id },
+                areas = areas.await().orEmpty().associateBy { it.areaId },
+                floors = floors.await().orEmpty().associateBy { it.floorId },
+            )
+        }
+
+    private suspend fun <T> fetchOrNull(registryName: String, fetch: suspend () -> T?): T? = try {
+        fetch()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Timber.e(e, "Couldn't load $registryName registry")
+        null
+    }
+
+    private fun resolveIcon(entity: Entity, customIcon: String?): IIcon {
+        val customMdiIcon = customIcon
+            ?.takeIf { it.startsWith(MDI_PREFIX) }
+            ?.let { IconicsDrawable(context, "cmd-${it.removePrefix(MDI_PREFIX)}").icon }
+        return customMdiIcon ?: entity.getIcon(context)
+    }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
@@ -170,7 +170,13 @@ class GetEntitiesForDisplayUseCase @Inject constructor(
 
     private suspend fun fetchRegistrySnapshot(serverId: Int, version: HomeAssistantVersion?): RegistrySnapshot =
         coroutineScope {
-            val webSocketRepository = serverManager.webSocketRepository(serverId)
+            val webSocketRepository = try {
+                serverManager.webSocketRepository(serverId)
+            } catch (e: IllegalStateException) {
+                Timber.e(e, "Failed to get WebSocketRepository for server $serverId")
+                return@coroutineScope RegistrySnapshot()
+            }
+
             val devices = async {
                 fetchOrNull("device") { webSocketRepository.getDeviceRegistry() }
             }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
@@ -168,7 +168,7 @@ class GetEntitiesForDisplayUseCaseTest {
 
     @Test
     fun `Given unknown server version when invoking then classic registry is used`() = runTest {
-        coEvery { serverManager.getServer(serverId) } returns null
+        givenServerVersion(null)
 
         useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
@@ -1,0 +1,428 @@
+package io.homeassistant.companion.android.common.data.integration.display
+
+import android.content.Context
+import app.cash.turbine.test
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.common.data.HomeAssistantVersion
+import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayEntry
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryOptions
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistrySensorOptions
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.FloorRegistryResponse
+import io.homeassistant.companion.android.database.server.Server
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import java.time.LocalDateTime
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class GetEntitiesForDisplayUseCaseTest {
+
+    private val context: Context = mockk()
+    private val serverManager: ServerManager = mockk()
+    private val webSocketRepository: WebSocketRepository = mockk()
+    private val integrationRepository: IntegrationRepository = mockk()
+    private lateinit var useCase: GetEntitiesForDisplayUseCase
+
+    private val serverId = 1
+
+    @BeforeEach
+    fun setUp() {
+        coEvery { serverManager.webSocketRepository(serverId) } returns webSocketRepository
+        coEvery { webSocketRepository.getDeviceRegistry() } returns emptyList()
+        coEvery { webSocketRepository.getAreaRegistry() } returns emptyList()
+        coEvery { webSocketRepository.getFloorRegistry() } returns emptyList()
+        coEvery { webSocketRepository.getEntityRegistry() } returns emptyList()
+        coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse()
+        useCase = GetEntitiesForDisplayUseCase(context, serverManager)
+    }
+
+    @AfterEach
+    fun tearDown() = unmockkAll()
+
+    private fun givenServerVersion(version: String?) {
+        val server = mockk<Server>()
+        every { server.version } returns version?.let { HomeAssistantVersion.fromString(it) }
+        coEvery { serverManager.getServer(serverId) } returns server
+    }
+
+    // No mdi icon attribute so Entity.getIcon stays on the context-free domain default branch
+    private fun entity(entityId: String, friendlyName: String? = null) = Entity(
+        entityId = entityId,
+        state = "on",
+        attributes = friendlyName?.let { mapOf<String, Any?>("friendly_name" to it) }.orEmpty(),
+        lastChanged = LocalDateTime.MIN,
+        lastUpdated = LocalDateTime.MIN,
+    )
+
+    /** Asserts the flow emits Loading then a terminal Loaded state, returning the items. */
+    private suspend fun Flow<EntityDisplayState>.awaitLoaded(): List<EntityDisplayItem> {
+        var items: List<EntityDisplayItem> = emptyList()
+        test {
+            assertEquals(EntityDisplayState.Loading, awaitItem())
+            items = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem()).entities
+            awaitComplete()
+        }
+        return items
+    }
+
+    @Test
+    fun `Given server 2024 10 when invoking then display registry is used and classic is not fetched`() = runTest {
+        givenServerVersion("2024.10.0")
+        coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse(
+            entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed")),
+        )
+
+        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        assertEquals("Bed", items.single().name)
+        coVerify(exactly = 0) { webSocketRepository.getEntityRegistry() }
+    }
+
+    @Test
+    fun `Given server 2024 9 when invoking then classic registry is used and display is not fetched`() = runTest {
+        givenServerVersion("2024.9.3")
+        coEvery { webSocketRepository.getEntityRegistry() } returns listOf(
+            EntityRegistryResponse(entityId = "light.bed", areaId = "bedroom"),
+        )
+        coEvery { webSocketRepository.getAreaRegistry() } returns listOf(
+            AreaRegistryResponse(areaId = "bedroom", name = "Bedroom"),
+        )
+
+        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        assertEquals("Bed Light", items.single().name)
+        assertEquals("Bedroom", items.single().areaName)
+        coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
+    }
+
+    @Test
+    fun `Given server older than 2024 3 when invoking then floor registry is not fetched`() = runTest {
+        givenServerVersion("2024.2.0")
+
+        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        coVerify(exactly = 0) { webSocketRepository.getFloorRegistry() }
+    }
+
+    @Test
+    fun `Given server 2024 3 when invoking then floor registry is fetched`() = runTest {
+        givenServerVersion("2024.3.0")
+        coEvery { webSocketRepository.getFloorRegistry() } returns listOf(
+            FloorRegistryResponse(floorId = "first", name = "First floor"),
+        )
+
+        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        coVerify(exactly = 1) { webSocketRepository.getFloorRegistry() }
+    }
+
+    @Test
+    fun `Given display registry failure when invoking then falls back to classic registry`() = runTest {
+        givenServerVersion("2025.1.0")
+        coEvery { webSocketRepository.getEntityRegistryDisplay() } returns null
+        coEvery { webSocketRepository.getEntityRegistry() } returns listOf(
+            EntityRegistryResponse(entityId = "light.bed", hiddenBy = "user"),
+        )
+
+        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        assertEquals(true, items.single().isHidden)
+        coVerify(exactly = 1) { webSocketRepository.getEntityRegistry() }
+    }
+
+    @Test
+    fun `Given all registries failing when invoking then metadata degrades without an error state`() = runTest {
+        givenServerVersion("2025.1.0")
+        coEvery { webSocketRepository.getEntityRegistryDisplay() } throws IllegalStateException("boom")
+        coEvery { webSocketRepository.getEntityRegistry() } throws IllegalStateException("boom")
+        coEvery { webSocketRepository.getDeviceRegistry() } throws IllegalStateException("boom")
+        coEvery { webSocketRepository.getAreaRegistry() } throws IllegalStateException("boom")
+        coEvery { webSocketRepository.getFloorRegistry() } throws IllegalStateException("boom")
+
+        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        assertEquals("Bed Light", items.single().name)
+        assertNull(items.single().areaName)
+    }
+
+    @Test
+    fun `Given unknown server version when invoking then classic registry is used`() = runTest {
+        coEvery { serverManager.getServer(serverId) } returns null
+
+        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+        coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
+        coVerify(exactly = 1) { webSocketRepository.getEntityRegistry() }
+    }
+
+    @Test
+    fun `Given no entity list when invoking then entities are fetched from the server`() = runTest {
+        givenServerVersion("2024.10.0")
+        coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
+        coEvery { integrationRepository.getEntities() } returns listOf(entity("light.bed", "Bed Light"))
+        coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse(
+            entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed")),
+        )
+
+        val items = useCase(serverId = serverId).awaitLoaded()
+
+        assertEquals("Bed", items.single().name)
+        coVerify(exactly = 1) { integrationRepository.getEntities() }
+    }
+
+    @Test
+    fun `Given a filter when invoking without list then only matching entities are resolved`() = runTest {
+        givenServerVersion("2024.10.0")
+        coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
+        coEvery { integrationRepository.getEntities() } returns listOf(
+            entity("light.bed", "Bed Light"),
+            entity("switch.fan", "Fan"),
+        )
+
+        val items = useCase(serverId = serverId) { it.domain == "light" }.awaitLoaded()
+
+        assertEquals(listOf("light.bed"), items.map { it.entityId })
+    }
+
+    @Test
+    fun `Given entities fetch failure when invoking without list then flow completes with error`() = runTest {
+        givenServerVersion("2024.10.0")
+        coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
+        coEvery { integrationRepository.getEntities() } throws IllegalStateException("boom")
+
+        useCase(serverId = serverId).test {
+            assertEquals(EntityDisplayState.Loading, awaitItem())
+            assertEquals(EntityDisplayState.Error, awaitItem())
+            awaitComplete()
+        }
+        coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
+    }
+
+    @Test
+    fun `Given null entities response when invoking without list then flow completes with error`() = runTest {
+        givenServerVersion("2024.10.0")
+        coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
+        coEvery { integrationRepository.getEntities() } returns null
+
+        useCase(serverId = serverId).test {
+            assertEquals(EntityDisplayState.Loading, awaitItem())
+            assertEquals(EntityDisplayState.Error, awaitItem())
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `Given no entities when invoking then loaded empty is emitted without registry fetch`() = runTest {
+        givenServerVersion("2025.1.0")
+
+        val items = useCase(serverId = serverId, entities = emptyList()).awaitLoaded()
+
+        assertEquals(emptyList<EntityDisplayItem>(), items)
+        coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
+        coVerify(exactly = 0) { webSocketRepository.getDeviceRegistry() }
+    }
+
+    @Nested
+    inner class Resolution {
+
+        private fun givenDisplayEntries(
+            vararg entries: EntityRegistryDisplayEntry,
+            categories: Map<Int, String> = emptyMap(),
+        ) {
+            givenServerVersion("2024.10.0")
+            coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse(
+                entityCategories = categories,
+                entities = entries.toList(),
+            )
+        }
+
+        @Test
+        fun `Given display entry without name when resolving then name falls back to friendly name`() = runTest {
+            givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed"))
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+
+            assertEquals("Bed Light", items.single().name)
+        }
+
+        @Test
+        fun `Given no friendly name when resolving then name falls back to entity id`() = runTest {
+            givenServerVersion("2025.1.0")
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+
+            assertEquals("light.bed", items.single().name)
+        }
+
+        @Test
+        fun `Given entity area when resolving then entity area wins over device area`() = runTest {
+            givenDisplayEntries(
+                EntityRegistryDisplayEntry(entityId = "light.bed", areaId = "bedroom", deviceId = "device1"),
+            )
+            coEvery { webSocketRepository.getDeviceRegistry() } returns listOf(
+                DeviceRegistryResponse(id = "device1", name = "Hub", areaId = "kitchen"),
+            )
+            coEvery { webSocketRepository.getAreaRegistry() } returns listOf(
+                AreaRegistryResponse(areaId = "bedroom", name = "Bedroom"),
+                AreaRegistryResponse(areaId = "kitchen", name = "Kitchen"),
+            )
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+
+            assertEquals("Bedroom", items.single().areaName)
+        }
+
+        @Test
+        fun `Given entity without area when resolving then area falls back to device area`() = runTest {
+            givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed", deviceId = "device1"))
+            coEvery { webSocketRepository.getDeviceRegistry() } returns listOf(
+                DeviceRegistryResponse(id = "device1", name = "Hub", areaId = "kitchen"),
+            )
+            coEvery { webSocketRepository.getAreaRegistry() } returns listOf(
+                AreaRegistryResponse(areaId = "kitchen", name = "Kitchen"),
+            )
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+
+            assertEquals("Kitchen", items.single().areaName)
+        }
+
+        @Test
+        fun `Given area with floor when resolving then floor name is resolved`() = runTest {
+            givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed", areaId = "bedroom"))
+            coEvery { webSocketRepository.getAreaRegistry() } returns listOf(
+                AreaRegistryResponse(areaId = "bedroom", name = "Bedroom", floorId = "first"),
+            )
+            coEvery { webSocketRepository.getFloorRegistry() } returns listOf(
+                FloorRegistryResponse(floorId = "first", name = "First floor"),
+            )
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+
+            assertEquals("First floor", items.single().floorName)
+        }
+
+        @Test
+        fun `Given device with user name when resolving then user name wins over device name`() = runTest {
+            givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed", deviceId = "device1"))
+            coEvery { webSocketRepository.getDeviceRegistry() } returns listOf(
+                DeviceRegistryResponse(id = "device1", name = "Hub", nameByUser = "My Hub"),
+            )
+
+            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+
+            assertEquals("My Hub", items.single().deviceName)
+        }
+
+        @Test
+        fun `Given classic entry when resolving then hidden category and precision are mapped`() = runTest {
+            givenServerVersion("2024.9.0")
+            coEvery { webSocketRepository.getEntityRegistry() } returns listOf(
+                EntityRegistryResponse(
+                    entityId = "sensor.temp",
+                    hiddenBy = "user",
+                    entityCategory = "diagnostic",
+                    options = EntityRegistryOptions(
+                        sensor = EntityRegistrySensorOptions(
+                            displayPrecision = null,
+                            suggestedDisplayPrecision = 2,
+                        ),
+                    ),
+                ),
+            )
+
+            val item = useCase(serverId = serverId, entities = listOf(entity("sensor.temp", "Temp")))
+                .awaitLoaded()
+                .single()
+
+            assertEquals(true, item.isHidden)
+            assertEquals(EntityCategory.DIAGNOSTIC, item.entityCategory)
+            assertEquals(2, item.displayPrecision)
+        }
+
+        @Test
+        fun `Given display entry when resolving then hidden category precision and labels are mapped`() = runTest {
+            givenDisplayEntries(
+                EntityRegistryDisplayEntry(
+                    entityId = "sensor.temp",
+                    entityCategory = 0,
+                    hidden = true,
+                    displayPrecision = 1,
+                    labels = listOf("label1"),
+                ),
+                categories = mapOf(0 to "config"),
+            )
+
+            val item = useCase(serverId = serverId, entities = listOf(entity("sensor.temp")))
+                .awaitLoaded()
+                .single()
+
+            assertEquals(true, item.isHidden)
+            assertEquals(EntityCategory.CONFIG, item.entityCategory)
+            assertEquals(1, item.displayPrecision)
+            assertEquals(listOf("label1"), item.labels)
+        }
+
+        @Test
+        fun `Given no custom icon when resolving then icon derives from the entity`() = runTest {
+            givenServerVersion("2025.1.0")
+            val lightEntity = entity("light.bed")
+
+            val items = useCase(serverId = serverId, entities = listOf(lightEntity)).awaitLoaded()
+
+            // The domain default branch of Entity.getIcon does not touch the context
+            assertEquals(lightEntity.getIcon(context), items.single().icon)
+        }
+
+        @Test
+        fun `Given entities when resolving then order and count are preserved`() = runTest {
+            givenServerVersion("2025.1.0")
+
+            val items = useCase(
+                serverId = serverId,
+                entities = listOf(entity("light.bed"), entity("switch.fan"), entity("sensor.temp")),
+            ).awaitLoaded()
+
+            assertEquals(listOf("light.bed", "switch.fan", "sensor.temp"), items.map { it.entityId })
+        }
+
+        @ParameterizedTest
+        @CsvSource(
+            "light.bed, light",
+            "sensor.temperature, sensor",
+            "binary_sensor.motion, binary_sensor",
+        )
+        fun `Given entity id when reading item domain then it is derived from the entity id`(
+            entityId: String,
+            expectedDomain: String,
+        ) {
+            val item = EntityDisplayItem(
+                entityId = entityId,
+                name = "Name",
+                icon = CommunityMaterial.Icon.cmd_bookmark,
+            )
+            assertEquals(expectedDomain, item.domain)
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR adds a new UseCase to act as an adapter layer holding the logic of getting the right information to display an entity. The goal is to centralize the logic and properly test it to avoid regression.

Closes #7148.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.