### PR TITLE
Fix notification sensor settings initialization

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
@@ -128,6 +128,9 @@ class NotificationListenerSensorManager @Inject constructor(
     }
 
     override suspend fun requestSensorUpdate() {
+        listOf(lastNotification, lastRemovedNotification)
+            .filter { isEnabled(it) }
+            .forEach { getNotificationSettings(it) }
         updateMediaSession()
     }
 
@@ -145,22 +148,11 @@ class NotificationListenerSensorManager @Inject constructor(
                 return@launch
             }
 
-            val allowPackages = getSetting(
-                lastNotification,
-                SETTING_ALLOW_LIST,
-                SensorSettingType.LIST_APPS,
-                default = "",
-            ).split(", ").filter { it.isNotBlank() }
-
-            val disableAllowListRequirement = getToggleSetting(
-                lastNotification,
-                SETTING_DISABLE_ALLOW_LIST,
-                default = false,
-            )
+            val settings = getNotificationSettings(lastNotification)
 
             if (sbn.packageName == applicationContext.packageName ||
-                (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) ||
-                (!disableAllowListRequirement && allowPackages.isEmpty())
+                (settings.allowPackages.isNotEmpty() && sbn.packageName !in settings.allowPackages) ||
+                (!settings.disableAllowListRequirement && settings.allowPackages.isEmpty())
             ) {
                 return@launch
             }
@@ -208,22 +200,11 @@ class NotificationListenerSensorManager @Inject constructor(
                 return@launch
             }
 
-            val allowPackages = getSetting(
-                lastRemovedNotification,
-                SETTING_ALLOW_LIST,
-                SensorSettingType.LIST_APPS,
-                default = "",
-            ).split(", ").filter { it.isNotBlank() }
-
-            val disableAllowListRequirement = getToggleSetting(
-                lastRemovedNotification,
-                SETTING_DISABLE_ALLOW_LIST,
-                default = false,
-            )
+            val settings = getNotificationSettings(lastRemovedNotification)
 
             if (sbn.packageName == applicationContext.packageName ||
-                (allowPackages.isNotEmpty() && sbn.packageName !in allowPackages) ||
-                (!disableAllowListRequirement && allowPackages.isEmpty())
+                (settings.allowPackages.isNotEmpty() && sbn.packageName !in settings.allowPackages) ||
+                (!settings.disableAllowListRequirement && settings.allowPackages.isEmpty())
             ) {
                 return@launch
             }
@@ -359,6 +340,24 @@ class NotificationListenerSensorManager @Inject constructor(
             forceUpdate = primaryPlaybackState == "Playing",
         )
     }
+
+    private suspend fun getNotificationSettings(sensor: SensorManager.BasicSensor): NotificationSettings {
+        val allowPackages = getSetting(
+            sensor,
+            SETTING_ALLOW_LIST,
+            SensorSettingType.LIST_APPS,
+            default = "",
+        ).split(", ").filter { it.isNotBlank() }
+        val disableAllowListRequirement = getToggleSetting(
+            sensor,
+            SETTING_DISABLE_ALLOW_LIST,
+            default = false,
+        )
+
+        return NotificationSettings(allowPackages, disableAllowListRequirement)
+    }
+
+    private data class NotificationSettings(val allowPackages: List<String>, val disableAllowListRequirement: Boolean)
 
     private fun getPlaybackState(state: Int?): String {
         return mediaStates.getOrDefault(state ?: PlaybackState.STATE_NONE, STATE_UNKNOWN)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
@@ -128,6 +128,7 @@ class NotificationListenerSensorManager @Inject constructor(
     }
 
     override suspend fun requestSensorUpdate() {
+        // Load settings to persist their defaults before the sensor detail screen observes them.
         listOf(lastNotification, lastRemovedNotification)
             .filter { isEnabled(it) }
             .forEach { getNotificationSettings(it) }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
@@ -145,16 +145,7 @@ class NotificationListenerSensorManager @Inject constructor(
         updateActiveNotificationCount(activeNotifications)
 
         sensorWorkerScope.launch {
-            if (!isEnabled(lastNotification)) {
-                return@launch
-            }
-
-            val settings = getNotificationSettings(lastNotification)
-
-            if (sbn.packageName == applicationContext.packageName ||
-                (settings.allowPackages.isNotEmpty() && sbn.packageName !in settings.allowPackages) ||
-                (!settings.disableAllowListRequirement && settings.allowPackages.isEmpty())
-            ) {
+            if (!shouldProcessNotification(lastNotification, sbn.packageName)) {
                 return@launch
             }
 
@@ -197,16 +188,7 @@ class NotificationListenerSensorManager @Inject constructor(
         updateActiveNotificationCount(activeNotifications)
 
         sensorWorkerScope.launch {
-            if (!isEnabled(lastRemovedNotification)) {
-                return@launch
-            }
-
-            val settings = getNotificationSettings(lastRemovedNotification)
-
-            if (sbn.packageName == applicationContext.packageName ||
-                (settings.allowPackages.isNotEmpty() && sbn.packageName !in settings.allowPackages) ||
-                (!settings.disableAllowListRequirement && settings.allowPackages.isEmpty())
-            ) {
+            if (!shouldProcessNotification(lastRemovedNotification, sbn.packageName)) {
                 return@launch
             }
 
@@ -356,6 +338,17 @@ class NotificationListenerSensorManager @Inject constructor(
         )
 
         return NotificationSettings(allowPackages, disableAllowListRequirement)
+    }
+
+    private suspend fun shouldProcessNotification(sensor: SensorManager.BasicSensor, packageName: String): Boolean {
+        if (!isEnabled(sensor)) {
+            return false
+        }
+
+        val settings = getNotificationSettings(sensor)
+        val packageAllowed = packageName in settings.allowPackages
+        val allowListDisabled = settings.allowPackages.isEmpty() && settings.disableAllowListRequirement
+        return packageName != applicationContext.packageName && (packageAllowed || allowListDisabled)
     }
 
     private data class NotificationSettings(val allowPackages: List<String>, val disableAllowListRequirement: Boolean)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManager.kt
@@ -347,8 +347,8 @@ class NotificationListenerSensorManager @Inject constructor(
 
         val settings = getNotificationSettings(sensor)
         val packageAllowed = packageName in settings.allowPackages
-        val allowListDisabled = settings.allowPackages.isEmpty() && settings.disableAllowListRequirement
-        return packageName != applicationContext.packageName && (packageAllowed || allowListDisabled)
+        val allowListRequirementDisabled = settings.allowPackages.isEmpty() && settings.disableAllowListRequirement
+        return packageName != applicationContext.packageName && (packageAllowed || allowListRequirementDisabled)
     }
 
     private data class NotificationSettings(val allowPackages: List<String>, val disableAllowListRequirement: Boolean)

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -4,7 +4,6 @@
     <release version="2026.7.4 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
         <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
-        <change>Notification sensor allow list can now be configured immediately after enabling the sensor</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.4 - Wear" versioncode="2">

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -4,6 +4,7 @@
     <release version="2026.7.4 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
         <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
+        <change>Notification sensor allow list can now be configured immediately after enabling the sensor</change>
         <change>Bug fixes and dependency updates</change>
     </release>
     <release version="2026.7.4 - Wear" versioncode="2">

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
@@ -1,0 +1,137 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import androidx.core.app.NotificationManagerCompat
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.common.sensors.SensorRepository
+import io.homeassistant.companion.android.database.sensor.Sensor
+import io.homeassistant.companion.android.database.sensor.SensorSetting
+import io.homeassistant.companion.android.database.sensor.SensorSettingType
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+private const val SETTING_ALLOW_LIST = "notification_allow_list"
+private const val SETTING_DISABLE_ALLOW_LIST = "notification_disable_allow_list"
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class NotificationListenerSensorManagerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val sensorRepository: SensorRepository = mockk(relaxed = true)
+    private val manager = NotificationListenerSensorManager(
+        context,
+        sensorRepository,
+        mockk<ServerManager>(relaxed = true),
+    )
+
+    @After
+    fun tearDown() {
+        unmockkStatic(NotificationManagerCompat::class)
+    }
+
+    @Test
+    fun `Given last notification enabled when requesting update then its settings are initialized`() = runTest {
+        prepareEnabledNotificationSensor(NotificationListenerSensorManager.lastNotification.id)
+        coEvery { sensorRepository.getSettings(any()) } returns emptyList()
+        val addedSettings = captureAddedSettings()
+
+        manager.requestSensorUpdate()
+
+        assertEquals(
+            defaultSettings(NotificationListenerSensorManager.lastNotification.id),
+            addedSettings,
+        )
+    }
+
+    @Test
+    fun `Given last removed notification enabled when requesting update then its settings are initialized`() = runTest {
+        prepareEnabledNotificationSensor(NotificationListenerSensorManager.lastRemovedNotification.id)
+        coEvery { sensorRepository.getSettings(any()) } returns emptyList()
+        val addedSettings = captureAddedSettings()
+
+        manager.requestSensorUpdate()
+
+        assertEquals(
+            defaultSettings(NotificationListenerSensorManager.lastRemovedNotification.id),
+            addedSettings,
+        )
+    }
+
+    @Test
+    fun `Given custom allow list when requesting update then existing value is preserved`() = runTest {
+        val sensorId = NotificationListenerSensorManager.lastNotification.id
+        val existingSetting = SensorSetting(
+            sensorId = sensorId,
+            name = SETTING_ALLOW_LIST,
+            value = "com.example.app",
+            valueType = SensorSettingType.LIST_APPS,
+        )
+        prepareEnabledNotificationSensor(sensorId)
+        coEvery { sensorRepository.getSettings(sensorId) } returns listOf(existingSetting)
+        val addedSettings = captureAddedSettings()
+
+        manager.requestSensorUpdate()
+
+        assertEquals(
+            listOf(
+                SensorSetting(
+                    sensorId = sensorId,
+                    name = SETTING_DISABLE_ALLOW_LIST,
+                    value = "false",
+                    valueType = SensorSettingType.TOGGLE,
+                ),
+            ),
+            addedSettings,
+        )
+    }
+
+    private fun prepareEnabledNotificationSensor(sensorId: String) {
+        mockkStatic(NotificationManagerCompat::class)
+        every { NotificationManagerCompat.getEnabledListenerPackages(context) } returns setOf(context.packageName)
+        coEvery { sensorRepository.get(any()) } returns emptyList()
+        coEvery { sensorRepository.get(sensorId) } returns listOf(
+            Sensor(
+                id = sensorId,
+                serverId = 1,
+                enabled = true,
+                state = "",
+            ),
+        )
+    }
+
+    private fun captureAddedSettings(): MutableList<SensorSetting> {
+        val addedSettings = mutableListOf<SensorSetting>()
+        coEvery { sensorRepository.add(any<SensorSetting>()) } answers {
+            addedSettings += firstArg<SensorSetting>()
+        }
+        return addedSettings
+    }
+
+    private fun defaultSettings(sensorId: String) = listOf(
+        SensorSetting(
+            sensorId = sensorId,
+            name = SETTING_ALLOW_LIST,
+            value = "",
+            valueType = SensorSettingType.LIST_APPS,
+        ),
+        SensorSetting(
+            sensorId = sensorId,
+            name = SETTING_DISABLE_ALLOW_LIST,
+            value = "false",
+            valueType = SensorSettingType.TOGGLE,
+        ),
+    )
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
@@ -43,29 +43,24 @@ class NotificationListenerSensorManagerTest {
     }
 
     @Test
-    fun `Given last notification enabled when requesting update then its settings are initialized`() = runTest {
-        prepareEnabledNotificationSensor(NotificationListenerSensorManager.lastNotification.id)
-        coEvery { sensorRepository.getSettings(any()) } returns emptyList()
-        val addedSettings = captureAddedSettings()
-
-        manager.requestSensorUpdate()
-
-        assertEquals(
-            defaultSettings(NotificationListenerSensorManager.lastNotification.id),
-            addedSettings,
-        )
+    fun `Given last notification enabled when requesting update then its settings are initialized`() {
+        assertSettingsInitialized(NotificationListenerSensorManager.lastNotification.id)
     }
 
     @Test
-    fun `Given last removed notification enabled when requesting update then its settings are initialized`() = runTest {
-        prepareEnabledNotificationSensor(NotificationListenerSensorManager.lastRemovedNotification.id)
+    fun `Given last removed notification enabled when requesting update then its settings are initialized`() {
+        assertSettingsInitialized(NotificationListenerSensorManager.lastRemovedNotification.id)
+    }
+
+    private fun assertSettingsInitialized(sensorId: String) = runTest {
+        prepareEnabledNotificationSensor(sensorId)
         coEvery { sensorRepository.getSettings(any()) } returns emptyList()
         val addedSettings = captureAddedSettings()
 
         manager.requestSensorUpdate()
 
         assertEquals(
-            defaultSettings(NotificationListenerSensorManager.lastRemovedNotification.id),
+            defaultSettings(sensorId),
             addedSettings,
         )
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
@@ -19,15 +19,18 @@ import org.junit.After
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
 import org.robolectric.annotation.Config
 
 private const val SETTING_ALLOW_LIST = "notification_allow_list"
 private const val SETTING_DISABLE_ALLOW_LIST = "notification_disable_allow_list"
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(application = HiltTestApplication::class)
-class NotificationListenerSensorManagerTest {
+class NotificationListenerSensorManagerTest(
+    private val sensorId: String,
+) {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val sensorRepository: SensorRepository = mockk(relaxed = true)
@@ -43,16 +46,7 @@ class NotificationListenerSensorManagerTest {
     }
 
     @Test
-    fun `Given last notification enabled when requesting update then its settings are initialized`() {
-        assertSettingsInitialized(NotificationListenerSensorManager.lastNotification.id)
-    }
-
-    @Test
-    fun `Given last removed notification enabled when requesting update then its settings are initialized`() {
-        assertSettingsInitialized(NotificationListenerSensorManager.lastRemovedNotification.id)
-    }
-
-    private fun assertSettingsInitialized(sensorId: String) = runTest {
+    fun `Given notification sensor enabled when requesting update then its settings are initialized`() = runTest {
         prepareEnabledNotificationSensor(sensorId)
         coEvery { sensorRepository.getSettings(any()) } returns emptyList()
         val addedSettings = captureAddedSettings()
@@ -67,7 +61,6 @@ class NotificationListenerSensorManagerTest {
 
     @Test
     fun `Given custom allow list when requesting update then existing value is preserved`() = runTest {
-        val sensorId = NotificationListenerSensorManager.lastNotification.id
         val existingSetting = SensorSetting(
             sensorId = sensorId,
             name = SETTING_ALLOW_LIST,
@@ -90,6 +83,15 @@ class NotificationListenerSensorManagerTest {
                 ),
             ),
             addedSettings,
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameters(name = "{0}")
+        fun sensorIds() = listOf(
+            NotificationListenerSensorManager.lastNotification.id,
+            NotificationListenerSensorManager.lastRemovedNotification.id,
         )
     }
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/NotificationListenerSensorManagerTest.kt
@@ -2,8 +2,6 @@ package io.homeassistant.companion.android.sensors
 
 import android.content.Context
 import androidx.core.app.NotificationManagerCompat
-import androidx.test.core.app.ApplicationProvider
-import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.sensors.SensorRepository
 import io.homeassistant.companion.android.database.sensor.Sensor
@@ -15,24 +13,19 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Test
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.runner.RunWith
-import org.robolectric.ParameterizedRobolectricTestRunner
-import org.robolectric.ParameterizedRobolectricTestRunner.Parameters
-import org.robolectric.annotation.Config
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
 
 private const val SETTING_ALLOW_LIST = "notification_allow_list"
 private const val SETTING_DISABLE_ALLOW_LIST = "notification_disable_allow_list"
 
-@RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(application = HiltTestApplication::class)
-class NotificationListenerSensorManagerTest(
-    private val sensorId: String,
-) {
+class NotificationListenerSensorManagerTest {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val context = mockk<Context> {
+        every { packageName } returns "io.homeassistant.companion.android"
+    }
     private val sensorRepository: SensorRepository = mockk(relaxed = true)
     private val manager = NotificationListenerSensorManager(
         context,
@@ -40,13 +33,16 @@ class NotificationListenerSensorManagerTest(
         mockk<ServerManager>(relaxed = true),
     )
 
-    @After
+    @AfterEach
     fun tearDown() {
         unmockkStatic(NotificationManagerCompat::class)
     }
 
-    @Test
-    fun `Given notification sensor enabled when requesting update then its settings are initialized`() = runTest {
+    @ParameterizedTest
+    @MethodSource("sensorIds")
+    fun `Given notification sensor enabled when requesting update then its settings are initialized`(
+        sensorId: String,
+    ) = runTest {
         prepareEnabledNotificationSensor(sensorId)
         coEvery { sensorRepository.getSettings(any()) } returns emptyList()
         val addedSettings = captureAddedSettings()
@@ -59,8 +55,11 @@ class NotificationListenerSensorManagerTest(
         )
     }
 
-    @Test
-    fun `Given custom allow list when requesting update then existing value is preserved`() = runTest {
+    @ParameterizedTest
+    @MethodSource("sensorIds")
+    fun `Given custom allow list when requesting update then existing value is preserved`(
+        sensorId: String,
+    ) = runTest {
         val existingSetting = SensorSetting(
             sensorId = sensorId,
             name = SETTING_ALLOW_LIST,
@@ -88,7 +87,6 @@ class NotificationListenerSensorManagerTest(
 
     companion object {
         @JvmStatic
-        @Parameters(name = "{0}")
         fun sensorIds() = listOf(
             NotificationListenerSensorManager.lastNotification.id,
             NotificationListenerSensorManager.lastRemovedNotification.id,


### PR DESCRIPTION
## Summary

Notification allow-list settings were only persisted after a notification callback. As a result, a newly enabled notification sensor could show no configurable settings until a notification was posted or removed.

Initialize the settings during the normal sensor refresh for enabled posted and removed notification sensors. The callback paths use the same settings helper, preserving existing values and filtering behavior. This also adds regression coverage for both sensors and custom allow-list preservation.

Fixes #6773

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots

Not applicable; this fixes when existing settings become available and does not change their appearance.

## Link to pull request in documentation repositories

No documentation changes are required.

## Any other notes

None.