### PR TITLE
Don't include awake/out of bed in Health Connect sleep duration

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -893,7 +893,7 @@ class HealthConnectSensorManager @Inject constructor(
         )
     }
 
-    /** @return Sleep duration based on the stages, excluding awake (in bed) and out of bed (assumed awake) */
+    /** @return Sleep duration based on the stages, excluding awake (+ in bed) and out of bed */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun calculateSleepDurationInMinutes(stages: List<SleepSessionRecord.Stage>): Long = stages
         .filter {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -51,6 +51,7 @@ import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -878,8 +879,16 @@ class HealthConnectSensorManager @Inject constructor(
             return
         }
         val lastSleepRecord = sleepRecords.records.last()
-        val sleepRecordDuration = (lastSleepRecord.endTime.toEpochMilli() - lastSleepRecord.startTime.toEpochMilli())
-            .toDuration(DurationUnit.MILLISECONDS)
+        // Get duration based on the sleep stages, as some stages may be awake/out of bed (assumed awake).
+        // Don't convert to minutes until the end to avoid losing detail.
+        val sleepRecordDuration = lastSleepRecord.stages
+            .filter {
+                it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE &&
+                    it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED &&
+                    it.stage != SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
+            }
+            .sumOf { Duration.between(it.startTime, it.endTime).seconds }
+            .toDuration(DurationUnit.SECONDS)
             .inWholeMinutes
         onSensorUpdated(
             sleepDuration,
@@ -887,6 +896,7 @@ class HealthConnectSensorManager @Inject constructor(
             sleepDuration.statelessIcon,
             attributes = mapOf(
                 "endTime" to lastSleepRecord.endTime,
+                "startTime" to lastSleepRecord.startTime,
                 "sources" to lastSleepRecord.metadata.dataOrigin.packageName,
             ),
         )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.sensors
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.annotation.VisibleForTesting
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.PermissionController
@@ -879,17 +880,7 @@ class HealthConnectSensorManager @Inject constructor(
             return
         }
         val lastSleepRecord = sleepRecords.records.last()
-        // Get duration based on the sleep stages, as some stages may be awake/out of bed (assumed awake).
-        // Don't convert to minutes until the end to avoid losing detail.
-        val sleepRecordDuration = lastSleepRecord.stages
-            .filter {
-                it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE &&
-                    it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED &&
-                    it.stage != SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
-            }
-            .sumOf { Duration.between(it.startTime, it.endTime).seconds }
-            .toDuration(DurationUnit.SECONDS)
-            .inWholeMinutes
+        val sleepRecordDuration = calculateSleepDurationInMinutes(lastSleepRecord.stages)
         onSensorUpdated(
             sleepDuration,
             sleepRecordDuration,
@@ -901,6 +892,19 @@ class HealthConnectSensorManager @Inject constructor(
             ),
         )
     }
+
+    /** @return Sleep duration based on the stages, excluding awake/out of bed (assumed awake) */
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun calculateSleepDurationInMinutes(stages: List<SleepSessionRecord.Stage>): Long = stages
+        .filter {
+            it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE &&
+                it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED &&
+                it.stage != SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
+        }
+        .sumOf { Duration.between(it.startTime, it.endTime).seconds }
+        .toDuration(DurationUnit.SECONDS)
+        // Don't convert to minutes until the end to avoid losing detail
+        .inWholeMinutes
 
     private suspend fun updateStepsSensor() {
         val healthConnectClient = getOrCreateHealthConnectClient() ?: return

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -893,7 +893,7 @@ class HealthConnectSensorManager @Inject constructor(
         )
     }
 
-    /** @return Sleep duration based on the stages, excluding awake/out of bed (assumed awake) */
+    /** @return Sleep duration based on the stages, excluding awake (in bed) and out of bed (assumed awake) */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun calculateSleepDurationInMinutes(stages: List<SleepSessionRecord.Stage>): Long = stages
         .filter {

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -3,6 +3,7 @@
     tools:ignore="MissingDefaultResource">
     <release version="2026.7.2 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
+        <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.2 - Wear" versioncode="2">
@@ -11,6 +12,7 @@
     </release>
     <release version="2026.7.2 - Automotive" versioncode="1">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
+        <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
         <change>Bug fixes and dependency updates</change>
     </release>
 </changelog>

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -4,11 +4,16 @@ import android.content.Context
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.HealthConnectFeatures
 import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.SleepSessionRecord
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -48,5 +53,58 @@ class HealthConnectSensorManagerTest {
             available,
             permissions.contains(HealthPermission.PERMISSION_READ_HEALTH_DATA_IN_BACKGROUND),
         )
+    }
+
+    @Test
+    fun `Given sleep with stages when duration calculated then ignores awake and out of bed stages`() = runTest {
+        // Mock a sleep session with all possible stage types
+        // Total duration: 12:00 AM-8:00 AM = 8 hours / 480 min
+        // Asleep duration: 12:00 AM-4:00 AM + 5:00 AM-6:00 AM = 5 hours / 300 min
+        val midnight = Instant.parse("2026-07-01T00:00:00Z")
+        val mockSleepStages = listOf(
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_SLEEPING
+                every { startTime } returns midnight // 12:00 AM
+                every { endTime } returns midnight.plus(1, ChronoUnit.HOURS) // 1:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_LIGHT
+                every { startTime } returns midnight.plus(1, ChronoUnit.HOURS) // 1:00 AM
+                every { endTime } returns midnight.plus(2, ChronoUnit.HOURS) // 2:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_DEEP
+                every { startTime } returns midnight.plus(2, ChronoUnit.HOURS) // 2:00 AM
+                every { endTime } returns midnight.plus(3, ChronoUnit.HOURS) // 3:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_REM
+                every { startTime } returns midnight.plus(3, ChronoUnit.HOURS) // 3:00 AM
+                every { endTime } returns midnight.plus(4, ChronoUnit.HOURS) // 4:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_AWAKE
+                every { startTime } returns midnight.plus(4, ChronoUnit.HOURS) // 4:00 AM
+                every { endTime } returns midnight.plus(5, ChronoUnit.HOURS) // 5:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_UNKNOWN
+                every { startTime } returns midnight.plus(5, ChronoUnit.HOURS) // 5:00 AM
+                every { endTime } returns midnight.plus(6, ChronoUnit.HOURS) // 6:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED
+                every { startTime } returns midnight.plus(6, ChronoUnit.HOURS) // 6:00 AM
+                every { endTime } returns midnight.plus(7, ChronoUnit.HOURS) // 7:00 AM
+            },
+            mockk<SleepSessionRecord.Stage> {
+                every { stage } returns SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
+                every { startTime } returns midnight.plus(7, ChronoUnit.HOURS) // 7:00 AM
+                every { endTime } returns midnight.plus(8, ChronoUnit.HOURS) // 8:00 AM
+            },
+        )
+
+        val result = sensorManager.calculateSleepDurationInMinutes(mockSleepStages)
+        assertEquals(300L, result)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -55,7 +55,7 @@ class HealthConnectSensorManagerTest {
     }
 
     @Test
-    fun `Given sleep with stages when duration calculated then ignores awake (in bed) and out of bed stages`() {
+    fun `Given sleep with stages when duration calculated then ignores awake (+ in bed) and out of bed stages`() {
         // Mock a sleep session with all possible stage types
         // Total duration: 12:00 AM-8:00 AM = 8 hours / 480 min
         // Asleep duration: 12:00 AM-4:00 AM + 5:00 AM-6:00 AM = 5 hours / 300 min

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.mockkObject
 import java.time.Instant
 import java.time.temporal.ChronoUnit
-import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -56,7 +55,7 @@ class HealthConnectSensorManagerTest {
     }
 
     @Test
-    fun `Given sleep with stages when duration calculated then ignores awake and out of bed stages`() = runTest {
+    fun `Given sleep with stages when duration calculated then ignores awake (in bed) and out of bed stages`() {
         // Mock a sleep session with all possible stage types
         // Total duration: 12:00 AM-8:00 AM = 8 hours / 480 min
         // Asleep duration: 12:00 AM-4:00 AM + 5:00 AM-6:00 AM = 5 hours / 300 min


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #7096 by ignoring `STAGE_TYPE_AWAKE`, `STAGE_TYPE_AWAKE_IN_BED` and `STAGE_TYPE_OUT_OF_BED` stages when calculating the sleep duration. This better matches what 3rd party apps contributing data to Health Connect calculate.

For any users that still want the simple end - start calculation, an attribute provides the time.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
<!-- User Documentation: home-assistant/companion.home-assistant# -->
I don't think this level of detail needs to be in the documentation as this is probably the expected value; let me know if you disagree.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->