### PR TITLE
FriendlyState allow show/hide unit

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -950,7 +950,7 @@ private fun sensorIcon(state: String?, entity: Entity): IIcon {
     }
 
     if (icon == null) {
-        val unitOfMeasurement = entity.attributes["unit_of_measurement"]
+        val unitOfMeasurement = entity.unitOfMeasurement()
         if (unitOfMeasurement != null && unitOfMeasurement in listOf("°C", "°F")) {
             icon = Icon3.cmd_thermometer
         }
@@ -1036,7 +1036,7 @@ val Entity.friendlyName: String
  * through `EntitiesForDisplayManager`.
  */
 fun Entity.friendlyState(context: Context, appendUnitOfMeasurement: Boolean = false): String =
-    friendlyState(displayPrecision = null, appendUnitOfMeasurement = appendUnitOfMeasurement).resolve(context)
+    friendlyState(displayPrecision = null).resolve(context, withUnit = appendUnitOfMeasurement)
 
 fun Entity.friendlyState(
     context: Context,
@@ -1044,10 +1044,14 @@ fun Entity.friendlyState(
     appendUnitOfMeasurement: Boolean = false,
 ): String = friendlyState(
     displayPrecision = options?.sensor?.let { it.displayPrecision ?: it.suggestedDisplayPrecision },
-    appendUnitOfMeasurement = appendUnitOfMeasurement,
-).resolve(context)
+).resolve(context, withUnit = appendUnitOfMeasurement)
 
 fun Entity.canSupportPrecision() = domain == "sensor" && state.toDoubleOrNull() != null
+
+/** The unit of measurement of the entity, null when it has none or it is blank. */
+fun Entity.unitOfMeasurement(): String? = attributes["unit_of_measurement"]?.toString()?.takeIf {
+    it.isNotBlank()
+}
 
 fun Entity.isExecuting() = when (state) {
     "arming" -> true

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyState.kt
@@ -19,8 +19,17 @@ import java.util.Locale
  */
 @Immutable
 sealed interface FriendlyState {
-    /** Resolves the display text, localizing with [context]. */
+    /**
+     * Resolves the display text, localizing with [context]. The unit of measurement is left out;
+     * use `resolve(context, withUnit = true)` to append it.
+     */
     fun resolve(context: Context): String
+
+    /**
+     * Resolves the display text, dropping the unit of measurement when [withUnit] is false. Only
+     * [WithUnit] carries a unit, so the other states resolve the same regardless of the flag.
+     */
+    fun resolve(context: Context, withUnit: Boolean): String = resolve(context)
 
     /** A translated state, see the `state_*` string resources. */
     data class Resource(@StringRes val resId: Int) : FriendlyState {
@@ -42,9 +51,15 @@ sealed interface FriendlyState {
         ).toString()
     }
 
-    /** A state with its unit of measurement appended. */
+    /**
+     * A state carrying its unit of measurement. Rendering the unit is opt-in: the default [resolve]
+     * leaves it out, `resolve(context, withUnit = true)` appends it.
+     */
     data class WithUnit(val state: FriendlyState, val unit: String) : FriendlyState {
-        override fun resolve(context: Context): String = "${state.resolve(context)} $unit"
+        override fun resolve(context: Context): String = resolve(context, withUnit = false)
+
+        override fun resolve(context: Context, withUnit: Boolean): String =
+            if (withUnit) "${state.resolve(context)} $unit" else state.resolve(context)
     }
 }
 
@@ -52,7 +67,7 @@ sealed interface FriendlyState {
  * Core [friendlyState] resolution, exposed to display consumers through `EntityDisplayItem.state`.
  * Context-free: the returned [FriendlyState] localizes at render time.
  */
-internal fun Entity.friendlyState(displayPrecision: Int?, appendUnitOfMeasurement: Boolean = false): FriendlyState {
+internal fun Entity.friendlyState(displayPrecision: Int?): FriendlyState {
     val resource = stateResource()
     val friendlyState = when {
         resource != null -> FriendlyState.Resource(resource)
@@ -61,13 +76,8 @@ internal fun Entity.friendlyState(displayPrecision: Int?, appendUnitOfMeasuremen
             ?: FriendlyState.Literal(titleCasedState())
     }
 
-    if (appendUnitOfMeasurement) {
-        val unit = attributes["unit_of_measurement"]?.toString()
-        if (unit?.isNotBlank() == true) {
-            return FriendlyState.WithUnit(friendlyState, unit)
-        }
-    }
-    return friendlyState
+    // The unit is always stored, whether it is displayed is decided when resolving the state
+    return unitOfMeasurement()?.let { FriendlyState.WithUnit(friendlyState, it) } ?: friendlyState
 }
 
 /** The `state_*` string resource translating the state, or null when there is none. */

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyState.kt
@@ -20,30 +20,24 @@ import java.util.Locale
 @Immutable
 sealed interface FriendlyState {
     /**
-     * Resolves the display text, localizing with [context]. The unit of measurement is left out;
-     * use `resolve(context, withUnit = true)` to append it.
+     * Resolves the display text, appending the unit of measurement when [withUnit] is true and
+     * the state carries one ([WithUnit]).
      */
-    fun resolve(context: Context): String
-
-    /**
-     * Resolves the display text, dropping the unit of measurement when [withUnit] is false. Only
-     * [WithUnit] carries a unit, so the other states resolve the same regardless of the flag.
-     */
-    fun resolve(context: Context, withUnit: Boolean): String = resolve(context)
+    fun resolve(context: Context, withUnit: Boolean = false): String = resolve(context)
 
     /** A translated state, see the `state_*` string resources. */
     data class Resource(@StringRes val resId: Int) : FriendlyState {
-        override fun resolve(context: Context): String = context.getString(resId)
+        override fun resolve(context: Context, withUnit: Boolean): String = context.getString(resId)
     }
 
     /** Text needing no localization, like a precision-formatted number. */
     data class Literal(val value: String) : FriendlyState {
-        override fun resolve(context: Context): String = value
+        override fun resolve(context: Context, withUnit: Boolean): String = value
     }
 
     /** A timestamp state shown relative to now, resolved at render time so it stays current. */
     data class RelativeTime(val epochMillis: Long) : FriendlyState {
-        override fun resolve(context: Context): String = DateUtils.getRelativeTimeSpanString(
+        override fun resolve(context: Context, withUnit: Boolean): String = DateUtils.getRelativeTimeSpanString(
             epochMillis,
             System.currentTimeMillis(),
             0,
@@ -56,8 +50,6 @@ sealed interface FriendlyState {
      * leaves it out, `resolve(context, withUnit = true)` appends it.
      */
     data class WithUnit(val state: FriendlyState, val unit: String) : FriendlyState {
-        override fun resolve(context: Context): String = resolve(context, withUnit = false)
-
         override fun resolve(context: Context, withUnit: Boolean): String =
             if (withUnit) "${state.resolve(context)} $unit" else state.resolve(context)
     }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyStateTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/FriendlyStateTest.kt
@@ -206,7 +206,7 @@ class FriendlyStateTest {
     // region Unit of measurement
 
     @Test
-    fun `Given a unit of measurement when appending it then the state is wrapped with the unit`() {
+    fun `Given a unit of measurement when resolving the state then it is wrapped with the unit`() {
         val entity = createEntity(
             entityId = "sensor.temperature",
             state = "20.126456",
@@ -215,26 +215,26 @@ class FriendlyStateTest {
 
         assertEquals(
             FriendlyState.WithUnit(FriendlyState.Literal("20.13"), "°C"),
-            entity.friendlyState(displayPrecision = 2, appendUnitOfMeasurement = true),
+            entity.friendlyState(displayPrecision = 2),
         )
     }
 
     @Test
-    fun `Given a unit of measurement when not appending it then the state is not wrapped`() {
+    fun `Given no unit of measurement when resolving the state then it is not wrapped`() {
         val entity = createEntity(
             entityId = "sensor.temperature",
             state = "20.126456",
-            attributes = mapOf("unit_of_measurement" to "°C"),
+            attributes = emptyMap(),
         )
 
         assertEquals(
             FriendlyState.Literal("20.126456"),
-            entity.friendlyState(displayPrecision = null, appendUnitOfMeasurement = false),
+            entity.friendlyState(displayPrecision = null),
         )
     }
 
     @Test
-    fun `Given a blank unit of measurement when appending it then the state is not wrapped`() {
+    fun `Given a blank unit of measurement when resolving the state then it is not wrapped`() {
         val entity = createEntity(
             entityId = "sensor.temperature",
             state = "20.126456",
@@ -243,12 +243,12 @@ class FriendlyStateTest {
 
         assertEquals(
             FriendlyState.Literal("20.126456"),
-            entity.friendlyState(displayPrecision = null, appendUnitOfMeasurement = true),
+            entity.friendlyState(displayPrecision = null),
         )
     }
 
     @Test
-    fun `Given a translated state with a unit of measurement when appending it then the resource keeps the unit`() {
+    fun `Given a translated state with a unit of measurement when resolving then the resource keeps the unit`() {
         val entity = createEntity(
             entityId = "sensor.status",
             state = "on",
@@ -257,7 +257,7 @@ class FriendlyStateTest {
 
         assertEquals(
             FriendlyState.WithUnit(FriendlyState.Resource(commonR.string.state_on), "W"),
-            entity.friendlyState(displayPrecision = null, appendUnitOfMeasurement = true),
+            entity.friendlyState(displayPrecision = null),
         )
     }
 
@@ -276,10 +276,17 @@ class FriendlyStateTest {
     }
 
     @Test
-    fun `Given a state with a unit when resolving then the unit is separated by a space`() {
+    fun `Given a state with a unit when resolving by default then the unit is not appended`() {
         val state = FriendlyState.WithUnit(FriendlyState.Resource(commonR.string.state_on), "W")
 
-        assertEquals("On W", state.resolve(context))
+        assertEquals("On", state.resolve(context))
+    }
+
+    @Test
+    fun `Given a state with a unit when resolving with the unit then it is separated by a space`() {
+        val state = FriendlyState.WithUnit(FriendlyState.Resource(commonR.string.state_on), "W")
+
+        assertEquals("On W", state.resolve(context, withUnit = true))
     }
 
     @Test


### PR DESCRIPTION
…etrable

<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR now replicate the previous behavior where it was possible to hide/show the unit on the state. To do so I've added a new resolve method to it and by default it doesn't show it.

Based on #7231 

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.