### PR TITLE
Remove custom apply of safe area and rely on WebView

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.asPaddingValues
-import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -30,8 +29,6 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -44,15 +41,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLayoutDirection
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.graphics.ColorUtils
-import androidx.core.util.TypedValueCompat.pxToDp
 import androidx.core.view.WindowCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -69,7 +62,6 @@ import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
 import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
 import io.homeassistant.companion.android.common.data.prefs.ScreenOrientation
 import io.homeassistant.companion.android.common.util.GestureDirection
-import io.homeassistant.companion.android.frontend.WebViewAction.ApplySafeAreaInsets.Companion.SafeAreaInsets
 import io.homeassistant.companion.android.frontend.barcode.BarcodeScannerUiState
 import io.homeassistant.companion.android.frontend.barcode.ui.BarcodeScanner
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialog
@@ -192,7 +184,6 @@ internal fun FrontendScreen(
         onErrorAction = viewModel::onErrorAction,
         onDownloadRequested = viewModel::onDownloadRequested,
         webViewActions = viewModel.webViewActions,
-        onSafeAreaInsetsChanged = viewModel::onSafeAreaInsetsChanged,
         onGesture = viewModel::onGesture,
         onLeavingApp = viewModel::onLeavingApp,
         onExoPlayerFullscreenChanged = viewModel::onExoPlayerFullscreenChanged,
@@ -241,7 +232,6 @@ internal fun FrontendScreenContent(
     onSecurityLevelDone: () -> Unit = {},
     onDownloadRequested: (url: String, contentDisposition: String, mimetype: String) -> Unit = { _, _, _ -> },
     webViewActions: Flow<WebViewAction> = emptyFlow(),
-    onSafeAreaInsetsChanged: (SafeAreaInsets) -> Unit = {},
     onGesture: (GestureDirection, Int) -> Unit = { _, _ -> },
     onLeavingApp: (String?) -> Unit = {},
     onExoPlayerFullscreenChanged: (Boolean) -> Unit = {},
@@ -278,7 +268,6 @@ internal fun FrontendScreenContent(
         onLeavingApp = onLeavingApp,
         statusBarColor = content?.statusBarColor ?: loadingSurfaceColor,
         navigationBarColor = content?.backgroundColor ?: loadingSurfaceColor,
-        onSafeAreaInsetsChanged = onSafeAreaInsetsChanged,
     )
 
     FrontendScreenHandlers(pendingPermissionRequest = pendingPermissionRequest, pendingDialog = pendingDialog)
@@ -361,14 +350,11 @@ private fun FrontendScreenEffects(
     onLeavingApp: (String?) -> Unit,
     statusBarColor: Color?,
     navigationBarColor: Color?,
-    onSafeAreaInsetsChanged: (SafeAreaInsets) -> Unit,
 ) {
     SystemBarsAppearanceEffect(
         statusBarColor = statusBarColor,
         navigationBarColor = navigationBarColor,
     )
-
-    ReportSafeAreaInsetsEffect(onSafeAreaInsetsChanged = onSafeAreaInsetsChanged)
 
     ImprovScanLifecycleEffect(
         scanRequested = improvScanRequested,
@@ -835,32 +821,6 @@ private fun SystemBarsAppearanceEffect(statusBarColor: Color?, navigationBarColo
 
 /** Whether this color is light enough that dark foreground icons are needed for contrast. */
 private fun Color.isLight(): Boolean = ColorUtils.calculateLuminance(toArgb()) >= 0.5
-
-/**
- * Reports the device safe-area insets (system bars and display cutouts, in dp) to
- * [onSafeAreaInsetsChanged] whenever they change, so the ViewModel can forward them to the frontend
- * for edge-to-edge layout. Reading window insets is a UI concern, so only the reporting lives here.
- */
-@Composable
-private fun ReportSafeAreaInsetsEffect(onSafeAreaInsetsChanged: (SafeAreaInsets) -> Unit) {
-    val insets = WindowInsets.systemBars.union(WindowInsets.displayCutout)
-    val density = LocalDensity.current
-    val displayMetrics = LocalResources.current.displayMetrics
-    val layoutDirection = LocalLayoutDirection.current
-
-    // The app already reserves and colors the status bar strip itself (see SafeHAWebView), so the
-    // frontend must not add its own top inset — otherwise the top spacing would be applied twice.
-    // Kept 0 until the frontend can go edge-to-edge at the top.
-    // https://github.com/home-assistant/frontend/issues/29125
-    val top = 0f
-    val bottom = pxToDp(insets.getBottom(density).toFloat(), displayMetrics)
-    val left = pxToDp(insets.getLeft(density, layoutDirection).toFloat(), displayMetrics)
-    val right = pxToDp(insets.getRight(density, layoutDirection).toFloat(), displayMetrics)
-
-    LaunchedEffect(top, bottom, left, right) {
-        onSafeAreaInsetsChanged(SafeAreaInsets(top = top, bottom = bottom, left = left, right = right))
-    }
-}
 
 /**
  * Renders PiP-eligible overlays and reports their combined [PipReadiness] to the host.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -20,7 +20,6 @@ import io.homeassistant.companion.android.common.data.prefs.PrefsRepository
 import io.homeassistant.companion.android.common.data.prefs.ScreenOrientation
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.GestureDirection
-import io.homeassistant.companion.android.frontend.WebViewAction.ApplySafeAreaInsets.Companion.SafeAreaInsets
 import io.homeassistant.companion.android.frontend.auth.FrontendHttpAuthHandler
 import io.homeassistant.companion.android.frontend.auth.HttpAuthResult
 import io.homeassistant.companion.android.frontend.barcode.FrontendBarcodeScannerHandler
@@ -228,15 +227,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
     private val _webViewActions = MutableSharedFlow<WebViewAction>(extraBufferCapacity = 1)
     val webViewActions: Flow<WebViewAction> = merge(_webViewActions, frontendBusObserver.webViewActions())
-
-    /**
-     * Latest device safe-area insets reported by the screen, reapplied to the frontend on connect and
-     * after each page load. Null until the screen first reports them.
-     *
-     * Only accessed on the main thread: writes come from the Compose reporter effect and reads run in
-     * [viewModelScope] (the main dispatcher), so no additional synchronization is needed.
-     */
-    private var latestSafeAreaInsets: SafeAreaInsets? = null
 
     override val urlFlow: StateFlow<String?> =
         _viewState.map { it.url }
@@ -1081,16 +1071,13 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     /**
      * Called when a page finishes loading in the WebView.
      *
-     * Reapplies the frontend safe-area insets, which a full page (re)load resets. Cancels any
-     * previous zoom observer and starts a fresh collection of
+     * Cancels any previous zoom observer and starts a fresh collection of
      * [PrefsRepository.zoomSettingsFlow]. Because the flow emits the current values
      * on start, this immediately applies zoom against the loaded DOM (needed because
      * navigations can reset the viewport meta tag). The collection then stays active
      * to react to settings changes until the next page load restarts it.
      */
     private fun onPageFinished(url: String?) {
-        viewModelScope.launch { applySafeAreaInsetsIfHandled() }
-
         // Open the more-info dialog for an older-server deep link now that the frontend has loaded.
         pendingMoreInfoEntityId?.let { entityId ->
             pendingMoreInfoEntityId = null
@@ -1144,27 +1131,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
         permissionManager.checkNotificationPermission(_viewState.value.serverId)
         viewModelScope.launch { updateThemeColors() }
-        viewModelScope.launch { applySafeAreaInsetsIfHandled() }
-    }
-
-    /**
-     * Reports the device safe-area [insets] read from the screen. Reapplied to the frontend whenever
-     * they change so it stays laid out edge-to-edge across rotations and display cutout changes.
-     */
-    fun onSafeAreaInsetsChanged(insets: SafeAreaInsets) {
-        if (latestSafeAreaInsets == insets) return
-        latestSafeAreaInsets = insets
-        viewModelScope.launch { applySafeAreaInsetsIfHandled() }
-    }
-
-    /**
-     * Pushes the last reported safe-area insets to the frontend, but only when the current server
-     * handles its own insets (see [serverHandlesInsets]) and insets have been reported.
-     */
-    private suspend fun applySafeAreaInsetsIfHandled() {
-        val insets = latestSafeAreaInsets ?: return
-        if ((_viewState.value as? FrontendViewState.Content)?.serverHandleInsets != true) return
-        _webViewActions.emit(WebViewAction.ApplySafeAreaInsets(insets))
     }
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/WebViewAction.kt
@@ -306,34 +306,6 @@ sealed interface WebViewAction {
             webView.evaluateJavascript(moreInfoScript(entityId)) {}
         }
     }
-
-    /**
-     * Publishes the device safe-area [insets] to the frontend as `--app-safe-area-inset-*` CSS
-     * custom properties so it can lay its content out edge-to-edge.
-     */
-    data class ApplySafeAreaInsets(val insets: SafeAreaInsets) : WebViewAction {
-        /**
-         * Opts into [EvaluateJavascriptUsage] because the safe area must be set directly on the
-         * document root as early as possible, even before the frontend is ready to receive external
-         * bus messages; no external bus message exposes it.
-         */
-        override fun run(webView: WebView) {
-            @OptIn(EvaluateJavascriptUsage::class)
-            webView.evaluateJavascript(insets.toCssPropertiesScript(), null)
-        }
-
-        companion object {
-            /** Device safe-area insets in density-independent pixels, as reported to the frontend. */
-            data class SafeAreaInsets(val top: Float, val bottom: Float, val left: Float, val right: Float)
-
-            private fun SafeAreaInsets.toCssPropertiesScript(): String = """
-                document.documentElement.style.setProperty('--app-safe-area-inset-top', '${top}px');
-                document.documentElement.style.setProperty('--app-safe-area-inset-bottom', '${bottom}px');
-                document.documentElement.style.setProperty('--app-safe-area-inset-left', '${left}px');
-                document.documentElement.style.setProperty('--app-safe-area-inset-right', '${right}px');
-            """.trimIndent()
-        }
-    }
 }
 
 /** Gates direct JavaScript evaluation in the WebView behind an explicit opt-in. */

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -26,7 +26,6 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.GestureDirection
 import io.homeassistant.companion.android.database.authentication.Authentication
 import io.homeassistant.companion.android.database.authentication.AuthenticationDao
-import io.homeassistant.companion.android.frontend.WebViewAction.ApplySafeAreaInsets.Companion.SafeAreaInsets
 import io.homeassistant.companion.android.frontend.auth.FrontendHttpAuthHandler
 import io.homeassistant.companion.android.frontend.barcode.FrontendBarcodeScannerHandler
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialog
@@ -1726,57 +1725,6 @@ class FrontendViewModelTest {
 
             val state = assertInstanceOf(FrontendViewState.Content::class.java, viewModel.viewState.value)
             assertFalse(state.serverHandleInsets)
-        }
-
-        @Test
-        fun `Given a server handling insets when safe area insets change then they are applied to the frontend`() = runTest {
-            val messageFlow = connectedMessageFlow()
-            coEvery { serverManager.getServer(serverId) } returns mockServer(
-                url = "https://example.com",
-                name = "test",
-                haVersion = HomeAssistantVersion(2026, 2, 0),
-                serverId = serverId,
-            )
-            val viewModel = createViewModel()
-            val insets = SafeAreaInsets(top = 10f, bottom = 20f, left = 5f, right = 8f)
-
-            viewModel.webViewActions.test {
-                advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
-                messageFlow.emit(FrontendHandlerEvent.Connected)
-                advanceUntilIdle()
-                completeConnect(this@runTest, themeColors = null)
-
-                viewModel.onSafeAreaInsetsChanged(insets)
-                advanceUntilIdle()
-
-                assertEquals(insets, (awaitItem() as WebViewAction.ApplySafeAreaInsets).insets)
-                cancelAndIgnoreRemainingEvents()
-            }
-        }
-
-        @Test
-        fun `Given a server not handling insets when safe area insets change then nothing is applied`() = runTest {
-            val messageFlow = connectedMessageFlow()
-            coEvery { serverManager.getServer(serverId) } returns mockServer(
-                url = "https://example.com",
-                name = "test",
-                haVersion = HomeAssistantVersion(2025, 1, 1),
-                serverId = serverId,
-            )
-            val viewModel = createViewModel()
-
-            viewModel.webViewActions.test {
-                advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
-                messageFlow.emit(FrontendHandlerEvent.Connected)
-                advanceUntilIdle()
-                completeConnect(this@runTest, themeColors = null)
-
-                viewModel.onSafeAreaInsetsChanged(SafeAreaInsets(top = 10f, bottom = 20f, left = 5f, right = 8f))
-                advanceUntilIdle()
-
-                expectNoEvents()
-                cancelAndIgnoreRemainingEvents()
-            }
         }
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/WebViewActionTest.kt
@@ -3,7 +3,6 @@ package io.homeassistant.companion.android.frontend
 import android.util.DisplayMetrics
 import android.webkit.ValueCallback
 import android.webkit.WebView
-import io.homeassistant.companion.android.frontend.WebViewAction.ApplySafeAreaInsets.Companion.SafeAreaInsets
 import io.homeassistant.companion.android.frontend.externalbus.incoming.HapticType
 import io.homeassistant.companion.android.frontend.haptic.HapticFeedbackPerformer
 import io.mockk.Runs
@@ -159,25 +158,6 @@ class WebViewActionTest {
         // The embedded double quote must be backslash-escaped (proof of JSON encoding), so the
         // payload stays inside the entityId string literal instead of becoming executable code.
         assertTrue(script.contains("\\\""))
-    }
-
-    @Test
-    fun `Given ApplySafeAreaInsets when run then the safe area CSS properties are set`() = runTest {
-        val action = WebViewAction.ApplySafeAreaInsets(SafeAreaInsets(top = 10f, bottom = 20f, left = 5f, right = 8f))
-
-        action.run(webView)
-
-        verify {
-            webView.evaluateJavascript(
-                match {
-                    it.contains("--app-safe-area-inset-top', '10.0px'") &&
-                        it.contains("--app-safe-area-inset-bottom', '20.0px'") &&
-                        it.contains("--app-safe-area-inset-left', '5.0px'") &&
-                        it.contains("--app-safe-area-inset-right', '8.0px'")
-                },
-                null,
-            )
-        }
     }
 
     @Test


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
It seems that we the new FrontendScreen we don't need to send the insets anymore to the Frontend. I decided to keep the handling of the statusbar within the app so we don't see the menu button jumps while rendering the frontend for the first time. I tested on Android 16 and 17 and it works ok with a top notch. I wonder if I've missed something.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
<img width="240" height="108" alt="image" src="https://github.com/user-attachments/assets/3bbfccbd-5e2f-4564-91f8-2c3d1f1c742a" />
<img width="108" height="240" alt="image" src="https://github.com/user-attachments/assets/68fdcfed-4a7d-466d-b84e-ce9319c4f709" />
