### PR TITLE
Increase maxHeapSize for Unit Tests

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidCommonConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidCommonConventionPlugin.kt
@@ -94,6 +94,9 @@ class AndroidCommonConventionPlugin : Plugin<Project> {
 
                 tasks.withType<Test> {
                     useJUnitPlatform()
+                    // Tests run in a forked JVM that does not inherit `org.gradle.jvmargs` and defaults to
+                    // 512m, which is not enough for our project.
+                    maxHeapSize = "1g"
                 }
 
                 with(lint) {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Recently we started to see a consistent OOM on the CI while running unit test tasks. This PR bump the max heap size from 512mb (default https://github.com/gradle/gradle/blob/f8b7e55026dc33f78bc5aa894e6a53b54c4ea1e8/platforms/core-execution/worker-process-services/src/main/java/org/gradle/process/internal/worker/DefaultWorkerProcessBuilder.java#L265) to 1g.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.