### PR TITLE
Fix server selector sheet positioning

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerChooser.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerChooser.kt
@@ -82,31 +82,49 @@ fun ServerChooser(
         onDismissRequest = onDismissRequest,
         modifier = modifier,
     ) {
-        LazyColumn {
-            item {
-                Text(
-                    text = stringResource(commonR.string.server_select),
-                    style = HATextStyle.HeadlineMedium,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = HADimens.SPACE4, vertical = HADimens.SPACE2),
-                )
-            }
+        ServerChooserContent(
+            items = items,
+            onServerSelected = onServerSelected,
+        )
+    }
+}
 
-            itemsIndexed(items, key = { _, item -> item.serverId }) { index, item ->
-                ServerChooserRow(item = item, onServerSelected = onServerSelected)
-                if (index < items.lastIndex) {
-                    HAHorizontalDivider(modifier = Modifier.padding(start = DIVIDER_START_INSET, end = HADimens.SPACE4))
-                }
+/**
+ * Content of the server chooser sheet.
+ *
+ * Renders the list only, without its own modal-sheet frame, so callers can provide the
+ * appropriate sheet container.
+ */
+@Composable
+fun ServerChooserContent(
+    items: List<ServerChooserItem>,
+    onServerSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier) {
+        item {
+            Text(
+                text = stringResource(commonR.string.server_select),
+                style = HATextStyle.HeadlineMedium,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = HADimens.SPACE4, vertical = HADimens.SPACE2),
+            )
+        }
+
+        itemsIndexed(items, key = { _, item -> item.serverId }) { index, item ->
+            ServerChooserRow(item = item, onServerSelected = onServerSelected)
+            if (index < items.lastIndex) {
+                HAHorizontalDivider(modifier = Modifier.padding(start = DIVIDER_START_INSET, end = HADimens.SPACE4))
             }
-            item {
-                Spacer(
-                    modifier = Modifier
-                        .height(HADimens.SPACE6)
-                        .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
-                )
-            }
+        }
+        item {
+            Spacer(
+                modifier = Modifier
+                    .height(HADimens.SPACE6)
+                    .windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom)),
+            )
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/server/ServerChooserFragment.kt
@@ -1,20 +1,26 @@
 package io.homeassistant.companion.android.settings.server
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.setFragmentResult
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dagger.hilt.android.AndroidEntryPoint
+import io.homeassistant.companion.android.common.compose.theme.HARadius
 import io.homeassistant.companion.android.common.compose.theme.HATheme
+import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.util.setLayoutAndExpandedByDefault
 import javax.inject.Inject
+import kotlinx.coroutines.flow.collectLatest
 
 @AndroidEntryPoint
 class ServerChooserFragment : BottomSheetDialogFragment() {
@@ -23,7 +29,9 @@ class ServerChooserFragment : BottomSheetDialogFragment() {
     lateinit var serverManager: ServerManager
 
     @Inject
-    lateinit var serverChooserItems: ServerChooserItemsUseCase
+    lateinit var serverChooserItemsUseCase: ServerChooserItemsUseCase
+
+    private var hasResult = false
 
     companion object {
         const val TAG = "ServerChooser"
@@ -32,24 +40,26 @@ class ServerChooserFragment : BottomSheetDialogFragment() {
         const val RESULT_SERVER = "server"
     }
 
-    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setContent {
-                val items by produceState(initialValue = emptyList()) {
-                    serverChooserItems(serverManager.servers()).collect { value = it }
+                val items by produceState(initialValue = emptyList<ServerChooserItem>()) {
+                    serverManager.serversFlow.collectLatest { servers ->
+                        serverChooserItemsUseCase(servers).collect { value = it }
+                    }
                 }
                 HATheme {
-                    ServerChooser(
+                    ServerChooserContent(
                         items = items,
                         onServerSelected = { serverId ->
+                            hasResult = true
                             setFragmentResult(RESULT_KEY, Bundle().apply { putInt(RESULT_SERVER, serverId) })
                             dismiss()
                         },
-                        onDismissRequest = {
-                            setFragmentResult(RESULT_KEY, Bundle())
-                            dismiss()
-                        },
+                        modifier = Modifier.background(
+                            color = LocalHAColorScheme.current.colorSurfaceDefault,
+                            shape = RoundedCornerShape(topStart = HARadius.X3L, topEnd = HARadius.X3L),
+                        ),
                     )
                 }
             }
@@ -59,5 +69,12 @@ class ServerChooserFragment : BottomSheetDialogFragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setLayoutAndExpandedByDefault()
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        if (!hasResult) {
+            setFragmentResult(RESULT_KEY, Bundle.EMPTY)
+        }
     }
 }

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,7 @@
     tools:ignore="MissingDefaultResource">
     <release version="2026.7.2 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
+        <change>Fixed the server selector jumping when opened with the three-finger gesture</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.2 - Wear" versioncode="2">
@@ -11,6 +12,7 @@
     </release>
     <release version="2026.7.2 - Automotive" versioncode="1">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
+        <change>Fixed the server selector jumping when opened with the three-finger gesture</change>
         <change>Bug fixes and dependency updates</change>
     </release>
 </changelog>

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/server/ServerChooserTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/server/ServerChooserTest.kt
@@ -1,0 +1,70 @@
+package io.homeassistant.companion.android.settings.server
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.isDialog
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.HiltComponentActivity
+import io.homeassistant.companion.android.common.compose.theme.HATheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+@HiltAndroidTest
+class ServerChooserTest {
+
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule(order = 1)
+    val composeTestRule = createAndroidComposeRule<HiltComponentActivity>()
+
+    private val items = listOf(
+        ServerChooserItem(serverId = 1, userName = "Alice Smith", serverName = "Home", isActive = true),
+        ServerChooserItem(serverId = 2, userName = "Bob", serverName = "Friends home"),
+    )
+
+    @Test
+    fun `Given server chooser content is hosted by another sheet then it does not create a nested Compose dialog`() {
+        composeTestRule.apply {
+            setContent {
+                HATheme {
+                    ServerChooserContent(
+                        items = items,
+                        onServerSelected = {},
+                    )
+                }
+            }
+
+            onNodeWithText("Home").assertIsDisplayed()
+            onNodeWithText("Friends home").assertIsDisplayed()
+            onAllNodes(isDialog()).assertCountEquals(0)
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Test
+    fun `Given server chooser is hosted directly then a modal dialog layer is created`() {
+        composeTestRule.apply {
+            setContent {
+                HATheme {
+                    ServerChooser(
+                        items = items,
+                        onServerSelected = {},
+                    )
+                }
+            }
+
+            onAllNodes(isDialog()).assertCountEquals(1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes the server selector jumping when opened with the three-finger gesture.

`ServerChooserFragment` is already hosted in a `BottomSheetDialogFragment`, so it now renders only the chooser content instead of nesting another Compose modal sheet inside the platform bottom sheet. Direct Compose callers still use `ServerChooser`, which keeps the `HAModalBottomSheet` wrapper.

This also restores the visible sheet surface for the fragment-hosted path and adds a regression test that verifies the content path does not create a nested Compose dialog while direct `ServerChooser` usage still does.

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots

## Link to pull request in documentation repositories

User Documentation: N/A

Developer Documentation: N/A

## Any other notes

Validated with:

- `./gradlew :build-logic:convention:ktlintFormat ktlintFormat --quiet`
- `./gradlew :app:testFullDebugUnitTest --tests 'io.homeassistant.companion.android.settings.server.ServerChooserTest'`