### PR TITLE
Remove friendly_name usage from TodoWidget

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetConfigureViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetConfigureViewModel.kt
@@ -21,7 +21,6 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationDom
 import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
 import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayState
 import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithContext
-import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.widget.TodoWidgetDao
 import io.homeassistant.companion.android.database.widget.TodoWidgetEntity
@@ -165,9 +164,9 @@ class TodoWidgetConfigureViewModel @AssistedInject constructor(
         selectedEntityMutex.withLock {
             val listEntityId = selectedEntityId!!
 
-            val integrationRepository = serverManager.integrationRepository(selectedServerId)
             val webSocketRepository = serverManager.webSocketRepository(selectedServerId)
-            val name = integrationRepository.getEntity(listEntityId)?.friendlyName
+            // The selection is valid, so the name is the one already resolved for the picker
+            val name = (displayEntities.value as? EntityDisplayState.Loaded)?.entity(listEntityId)?.name
             val todos = webSocketRepository.getTodos(listEntityId)?.response?.get(listEntityId)?.items.orEmpty()
 
             return TodoWidgetEntity(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetState.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetState.kt
@@ -9,8 +9,7 @@ import androidx.core.graphics.toColorInt
 import androidx.glance.GlanceTheme
 import androidx.glance.color.ColorProviders
 import androidx.glance.material.ColorProviders
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetTodosResponse.TodoItem.Companion.COMPLETED_STATUS
 import io.homeassistant.companion.android.common.util.SdkVersion
 import io.homeassistant.companion.android.database.widget.TodoWidgetEntity
@@ -91,15 +90,15 @@ internal data class TodoStateWithData(
          */
         fun from(
             todoEntity: TodoWidgetEntity,
-            entity: Entity,
+            displayEntity: EntityDisplay,
             todos: List<TodoWidgetEntity.TodoItem>,
         ): TodoStateWithData {
             return TodoStateWithData(
                 backgroundType = todoEntity.backgroundType,
                 textColor = todoEntity.textColor,
                 serverId = todoEntity.serverId,
-                listEntityId = entity.entityId,
-                listName = entity.friendlyName,
+                listEntityId = displayEntity.entityId,
+                listName = displayEntity.name,
                 todoItems = todos.map(TodoItemState::from),
                 outOfSync = false,
                 showComplete = todoEntity.showCompleted,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdater.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdater.kt
@@ -1,7 +1,7 @@
 package io.homeassistant.companion.android.widgets.todo
 
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayState
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.database.widget.TodoWidgetDao
@@ -14,11 +14,9 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onCompletion
-import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 
 /**
@@ -26,60 +24,10 @@ import timber.log.Timber
  * by exposing a flow through [stateFlow].
  */
 internal class TodoWidgetStateUpdater @Inject constructor(
-    val todoWidgetDao: TodoWidgetDao,
-    val serverManager: ServerManager,
+    private val todoWidgetDao: TodoWidgetDao,
+    private val serverManager: ServerManager,
+    private val entitiesForDisplayManager: EntitiesForDisplayManager,
 ) {
-
-    private suspend fun WebSocketRepository.getTodoItems(listEntityId: String): List<TodoWidgetEntity.TodoItem> {
-        return getTodos(listEntityId)?.response?.get(listEntityId)?.items.orEmpty().map {
-            TodoWidgetEntity.TodoItem(
-                uid = it.uid,
-                summary = it.summary,
-                status = it.status,
-            )
-        }
-    }
-
-    private fun getTodoEntityOnConfigurationChange(widgetId: Int): Flow<TodoWidgetEntity> {
-        // The flow starts with a null dao entity until the configuration is done
-        // We emit again when the configuration f the widget change
-        return todoWidgetDao.getFlow(widgetId).filterNotNull().distinctUntilChanged { old, new ->
-            old.isSameConfiguration(new)
-        }
-    }
-
-    private suspend fun getAndSubscribeEntityUpdates(serverId: Int, listEntityId: String): Flow<Entity?>? {
-        if (serverManager.getServer(serverId) == null) {
-            Timber.w("Server has been removed and the widget needs to be reconfigured")
-            return null
-        }
-
-        // Since we might be re-subscribing we might not have get the entity update when subscribing so we query it first
-        val currentEntity = serverManager.integrationRepository(serverId).getEntity(listEntityId)
-
-        val entityUpdateFlow = serverManager.integrationRepository(serverId).getEntityUpdates(listOf(listEntityId))
-
-        if (entityUpdateFlow == null) {
-            Timber.w("Integration return null for entity update the widget won't update")
-        }
-
-        return entityUpdateFlow?.onStart {
-            currentEntity?.let {
-                emit(currentEntity)
-            }
-        }
-    }
-
-    private fun getInitialStateFlow(widgetId: Int): Flow<TodoState> {
-        return suspend { todoWidgetDao.get(widgetId) }.asFlow().map {
-            if (it == null) {
-                EmptyTodoState
-            } else {
-                TodoStateWithData.from(it)
-            }
-        }
-    }
-
     /**
      * Observes and provides the state of the widget identified by the given [widgetId].
      *
@@ -105,22 +53,34 @@ internal class TodoWidgetStateUpdater @Inject constructor(
                 val serverId = todoEntity.serverId
                 val listEntityId = todoEntity.entityId
 
-                getAndSubscribeEntityUpdates(
-                    serverId,
-                    listEntityId,
-                )?.filterNotNull()?.distinctUntilChanged()?.map { entity ->
-                    Timber.d("Got an update of the entity $entity getting todos")
-                    val todos = serverManager.webSocketRepository(serverId).getTodoItems(listEntityId)
-                    // We update the DAO to keep it up to date for the next update of the widget
-                    todoWidgetDao.updateWidgetLastUpdate(
-                        widgetId = widgetId,
-                        lastUpdateData = TodoWidgetEntity.LastUpdateData(
-                            entityName = entity.friendlyName,
-                            todos = todos,
-                        ),
-                    )
-                    TodoStateWithData.from(todoEntity, entity, todos)
-                } ?: flowOf(TodoStateWithData.from(todoEntity))
+                // Every emission is a change of the entity or of its name, so each one refreshes
+                entitiesForDisplayManager.observe(serverId, listOf(listEntityId))
+                    .map { state ->
+                        val displayEntity = when (state) {
+                            // Nothing was ever loaded for this widget, so there is nothing to show yet
+                            EntityDisplayState.Loading if todoEntity.latestUpdateData == null -> {
+                                return@map LoadingTodoState
+                            }
+                            // Still loading, or the entity is gone (removed server, deleted list),
+                            // so the widget keeps showing the data of the database
+                            EntityDisplayState.Loading, EntityDisplayState.Error -> {
+                                return@map TodoStateWithData.from(todoEntity)
+                            }
+                            is EntityDisplayState.Loaded -> state.entity(listEntityId)
+                                ?: return@map TodoStateWithData.from(todoEntity)
+                        }
+                        Timber.d("Got an update of the entity ${displayEntity.entityId} getting todos")
+                        val todos = serverManager.webSocketRepository(serverId).getTodoItems(listEntityId)
+                        // We update the DAO to keep it up to date for the next update of the widget
+                        todoWidgetDao.updateWidgetLastUpdate(
+                            widgetId = widgetId,
+                            lastUpdateData = TodoWidgetEntity.LastUpdateData(
+                                entityName = displayEntity.name,
+                                todos = todos,
+                            ),
+                        )
+                        TodoStateWithData.from(todoEntity, displayEntity, todos)
+                    }
             }
 
         // Initial state should emit before watch but if an issue occur make it explicit in the flow
@@ -129,6 +89,34 @@ internal class TodoWidgetStateUpdater @Inject constructor(
             Timber.e(it, "Error while watching for changes for widget $widgetId")
         }.onCompletion {
             Timber.d("Stop watching for changes for widget $widgetId")
+        }
+    }
+
+    private suspend fun WebSocketRepository.getTodoItems(listEntityId: String): List<TodoWidgetEntity.TodoItem> {
+        return getTodos(listEntityId)?.response?.get(listEntityId)?.items.orEmpty().map {
+            TodoWidgetEntity.TodoItem(
+                uid = it.uid,
+                summary = it.summary,
+                status = it.status,
+            )
+        }
+    }
+
+    private fun getTodoEntityOnConfigurationChange(widgetId: Int): Flow<TodoWidgetEntity> {
+        // The flow starts with a null dao entity until the configuration is done
+        // We emit again when the configuration f the widget change
+        return todoWidgetDao.getFlow(widgetId).filterNotNull().distinctUntilChanged { old, new ->
+            old.isSameConfiguration(new)
+        }
+    }
+
+    private fun getInitialStateFlow(widgetId: Int): Flow<TodoState> {
+        return suspend { todoWidgetDao.get(widgetId) }.asFlow().map {
+            if (it == null) {
+                EmptyTodoState
+            } else {
+                TodoStateWithData.from(it)
+            }
         }
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateTest.kt
@@ -1,5 +1,8 @@
 package io.homeassistant.companion.android.widgets.todo
 
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial.Icon
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetTodosResponse.TodoItem.Companion.COMPLETED_STATUS
 import io.homeassistant.companion.android.database.widget.TodoWidgetEntity
 import io.homeassistant.companion.android.database.widget.WidgetBackgroundType
@@ -63,14 +66,14 @@ class TodoWidgetStateTest {
             serverId = 1,
             entityId = "41",
         )
-        val entity = fakeServerEntity("41", friendlyName = "home")
+        val displayEntity = fakeEntityDisplay("41", "home")
 
         val todos = listOf(
             TodoWidgetEntity.TodoItem(uid = "1", summary = "Task 1", status = COMPLETED_STATUS),
             TodoWidgetEntity.TodoItem(uid = "2", summary = "Task 2", status = "hello"),
         )
 
-        val result = TodoStateWithData.from(todoEntity, entity, todos)
+        val result = TodoStateWithData.from(todoEntity, displayEntity, todos)
 
         assertEquals(WidgetBackgroundType.DAYNIGHT, result.backgroundType)
         assertEquals("#FFFFFF", result.textColor)
@@ -166,5 +169,9 @@ class TodoWidgetStateTest {
         )
 
         assertFalse(todoState.hasDisplayableItems())
+    }
+
+    private fun fakeEntityDisplay(entityId: String, name: String, icon: IIcon? = null): EntityDisplayWithoutContext {
+        return EntityDisplayWithoutContext(entityId, name, icon ?: Icon.cmd_bookmark)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdaterTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/todo/TodoWidgetStateUpdaterTest.kt
@@ -2,18 +2,22 @@ package io.homeassistant.companion.android.widgets.todo
 
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.IntegrationRepository
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial.Icon
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayState
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketRepository
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.GetTodosResponse
 import io.homeassistant.companion.android.database.widget.TodoWidgetDao
 import io.homeassistant.companion.android.database.widget.TodoWidgetEntity
 import io.mockk.coEvery
-import io.mockk.coJustAwait
 import io.mockk.coJustRun
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.delay
@@ -26,13 +30,12 @@ import org.junit.jupiter.api.Test
 class TodoWidgetStateUpdaterTest {
 
     private val dao = mockk<TodoWidgetDao>()
-    private val integrationRepository = mockk<IntegrationRepository>()
     private val webSocketRepository = mockk<WebSocketRepository>()
     private val serverManager = mockk<ServerManager>().apply {
-        coEvery { integrationRepository(any()) } returns integrationRepository
         coEvery { webSocketRepository(any()) } returns webSocketRepository
     }
-    private val updater = TodoWidgetStateUpdater(dao, serverManager)
+    private val entitiesForDisplayManager = mockk<EntitiesForDisplayManager>()
+    private val updater = TodoWidgetStateUpdater(dao, serverManager, entitiesForDisplayManager)
 
     /*
 Initial state emission
@@ -64,8 +67,7 @@ Initial state emission
             awaitClose()
         }
         coEvery { dao.get(widgetId) } returns todoWidgetEntity
-        coEvery { serverManager.getServer(any<Int>()) } returns mockk()
-        coJustAwait { integrationRepository.getEntity(entityId) }
+        mockDisplayEntities(entityId) { awaitClose() }
 
         updater.stateFlow(42).test {
             val state = awaitItem()
@@ -85,8 +87,8 @@ Initial state emission
             awaitClose()
         }
         coEvery { dao.get(widgetId) } returns todoWidgetEntity
-        coEvery { serverManager.getServer(any<Int>()) } returns null
-        coJustAwait { integrationRepository.getEntity(entityId) }
+        // A removed server has nothing to observe, so the widget keeps the data of the database
+        mockDisplayEntities(entityId) { send(EntityDisplayState.Error) }
 
         updater.stateFlow(42).test {
             assertEquals(TodoStateWithData.from(todoWidgetEntity), awaitItem())
@@ -117,7 +119,7 @@ Watch for update
         val widgetId = 42
         val entityId = "test"
         val todoWidgetEntity = TodoWidgetEntity(widgetId, 1, entityId)
-        val serverEntity = fakeServerEntity(entityId)
+        val displayEntity = fakeEntityDisplay(entityId, "My list")
         val getTodoResponse = GetTodosResponse.TodoItem("testUID", "test", "test")
         val getTodosResponse = fakeTodosResponse(entityId, items = listOf(getTodoResponse))
 
@@ -128,10 +130,9 @@ Watch for update
             awaitClose()
         }
         coJustRun { dao.updateWidgetLastUpdate(any(), any()) }
-        coEvery { serverManager.getServer(any<Int>()) } returns mockk()
 
-        coEvery { integrationRepository.getEntity(entityId) } returns serverEntity
-        coEvery { integrationRepository.getEntityUpdates(any()) } returns channelFlow {
+        mockDisplayEntities(entityId) {
+            send(loaded(displayEntity))
             awaitClose()
         }
 
@@ -142,7 +143,7 @@ Watch for update
             assertEquals(
                 TodoStateWithData.from(
                     todoWidgetEntity,
-                    serverEntity,
+                    displayEntity,
                     listOf(
                         TodoWidgetEntity.TodoItem(
                             uid = getTodoResponse.uid,
@@ -164,12 +165,12 @@ Watch for update
         val widgetId = 42
         val entityId = "test"
         val todoWidgetEntity = TodoWidgetEntity(widgetId, 1, entityId)
-        val serverEntity = fakeServerEntity(entityId)
+        val displayEntity = fakeEntityDisplay(entityId, "My list")
         val getTodoResponse = GetTodosResponse.TodoItem("testUID", "test", "test")
         val getTodosResponse = fakeTodosResponse(entityId, items = listOf(getTodoResponse))
 
         var daoFlowEmitter: ProducerScope<TodoWidgetEntity?>? = null
-        var entityUpdatesEmitter: ProducerScope<Entity>? = null
+        var entityUpdatesEmitter: ProducerScope<EntityDisplayState<EntityDisplayWithoutContext>>? = null
 
         mockInitialStateForEmpty()
 
@@ -179,11 +180,10 @@ Watch for update
             awaitClose()
         }
         coJustRun { dao.updateWidgetLastUpdate(any(), any()) }
-        coEvery { serverManager.getServer(any<Int>()) } returns mockk()
 
-        coEvery { integrationRepository.getEntity(entityId) } returns serverEntity
-        coEvery { integrationRepository.getEntityUpdates(any()) } returns channelFlow {
+        mockDisplayEntities(entityId) {
             entityUpdatesEmitter = this
+            send(loaded(displayEntity))
             awaitClose()
         }
 
@@ -209,25 +209,24 @@ Watch for update
             verifyDaoUpdate(exactly = 2)
             verifyEntityUpdates(exactly = 2) // Subscribe a second time since the configuration changed
 
-            // Send same EntityUpdate doesn't do anything
-            entityUpdatesEmitter!!.send(serverEntity)
-            verifyDaoUpdate(exactly = 2)
-
-            // Send new EntityUpdate trigger an update
-            entityUpdatesEmitter.send(serverEntity.copy(attributes = mapOf("test" to 1)))
+            // Every emission is a change of the entity upstream, so each one refreshes the todos
+            entityUpdatesEmitter!!.send(loaded(displayEntity))
             awaitItem()
             verifyDaoUpdate(exactly = 3)
+
+            entityUpdatesEmitter.send(loaded(displayEntity.copy(name = "Renamed list")))
+            awaitItem()
+            verifyDaoUpdate(exactly = 4)
 
             expectNoEvents()
         }
     }
 
     @Test
-    fun `Given widgetID in DAO when subscribing to stateFlow with null entityUpdates then it emits dao entity with out of sync`() = runTest {
+    fun `Given widgetID in DAO when subscribing to stateFlow without entity to observe then it emits dao entity with out of sync`() = runTest {
         val widgetId = 42
         val entityId = "test"
         val todoWidgetEntity = TodoWidgetEntity(widgetId, 1, entityId)
-        val serverEntity = fakeServerEntity(entityId)
 
         mockInitialStateForEmpty()
 
@@ -236,10 +235,8 @@ Watch for update
             awaitClose()
         }
         coJustRun { dao.updateWidgetLastUpdate(any(), any()) }
-        coEvery { serverManager.getServer(any<Int>()) } returns mockk()
 
-        coEvery { integrationRepository.getEntity(entityId) } returns serverEntity
-        coEvery { integrationRepository.getEntityUpdates(any()) } returns null
+        mockDisplayEntities(entityId) { send(EntityDisplayState.Error) }
 
         updater.stateFlow(widgetId).test {
             awaitEmptyTodoState()
@@ -253,9 +250,74 @@ Watch for update
         }
     }
 
+    @Test
+    fun `Given widget without data in DAO when loading then emits loading state`() = runTest {
+        val widgetId = 42
+        val entityId = "test"
+        val todoWidgetEntity = TodoWidgetEntity(widgetId, 1, entityId)
+        val displayEntity = fakeEntityDisplay(entityId, "My list")
+
+        mockInitialStateForEmpty()
+
+        coEvery { dao.getFlow(widgetId) } returns channelFlow {
+            send(todoWidgetEntity)
+            awaitClose()
+        }
+        coJustRun { dao.updateWidgetLastUpdate(any(), any()) }
+        coEvery { webSocketRepository.getTodos(entityId) } returns fakeTodosResponse(entityId)
+
+        mockDisplayEntities(entityId) {
+            send(EntityDisplayState.Loading)
+            send(loaded(displayEntity))
+            awaitClose()
+        }
+
+        updater.stateFlow(widgetId).test {
+            awaitEmptyTodoState()
+            // Nothing was ever loaded for this widget, an empty list would be misleading
+            assertEquals(LoadingTodoState, awaitItem())
+            assertEquals(TodoStateWithData.from(todoWidgetEntity, displayEntity, emptyList()), awaitItem())
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `Given widget with data in DAO when loading then emits the DAO data instead of loading`() = runTest {
+        val widgetId = 42
+        val entityId = "test"
+        val todoWidgetEntity = TodoWidgetEntity(widgetId, 1, entityId).copy(
+            latestUpdateData = TodoWidgetEntity.LastUpdateData(
+                entityName = "My list",
+                todos = listOf(TodoWidgetEntity.TodoItem(uid = "1", summary = "Task 1", status = "needs_action")),
+            ),
+        )
+
+        coEvery { dao.getFlow(widgetId) } returns channelFlow {
+            send(todoWidgetEntity)
+            awaitClose()
+        }
+        coEvery { dao.get(widgetId) } returns todoWidgetEntity
+
+        mockDisplayEntities(entityId) {
+            send(EntityDisplayState.Loading)
+            awaitClose()
+        }
+
+        updater.stateFlow(widgetId).test {
+            // The cached data is shown while loading rather than a spinner over readable content
+            assertEquals(TodoStateWithData.from(todoWidgetEntity), awaitItem())
+            assertEquals(TodoStateWithData.from(todoWidgetEntity), awaitItem())
+            expectNoEvents()
+        }
+    }
+
+    private fun fakeEntityDisplay(entityId: String, name: String, icon: IIcon? = null): EntityDisplayWithoutContext {
+        return EntityDisplayWithoutContext(entityId, name, icon ?: Icon.cmd_bookmark)
+    }
+
     private fun verifyEntityUpdates(exactly: Int) {
-        coVerify(exactly = exactly) {
-            integrationRepository.getEntityUpdates(any())
+        verify(exactly = exactly) {
+            entitiesForDisplayManager.observe(any(), any())
         }
     }
 
@@ -283,4 +345,12 @@ Watch for update
     private fun mockInitialStateForEmpty() {
         coEvery { dao.get(any()) } returns null
     }
+
+    private fun mockDisplayEntities(entityId: String, emissions: suspend ProducerScope<EntityDisplayState<EntityDisplayWithoutContext>>.() -> Unit) {
+        every { entitiesForDisplayManager.observe(any(), listOf(entityId)) } returns channelFlow {
+            emissions()
+        }
+    }
+
+    private fun loaded(display: EntityDisplayWithoutContext) = EntityDisplayState.Loaded(listOf(display))
 }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Closes #7242. Replace the usge of friendly name within the TODO widget with the EntityDisplay.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.