### PR TITLE
Match hand-typed command targets ignoring case and surrounding spaces

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
@@ -26,11 +26,11 @@ sealed interface FrontendTarget : Parcelable {
         /**
          * Parses a raw path string into a [FrontendTarget].
          *
-         * A `null` or blank path maps to [Default]. Surrounding whitespace and the case of the
-         * [ENTITY_ID_PREFIX] are ignored since the value is often typed by hand in a notification
-         * command.
+         * A `null` or blank path maps to [Default].
          */
         fun fromRawPath(path: String?): FrontendTarget {
+            // Parse leniently (trim whitespace, match the prefix case-insensitively) since the
+            // value can be hand-typed, e.g. in a notification command.
             val trimmed = path?.trim()
             return when {
                 trimmed.isNullOrEmpty() -> Default

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
@@ -26,12 +26,18 @@ sealed interface FrontendTarget : Parcelable {
         /**
          * Parses a raw path string into a [FrontendTarget].
          *
-         * A `null` path maps to [Default].
+         * A `null` or blank path maps to [Default]. Surrounding whitespace and the case of the
+         * [ENTITY_ID_PREFIX] are ignored since the value is often typed by hand in a notification
+         * command.
          */
-        fun fromRawPath(path: String?): FrontendTarget = when {
-            path == null -> Default
-            path.startsWith(ENTITY_ID_PREFIX) -> EntityMoreInfo(path.removePrefix(ENTITY_ID_PREFIX))
-            else -> Path(path)
+        fun fromRawPath(path: String?): FrontendTarget {
+            val trimmed = path?.trim()
+            return when {
+                trimmed.isNullOrEmpty() -> Default
+                trimmed.startsWith(ENTITY_ID_PREFIX, ignoreCase = true) ->
+                    EntityMoreInfo(trimmed.substring(ENTITY_ID_PREFIX.length).trim())
+                else -> Path(trimmed)
+            }
         }
 
         /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTarget.kt
@@ -26,7 +26,7 @@ sealed interface FrontendTarget : Parcelable {
         /**
          * Parses a raw path string into a [FrontendTarget].
          *
-         * A `null` or blank path maps to [Default].
+         * A `null` or blank path, or a blank entity id, maps to [Default].
          */
         fun fromRawPath(path: String?): FrontendTarget {
             // Parse leniently (trim whitespace, match the prefix case-insensitively) since the
@@ -34,8 +34,10 @@ sealed interface FrontendTarget : Parcelable {
             val trimmed = path?.trim()
             return when {
                 trimmed.isNullOrEmpty() -> Default
-                trimmed.startsWith(ENTITY_ID_PREFIX, ignoreCase = true) ->
-                    EntityMoreInfo(trimmed.substring(ENTITY_ID_PREFIX.length).trim())
+                trimmed.startsWith(ENTITY_ID_PREFIX, ignoreCase = true) -> {
+                    val entityId = trimmed.substring(ENTITY_ID_PREFIX.length).trim()
+                    if (entityId.isEmpty()) Default else EntityMoreInfo(entityId)
+                }
                 else -> Path(trimmed)
             }
         }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
@@ -25,6 +25,21 @@ class FrontendTargetTest {
     }
 
     @Test
+    fun `Given a hand-typed path when fromRawPath then case and surrounding spaces are normalized`() {
+        assertEquals(FrontendTarget.Default, FrontendTarget.fromRawPath(""))
+        assertEquals(FrontendTarget.Default, FrontendTarget.fromRawPath("   "))
+        assertEquals(FrontendTarget.Path("/lovelace/0"), FrontendTarget.fromRawPath("  /lovelace/0  "))
+        assertEquals(
+            FrontendTarget.EntityMoreInfo("light.kitchen"),
+            FrontendTarget.fromRawPath("EntityId:light.kitchen"),
+        )
+        assertEquals(
+            FrontendTarget.EntityMoreInfo("light.kitchen"),
+            FrontendTarget.fromRawPath("  entityId: light.kitchen  "),
+        )
+    }
+
+    @Test
     fun `Given any target when toLegacyPath then round-trips through fromRawPath`() {
         samples.forEach { target ->
             assertEquals(target, FrontendTarget.fromRawPath(target.toRawPath()))

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/navigation/FrontendTargetTest.kt
@@ -40,6 +40,12 @@ class FrontendTargetTest {
     }
 
     @Test
+    fun `Given a blank entity id when fromRawPath then maps to Default`() {
+        assertEquals(FrontendTarget.Default, FrontendTarget.fromRawPath("entityId:"))
+        assertEquals(FrontendTarget.Default, FrontendTarget.fromRawPath("  entityId:   "))
+    }
+
+    @Test
     fun `Given any target when toLegacyPath then round-trips through fromRawPath`() {
         samples.forEach { target ->
             assertEquals(target, FrontendTarget.fromRawPath(target.toRawPath()))

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -16,6 +16,9 @@ import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import timber.log.Timber
 
+// Matched ignoring case since the value is often typed by hand in a notification command
+private val absoluteUrlRegex = Regex("^https?://", RegexOption.IGNORE_CASE)
+
 object UrlUtil {
     /**
      * Extracts the base URL (scheme, host, and port) from the given URL string,
@@ -85,6 +88,26 @@ object UrlUtil {
         }
     }
 
+    fun isAbsoluteUrl(it: String?): Boolean {
+        return absoluteUrlRegex.containsMatchIn(it.orEmpty())
+    }
+
+    fun splitNfcTagId(it: Uri?): String? {
+        val matches = nfcTagUrlRegex.find(it.toString())
+        return matches?.groups?.get(1)?.value
+    }
+
+    /**
+     * Matches `https://www.home-assistant.io/tag/<id>` URLs in production. Debug builds also
+     * accept `next.home-assistant.io` so the tag flow can be exercised against the next branch
+     * of the documentation site.
+     */
+    private val nfcTagUrlRegex: Regex = if (BuildConfig.DEBUG) {
+        Regex("^https?://(?:www|next)\\.home-assistant\\.io/tag/(.*)")
+    } else {
+        Regex("^https?://www\\.home-assistant\\.io/tag/(.*)")
+    }
+
     private fun buildRelativeUrl(base: URL?, uri: URI): URL? {
         val builder = base?.toHttpUrlOrNull()?.newBuilder() ?: return null
 
@@ -99,47 +122,6 @@ object UrlUtil {
                 fragment(it.trim())
             }
         }.build().toUrl()
-    }
-
-    // Matched ignoring case since the value is often typed by hand in a notification command
-    private val absoluteUrlRegex = Regex("^https?://", RegexOption.IGNORE_CASE)
-
-    fun isAbsoluteUrl(it: String?): Boolean {
-        return absoluteUrlRegex.containsMatchIn(it.orEmpty())
-    }
-
-    /** @return `true` if both URLs have the same 'base': an equal protocol, host, port and userinfo */
-    fun URL.baseIsEqual(other: URL?): Boolean = if (other == null) {
-        false
-    } else {
-        host.equals(other.host, ignoreCase = true) &&
-            port.let {
-                if (it ==
-                    -1
-                ) {
-                    defaultPort
-                } else {
-                    it
-                }
-            } == other.port.let { if (it == -1) defaultPort else it } &&
-            protocol.equals(other.protocol, ignoreCase = true) &&
-            userInfo == other.userInfo
-    }
-
-    /**
-     * Matches `https://www.home-assistant.io/tag/<id>` URLs in production. Debug builds also
-     * accept `next.home-assistant.io` so the tag flow can be exercised against the next branch
-     * of the documentation site.
-     */
-    private val nfcTagUrlRegex: Regex = if (BuildConfig.DEBUG) {
-        Regex("^https?://(?:www|next)\\.home-assistant\\.io/tag/(.*)")
-    } else {
-        Regex("^https?://www\\.home-assistant\\.io/tag/(.*)")
-    }
-
-    fun splitNfcTagId(it: Uri?): String? {
-        val matches = nfcTagUrlRegex.find(it.toString())
-        return matches?.groups?.get(1)?.value
     }
 }
 

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -102,7 +102,8 @@ object UrlUtil {
     }
 
     fun isAbsoluteUrl(it: String?): Boolean {
-        return Regex("^https?://").containsMatchIn(it.toString())
+        // Matched ignoring case since the value is often typed by hand in a notification command
+        return Regex("^https?://", RegexOption.IGNORE_CASE).containsMatchIn(it.toString())
     }
 
     /** @return `true` if both URLs have the same 'base': an equal protocol, host, port and userinfo */

--- a/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/util/UrlUtil.kt
@@ -101,9 +101,11 @@ object UrlUtil {
         }.build().toUrl()
     }
 
+    // Matched ignoring case since the value is often typed by hand in a notification command
+    private val absoluteUrlRegex = Regex("^https?://", RegexOption.IGNORE_CASE)
+
     fun isAbsoluteUrl(it: String?): Boolean {
-        // Matched ignoring case since the value is often typed by hand in a notification command
-        return Regex("^https?://", RegexOption.IGNORE_CASE).containsMatchIn(it.toString())
+        return absoluteUrlRegex.containsMatchIn(it.orEmpty())
     }
 
     /** @return `true` if both URLs have the same 'base': an equal protocol, host, port and userinfo */

--- a/common/src/test/kotlin/io/homeassistant/companion/android/util/UrlUtilTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/util/UrlUtilTest.kt
@@ -241,4 +241,18 @@ class UrlUtilTest {
 
         assertEquals(expected, httpUrl1.hasSameOrigin(httpUrl2))
     }
+
+    @ParameterizedTest(name = "isAbsoluteUrl: {0} -> {1}")
+    @CsvSource(
+        "https://example.com, true",
+        "http://example.com, true",
+        "HTTPS://example.com, true",
+        "HtTp://EXAMPLE.COM, true",
+        "/lovelace/default, false",
+        "app://com.example.app, false",
+        "entityId:light.kitchen, false",
+    )
+    fun `isAbsoluteUrl returns expected value`(input: String, expected: Boolean) {
+        assertEquals(expected, UrlUtil.isAbsoluteUrl(input))
+    }
 }


### PR DESCRIPTION
## Summary

Notification commands carry values the user types by hand, but two of the matchers treated them as if they were machine-generated — matching case-sensitively and keeping surrounding whitespace:

* `UrlUtil.isAbsoluteUrl` matched the scheme with a case-sensitive `^https?://` regex. An uppercase `HTTPS://…` value — in a `command_webview`/URI, or a notification `image`/`icon`/`video` URL — was therefore treated as **relative** and resolved against the server base URL instead of used as an absolute URL.
* `FrontendTarget.fromRawPath` matched the `entityId:` prefix case-sensitively and kept surrounding whitespace, so `EntityId:light.kitchen` opened as a dashboard path instead of the more-info dialog, and a blank value became `Path("")` rather than the default dashboard.

Both matchers now ignore case; `fromRawPath` also trims the value and maps a blank path to the default dashboard. Behavior for well-formed values is unchanged. These are the paths exercised by `MessagingManager` (`command_webview`, notification media URLs) and the device-controls panel / frontend deep links.

Split out from home-assistant/android#7163 per review feedback there, so the navigation change stays focused. The `isAbsoluteUrl` change was reverted out of #7163; the `FrontendTarget.fromRawPath` change is byte-identical in both, so whichever merges first the other's hunk merges cleanly — no rebase needed.

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Link to pull request in documentation repositories

User Documentation: home-assistant/companion.home-assistant#

Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes

`isAbsoluteUrl` (`:common`) and `fromRawPath` (`:app`) are covered by parameterized/added unit tests including the uppercase-scheme, mixed-case `entityId:` prefix, blank, and surrounding-whitespace cases. No user-facing UI change, so no screenshots.
