### PR TITLE
Introduce observe entity for display

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/settings/wear/views/SettingsWearFavoritesView.kt
@@ -125,7 +125,7 @@ fun LoadWearFavoritesSettings(
                 val favoriteEntityID = favoriteEntities[index].replace("[", "").replace("]", "")
                 settingsWearViewModel.entities[favoriteEntityID]?.let { entity ->
                     // Metadata-free item, this screen has no websocket access (see the picker above)
-                    val displayEntity = remember(entity) { EntityDisplayItem.from(entity) }
+                    val displayEntity = remember(entity) { EntityDisplayItem(entity) }
                     ReorderableItem(
                         state = reorderState,
                         key = favoriteEntities[index],

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/ManageControlsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/ManageControlsViewModel.kt
@@ -106,7 +106,9 @@ class ManageControlsViewModel @VisibleForTesting constructor(
                 async {
                     // The flow completes with a terminal state after Loading, failures surface as Error
                     // and leave the server out of the list to not block configuration of other server's entities
-                    val displayState = getEntitiesForDisplay(server.id) { it.domain in supportedDomains }.last()
+                    val displayState = getEntitiesForDisplay.snapshot(server.id) {
+                        it.domain in supportedDomains
+                    }.last()
                     if (displayState is EntityDisplayState.Loaded) {
                         entitiesList[server.id] = withContext(backgroundDispatcher) {
                             displayState.entities

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModel.kt
@@ -171,7 +171,7 @@ internal class ManageTilesViewModel @Inject constructor(
     private fun loadEntities(serverId: Int) {
         loadEntitiesJob?.cancel()
         loadEntitiesJob = viewModelScope.launch {
-            getEntitiesForDisplay(serverId) { it.isUsableInTile() }.collect { state ->
+            getEntitiesForDisplay.snapshot(serverId) { it.isUsableInTile() }.collect { state ->
                 _state.update { it.copy(entityDisplayState = state) }
             }
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
@@ -96,7 +96,7 @@ internal class ManageShortcutsViewModel @Inject constructor(
             this@ManageShortcutsViewModel.servers = servers
             servers.forEach { server ->
                 launch {
-                    getEntitiesForDisplay(serverId = server.id).collect { state ->
+                    getEntitiesForDisplay.snapshot(serverId = server.id).collect { state ->
                         displayEntities[server.id] = state
                     }
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/vehicle/ManageAndroidAutoViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/vehicle/ManageAndroidAutoViewModel.kt
@@ -56,7 +56,7 @@ class ManageAndroidAutoViewModel @Inject constructor(
             servers.map { server ->
                 val serverId = server.id
                 async {
-                    getEntitiesForDisplay(serverId) { isVehicleDomain(it) }.collect { state ->
+                    getEntitiesForDisplay.snapshot(serverId) { isVehicleDomain(it) }.collect { state ->
                         displayEntitiesByServer[serverId] = state
                     }
                 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPicker.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPicker.kt
@@ -226,7 +226,7 @@ fun rememberEntityDisplayState(entities: List<Entity>): EntityDisplayState {
     // Conversion runs on a background dispatcher to avoid ANRs on large entity lists
     LaunchedEffect(entities) {
         displayState = withContext(Dispatchers.Default) {
-            EntityDisplayState.Loaded(entities.map(EntityDisplayItem::from))
+            EntityDisplayState.Loaded(entities.map(::EntityDisplayItem))
         }
     }
     return displayState

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetConfigureViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetConfigureViewModel.kt
@@ -66,7 +66,7 @@ class TodoWidgetConfigureViewModel @AssistedInject constructor(
         .distinctUntilChanged()
         .flatMapLatest { serverId ->
             if (serverManager.isRegistered()) {
-                getEntitiesForDisplay(serverId = serverId) { it.domain == TODO_DOMAIN }
+                getEntitiesForDisplay.snapshot(serverId = serverId) { it.domain == TODO_DOMAIN }
             } else {
                 Timber.w("No server registered")
                 flowOf(EntityDisplayState.Loaded(emptyList()))

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/controls/ManageControlsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/controls/ManageControlsViewModelTest.kt
@@ -81,7 +81,7 @@ class ManageControlsViewModelTest {
     @Test
     fun `Given resolved entities when created then hidden entities are included and the rest sorted by display name`() = runTest {
         coEvery { serverManager.servers() } returns listOf(fakeServer(1))
-        every { getEntitiesForDisplay(1, any<(Entity) -> Boolean>()) } returns flowOf(
+        every { getEntitiesForDisplay.snapshot(1, any<(Entity) -> Boolean>()) } returns flowOf(
             EntityDisplayState.Loading,
             EntityDisplayState.Loaded(
                 listOf(
@@ -102,11 +102,11 @@ class ManageControlsViewModelTest {
     @Test
     fun `Given a server failing to resolve entities when created then that server is left out but loading completes`() = runTest {
         coEvery { serverManager.servers() } returns listOf(fakeServer(1), fakeServer(2))
-        every { getEntitiesForDisplay(1, any<(Entity) -> Boolean>()) } returns flowOf(
+        every { getEntitiesForDisplay.snapshot(1, any<(Entity) -> Boolean>()) } returns flowOf(
             EntityDisplayState.Loading,
             EntityDisplayState.Error,
         )
-        every { getEntitiesForDisplay(2, any<(Entity) -> Boolean>()) } returns flowOf(
+        every { getEntitiesForDisplay.snapshot(2, any<(Entity) -> Boolean>()) } returns flowOf(
             EntityDisplayState.Loading,
             EntityDisplayState.Loaded(listOf(fakeItem("light.bulb", name = "Bulb"))),
         )

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/qs/ManageTilesViewModelTest.kt
@@ -71,8 +71,8 @@ class ManageTilesViewModelTest {
         coEvery { tileDao.get(any()) } returns null
         coEvery { tileDao.getAll() } returns emptyList()
         coEvery { tileDao.add(any()) } returns 1L
+        every { getEntitiesForDisplay.snapshot(any(), any<(Entity) -> Boolean>()) } returns flowOf(EntityDisplayState.Loading)
         every { tileDao.getAllFlow() } returns flowOf(emptyList())
-        every { getEntitiesForDisplay(any(), any<(Entity) -> Boolean>()) } returns flowOf(EntityDisplayState.Loading)
     }
 
     private fun fakeServer(id: Int) = Server(
@@ -464,7 +464,7 @@ class ManageTilesViewModelTest {
         // Regression test: the filter passed to the use case must exclude entities a tile
         // cannot act on, otherwise the picker offers entities that do nothing when clicked.
         val filter = slot<(Entity) -> Boolean>()
-        every { getEntitiesForDisplay(any(), capture(filter)) } returns flowOf(EntityDisplayState.Loading)
+        every { getEntitiesForDisplay.snapshot(any(), capture(filter)) } returns flowOf(EntityDisplayState.Loading)
 
         createViewModel()
         advanceUntilIdle()
@@ -481,7 +481,7 @@ class ManageTilesViewModelTest {
         val tileId = tileSlots[0].id.value
         coEvery { tileDao.get(tileId) } returns
             fakeTile(tileId = tileId, label = "Living Room", entityId = "switch.lamp", serverId = 2)
-        every { getEntitiesForDisplay(2, any<(Entity) -> Boolean>()) } returns flow {
+        every { getEntitiesForDisplay.snapshot(2, any<(Entity) -> Boolean>()) } returns flow {
             emit(EntityDisplayState.Loading)
             delay(10_000.milliseconds)
             emit(EntityDisplayState.Loaded(emptyList()))
@@ -502,12 +502,12 @@ class ManageTilesViewModelTest {
         // that is expected to win. Without cancelling the stale in-flight collection, the slow flow
         // would emit last and clobber the fresh one.
         val icon = CommunityMaterial.getIconByMdiName("mdi:account")!!
-        every { getEntitiesForDisplay(1, any<(Entity) -> Boolean>()) } returns flow {
+        every { getEntitiesForDisplay.snapshot(1, any<(Entity) -> Boolean>()) } returns flow {
             emit(EntityDisplayState.Loading)
             delay(100.milliseconds)
             emit(EntityDisplayState.Loaded(listOf(EntityDisplayItem(entityId = "light.stale", name = "Stale", icon = icon))))
         }
-        every { getEntitiesForDisplay(2, any<(Entity) -> Boolean>()) } returns flow {
+        every { getEntitiesForDisplay.snapshot(2, any<(Entity) -> Boolean>()) } returns flow {
             emit(EntityDisplayState.Loading)
             delay(10.milliseconds)
             emit(EntityDisplayState.Loaded(listOf(EntityDisplayItem(entityId = "light.fresh", name = "Fresh", icon = icon))))

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayItem.kt
@@ -4,8 +4,12 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.LayoutDirection
 import com.mikepenz.iconics.typeface.IIcon
 import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.FriendlyState
 import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.friendlyState
 import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.isActive
+import io.homeassistant.companion.android.common.data.integration.isExecuting
 
 private const val CATEGORY_CONFIG = "config"
 private const val CATEGORY_DIAGNOSTIC = "diagnostic"
@@ -25,12 +29,31 @@ enum class EntityCategory {
     }
 }
 
-/** Fully resolved display information for an entity. */
+/** Geographic position of an entity, resolved from its state attributes. */
+@Immutable
+data class EntityCoordinates(val latitude: Double, val longitude: Double)
+
+/**
+ * Everything needed to display an entity, fully resolved from the entity state and the
+ * registries: the single source of truth for entity displays, so anything a display needs
+ * should be resolved into this class at creation (see the [EntityDisplayItem] constructor
+ * that takes a [Entity]).
+ *
+ * The item is a snapshot at resolution time.
+ */
 @Immutable
 data class EntityDisplayItem(
     val entityId: String,
     val name: String,
     val icon: IIcon,
+    val state: FriendlyState = FriendlyState.Literal(""),
+    val rawState: String = "",
+    /** Whether the entity is currently executing an action. */
+    val isExecuting: Boolean = false,
+    /** Whether the entity is in an active state, for state-colored rendering. */
+    val isActive: Boolean = false,
+    /** Geographic position of the entity, null when it has none. */
+    val coordinates: EntityCoordinates? = null,
     val areaName: String? = null,
     val floorName: String? = null,
     val deviceName: String? = null,
@@ -39,6 +62,40 @@ data class EntityDisplayItem(
     val displayPrecision: Int? = null,
     val labels: List<String> = emptyList(),
 ) {
+    /**
+     * Resolves the entity-derived fields from an [Entity], applying the [customIcon]
+     * and [displayPrecision] when the caller has them, so [icon] and [state] are resolved
+     * exactly once.
+     */
+    constructor(
+        entity: Entity,
+        name: String = entity.friendlyName,
+        customIcon: IIcon? = null,
+        areaName: String? = null,
+        floorName: String? = null,
+        deviceName: String? = null,
+        isHidden: Boolean = false,
+        entityCategory: EntityCategory? = null,
+        displayPrecision: Int? = null,
+        labels: List<String> = emptyList(),
+    ) : this(
+        entityId = entity.entityId,
+        name = name,
+        icon = customIcon ?: entity.getIcon(),
+        state = entity.friendlyState(displayPrecision = displayPrecision),
+        rawState = entity.state,
+        isExecuting = entity.isExecuting(),
+        isActive = entity.isActive(),
+        coordinates = entity.coordinates(),
+        areaName = areaName,
+        floorName = floorName,
+        deviceName = deviceName,
+        isHidden = isHidden,
+        entityCategory = entityCategory,
+        displayPrecision = displayPrecision,
+        labels = labels,
+    )
+
     val domain: String get() = entityId.substringBefore('.')
 
     /**
@@ -51,15 +108,11 @@ data class EntityDisplayItem(
         ?.takeIf { it != name }
 
     companion object {
-        /**
-         * Builds an item from an [Entity] alone, without any registry metadata (no
-         * area/floor/device names). Meant for callers that cannot reach the websocket API,
-         * such as the Wear favorites settings screen, and for previews.
-         */
-        fun from(entity: Entity): EntityDisplayItem = EntityDisplayItem(
-            entityId = entity.entityId,
-            name = entity.friendlyName,
-            icon = entity.getIcon(),
-        )
+
+        private fun Entity.coordinates(): EntityCoordinates? {
+            val latitude = (attributes["latitude"] as? Number)?.toDouble()
+            val longitude = (attributes["longitude"] as? Number)?.toDouble()
+            return if (latitude != null && longitude != null) EntityCoordinates(latitude, longitude) else null
+        }
     }
 }

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCase.kt
@@ -1,27 +1,30 @@
 package io.homeassistant.companion.android.common.data.integration.display
 
-import android.content.Context
-import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.typeface.IIcon
-import dagger.hilt.android.qualifiers.ApplicationContext
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.HomeAssistantVersion
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.friendlyName
-import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayEntry
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.FloorRegistryResponse
+import io.homeassistant.companion.android.common.util.MDI_PREFIX
+import io.homeassistant.companion.android.common.util.getIconByMdiName
 import javax.inject.Inject
 import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import timber.log.Timber
 
 /**
@@ -40,7 +43,23 @@ private val MIN_VERSION_ENTITY_REGISTRY_DISPLAY = HomeAssistantVersion(year = 20
 /** Minimum server version of the `config/floor_registry/list` command (https://github.com/home-assistant/core/pull/110741). */
 private val MIN_VERSION_FLOOR_REGISTRY = HomeAssistantVersion(year = 2024, month = 3, release = 0)
 
-private const val MDI_PREFIX = "mdi:"
+/**
+ * Events driving new emissions of [GetEntitiesForDisplayUseCase.observe]. Registry events name
+ * the registry that changed, so only that part of the [RegistrySnapshot] is refetched.
+ */
+private sealed interface ObserveEvent {
+    /** An entity state changed. */
+    data class StateChanged(val entity: Entity) : ObserveEvent
+
+    /** An area registry entry changed; the floors are refetched along, they resolve through areas. */
+    data object AreaRegistryChanged : ObserveEvent
+
+    /** A device registry entry changed. */
+    data object DeviceRegistryChanged : ObserveEvent
+
+    /** An entity registry entry changed. */
+    data object EntityRegistryChanged : ObserveEvent
+}
 
 /**
  * Registry data fetched once per resolution, indexed by id for the merge.
@@ -62,36 +81,27 @@ private data class RegistrySnapshot(
  *   command (see [MIN_VERSION_ENTITY_REGISTRY_DISPLAY] for the rationale)
  * - older servers use the classic entity registry
  *
- * Both variants return a cold [Flow] that emits [EntityDisplayState.Loading] first and
- * completes with a terminal state, so consumers can render loading and error indicators.
- * Registry failures never produce [EntityDisplayState.Error]: the affected metadata degrades
- * to null and the entities are still returned, one item per input entity, in the same order.
- * The whole resolution runs on [Dispatchers.Default], making collection main thread safe.
+ * The [snapshot] variants return a cold [Flow] that emits [EntityDisplayState.Loading] first and
+ * completes with a terminal state, so consumers can render loading and error indicators;
+ * [observe] keeps emitting a fresh [EntityDisplayState.Loaded] as entity states and
+ * registries change. Registry failures never produce an error state: the affected metadata
+ * degrades to null and the entities are still returned, one item per input entity, in the same
+ * order. The whole resolution runs on [Dispatchers.Default], making collection main thread safe.
  */
-class GetEntitiesForDisplayUseCase @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val serverManager: ServerManager,
-) {
+class GetEntitiesForDisplayUseCase @Inject constructor(private val serverManager: ServerManager) {
 
     /**
      * Variant that retrieves all entities of the server itself before resolving them,
      * keeping only the ones matching [filter] (which receives the raw [Entity] so it can
      * inspect attributes, like domain based or capability based filtering).
      *
-     * Prefer the [invoke] overload taking an entity list when the caller already has the
+     * Prefer the [snapshot] overload taking an entity list when the caller already has the
      * entities for other purposes. When the entities cannot be retrieved the flow completes
      * with [EntityDisplayState.Error].
      */
-    operator fun invoke(serverId: Int, filter: (Entity) -> Boolean = { true }): Flow<EntityDisplayState> = flow {
-        emit(EntityDisplayState.Loading)
-        val entities = fetchOrNull("entities") {
-            serverManager.integrationRepository(serverId).getEntities()
-        }
-        if (entities == null) {
-            emit(EntityDisplayState.Error)
-        } else {
-            emit(resolveState(serverId = serverId, entities = entities.filter(filter)))
-        }
+    fun snapshot(serverId: Int, filter: (Entity) -> Boolean = { true }): Flow<EntityDisplayState> = flow {
+        val entities = loadEntities(serverId) ?: return@flow
+        emit(resolveState(serverId = serverId, entities = entities.filter(filter)))
     }.flowOn(Dispatchers.Default)
 
     /**
@@ -101,16 +111,83 @@ class GetEntitiesForDisplayUseCase @Inject constructor(
      * The flow always completes with [EntityDisplayState.Loaded] containing one item per
      * input entity in the same order; missing registry data degrades to null metadata.
      */
-    operator fun invoke(serverId: Int, entities: List<Entity>): Flow<EntityDisplayState> = flow {
+    fun snapshot(serverId: Int, entities: List<Entity>): Flow<EntityDisplayState> = flow {
         emit(EntityDisplayState.Loading)
         emit(resolveState(serverId = serverId, entities = entities))
     }.flowOn(Dispatchers.Default)
+
+    /**
+     * Observes the display state of the entities matching [filter]: a new
+     * [EntityDisplayState.Loaded] is emitted whenever an entity state change or an area,
+     * device, or entity registry update changes the resolved items, so each emission is the
+     * current display truth (including the state-dependent [EntityDisplayItem.icon] and
+     * [EntityDisplayItem.state]). Updates that leave the items unchanged are skipped. Since
+     * emissions are complete snapshots, slow consumers can safely `conflate()` the flow and
+     * only render the latest one.
+     *
+     * The flow completes with [EntityDisplayState.Error] when the entities cannot be
+     * retrieved, and completes after the initial [EntityDisplayState.Loaded] when no update
+     * subscription is available (for example when the websocket connection is unavailable).
+     */
+    fun observe(serverId: Int, filter: (Entity) -> Boolean = { true }): Flow<EntityDisplayState> = flow {
+        val initial = loadEntities(serverId) ?: return@flow
+
+        val version = serverManager.getServer(serverId)?.version
+        val entities = LinkedHashMap<String, Entity>()
+        initial.filter(filter).forEach { entities[it.entityId] = it }
+
+        val webSocketRepository = webSocketRepositoryOrNull(serverId)
+        var snapshot = fetchRegistrySnapshot(webSocketRepository, version)
+        var lastItems = resolveEntityDisplayItems(entities = entities.values.toList(), snapshot = snapshot)
+        emit(EntityDisplayState.Loaded(lastItems))
+
+        observeEvents(serverId, webSocketRepository).collect { event ->
+            when (event) {
+                is ObserveEvent.StateChanged -> with(event.entity) {
+                    if (filter(this)) entities[entityId] = this else entities.remove(entityId)
+                }
+                ObserveEvent.AreaRegistryChanged -> webSocketRepository?.let {
+                    snapshot = snapshot.copy(areas = it.fetchAreas(), floors = it.fetchFloors(version))
+                }
+                ObserveEvent.DeviceRegistryChanged -> webSocketRepository?.let {
+                    snapshot = snapshot.copy(devices = it.fetchDevices())
+                }
+                ObserveEvent.EntityRegistryChanged -> webSocketRepository?.let {
+                    snapshot = snapshot.withEntityEntries(it, version)
+                }
+            }
+            val items = resolveEntityDisplayItems(entities = entities.values.toList(), snapshot = snapshot)
+            if (items != lastItems) {
+                lastItems = items
+                emit(EntityDisplayState.Loaded(items))
+            }
+        }
+    }.flowOn(Dispatchers.Default)
+
+    /**
+     * Merges the entity state changes and the registry update events of the server into a
+     * single [ObserveEvent] flow. Subscriptions that cannot be established are skipped, so the
+     * flow is empty when the server supports none.
+     */
+    private suspend fun observeEvents(serverId: Int, webSocketRepository: WebSocketRepository?): Flow<ObserveEvent> =
+        buildList {
+            fetchOrNull("entity updates") { serverManager.integrationRepository(serverId).getEntityUpdates() }
+                ?.let { updates -> add(updates.map { ObserveEvent.StateChanged(it) }) }
+
+            if (webSocketRepository == null) return@buildList
+            fetchOrNull("area updates") { webSocketRepository.getAreaRegistryUpdates() }
+                ?.let { updates -> add(updates.map { ObserveEvent.AreaRegistryChanged }) }
+            fetchOrNull("device updates") { webSocketRepository.getDeviceRegistryUpdates() }
+                ?.let { updates -> add(updates.map { ObserveEvent.DeviceRegistryChanged }) }
+            fetchOrNull("entity registry updates") { webSocketRepository.getEntityRegistryUpdates() }
+                ?.let { updates -> add(updates.map { ObserveEvent.EntityRegistryChanged }) }
+        }.merge()
 
     private suspend fun resolveState(serverId: Int, entities: List<Entity>): EntityDisplayState.Loaded {
         if (entities.isEmpty()) return EntityDisplayState.Loaded(emptyList())
 
         val version = serverManager.getServer(serverId)?.version
-        val snapshot = fetchRegistrySnapshot(serverId, version)
+        val snapshot = fetchRegistrySnapshot(webSocketRepositoryOrNull(serverId), version)
 
         return EntityDisplayState.Loaded(resolveEntityDisplayItems(entities = entities, snapshot = snapshot))
     }
@@ -150,11 +227,14 @@ class GetEntitiesForDisplayUseCase @Inject constructor(
         val areaId = displayEntry?.areaId ?: classicEntry?.areaId ?: device?.areaId
         val area = areaId?.let { snapshot.areas[it] }
         val floor = area?.floorId?.let { snapshot.floors[it] }
+        val customIcon = resolveCustomIcon(displayEntry?.icon)
+        val displayPrecision = displayEntry?.displayPrecision
+            ?: classicEntry?.options?.sensor?.let { it.displayPrecision ?: it.suggestedDisplayPrecision }
 
         EntityDisplayItem(
-            entityId = entity.entityId,
+            entity = entity,
             name = displayEntry?.name?.takeIf { it.isNotBlank() } ?: entity.friendlyName,
-            icon = resolveIcon(entity, displayEntry?.icon),
+            customIcon = customIcon,
             areaName = area?.name,
             floorName = floor?.name,
             deviceName = device?.nameByUser ?: device?.name,
@@ -162,70 +242,97 @@ class GetEntitiesForDisplayUseCase @Inject constructor(
             entityCategory = displayEntry?.entityCategory
                 ?.let { EntityCategory.fromString(snapshot.entityCategories[it]) }
                 ?: EntityCategory.fromString(classicEntry?.entityCategory),
-            displayPrecision = displayEntry?.displayPrecision
-                ?: classicEntry?.options?.sensor?.let { it.displayPrecision ?: it.suggestedDisplayPrecision },
+            displayPrecision = displayPrecision,
             labels = displayEntry?.labels.orEmpty(),
         )
     }
 
-    private suspend fun fetchRegistrySnapshot(serverId: Int, version: HomeAssistantVersion?): RegistrySnapshot =
-        coroutineScope {
-            val webSocketRepository = try {
-                serverManager.webSocketRepository(serverId)
-            } catch (e: IllegalStateException) {
-                Timber.e(e, "Failed to get WebSocketRepository for server $serverId")
-                return@coroutineScope RegistrySnapshot()
-            }
-
-            val devices = async {
-                fetchOrNull("device") { webSocketRepository.getDeviceRegistry() }
-            }
-            val areas = async {
-                fetchOrNull("area") { webSocketRepository.getAreaRegistry() }
-            }
-            val floors = async {
-                if (version?.isAtLeast(MIN_VERSION_FLOOR_REGISTRY) == true) {
-                    fetchOrNull("floor") { webSocketRepository.getFloorRegistry() }
-                } else {
-                    null
-                }
-            }
-
-            val displayResponse = if (version?.isAtLeast(MIN_VERSION_ENTITY_REGISTRY_DISPLAY) == true) {
-                fetchOrNull("entity display") { webSocketRepository.getEntityRegistryDisplay() }
-            } else {
-                null
-            }
-            // Fall back to the classic registry when the display command is unavailable or failed
-            val classicEntries = if (displayResponse == null) {
-                fetchOrNull("entity") { webSocketRepository.getEntityRegistry() }
-            } else {
-                null
-            }
-
-            RegistrySnapshot(
-                displayEntries = displayResponse?.entities?.associateBy { it.entityId },
-                entityCategories = displayResponse?.entityCategories.orEmpty(),
-                classicEntries = classicEntries?.associateBy { it.entityId },
-                devices = devices.await().orEmpty().associateBy { it.id },
-                areas = areas.await().orEmpty().associateBy { it.areaId },
-                floors = floors.await().orEmpty().associateBy { it.floorId },
-            )
+    /**
+     * Emits [EntityDisplayState.Loading] and fetches the entities of the server, emitting
+     * [EntityDisplayState.Error] and returning null when they cannot be retrieved.
+     */
+    private suspend fun FlowCollector<EntityDisplayState>.loadEntities(serverId: Int): List<Entity>? {
+        emit(EntityDisplayState.Loading)
+        val entities = fetchOrNull("entities") {
+            serverManager.integrationRepository(serverId).getEntities()
         }
+        if (entities == null) emit(EntityDisplayState.Error)
+        return entities
+    }
 
-    private suspend fun <T> fetchOrNull(registryName: String, fetch: suspend () -> T?): T? = try {
-        fetch()
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        Timber.e(e, "Couldn't load $registryName registry")
+    /** The [ServerManager.webSocketRepository] of the server, or null when it cannot be provided. */
+    private suspend fun webSocketRepositoryOrNull(serverId: Int): WebSocketRepository? = try {
+        serverManager.webSocketRepository(serverId)
+    } catch (e: IllegalStateException) {
+        Timber.e(e, "Failed to get WebSocketRepository for server $serverId")
         null
     }
 
-    private fun resolveIcon(entity: Entity, customIcon: String?): IIcon {
-        val customMdiIcon = customIcon
-            ?.takeIf { it.startsWith(MDI_PREFIX) }
-            ?.let { IconicsDrawable(context, "cmd-${it.removePrefix(MDI_PREFIX)}").icon }
-        return customMdiIcon ?: entity.getIcon()
+    private suspend fun fetchRegistrySnapshot(
+        webSocketRepository: WebSocketRepository?,
+        version: HomeAssistantVersion?,
+    ): RegistrySnapshot = coroutineScope {
+        if (webSocketRepository == null) return@coroutineScope RegistrySnapshot()
+
+        val devices = async { webSocketRepository.fetchDevices() }
+        val areas = async { webSocketRepository.fetchAreas() }
+        val floors = async { webSocketRepository.fetchFloors(version) }
+
+        RegistrySnapshot(
+            devices = devices.await(),
+            areas = areas.await(),
+            floors = floors.await(),
+        ).withEntityEntries(webSocketRepository, version)
     }
+
+    private suspend fun WebSocketRepository.fetchDevices(): Map<String, DeviceRegistryResponse> =
+        fetchOrNull("device") { getDeviceRegistry() }.orEmpty().associateBy { it.id }
+
+    private suspend fun WebSocketRepository.fetchAreas(): Map<String, AreaRegistryResponse> =
+        fetchOrNull("area") { getAreaRegistry() }.orEmpty().associateBy { it.areaId }
+
+    private suspend fun WebSocketRepository.fetchFloors(
+        version: HomeAssistantVersion?,
+    ): Map<String, FloorRegistryResponse> = if (version?.isAtLeast(MIN_VERSION_FLOOR_REGISTRY) == true) {
+        fetchOrNull("floor") { getFloorRegistry() }.orEmpty().associateBy { it.floorId }
+    } else {
+        emptyMap()
+    }
+
+    /** Returns a copy of the snapshot with freshly fetched entity registry entries. */
+    private suspend fun RegistrySnapshot.withEntityEntries(
+        webSocketRepository: WebSocketRepository,
+        version: HomeAssistantVersion?,
+    ): RegistrySnapshot {
+        val displayResponse = if (version?.isAtLeast(MIN_VERSION_ENTITY_REGISTRY_DISPLAY) == true) {
+            fetchOrNull("entity display") { webSocketRepository.getEntityRegistryDisplay() }
+        } else {
+            null
+        }
+        // Fall back to the classic registry when the display command is unavailable or failed
+        val classicEntries = if (displayResponse == null) {
+            fetchOrNull("entity") { webSocketRepository.getEntityRegistry() }
+        } else {
+            null
+        }
+
+        return copy(
+            displayEntries = displayResponse?.entities?.associateBy { it.entityId },
+            entityCategories = displayResponse?.entityCategories.orEmpty(),
+            classicEntries = classicEntries?.associateBy { it.entityId },
+        )
+    }
+
+    private fun resolveCustomIcon(customIcon: String?): IIcon? = customIcon
+        ?.takeIf { it.startsWith(MDI_PREFIX) }
+        ?.let { CommunityMaterial.getIconByMdiName(it) }
+}
+
+private suspend fun <T> fetchOrNull(registryName: String, fetch: suspend () -> T?): T? = try {
+    fetch()
+} catch (e: CancellationException) {
+    throw e
+} catch (e: Exception) {
+    Timber.e(e, "Couldn't load $registryName registry")
+    null
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
@@ -1,6 +1,5 @@
 package io.homeassistant.companion.android.common.data.integration.display
 
-import android.content.Context
 import androidx.compose.ui.unit.LayoutDirection
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
@@ -274,7 +273,7 @@ class GetEntitiesForDisplayUseCaseTest {
         fun `Given display entry with a blank name when resolving then name falls back to friendly name`() = runTest {
             givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed", name = " "))
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
             assertEquals("Bed Light", items.single().name)
         }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/GetEntitiesForDisplayUseCaseTest.kt
@@ -2,6 +2,7 @@ package io.homeassistant.companion.android.common.data.integration.display
 
 import android.content.Context
 import androidx.compose.ui.unit.LayoutDirection
+import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.data.HomeAssistantVersion
@@ -11,12 +12,14 @@ import io.homeassistant.companion.android.common.data.integration.getIcon
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayEntry
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryDisplayResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryOptions
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistrySensorOptions
+import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryUpdatedEvent
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.FloorRegistryResponse
 import io.homeassistant.companion.android.database.server.Server
 import io.mockk.coEvery
@@ -26,6 +29,8 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import java.time.LocalDateTime
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -39,7 +44,6 @@ import org.junit.jupiter.params.provider.CsvSource
 
 class GetEntitiesForDisplayUseCaseTest {
 
-    private val context: Context = mockk()
     private val serverManager: ServerManager = mockk()
     private val webSocketRepository: WebSocketRepository = mockk()
     private val integrationRepository: IntegrationRepository = mockk()
@@ -55,7 +59,7 @@ class GetEntitiesForDisplayUseCaseTest {
         coEvery { webSocketRepository.getFloorRegistry() } returns emptyList()
         coEvery { webSocketRepository.getEntityRegistry() } returns emptyList()
         coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse()
-        useCase = GetEntitiesForDisplayUseCase(context, serverManager)
+        useCase = GetEntitiesForDisplayUseCase(serverManager)
     }
 
     @AfterEach
@@ -67,7 +71,6 @@ class GetEntitiesForDisplayUseCaseTest {
         coEvery { serverManager.getServer(serverId) } returns server
     }
 
-    // No mdi icon attribute so Entity.getIcon stays on the context-free domain default branch
     private fun entity(entityId: String, friendlyName: String? = null) = Entity(
         entityId = entityId,
         state = "on",
@@ -94,7 +97,7 @@ class GetEntitiesForDisplayUseCaseTest {
             entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed")),
         )
 
-        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         assertEquals("Bed", items.single().name)
         coVerify(exactly = 0) { webSocketRepository.getEntityRegistry() }
@@ -110,7 +113,7 @@ class GetEntitiesForDisplayUseCaseTest {
             AreaRegistryResponse(areaId = "bedroom", name = "Bedroom"),
         )
 
-        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         assertEquals("Bed Light", items.single().name)
         assertEquals("Bedroom", items.single().areaName)
@@ -121,7 +124,7 @@ class GetEntitiesForDisplayUseCaseTest {
     fun `Given server older than 2024 3 when invoking then floor registry is not fetched`() = runTest {
         givenServerVersion("2024.2.0")
 
-        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         coVerify(exactly = 0) { webSocketRepository.getFloorRegistry() }
     }
@@ -133,7 +136,7 @@ class GetEntitiesForDisplayUseCaseTest {
             FloorRegistryResponse(floorId = "first", name = "First floor"),
         )
 
-        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         coVerify(exactly = 1) { webSocketRepository.getFloorRegistry() }
     }
@@ -146,7 +149,7 @@ class GetEntitiesForDisplayUseCaseTest {
             EntityRegistryResponse(entityId = "light.bed", hiddenBy = "user"),
         )
 
-        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         assertEquals(true, items.single().isHidden)
         coVerify(exactly = 1) { webSocketRepository.getEntityRegistry() }
@@ -161,7 +164,7 @@ class GetEntitiesForDisplayUseCaseTest {
         coEvery { webSocketRepository.getAreaRegistry() } throws IllegalStateException("boom")
         coEvery { webSocketRepository.getFloorRegistry() } throws IllegalStateException("boom")
 
-        val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         assertEquals("Bed Light", items.single().name)
         assertNull(items.single().areaName)
@@ -171,7 +174,7 @@ class GetEntitiesForDisplayUseCaseTest {
     fun `Given unknown server version when invoking then classic registry is used`() = runTest {
         givenServerVersion(null)
 
-        useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+        useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
         coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
         coVerify(exactly = 1) { webSocketRepository.getEntityRegistry() }
@@ -186,7 +189,7 @@ class GetEntitiesForDisplayUseCaseTest {
             entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed")),
         )
 
-        val items = useCase(serverId = serverId).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId).awaitLoaded()
 
         assertEquals("Bed", items.single().name)
         coVerify(exactly = 1) { integrationRepository.getEntities() }
@@ -201,7 +204,7 @@ class GetEntitiesForDisplayUseCaseTest {
             entity("switch.fan", "Fan"),
         )
 
-        val items = useCase(serverId = serverId) { it.domain == "light" }.awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId) { it.domain == "light" }.awaitLoaded()
 
         assertEquals(listOf("light.bed"), items.map { it.entityId })
     }
@@ -212,7 +215,7 @@ class GetEntitiesForDisplayUseCaseTest {
         coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
         coEvery { integrationRepository.getEntities() } throws IllegalStateException("boom")
 
-        useCase(serverId = serverId).test {
+        useCase.snapshot(serverId = serverId).test {
             assertEquals(EntityDisplayState.Loading, awaitItem())
             assertEquals(EntityDisplayState.Error, awaitItem())
             awaitComplete()
@@ -226,7 +229,7 @@ class GetEntitiesForDisplayUseCaseTest {
         coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
         coEvery { integrationRepository.getEntities() } returns null
 
-        useCase(serverId = serverId).test {
+        useCase.snapshot(serverId = serverId).test {
             assertEquals(EntityDisplayState.Loading, awaitItem())
             assertEquals(EntityDisplayState.Error, awaitItem())
             awaitComplete()
@@ -237,7 +240,7 @@ class GetEntitiesForDisplayUseCaseTest {
     fun `Given no entities when invoking then loaded empty is emitted without registry fetch`() = runTest {
         givenServerVersion("2025.1.0")
 
-        val items = useCase(serverId = serverId, entities = emptyList()).awaitLoaded()
+        val items = useCase.snapshot(serverId = serverId, entities = emptyList()).awaitLoaded()
 
         assertEquals(emptyList<EntityDisplayItem>(), items)
         coVerify(exactly = 0) { webSocketRepository.getEntityRegistryDisplay() }
@@ -262,7 +265,7 @@ class GetEntitiesForDisplayUseCaseTest {
         fun `Given display entry without name when resolving then name falls back to friendly name`() = runTest {
             givenDisplayEntries(EntityRegistryDisplayEntry(entityId = "light.bed"))
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed", "Bed Light"))).awaitLoaded()
 
             assertEquals("Bed Light", items.single().name)
         }
@@ -280,7 +283,7 @@ class GetEntitiesForDisplayUseCaseTest {
         fun `Given no friendly name when resolving then name falls back to entity id`() = runTest {
             givenServerVersion("2025.1.0")
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
 
             assertEquals("light.bed", items.single().name)
         }
@@ -298,7 +301,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 AreaRegistryResponse(areaId = "kitchen", name = "Kitchen"),
             )
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
 
             assertEquals("Bedroom", items.single().areaName)
         }
@@ -313,7 +316,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 AreaRegistryResponse(areaId = "kitchen", name = "Kitchen"),
             )
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
 
             assertEquals("Kitchen", items.single().areaName)
         }
@@ -328,7 +331,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 FloorRegistryResponse(floorId = "first", name = "First floor"),
             )
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
 
             assertEquals("First floor", items.single().floorName)
         }
@@ -340,7 +343,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 DeviceRegistryResponse(id = "device1", name = "Hub", nameByUser = "My Hub"),
             )
 
-            val items = useCase(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(entity("light.bed"))).awaitLoaded()
 
             assertEquals("My Hub", items.single().deviceName)
         }
@@ -362,7 +365,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 ),
             )
 
-            val item = useCase(serverId = serverId, entities = listOf(entity("sensor.temp", "Temp")))
+            val item = useCase.snapshot(serverId = serverId, entities = listOf(entity("sensor.temp", "Temp")))
                 .awaitLoaded()
                 .single()
 
@@ -384,7 +387,7 @@ class GetEntitiesForDisplayUseCaseTest {
                 categories = mapOf(0 to "config"),
             )
 
-            val item = useCase(serverId = serverId, entities = listOf(entity("sensor.temp")))
+            val item = useCase.snapshot(serverId = serverId, entities = listOf(entity("sensor.temp")))
                 .awaitLoaded()
                 .single()
 
@@ -399,7 +402,7 @@ class GetEntitiesForDisplayUseCaseTest {
             givenServerVersion("2025.1.0")
             val lightEntity = entity("light.bed")
 
-            val items = useCase(serverId = serverId, entities = listOf(lightEntity)).awaitLoaded()
+            val items = useCase.snapshot(serverId = serverId, entities = listOf(lightEntity)).awaitLoaded()
 
             assertEquals(lightEntity.getIcon(), items.single().icon)
         }
@@ -408,12 +411,23 @@ class GetEntitiesForDisplayUseCaseTest {
         fun `Given entities when resolving then order and count are preserved`() = runTest {
             givenServerVersion("2025.1.0")
 
-            val items = useCase(
+            val items = useCase.snapshot(
                 serverId = serverId,
                 entities = listOf(entity("light.bed"), entity("switch.fan"), entity("sensor.temp")),
             ).awaitLoaded()
 
             assertEquals(listOf("light.bed", "switch.fan", "sensor.temp"), items.map { it.entityId })
+        }
+
+        @Test
+        fun `Given an entity alone when building an item from it then entity fields are resolved`() {
+            val lightEntity = entity("light.bed", "Bed Light")
+
+            val item = EntityDisplayItem(lightEntity)
+
+            assertEquals("Bed Light", item.name)
+            assertEquals(lightEntity.getIcon(), item.icon)
+            assertEquals("on", item.rawState)
         }
 
         @ParameterizedTest
@@ -469,6 +483,172 @@ class GetEntitiesForDisplayUseCaseTest {
             )
 
             assertNull(item.subtitle(LayoutDirection.Ltr))
+        }
+    }
+
+    @Nested
+    inner class Observe {
+
+        private val entityUpdates = MutableSharedFlow<Entity>()
+        private val entityRegistryUpdates = MutableSharedFlow<EntityRegistryUpdatedEvent>()
+
+        @BeforeEach
+        fun setUpObserve() {
+            givenServerVersion("2025.1.0")
+            coEvery { serverManager.integrationRepository(serverId) } returns integrationRepository
+            coEvery { integrationRepository.getEntities() } returns listOf(entity("light.bed", "Bed Light"))
+            coEvery { integrationRepository.getEntityUpdates() } returns entityUpdates
+            coEvery { webSocketRepository.getAreaRegistryUpdates() } returns null
+            coEvery { webSocketRepository.getDeviceRegistryUpdates() } returns null
+            coEvery { webSocketRepository.getEntityRegistryUpdates() } returns entityRegistryUpdates
+        }
+
+        /** Asserts the flow emits Loading then the initial Loaded state, returning the items. */
+        private suspend fun ReceiveTurbine<EntityDisplayState>.awaitInitialLoad(): List<EntityDisplayItem> {
+            assertEquals(EntityDisplayState.Loading, awaitItem())
+            return assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem()).entities.toList()
+        }
+
+        /**
+         * Suspends until [observe] subscribed to this update flow: the initial Loaded state is
+         * emitted before the subscriptions are established, so emitting right after it races.
+         */
+        private suspend fun MutableSharedFlow<*>.awaitSubscribed() = subscriptionCount.first { it > 0 }
+
+        @Test
+        fun `Given an entity state change when observing then a new loaded state is emitted`() = runTest {
+            useCase.observe(serverId).test {
+                assertEquals("Bed Light", awaitInitialLoad().single().name)
+                entityUpdates.awaitSubscribed()
+
+                entityUpdates.emit(entity("light.bed", "Renamed Light"))
+
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals("Renamed Light", updated.entities.single().name)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given an update that does not change the items when observing then nothing is emitted`() = runTest {
+            useCase.observe(serverId).test {
+                awaitInitialLoad()
+                entityUpdates.awaitSubscribed()
+
+                entityUpdates.emit(entity("light.bed", "Bed Light"))
+                entityUpdates.emit(entity("light.bed", "Renamed Light"))
+
+                // Only the renaming update emits: the unchanged one before it was skipped
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals("Renamed Light", updated.entities.single().name)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given a new entity when observing then it is appended to the items`() = runTest {
+            useCase.observe(serverId).test {
+                awaitInitialLoad()
+                entityUpdates.awaitSubscribed()
+
+                entityUpdates.emit(entity("switch.fan", "Fan"))
+
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals(listOf("light.bed", "switch.fan"), updated.entities.map { it.entityId })
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given a filter when observing then non matching updates are ignored`() = runTest {
+            useCase.observe(serverId) { it.domain == "light" }.test {
+                awaitInitialLoad()
+                entityUpdates.awaitSubscribed()
+
+                entityUpdates.emit(entity("switch.fan", "Fan"))
+                entityUpdates.emit(entity("light.bed", "Renamed Light"))
+
+                // Only the light update emits: the switch was filtered out
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals(listOf("Renamed Light"), updated.entities.map { it.name })
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `Given an entity registry update when observing then only the entity registry is refetched`() = runTest {
+            givenServerVersion("2024.10.0")
+            coEvery { webSocketRepository.getEntityRegistryDisplay() } returns
+                EntityRegistryDisplayResponse(
+                    entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed")),
+                ) andThen
+                EntityRegistryDisplayResponse(
+                    entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", name = "Bed renamed")),
+                )
+
+            useCase.observe(serverId).test {
+                assertEquals("Bed", awaitInitialLoad().single().name)
+                entityRegistryUpdates.awaitSubscribed()
+
+                entityRegistryUpdates.emit(EntityRegistryUpdatedEvent("update", "light.bed"))
+
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals("Bed renamed", updated.entities.single().name)
+                cancelAndIgnoreRemainingEvents()
+            }
+            coVerify(exactly = 2) { webSocketRepository.getEntityRegistryDisplay() }
+            coVerify(exactly = 1) { webSocketRepository.getAreaRegistry() }
+            coVerify(exactly = 1) { webSocketRepository.getDeviceRegistry() }
+        }
+
+        @Test
+        fun `Given an area registry update when observing then only the areas and floors are refetched`() = runTest {
+            givenServerVersion("2024.10.0")
+            val areaUpdates = MutableSharedFlow<AreaRegistryUpdatedEvent>()
+            coEvery { webSocketRepository.getAreaRegistryUpdates() } returns areaUpdates
+            coEvery { webSocketRepository.getEntityRegistryDisplay() } returns EntityRegistryDisplayResponse(
+                entities = listOf(EntityRegistryDisplayEntry(entityId = "light.bed", areaId = "bedroom")),
+            )
+            coEvery { webSocketRepository.getAreaRegistry() } returns
+                listOf(AreaRegistryResponse(areaId = "bedroom", name = "Bedroom")) andThen
+                listOf(AreaRegistryResponse(areaId = "bedroom", name = "Bedroom renamed"))
+
+            useCase.observe(serverId).test {
+                assertEquals("Bedroom", awaitInitialLoad().single().areaName)
+                areaUpdates.awaitSubscribed()
+
+                areaUpdates.emit(AreaRegistryUpdatedEvent("update", "bedroom"))
+
+                val updated = assertInstanceOf(EntityDisplayState.Loaded::class.java, awaitItem())
+                assertEquals("Bedroom renamed", updated.entities.single().areaName)
+                cancelAndIgnoreRemainingEvents()
+            }
+            coVerify(exactly = 2) { webSocketRepository.getAreaRegistry() }
+            coVerify(exactly = 2) { webSocketRepository.getFloorRegistry() }
+            coVerify(exactly = 1) { webSocketRepository.getEntityRegistryDisplay() }
+            coVerify(exactly = 1) { webSocketRepository.getDeviceRegistry() }
+        }
+
+        @Test
+        fun `Given entities fetch failure when observing then flow completes with error`() = runTest {
+            coEvery { integrationRepository.getEntities() } throws IllegalStateException("boom")
+
+            useCase.observe(serverId).test {
+                assertEquals(EntityDisplayState.Loading, awaitItem())
+                assertEquals(EntityDisplayState.Error, awaitItem())
+                awaitComplete()
+            }
+        }
+
+        @Test
+        fun `Given no update subscriptions when observing then flow completes after the loaded state`() = runTest {
+            coEvery { integrationRepository.getEntityUpdates() } returns null
+            coEvery { webSocketRepository.getEntityRegistryUpdates() } returns null
+
+            useCase.observe(serverId).test {
+                awaitInitialLoad()
+                awaitComplete()
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
In the automotive screen we are going to need to be able to have updates of the entity that we are going to be display. This PR add the `obverse` capability to the `GetEntityForDisplayUseCase` so that a consumer can get the entity updates from the WebSocket when available. I replace the invoke operator with a `snapshot` method.

I tested the `observe` method by simply replacing the snapshot per a observe in the `ManageTileViewModel` and the entities were properly updating within the UI when the state was changing.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I'm not sure if we should use `observe` instead of `snapshot` in the EntityPicker. @jpelgrom wdyt?