### PR TITLE
Improve testing skill loading and more explicit on screenshot test fail

### DIFF
--- a/.agents/skills/ha-android-testing/SKILL.md
+++ b/.agents/skills/ha-android-testing/SKILL.md
@@ -14,7 +14,13 @@ Use this skill when writing, changing, or reviewing tests.
 
 After an intentional UI change, update the reference screenshots (stored under `src/screenshotTestFullDebug/reference` in `:app`, `src/screenshotTestDebug/reference` in `:common` and `:wear`) with `./gradlew updateDebugScreenshotTest updateFullDebugScreenshotTest`. Rendering differs subtly between hosts, so if CI still fails on thresholds, a maintainer triggers the `Update Screenshots` workflow to regenerate them on the CI host — don't chase pixel diffs locally.
 
-Known local false positive: `ServerDiscoveryScreenshotTest` (onboarding server discovery screen) fails local validation because of host rendering differences. Running validate and update locally is fine — just ignore this test's failures (CI is the source of truth), and after an update run, revert its regenerated reference images instead of including them in the change, unless the screen intentionally changed.
+### Known false positive
+
+`ServerDiscoveryScreenshotTest` could fails validation because of host rendering differences. CI is the source of truth, so treat its failure as expected output, not a result:
+
+- Never report it — not as a finding, a regression, a pre-existing failure, or a caveat next to other results. It is noise, so say nothing about it.
+- Never investigate it, and never regenerate or commit its reference images; after an update run, revert them unless that screen is what you intentionally changed.
+- A screenshot run whose only failure is this test counts as passing.
 
 ## Frameworks
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Write(**/src/*test*/**)",
+            "command": "printf '%s' '{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"additionalContext\": \"Load the ha-android-testing skill (Skill tool) if not already loaded.\"}}'"
+          },
+          {
+            "type": "command",
+            "if": "Edit(**/src/*test*/**)",
+            "command": "printf '%s' '{\"hookSpecificOutput\": {\"hookEventName\": \"PreToolUse\", \"additionalContext\": \"Load the ha-android-testing skill (Skill tool) if not already loaded.\"}}'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -373,4 +373,5 @@ merged_results.sarif
 # AI tooling
 .claude/*
 !.claude/skills
+!.claude/settings.json
 .cursor


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Make the loading of the testing skill with Claude even more explicit. Make the screenshot failure more explicit for the server discovery screen to avoid any unwanted investigation from the agent.