### PR TITLE
Fix CI upload reports on failure

### DIFF
--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -4,6 +4,11 @@ inputs:
   test-name:
     description: "Name of the test used as prefix for the artifact names."
     required: true
+  job-status:
+    description: >-
+      Status of the calling job, pass `${{ job.status }}`. Reports are only uploaded when it is
+      `failure`.
+    required: true
 runs:
   using: "composite"
   steps:
@@ -18,7 +23,7 @@ runs:
           **/build/outputs/*/connected/*
 
     - name: Upload test reports
-      if: failure()
+      if: ${{ inputs.job-status == 'failure' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.test-name }} reports

--- a/.github/actions/upload-test-results/action.yml
+++ b/.github/actions/upload-test-results/action.yml
@@ -6,7 +6,7 @@ inputs:
     required: true
   job-status:
     description: >-
-      Status of the calling job, pass `${{ job.status }}`. Reports are only uploaded when it is
+      Status of the calling job, pass the job.status context. Reports are only uploaded when it is
       `failure`.
     required: true
 runs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -216,6 +216,7 @@ jobs:
         if: always()
         with:
           test-name: Screenshot test
+          job-status: ${{ job.status }}
 
   pr_build:
     needs: [lockfiles, ktlint]
@@ -318,6 +319,7 @@ jobs:
         if: always()
         with:
           test-name: Unit test
+          job-status: ${{ job.status }}
 
   build_emulator_wtf_apks:
     name: "Build Emulator.wtf APKs"
@@ -433,3 +435,4 @@ jobs:
         if: always()
         with:
           test-name: Instrumentation test (API${{ matrix.configuration.api-level }}) ${{ matrix.configuration.target }}
+          job-status: ${{ job.status }}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We were using `failure()` in the test reports composite action, but it seems that it only check the status of the composite action not the parent job, so we need to pass the value manually.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.