### PR TITLE
Disable Horizontal insets in HAApp for FrontendScreen

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HAApp.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/HAApp.kt
@@ -15,9 +15,13 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SnackbarResult.ActionPerformed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import io.homeassistant.companion.android.common.compose.theme.LocalHAColorScheme
+import io.homeassistant.companion.android.frontend.navigation.FrontendRoute
 import io.homeassistant.companion.android.launch.HAStartDestinationRoute
 import io.homeassistant.companion.android.launch.PipReadiness
 import io.homeassistant.companion.android.loading.LoadingScreen
@@ -28,7 +32,8 @@ import io.homeassistant.companion.android.loading.LoadingScreen
  * This composable sets up the basic structure of the app, including the [Scaffold] for layout,
  * a [SnackbarHost], and the [HANavHost] for handling navigation.
  *
- * It also handles horizontal window insets to ensure content is displayed correctly within the screen's safe areas.
+ * It also handles horizontal window insets to ensure content is displayed correctly within the screen's safe areas,
+ * except for the frontend destination, which draws edge-to-edge and handles all its insets itself.
  * Sub composable needs to handle vertical insets themselves.
  *
  * @param navController The NavHostController to use for navigation.
@@ -58,15 +63,19 @@ internal fun HAApp(
             )
         },
     ) { padding ->
+        val currentBackStackEntry by navController.currentBackStackEntryAsState()
+        val isFrontend = currentBackStackEntry?.destination?.hasRoute<FrontendRoute>() == true
         Column(
             Modifier
                 .fillMaxSize()
                 .padding(padding)
                 .consumeWindowInsets(padding)
-                .windowInsetsPadding(
-                    WindowInsets.safeDrawing.only(
-                        WindowInsetsSides.Horizontal,
-                    ),
+                .then(
+                    if (isFrontend) {
+                        Modifier
+                    } else {
+                        Modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal))
+                    },
                 ),
         ) {
             HANavHost(


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
HAApp was always applying the Horizontal insets and we were also sending the insets to the Frontend to apply the safe area padding. It was causing double padding being applied. To address the issue I've simply skip the insets when we are in the frontend screen since we need the WebView to handle it to have the right color everywhere when a user override the theme.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.