### PR TITLE
Disable WIPFeature.USE_SHORTCUTS_V2 by default

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/WIPFeature.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/WIPFeature.kt
@@ -18,7 +18,7 @@ object WIPFeature {
      * When true, the settings entry navigates to [io.homeassistant.companion.android.settings.shortcuts.ManageShortcutsSettingsFragment].
      * When false, the settings entry navigates to [io.homeassistant.companion.android.settings.shortcuts.legacy.ManageShortcutsSettingsFragment].
      *
-     * This flag is only enabled in DEBUG builds during development.
+     * This flag is currently not enabled by default as the feature is on hold (no active contributor).
      */
-    val USE_SHORTCUTS_V2: Boolean = BuildConfig.DEBUG
+    val USE_SHORTCUTS_V2: Boolean = false
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Disable `WIPFeature.USE_SHORTCUTS_V2` by default as there is currently no active work being done on it per https://github.com/home-assistant/android/issues/6258#issuecomment-5035683832, and it blocks debug builds from having a functional way to use shortcuts.

Depending on if it's picked up again soon or not the flag can be changed again or removed completely (alongside the scaffolding created with the flag).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.

## Screenshots
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
https://discord.com/channels/330944238910963714/1346948551892009101/1529116380278947861