### PR TITLE
Handle FrontendScreen paused

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -58,6 +58,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.repeatOnLifecycle
@@ -192,6 +193,7 @@ internal fun FrontendScreen(
         onDownloadRequested = viewModel::onDownloadRequested,
         webViewActions = viewModel.webViewActions,
         onSafeAreaInsetsChanged = viewModel::onSafeAreaInsetsChanged,
+        onScreenStartedChanged = viewModel::onScreenStartedChanged,
         onGesture = viewModel::onGesture,
         onLeavingApp = viewModel::onLeavingApp,
         onExoPlayerFullscreenChanged = viewModel::onExoPlayerFullscreenChanged,
@@ -241,6 +243,7 @@ internal fun FrontendScreenContent(
     onDownloadRequested: (url: String, contentDisposition: String, mimetype: String) -> Unit = { _, _, _ -> },
     webViewActions: Flow<WebViewAction> = emptyFlow(),
     onSafeAreaInsetsChanged: (SafeAreaInsets) -> Unit = {},
+    onScreenStartedChanged: (Boolean) -> Unit = {},
     onGesture: (GestureDirection, Int) -> Unit = { _, _ -> },
     onLeavingApp: (String?) -> Unit = {},
     onExoPlayerFullscreenChanged: (Boolean) -> Unit = {},
@@ -278,6 +281,7 @@ internal fun FrontendScreenContent(
         statusBarColor = content?.statusBarColor ?: loadingSurfaceColor,
         navigationBarColor = content?.backgroundColor ?: loadingSurfaceColor,
         onSafeAreaInsetsChanged = onSafeAreaInsetsChanged,
+        onScreenStartedChanged = onScreenStartedChanged,
     )
 
     FrontendScreenHandlers(pendingPermissionRequest = pendingPermissionRequest, pendingDialog = pendingDialog)
@@ -361,6 +365,7 @@ private fun FrontendScreenEffects(
     statusBarColor: Color?,
     navigationBarColor: Color?,
     onSafeAreaInsetsChanged: (SafeAreaInsets) -> Unit,
+    onScreenStartedChanged: (Boolean) -> Unit,
 ) {
     SystemBarsAppearanceEffect(
         statusBarColor = statusBarColor,
@@ -368,6 +373,8 @@ private fun FrontendScreenEffects(
     )
 
     ReportSafeAreaInsetsEffect(onSafeAreaInsetsChanged = onSafeAreaInsetsChanged)
+
+    ReportScreenStartedEffect(onScreenStartedChanged = onScreenStartedChanged)
 
     ImprovScanLifecycleEffect(
         scanRequested = improvScanRequested,
@@ -391,6 +398,14 @@ private fun FrontendScreenEffects(
     KeepScreenOnEffect(enabled = keepScreenOnEnabled)
 
     LeavingAppEffect(webView = webView, onLeavingApp = onLeavingApp)
+}
+
+@Composable
+private fun ReportScreenStartedEffect(onScreenStartedChanged: (Boolean) -> Unit) {
+    LifecycleStartEffect(Unit) {
+        onScreenStartedChanged(true)
+        onStopOrDispose { onScreenStartedChanged(false) }
+    }
 }
 
 /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendScreen.kt
@@ -400,6 +400,10 @@ private fun FrontendScreenEffects(
     LeavingAppEffect(webView = webView, onLeavingApp = onLeavingApp)
 }
 
+/**
+ * Reports the lifecycle start/stop events to [onScreenStartedChanged] whenever the
+ * [LifecycleStartEffect] changes.
+ */
 @Composable
 private fun ReportScreenStartedEffect(onScreenStartedChanged: (Boolean) -> Unit) {
     LifecycleStartEffect(Unit) {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -744,7 +744,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     }
 
     /**
-     * Waits the [CONNECTION_TIMEOUT] and emits an [FrontendConnectionError.ExternalBusTimeout] if the
+     * Awaits the [CONNECTION_TIMEOUT] and emits a [FrontendConnectionError.ExternalBusTimeout] if the
      * frontend has not completed its external-bus handshake (left [FrontendViewState.Loading]) by then.
      */
     private suspend fun watchLoadingTimeout() {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -226,6 +227,8 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     private val _events = MutableSharedFlow<FrontendEvent>(extraBufferCapacity = 1)
     val events: SharedFlow<FrontendEvent> = _events.asSharedFlow()
 
+    private val isScreenStarted = MutableStateFlow(true)
+
     private val _webViewActions = MutableSharedFlow<WebViewAction>(extraBufferCapacity = 1)
     val webViewActions: Flow<WebViewAction> = merge(_webViewActions, frontendBusObserver.webViewActions())
 
@@ -351,10 +354,18 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
     init {
         viewModelScope.launch {
-            _viewState.collectLatest { state ->
+            _viewState.collect { state ->
                 releaseExoPlayerIfLeavingContent(state)
-                // Timeout watcher - cancels automatically when state changes from Loading
-                watchLoadingTimeout(state)
+            }
+        }
+
+        viewModelScope.launch {
+            // Timeout watcher - collectLatest cancels the countdown when the state leaves Loading
+            // or the screen stops, and restarts it from zero when watching resumes.
+            combine(_viewState, isScreenStarted) { state, screenStarted ->
+                state is FrontendViewState.Loading && screenStarted
+            }.collectLatest { watchTimeout ->
+                if (watchTimeout) watchLoadingTimeout()
             }
         }
 
@@ -482,6 +493,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                 _events.tryEmit(FrontendEvent.RequestFullscreen(fullscreen = false))
             },
         )
+
+    fun onScreenStartedChanged(started: Boolean) {
+        isScreenStarted.value = started
+    }
 
     fun onRetry() {
         _viewState.update {
@@ -729,12 +744,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     }
 
     /**
-     * Waits the [CONNECTION_TIMEOUT] in [FrontendViewState.Loading] and emits an
-     * [FrontendConnectionError.ExternalBusTimeout] if the frontend has not completed its external-bus
-     * handshake (transitioned to [FrontendViewState.Content]) by then.
+     * Waits the [CONNECTION_TIMEOUT] and emits an [FrontendConnectionError.ExternalBusTimeout] if the
+     * frontend has not completed its external-bus handshake (left [FrontendViewState.Loading]) by then.
      */
-    private suspend fun watchLoadingTimeout(state: FrontendViewState) {
-        if (state !is FrontendViewState.Loading) return
+    private suspend fun watchLoadingTimeout() {
         delay(CONNECTION_TIMEOUT)
         if (_viewState.value is FrontendViewState.Loading) {
             onError(FrontendConnectionError.ExternalBusTimeout)
@@ -1119,15 +1132,23 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     }
 
     /**
-     * Transitions from [FrontendViewState.Loading] to [FrontendViewState.Content] once the frontend
-     * connects, clearing the intermediate navigation history and syncing the system bar colors to
+     * Whether the frontend may still complete its external-bus handshake: while [FrontendViewState.Loading],
+     * or showing an [FrontendConnectionError.ExternalBusTimeout] error, since the WebView keeps loading
+     * under the error overlay and a late handshake should dismiss it.
+     */
+    private fun FrontendViewState.isAwaitingConnection(): Boolean = this is FrontendViewState.Loading ||
+        (this is FrontendViewState.Error && error is FrontendConnectionError.ExternalBusTimeout)
+
+    /**
+     * Transitions to [FrontendViewState.Content] once the frontend connects (see [isAwaitingConnection]),
+     * clearing the intermediate navigation history and syncing the system bar colors to
      * the now-available frontend theme.
      */
     private suspend fun onConnected() {
-        val wasLoading = _viewState.value is FrontendViewState.Loading
+        val wasAwaitingConnection = _viewState.value.isAwaitingConnection()
         val serverHandleInsets = serverHandlesInsets(_viewState.value.serverId)
         _viewState.update { currentState ->
-            if (currentState is FrontendViewState.Loading) {
+            if (currentState.isAwaitingConnection()) {
                 FrontendViewState.Content(
                     serverId = currentState.serverId,
                     url = currentState.url,
@@ -1137,7 +1158,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
                 currentState
             }
         }
-        if (wasLoading) {
+        if (wasAwaitingConnection) {
             // Remove any previous navigation
             _webViewActions.emit(WebViewAction.ClearHistory())
             checkSecurityVersion(_viewState.value.serverId)

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -1984,6 +1984,83 @@ class FrontendViewModelTest {
             // Should still be content state, not error
             assertInstanceOf(FrontendViewState.Content::class.java, viewModel.viewState.value)
         }
+
+        @Test
+        fun `Given loading state when screen is stopped then timeout does not fire while stopped`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(1.seconds)
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+
+            // The WebView is frozen while the screen is stopped, so the countdown must not run
+            viewModel.onScreenStartedChanged(false)
+            advanceTimeBy(CONNECTION_TIMEOUT * 2)
+
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+        }
+
+        @Test
+        fun `Given screen stopped while loading when screen starts again then timeout restarts from zero`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            viewModel.onScreenStartedChanged(false)
+            advanceTimeBy(CONNECTION_TIMEOUT)
+            viewModel.onScreenStartedChanged(true)
+
+            // The countdown restarted on start: just before a full timeout it is still loading
+            advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+
+            advanceTimeBy(2.seconds)
+            val state = assertInstanceOf(FrontendViewState.Error::class.java, viewModel.viewState.value)
+            assertEquals(FrontendConnectionError.ExternalBusTimeout, state.error)
+        }
+
+        @Test
+        fun `Given external bus timeout error when frontend connects then state recovers to Content`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(CONNECTION_TIMEOUT + 1.seconds)
+            val errorState = assertInstanceOf(FrontendViewState.Error::class.java, viewModel.viewState.value)
+            assertEquals(FrontendConnectionError.ExternalBusTimeout, errorState.error)
+
+            // The WebView keeps loading under the error overlay and completes the handshake
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+
+            val state = assertInstanceOf(FrontendViewState.Content::class.java, viewModel.viewState.value)
+            assertEquals(testUrlWithAuth, state.url)
+        }
+
+        @Test
+        fun `Given a non-timeout error when frontend connects then error state is kept`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.ServerNotFound(serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceUntilIdle()
+            assertInstanceOf(FrontendViewState.Error::class.java, viewModel.viewState.value)
+
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceUntilIdle()
+
+            assertInstanceOf(FrontendViewState.Error::class.java, viewModel.viewState.value)
+        }
     }
 
     @Nested


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The ViewModel is surviving the pause of the screen because of that the logic of timeout of the WebView continues in background and if a URL changes occur while the app is in background it might show the timeout screen. With this change it would discard the timeout while in background and restart when opening again the app. It also discard the timeout page if ever the connection happen while the timeout is shown.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.