### PR TITLE
Remove friendly name usage from wear

### DIFF
--- a/common/schemas/io.homeassistant.companion.android.database.AppDatabase/53.json
+++ b/common/schemas/io.homeassistant.companion.android.database.AppDatabase/53.json
@@ -1,0 +1,1158 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 53,
+    "identityHash": "265c4166ed87c4c3c6c06c933f6b8741",
+    "entities": [
+      {
+        "tableName": "sensor_attributes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "authentication_list",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`host` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, PRIMARY KEY(`host`))",
+        "fields": [
+          {
+            "fieldPath": "host",
+            "columnName": "host",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "host"
+          ]
+        }
+      },
+      {
+        "tableName": "sensors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `enabled` INTEGER NOT NULL, `registered` INTEGER DEFAULT NULL, `state` TEXT NOT NULL, `last_sent_state` TEXT DEFAULT NULL, `last_sent_icon` TEXT DEFAULT NULL, `state_type` TEXT NOT NULL, `type` TEXT NOT NULL, `icon` TEXT NOT NULL, `name` TEXT NOT NULL, `device_class` TEXT, `unit_of_measurement` TEXT, `state_class` TEXT, `entity_category` TEXT, `core_registration` TEXT, `app_registration` TEXT, PRIMARY KEY(`id`, `server_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "registered",
+            "columnName": "registered",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSentState",
+            "columnName": "last_sent_state",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "lastSentIcon",
+            "columnName": "last_sent_icon",
+            "affinity": "TEXT",
+            "defaultValue": "NULL"
+          },
+          {
+            "fieldPath": "stateType",
+            "columnName": "state_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceClass",
+            "columnName": "device_class",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unitOfMeasurement",
+            "columnName": "unit_of_measurement",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "stateClass",
+            "columnName": "state_class",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "entityCategory",
+            "columnName": "entity_category",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coreRegistration",
+            "columnName": "core_registration",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appRegistration",
+            "columnName": "app_registration",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id",
+            "server_id"
+          ]
+        }
+      },
+      {
+        "tableName": "sensor_settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sensor_id` TEXT NOT NULL, `name` TEXT NOT NULL, `value` TEXT NOT NULL, `value_type` TEXT NOT NULL, `enabled` INTEGER NOT NULL, `entries` TEXT NOT NULL, PRIMARY KEY(`sensor_id`, `name`))",
+        "fields": [
+          {
+            "fieldPath": "sensorId",
+            "columnName": "sensor_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueType",
+            "columnName": "value_type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "enabled",
+            "columnName": "enabled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entries",
+            "columnName": "entries",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sensor_id",
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "button_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `icon_name` TEXT NOT NULL, `domain` TEXT NOT NULL, `service` TEXT NOT NULL, `service_data` TEXT NOT NULL, `label` TEXT, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, `require_authentication` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "icon_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "domain",
+            "columnName": "domain",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "service",
+            "columnName": "service",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serviceData",
+            "columnName": "service_data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "requireAuthentication",
+            "columnName": "require_authentication",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "camera_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `tap_action` TEXT NOT NULL DEFAULT 'REFRESH', PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tapAction",
+            "columnName": "tap_action",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'REFRESH'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "media_player_controls_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `label` TEXT, `show_skip` INTEGER NOT NULL, `show_seek` INTEGER NOT NULL, `show_volume` INTEGER NOT NULL, `show_source` INTEGER NOT NULL DEFAULT false, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showSkip",
+            "columnName": "show_skip",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showSeek",
+            "columnName": "show_seek",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showVolume",
+            "columnName": "show_volume",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showSource",
+            "columnName": "show_source",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "static_widget",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `attribute_ids` TEXT, `label` TEXT, `text_size` REAL NOT NULL, `state_separator` TEXT NOT NULL, `attribute_separator` TEXT NOT NULL, `tap_action` TEXT NOT NULL DEFAULT 'REFRESH', `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeIds",
+            "columnName": "attribute_ids",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stateSeparator",
+            "columnName": "state_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "attributeSeparator",
+            "columnName": "attribute_separator",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tapAction",
+            "columnName": "tap_action",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'REFRESH'"
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "todo_widget",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `entity_id` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, `show_completed` INTEGER NOT NULL DEFAULT true, `latest_update_data` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "showCompleted",
+            "columnName": "show_completed",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "latestUpdateData",
+            "columnName": "latest_update_data",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "template_widgets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `server_id` INTEGER NOT NULL DEFAULT 0, `template` TEXT NOT NULL, `text_size` REAL NOT NULL DEFAULT 12.0, `last_update` TEXT NOT NULL, `background_type` TEXT NOT NULL DEFAULT 'DAYNIGHT', `text_color` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "template",
+            "columnName": "template",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "textSize",
+            "columnName": "text_size",
+            "affinity": "REAL",
+            "notNull": true,
+            "defaultValue": "12.0"
+          },
+          {
+            "fieldPath": "lastUpdate",
+            "columnName": "last_update",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "backgroundType",
+            "columnName": "background_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'DAYNIGHT'"
+          },
+          {
+            "fieldPath": "textColor",
+            "columnName": "text_color",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "notification_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `received` INTEGER NOT NULL, `message` TEXT NOT NULL, `data` TEXT NOT NULL, `source` TEXT NOT NULL, `server_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "received",
+            "columnName": "received",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "location_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `created` INTEGER NOT NULL, `trigger` TEXT NOT NULL, `result` TEXT NOT NULL, `latitude` REAL, `longitude` REAL, `location_name` TEXT, `in_zones` TEXT NOT NULL DEFAULT '[]', `accuracy` INTEGER, `data` TEXT, `server_id` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trigger",
+            "columnName": "trigger",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "result",
+            "columnName": "result",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "locationName",
+            "columnName": "location_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "inZones",
+            "columnName": "in_zones",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "accuracy",
+            "columnName": "accuracy",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "data",
+            "columnName": "data",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "qs_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tile_id` TEXT NOT NULL, `added` INTEGER NOT NULL DEFAULT 1, `server_id` INTEGER NOT NULL DEFAULT 0, `icon_name` TEXT, `entity_id` TEXT NOT NULL, `label` TEXT NOT NULL, `subtitle` TEXT, `should_vibrate` INTEGER NOT NULL DEFAULT 0, `auth_required` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tileId",
+            "columnName": "tile_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "added",
+            "columnName": "added",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "iconName",
+            "columnName": "icon_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shouldVibrate",
+            "columnName": "should_vibrate",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "authRequired",
+            "columnName": "auth_required",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "favorites",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "favorite_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "camera_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT, `refresh_interval` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "refreshInterval",
+            "columnName": "refresh_interval",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "thermostat_tiles",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT, `refresh_interval` INTEGER, `target_temperature` REAL, `show_entity_name` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "refreshInterval",
+            "columnName": "refresh_interval",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "targetTemperature",
+            "columnName": "target_temperature",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "showEntityName",
+            "columnName": "show_entity_name",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "entity_state_complications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `entity_id` TEXT NOT NULL, `show_title` INTEGER NOT NULL DEFAULT 1, `show_unit` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "entityId",
+            "columnName": "entity_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showTitle",
+            "columnName": "show_title",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "1"
+          },
+          {
+            "fieldPath": "showUnit",
+            "columnName": "show_unit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "servers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `_name` TEXT NOT NULL, `name_override` TEXT, `_version` TEXT, `device_registry_id` TEXT, `list_order` INTEGER NOT NULL, `device_name` TEXT, `external_url` TEXT NOT NULL, `internal_url` TEXT, `cloud_url` TEXT, `webhook_id` TEXT, `secret` TEXT, `cloudhook_url` TEXT, `use_cloud` INTEGER NOT NULL, `internal_ssids` TEXT NOT NULL, `internal_ethernet` INTEGER, `internal_vpn` INTEGER, `prioritize_internal` INTEGER NOT NULL, `allow_insecure_connection` INTEGER, `access_token` TEXT, `refresh_token` TEXT, `token_expiration` INTEGER, `token_type` TEXT, `install_id` TEXT, `user_id` TEXT, `user_name` TEXT, `user_is_owner` INTEGER, `user_is_admin` INTEGER)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "_name",
+            "columnName": "_name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nameOverride",
+            "columnName": "name_override",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "_version",
+            "columnName": "_version",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deviceRegistryId",
+            "columnName": "device_registry_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "listOrder",
+            "columnName": "list_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "device_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.externalUrl",
+            "columnName": "external_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.internalUrl",
+            "columnName": "internal_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.cloudUrl",
+            "columnName": "cloud_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.webhookId",
+            "columnName": "webhook_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.secret",
+            "columnName": "secret",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.cloudhookUrl",
+            "columnName": "cloudhook_url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connection.useCloud",
+            "columnName": "use_cloud",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.internalSsids",
+            "columnName": "internal_ssids",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.internalEthernet",
+            "columnName": "internal_ethernet",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "connection.internalVpn",
+            "columnName": "internal_vpn",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "connection.prioritizeInternal",
+            "columnName": "prioritize_internal",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "connection.allowInsecureConnection",
+            "columnName": "allow_insecure_connection",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "session.accessToken",
+            "columnName": "access_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "session.refreshToken",
+            "columnName": "refresh_token",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "session.tokenExpiration",
+            "columnName": "token_expiration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "session.tokenType",
+            "columnName": "token_type",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "session.installId",
+            "columnName": "install_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "user.id",
+            "columnName": "user_id",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "user.name",
+            "columnName": "user_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "user.isOwner",
+            "columnName": "user_is_owner",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "user.isAdmin",
+            "columnName": "user_is_admin",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "settings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `websocket_setting` TEXT NOT NULL, `sensor_update_frequency` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "websocketSetting",
+            "columnName": "websocket_setting",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sensorUpdateFrequency",
+            "columnName": "sensor_update_frequency",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '265c4166ed87c4c3c6c06c933f6b8741')"
+    ]
+  }
+}

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -155,6 +155,15 @@ data class ColorTemperatureControl(val current: Float, val min: Float, val max: 
 @Immutable
 data class LightControls(val brightness: EntityPosition?, val colorTemperature: ColorTemperatureControl?)
 
+/** Controls of a climate entity, resolved from its state attributes, each null when it has none. */
+@Immutable
+data class ClimateControls(
+    val currentTemperature: Float?,
+    val targetTemperature: Float?,
+    val targetTemperatureStep: Float?,
+    val hvacAction: String?,
+)
+
 object EntityExt {
     const val TAG = "EntityExt"
 
@@ -442,6 +451,22 @@ fun Entity.getCoordinates(): EntityCoordinates? {
 }
 
 private fun Entity.floatAttributeOrNull(name: String): Float? = (attributes[name] as? Number)?.toFloat()
+
+/** Controls of a climate entity, null when the entity is not a climate one. */
+fun Entity.getClimateControls(): ClimateControls? {
+    if (domain != CLIMATE_DOMAIN) return null
+
+    /** Numeric attribute of the entity, accepting both a number and a numeric string, else null. */
+    fun Entity.numberAttributeOrNull(name: String): Float? =
+        floatAttributeOrNull(name) ?: attributes[name]?.toString()?.toFloatOrNull()
+
+    return ClimateControls(
+        currentTemperature = numberAttributeOrNull("current_temperature"),
+        targetTemperature = numberAttributeOrNull("temperature"),
+        targetTemperatureStep = numberAttributeOrNull("target_temp_step"),
+        hvacAction = attributes["hvac_action"]?.toString(),
+    )
+}
 
 fun Entity.getLightColor(): Int? {
     // https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/cards/hui-light-card.ts#L243

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplay.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplay.kt
@@ -3,6 +3,7 @@ package io.homeassistant.companion.android.common.data.integration.display
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.LayoutDirection
 import com.mikepenz.iconics.typeface.IIcon
+import io.homeassistant.companion.android.common.data.integration.ClimateControls
 import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityCoordinates
 import io.homeassistant.companion.android.common.data.integration.EntityPosition
@@ -12,6 +13,7 @@ import io.homeassistant.companion.android.common.data.integration.IntegrationDom
 import io.homeassistant.companion.android.common.data.integration.LightControls
 import io.homeassistant.companion.android.common.data.integration.friendlyName
 import io.homeassistant.companion.android.common.data.integration.friendlyState
+import io.homeassistant.companion.android.common.data.integration.getClimateControls
 import io.homeassistant.companion.android.common.data.integration.getColorTemperature
 import io.homeassistant.companion.android.common.data.integration.getCoordinates
 import io.homeassistant.companion.android.common.data.integration.getCoverPosition
@@ -90,6 +92,9 @@ interface EntityDisplay {
     /** Controls of the entity, null when it is not a light. */
     val lightControls: LightControls?
 
+    /** Controls of the entity, null when it is not a climate one. */
+    val climateControls: ClimateControls?
+
     /**
      * When the state of the entity last changed.
      *
@@ -127,6 +132,7 @@ data class EntityDisplayWithoutContext(
     override val color: Int? = null,
     override val fanControls: FanControls? = null,
     override val lightControls: LightControls? = null,
+    override val climateControls: ClimateControls? = null,
     override val lastChanged: LocalDateTime? = null,
     override val lastUpdated: LocalDateTime? = null,
     override val isHidden: Boolean = false,
@@ -163,6 +169,7 @@ data class EntityDisplayWithoutContext(
         color = entity.getLightColor(),
         fanControls = entity.fanControls(),
         lightControls = entity.lightControls(),
+        climateControls = entity.getClimateControls(),
         lastChanged = entity.lastChanged,
         lastUpdated = entity.lastUpdated,
         isHidden = isHidden,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayState.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayState.kt
@@ -31,8 +31,10 @@ sealed interface EntityDisplayState<out T : EntityDisplay> {
 }
 
 /**
- * Awaits the resolved items of a snapshot flow, null when they could not be retrieved, for the
- * callers resolving entities once rather than observing them.
+ * Awaits the first [EntityDisplayState.Loaded] of the flow, for the callers resolving entities once
+ * rather than observing them. The [EntityDisplayState.Loading] emitted first is skipped, and null is
+ * returned when the flow completes without a loaded state (an [EntityDisplayState.Error]). Collecting
+ * an observing flow stops it after the first loaded state.
  */
 suspend fun <T : EntityDisplay> Flow<EntityDisplayState<T>>.awaitLoadedOrNull(): EntityDisplayState.Loaded<T>? =
     filterIsInstance<EntityDisplayState.Loaded<T>>().firstOrNull()

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/AppDatabase.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/AppDatabase.kt
@@ -10,6 +10,7 @@ import io.homeassistant.companion.android.database.location.LocationHistoryDao
 import io.homeassistant.companion.android.database.location.LocationHistoryItem
 import io.homeassistant.companion.android.database.migration.Migration27to28
 import io.homeassistant.companion.android.database.migration.Migration36to37
+import io.homeassistant.companion.android.database.migration.Migration52to53
 import io.homeassistant.companion.android.database.notification.NotificationDao
 import io.homeassistant.companion.android.database.notification.NotificationItem
 import io.homeassistant.companion.android.database.qs.TileDao
@@ -74,7 +75,7 @@ import io.homeassistant.companion.android.database.widget.WidgetTapActionConvert
         Server::class,
         Setting::class,
     ],
-    version = 52,
+    version = 53,
     autoMigrations = [
         AutoMigration(from = 24, to = 25),
         AutoMigration(from = 25, to = 26),
@@ -102,6 +103,7 @@ import io.homeassistant.companion.android.database.widget.WidgetTapActionConvert
         AutoMigration(from = 49, to = 50),
         AutoMigration(from = 50, to = 51),
         AutoMigration(from = 51, to = 52),
+        AutoMigration(from = 52, to = 53, spec = Migration52to53::class),
     ],
 )
 @TypeConverters(

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/migration/DatabaseMigration.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/migration/DatabaseMigration.kt
@@ -860,3 +860,14 @@ private class Migration40to41(private val context: Context) : Migration(40, 41) 
         }
     }
 }
+
+/**
+ * The cached name of a favorite is the display name of the entity, resolved from the entity
+ * registry, not its `friendly_name` state attribute anymore.
+ */
+@RenameColumn(
+    tableName = "favorite_cache",
+    fromColumnName = "friendly_name",
+    toColumnName = "name",
+)
+internal class Migration52to53 : AutoMigrationSpec

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/FavoriteCaches.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/FavoriteCaches.kt
@@ -12,8 +12,9 @@ data class FavoriteCaches(
     @PrimaryKey
     @ColumnInfo(name = "id")
     val id: String,
-    @ColumnInfo(name = "friendly_name")
-    val friendlyName: String,
+    /** Name to display for the entity, resolved when it was cached. */
+    @ColumnInfo(name = "name")
+    val name: String,
     @ColumnInfo(name = "icon")
     val icon: String?,
 )

--- a/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/ThermostatTile.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/database/wear/ThermostatTile.kt
@@ -23,7 +23,7 @@ data class ThermostatTile(
     /** The target temperature to allow quick repeated changes */
     @ColumnInfo(name = "target_temperature")
     val targetTemperature: Float? = null,
-    /** Whether or not to show the entity friendly name on the tile. */
+    /** Whether or not to show the entity name on the tile. */
     @ColumnInfo(name = "show_entity_name")
     val showEntityName: Boolean? = true,
 )

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/complications/ComplicationConfigViewModel.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/complications/ComplicationConfigViewModel.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.awaitLoadedOrNull
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketState
+import io.homeassistant.companion.android.common.util.mdiName
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.wear.EntityStateComplications
 import io.homeassistant.companion.android.database.wear.EntityStateComplicationsDao
@@ -24,6 +26,7 @@ import timber.log.Timber
 class ComplicationConfigViewModel @Inject constructor(
     application: Application,
     favoritesDao: FavoritesDao,
+    private val entitiesForDisplayManager: EntitiesForDisplayManager,
     private val serverManager: ServerManager,
     private val entityStateComplicationsDao: EntityStateComplicationsDao,
 ) : AndroidViewModel(application) {
@@ -40,7 +43,7 @@ class ComplicationConfigViewModel @Inject constructor(
         val entityShowTitle: Boolean = true,
         val entityShowUnit: Boolean = true,
         val entitiesByDomainOrder: List<String> = emptyList(),
-        val entitiesByDomain: Map<String, List<Entity>> = emptyMap(),
+        val entitiesByDomain: Map<String, List<EntityDisplay>> = emptyMap(),
         val favoriteEntityIds: List<String> = emptyList(),
     )
 
@@ -82,7 +85,10 @@ class ComplicationConfigViewModel @Inject constructor(
             try {
                 _viewState.update { it.copy(loadingState = LoadingState.LOADING) }
 
-                val entitiesList = serverManager.integrationRepository().getEntities()
+                val entitiesList = entitiesForDisplayManager
+                    .snapshotInContext(ServerManager.SERVER_ID_ACTIVE)
+                    .awaitLoadedOrNull()
+                    ?.entities
                     ?.sortedBy { it.entityId }
                     .orEmpty()
                 val domainsList = entitiesList.map { it.domain }.distinct()
@@ -120,13 +126,13 @@ class ComplicationConfigViewModel @Inject constructor(
      */
     private fun resolveEntity(
         entityId: String,
-        entitiesList: List<Entity> = _viewState.value.entitiesByDomain.values.flatten(),
+        entitiesList: List<EntityDisplay> = _viewState.value.entitiesByDomain.values.flatten(),
     ): SimplifiedEntity? {
-        val fullEntity = entitiesList.firstOrNull { it.entityId == entityId } ?: return null
+        val item = entitiesList.firstOrNull { it.entityId == entityId } ?: return null
         return SimplifiedEntity(
-            entityId = fullEntity.entityId,
-            friendlyName = fullEntity.friendlyName,
-            icon = fullEntity.attributes["icon"] as? String ?: "",
+            entityId = item.entityId,
+            name = item.name,
+            icon = item.statelessIcon.mdiName,
         )
     }
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
@@ -15,15 +15,11 @@ import com.mikepenz.iconics.IconicsDrawable
 import com.mikepenz.iconics.utils.colorInt
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R
-import io.homeassistant.companion.android.common.data.integration.canSupportPrecision
-import io.homeassistant.companion.android.common.data.integration.friendlyName
-import io.homeassistant.companion.android.common.data.integration.friendlyState
-import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.awaitLoadedOrNull
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.wear.EntityStateComplicationsDao
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
-import retrofit2.HttpException
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -34,6 +30,9 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
 
     @Inject
     lateinit var entityStateComplicationsDao: EntityStateComplicationsDao
+
+    @Inject
+    lateinit var entitiesForDisplayManager: EntitiesForDisplayManager
 
     override suspend fun onComplicationRequest(request: ComplicationRequest): ComplicationData? {
         if (request.complicationType != ComplicationType.SHORT_TEXT &&
@@ -46,51 +45,23 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
         val entityId = settings?.entityId
             ?: return getErrorComplication(request, R.string.complication_entity_invalid, true)
 
-        val entity = try {
-            serverManager.integrationRepository().getEntity(entityId)
-                ?: return getErrorComplication(request, R.string.state_unknown)
-        } catch (t: Throwable) {
-            Timber.e(t, "Unable to get entity state for $entityId")
-            return if (t is HttpException && t.code() == 404) {
-                getErrorComplication(request, R.string.complication_entity_invalid)
-            } else {
-                null
-            }
-        }
+        val displayEntity = entitiesForDisplayManager.snapshot(ServerManager.SERVER_ID_ACTIVE, listOf(entityId))
+            .awaitLoadedOrNull()
+            ?.entity(entityId)
+            ?: return getErrorComplication(request, R.string.complication_entity_invalid)
 
-        val entityOptions = if (
-            entity.canSupportPrecision() &&
-            serverManager.getServer()?.version?.isAtLeast(2023, 3) == true
-        ) {
-            try {
-                serverManager.webSocketRepository().getEntityRegistryFor(entityId)?.options
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                Timber.e(e, "Failed to get entity registry for $entityId")
-                null
-            }
-        } else {
-            null
-        }
-
-        val icon = entity.getIcon()
-        val iconBitmap = IconicsDrawable(this, icon).apply {
+        val iconBitmap = IconicsDrawable(this, displayEntity.icon).apply {
             colorInt = Color.WHITE
         }.toBitmap()
 
         val title = if (settings.showTitle) {
-            PlainComplicationText.Builder(entity.friendlyName).build()
+            PlainComplicationText.Builder(displayEntity.name).build()
         } else {
             null
         }
 
         val text = PlainComplicationText.Builder(
-            entity.friendlyState(
-                this,
-                entityOptions,
-                appendUnitOfMeasurement = settings.showUnit,
-            ),
+            displayEntity.state.resolve(this, withUnit = settings.showUnit),
         ).build()
 
         val contentDescription = PlainComplicationText.Builder(
@@ -110,6 +81,7 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
                     .setMonochromaticImage(monochromaticImage)
                     .build()
             }
+
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     text = text,
@@ -120,6 +92,7 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
                     .setMonochromaticImage(monochromaticImage)
                     .build()
             }
+
             else -> null // Already handled at the start of the function
         }
     }
@@ -146,6 +119,7 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
                     .setMonochromaticImage(monochromaticImage)
                     .build()
             }
+
             ComplicationType.LONG_TEXT -> {
                 LongTextComplicationData.Builder(
                     text = text,
@@ -155,6 +129,7 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
                     .setMonochromaticImage(monochromaticImage)
                     .build()
             }
+
             else -> {
                 Timber.w("Preview for unsupported complication type $type requested")
                 null

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/complications/EntityStateDataSourceService.kt
@@ -45,9 +45,10 @@ class EntityStateDataSourceService : SuspendingComplicationDataSourceService() {
         val entityId = settings?.entityId
             ?: return getErrorComplication(request, R.string.complication_entity_invalid, true)
 
-        val displayEntity = entitiesForDisplayManager.snapshot(ServerManager.SERVER_ID_ACTIVE, listOf(entityId))
-            .awaitLoadedOrNull()
-            ?.entity(entityId)
+        val loadedState = entitiesForDisplayManager.snapshot(ServerManager.SERVER_ID_ACTIVE, listOf(entityId))
+            .awaitLoadedOrNull() ?: return getErrorComplication(request, R.string.state_unknown)
+
+        val displayEntity = loadedState.entity(entityId)
             ?: return getErrorComplication(request, R.string.complication_entity_invalid)
 
         val iconBitmap = IconicsDrawable(this, displayEntity.icon).apply {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/complications/views/ComplicationConfigMainView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/complications/views/ComplicationConfigMainView.kt
@@ -117,7 +117,7 @@ fun MainConfigView(
                     secondaryLabel = {
                         Text(
                             if (loaded) {
-                                entity?.friendlyName ?: ""
+                                entity?.name ?: ""
                             } else {
                                 stringResource(R.string.loading)
                             },

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/data/SimplifiedEntity.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/data/SimplifiedEntity.kt
@@ -1,6 +1,6 @@
 package io.homeassistant.companion.android.data
 
-data class SimplifiedEntity(val entityId: String, val friendlyName: String = entityId, val icon: String = "") {
+data class SimplifiedEntity(val entityId: String, val name: String = entityId, val icon: String = "") {
     constructor(entityString: String) : this(
         entityString.split(",")[0],
         entityString.split(",")[1],
@@ -11,5 +11,5 @@ data class SimplifiedEntity(val entityId: String, val friendlyName: String = ent
         get() = entityId.split(".")[0]
 
     val entityString: String
-        get() = "$entityId,$friendlyName,$icon"
+        get() = "$entityId,$name,$icon"
 }

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomeActivity.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/HomeActivity.kt
@@ -27,10 +27,8 @@ import io.homeassistant.companion.android.onboarding.OnboardingActivity
 import io.homeassistant.companion.android.sensors.SensorReceiver
 import io.homeassistant.companion.android.tiles.OpenTileSettingsActivity
 import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class HomeActivity :
@@ -149,17 +147,7 @@ class HomeActivity :
 
         lifecycleScope.launch {
             lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
-                launch {
-                    mainViewModel.supportedEntities.collect {
-                        if (entityUpdateJob?.isActive == true) entityUpdateJob?.cancel()
-                        entityUpdateJob = launch { mainViewModel.entityUpdates() }
-                    }
-                }
-                launch { mainViewModel.entityRegistryUpdates() }
-                if (!mainViewModel.mainViewUiState.value.isFavoritesOnly) {
-                    launch { mainViewModel.areaUpdates() }
-                    launch { mainViewModel.deviceUpdates() }
-                }
+                launch { mainViewModel.observeEntities() }
             }
         }
     }
@@ -170,17 +158,6 @@ class HomeActivity :
 
         mainViewModel.initAllSensors()
 
-        lifecycleScope.launch {
-            if (mainViewModel.mainViewUiState.value.loadingState == MainViewModel.LoadingState.READY) {
-                try {
-                    mainViewModel.updateUI()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Timber.e(e, "Failed to update UI")
-                }
-            }
-        }
         if (
             intent.getBooleanExtra(EXTRA_FROM_ONBOARDING, false) &&
             SdkVersion.isAtLeast(Build.VERSION_CODES.TIRAMISU) &&

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/MainViewModel.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/MainViewModel.kt
@@ -12,16 +12,18 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.homeassistant.companion.android.BuildConfig
 import io.homeassistant.companion.android.HomeAssistantApplication
-import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.CAMERA_DOMAIN
 import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.CLIMATE_DOMAIN
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayState
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithContext
 import io.homeassistant.companion.android.common.data.prefs.impl.entities.TemplateTileConfig
+import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.WebSocketState
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.AreaRegistryResponse
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.DeviceRegistryResponse
-import io.homeassistant.companion.android.common.data.websocket.impl.entities.EntityRegistryResponse
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorRepository
+import io.homeassistant.companion.android.common.util.mdiName
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.database.wear.CameraTile
 import io.homeassistant.companion.android.database.wear.CameraTileDao
@@ -33,11 +35,8 @@ import io.homeassistant.companion.android.database.wear.ThermostatTileDao
 import io.homeassistant.companion.android.database.wear.getAll
 import io.homeassistant.companion.android.database.wear.getAllFlow
 import io.homeassistant.companion.android.sensors.SensorReceiver
-import io.homeassistant.companion.android.util.RegistriesDataHandler
-import io.homeassistant.companion.android.util.throttleLatest
 import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -48,6 +47,7 @@ import timber.log.Timber
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+    private val entitiesForDisplayManager: EntitiesForDisplayManager,
     private val favoritesDao: FavoritesDao,
     private val favoriteCachesDao: FavoriteCachesDao,
     private val sensorRepository: SensorRepository,
@@ -85,8 +85,8 @@ class MainViewModel @Inject constructor(
     data class EntityListNavigation(
         val entityListIds: Map<String, List<String>> = emptyMap(),
         val entityListsOrder: List<String> = emptyList(),
-        val entityListFilter: (Entity) -> Boolean = { true },
-        val entityLists: Map<String, List<Entity>> = emptyMap(),
+        val entityListFilter: (EntityDisplay) -> Boolean = { true },
+        val entityLists: Map<String, List<EntityDisplay>> = emptyMap(),
     )
 
     /**
@@ -94,9 +94,9 @@ class MainViewModel @Inject constructor(
      */
     @Immutable
     data class MainViewUiState(
-        val entities: Map<String, Entity> = emptyMap(),
-        val cameraEntities: List<Entity> = emptyList(),
-        val climateEntities: List<Entity> = emptyList(),
+        val displayItems: Map<String, EntityDisplayWithContext> = emptyMap(),
+        val cameraItems: List<EntityDisplay> = emptyList(),
+        val climateItems: List<EntityDisplay> = emptyList(),
         val favoriteCaches: List<FavoriteCaches> = emptyList(),
         val isFavoritesOnly: Boolean = false,
         val isHapticEnabled: Boolean = false,
@@ -108,12 +108,12 @@ class MainViewModel @Inject constructor(
         val shortcutEntitiesMap: Map<Int?, List<SimplifiedEntity>> = emptyMap(),
         val loadingState: LoadingState = LoadingState.LOADING,
         val entitiesByArea: Map<String, List<String>> = emptyMap(),
-        val areas: List<AreaRegistryResponse> = emptyList(),
+        val areas: List<String> = emptyList(),
         val entitiesByDomainFilteredOrder: List<String> = emptyList(),
         val entitiesByDomainFiltered: Map<String, List<String>> = emptyMap(),
         val entitiesByDomain: Map<String, List<String>> = emptyMap(),
         val favoriteEntityIds: List<String> = emptyList(),
-        val allEntitiesByDomain: Map<String, List<Entity>> = emptyMap(),
+        val allDisplayItemsByDomain: Map<String, List<EntityDisplay>> = emptyMap(),
         val domainNames: Map<String, String> = emptyMap(),
         val entityListNavigation: EntityListNavigation = EntityListNavigation(),
     )
@@ -126,14 +126,6 @@ class MainViewModel @Inject constructor(
      * Internal thread-safe holder for registry data used for entity classification.
      * Wrapped in a [MutableStateFlow] to guarantee visibility and consistency across dispatchers.
      */
-    private data class Registries(
-        val area: List<AreaRegistryResponse> = emptyList(),
-        val device: List<DeviceRegistryResponse> = emptyList(),
-        val entity: List<EntityRegistryResponse> = emptyList(),
-    )
-
-    private val registries = MutableStateFlow(Registries())
-
     // TODO: This is bad, do this instead: https://stackoverflow.com/questions/46283981/android-viewmodel-additional-arguments
     fun init(homePresenter: HomePresenter) {
         this.homePresenter = homePresenter
@@ -141,8 +133,8 @@ class MainViewModel @Inject constructor(
         loadEntities()
     }
 
-    private val _supportedEntities = MutableStateFlow(emptyList<String>())
-    val supportedEntities = _supportedEntities.asStateFlow()
+    /** Grouping key of the last snapshot the entities were grouped for, see [groupingKey]. */
+    private var lastGroupingKey: List<Any?>? = null
 
     private val _entityClassification = MutableStateFlow(EntityClassification())
     val entityClassification = _entityClassification.asStateFlow()
@@ -161,7 +153,7 @@ class MainViewModel @Inject constructor(
     fun setEntityListNavigation(
         entityListIds: Map<String, List<String>>,
         entityListsOrder: List<String>,
-        entityListFilter: (Entity) -> Boolean,
+        entityListFilter: (EntityDisplay) -> Boolean,
     ) {
         updateUiState {
             it.copy(
@@ -169,16 +161,16 @@ class MainViewModel @Inject constructor(
                     entityListIds = entityListIds,
                     entityListsOrder = entityListsOrder,
                     entityListFilter = entityListFilter,
-                    entityLists = entityListIds.resolveEntities(it.entities),
+                    entityLists = entityListIds.resolveEntities(it.displayItems),
                 ),
             )
         }
     }
 
     private fun Map<String, List<String>>.resolveEntities(
-        allEntities: Map<String, Entity>,
-    ): Map<String, List<Entity>> = mapValues { (_, ids) ->
-        ids.mapNotNull { id -> allEntities[id] }
+        allItems: Map<String, EntityDisplay>,
+    ): Map<String, List<EntityDisplay>> = mapValues { (_, ids) ->
+        ids.mapNotNull { id -> allItems[id] }
     }
 
     init {
@@ -247,7 +239,6 @@ class MainViewModel @Inject constructor(
             try {
                 // Load initial state
                 updateUiState { it.copy(loadingState = LoadingState.LOADING) }
-                updateUI()
 
                 // Finished initial load, update state
                 val webSocketState = homePresenter.getWebSocketState()
@@ -271,133 +262,60 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    suspend fun updateUI() = withContext(Dispatchers.IO) {
-        if (!homePresenter.isConnected()) return@withContext
-        val getAreaRegistry = async { homePresenter.getAreaRegistry() }
-        val getDeviceRegistry = async { homePresenter.getDeviceRegistry() }
-        val getEntityRegistry = async { homePresenter.getEntityRegistry() }
-        val getEntities = async { homePresenter.getEntities() }
+    /**
+     * Observes the entities of the supported domains with their display information. Emissions are
+     * complete snapshots, so each one replaces the state of the screen.
+     *
+     * Collected on [Dispatchers.Default]: an emission walks every entity of the server, and
+     * regroups them when [groupingKey] changed, which is too much work for the main thread the
+     * caller collects from.
+     */
+    suspend fun observeEntities() = withContext(Dispatchers.Default) {
+        entitiesForDisplayManager
+            .observeInContext(ServerManager.SERVER_ID_ACTIVE) { it.domain in supportedDomains() }
+            .collect { state ->
+                if (state !is EntityDisplayState.Loaded) return@collect
 
-        val newEntityRegistry = getEntityRegistry.await().orEmpty()
-        val isFavoritesOnly = mainViewUiState.value.isFavoritesOnly
-        if (!isFavoritesOnly) {
-            val newAreaRegistry = getAreaRegistry.await().orEmpty()
-            val newDeviceRegistry = getDeviceRegistry.await().orEmpty()
-            registries.update {
-                Registries(area = newAreaRegistry, device = newDeviceRegistry, entity = newEntityRegistry)
+                updateDisplayItems(state.entitiesById)
+
+                if (mainViewUiState.value.isFavoritesOnly) return@collect
+
+                // States change far more often than what the groupings are made of
+                val groupingKey = groupingKey(state.entitiesById)
+                if (groupingKey != lastGroupingKey) {
+                    lastGroupingKey = groupingKey
+                    updateEntityDomains()
+                }
             }
-        } else {
-            registries.update { it.copy(entity = newEntityRegistry) }
-        }
-
-        _supportedEntities.value = getSupportedEntities()
-
-        getEntities.await()?.let { updateEntityStates(it, replaceAll = true) }
-        if (!isFavoritesOnly) {
-            updateEntityDomains()
-        }
-    }
-
-    suspend fun entityUpdates() {
-        if (!homePresenter.isConnected()) {
-            return
-        }
-        homePresenter.getEntityUpdates(supportedEntities.value)?.collect { entity ->
-            updateEntityStates(listOf(entity))
-            if (!mainViewUiState.value.isFavoritesOnly) {
-                updateEntityDomains()
-            }
-        }
     }
 
     /**
-     * Filters supported entities, updates UI state, and caches favorites.
-     * When [replaceAll] is true, replaces the entire entity map; otherwise merges into existing.
+     * What [updateEntityDomains] groups the entities by: two snapshots sharing it group the same
+     * way, whatever their states are. Keep it in sync with the fields the grouping reads.
      */
-    private fun updateEntityStates(entities: List<Entity>, replaceAll: Boolean = false) {
-        val supportedDomains = supportedDomains()
-        val supportedIds = mutableSetOf<String>()
+    private fun groupingKey(items: Map<String, EntityDisplayWithContext>): List<Any?> = items.values.map {
+        listOf(it.entityId, it.name, it.domain, it.areaName, it.isHidden, it.entityCategory)
+    }
+
+    /** Applies a snapshot of the entities to the UI state and caches the favorites of the user. */
+    private fun updateDisplayItems(items: Map<String, EntityDisplayWithContext>) {
         updateUiState { uiState ->
-            val supported = mutableMapOf<String, Entity>()
-            val cameraEntities = if (replaceAll) {
-                mutableMapOf()
-            } else {
-                uiState.cameraEntities.associateByTo(
-                    mutableMapOf(),
-                ) {
-                    it.entityId
-                }
-            }
-            val climateEntities = if (replaceAll) {
-                mutableMapOf()
-            } else {
-                uiState.climateEntities.associateByTo(
-                    mutableMapOf(),
-                ) {
-                    it.entityId
-                }
-            }
-            for (entity in entities) {
-                when (entity.domain) {
-                    CAMERA_DOMAIN -> cameraEntities[entity.entityId] = entity
-                    CLIMATE_DOMAIN -> climateEntities[entity.entityId] = entity
-                }
-                if (entity.domain in supportedDomains) {
-                    supported[entity.entityId] = entity
-                }
-            }
-            supportedIds.addAll(supported.keys)
-            val updatedEntities = if (replaceAll) supported else uiState.entities + supported
+            val itemsByDomain = items.values.groupBy { it.domain }
             uiState.copy(
-                entities = updatedEntities,
-                cameraEntities = cameraEntities.values.toList(),
-                climateEntities = climateEntities.values.toList(),
-                allEntitiesByDomain = updatedEntities.values.groupBy { it.domain },
+                displayItems = items,
+                cameraItems = itemsByDomain[CAMERA_DOMAIN].orEmpty(),
+                climateItems = itemsByDomain[CLIMATE_DOMAIN].orEmpty(),
+                allDisplayItemsByDomain = itemsByDomain,
                 entityListNavigation = uiState.entityListNavigation.copy(
-                    entityLists = uiState.entityListNavigation.entityListIds.resolveEntities(updatedEntities),
+                    entityLists = uiState.entityListNavigation.entityListIds.resolveEntities(items),
                 ),
             )
         }
         val favoriteIds = mainViewUiState.value.favoriteEntityIds
-        supportedIds
+        items.keys
             .filter { it in favoriteIds }
             .forEach { addCachedFavorite(it) }
     }
-
-    suspend fun areaUpdates() {
-        if (!homePresenter.isConnected() || mainViewUiState.value.isFavoritesOnly) {
-            return
-        }
-        homePresenter.getAreaRegistryUpdates()?.throttleLatest(1000)?.collect {
-            registries.update { it.copy(area = homePresenter.getAreaRegistry().orEmpty()) }
-            updateEntityDomains()
-        }
-    }
-
-    suspend fun deviceUpdates() {
-        if (!homePresenter.isConnected() || mainViewUiState.value.isFavoritesOnly) {
-            return
-        }
-        homePresenter.getDeviceRegistryUpdates()?.throttleLatest(1000)?.collect {
-            registries.update { it.copy(device = homePresenter.getDeviceRegistry().orEmpty()) }
-            updateEntityDomains()
-        }
-    }
-
-    suspend fun entityRegistryUpdates() {
-        if (!homePresenter.isConnected()) {
-            return
-        }
-        homePresenter.getEntityRegistryUpdates()?.throttleLatest(1000)?.collect {
-            registries.update { it.copy(entity = homePresenter.getEntityRegistry().orEmpty()) }
-            _supportedEntities.value = getSupportedEntities()
-            updateEntityDomains()
-        }
-    }
-
-    private fun getSupportedEntities(): List<String> = registries.value.entity
-        .map { it.entityId }
-        .filter { it.split(".")[0] in supportedDomains() }
 
     /**
      * Computes entity groupings by area and domain, then updates UiState in a single shot.
@@ -405,32 +323,28 @@ class MainViewModel @Inject constructor(
      * to make sure it doesn't happen in the Main thread.
      */
     private suspend fun updateEntityDomains() = withContext(Dispatchers.Default) {
-        val entities = mainViewUiState.value.entities
-        val entitiesList = entities.values.sortedBy { it.entityId }
-        val regs = registries.value
-        val areasList = regs.area.sortedBy { it.name }
-        val domainsList = entitiesList.map { it.domain }.distinct()
+        val items = mainViewUiState.value.displayItems
+        val itemsList = items.values.sortedBy { it.entityId }
+        val domainsList = itemsList.map { it.domain }.distinct()
 
-        // Single pass: compute entity metadata and cache area lookups to avoid redundant calls
-        val entityAreaMap = mutableMapOf<String, AreaRegistryResponse?>()
         val withoutArea = mutableSetOf<String>()
         val withCategory = mutableSetOf<String>()
         val hidden = mutableSetOf<String>()
 
-        entities.keys.forEach { entityId ->
-            val area = RegistriesDataHandler.getAreaForEntity(entityId, regs.area, regs.device, regs.entity)
-            entityAreaMap[entityId] = area
-
-            if (area == null) {
-                withoutArea.add(entityId)
+        itemsList.forEach { item ->
+            if (item.areaName == null) {
+                withoutArea.add(item.entityId)
             }
-            if (RegistriesDataHandler.getCategoryForEntity(entityId, regs.entity) != null) {
-                withCategory.add(entityId)
+            if (item.entityCategory != null) {
+                withCategory.add(item.entityId)
             }
-            if (RegistriesDataHandler.getHiddenByForEntity(entityId, regs.entity) != null) {
-                hidden.add(entityId)
+            if (item.isHidden) {
+                hidden.add(item.entityId)
             }
         }
+
+        // Areas holding at least one entity, the only ones the UI can navigate to
+        val areasList = itemsList.mapNotNull { it.areaName }.distinct().sorted()
 
         // Determine if entity should be shown in filtered views
         val shouldShowEntity: (String) -> Boolean = { entityId ->
@@ -440,22 +354,22 @@ class MainViewModel @Inject constructor(
         // Group entities by area
         val computedEntitiesByArea = mutableMapOf<String, List<String>>()
         areasList.forEach { area ->
-            val entitiesInArea = entitiesList
-                .filter { entityAreaMap[it.entityId]?.areaId == area.areaId }
-                .sortedBy { (it.attributes["friendly_name"] ?: it.entityId) as String }
-            computedEntitiesByArea[area.areaId] = entitiesInArea.map { it.entityId }
+            val entitiesInArea = itemsList
+                .filter { it.areaName == area }
+                .sortedBy { it.name }
+            computedEntitiesByArea[area] = entitiesInArea.map { it.entityId }
         }
 
         // Group entities by domain (both full and filtered) in a single pass
         val computedEntitiesByDomain = mutableMapOf<String, List<String>>()
-        val computedAllEntitiesByDomain = mutableMapOf<String, List<Entity>>()
+        val computedItemsByDomain = mutableMapOf<String, List<EntityDisplay>>()
         val computedEntitiesByDomainFiltered = mutableMapOf<String, List<String>>()
         val filteredDomainsList = mutableListOf<String>()
 
         domainsList.forEach { domain ->
-            val entitiesInDomain = entitiesList.filter { it.domain == domain }
+            val entitiesInDomain = itemsList.filter { it.domain == domain }
             computedEntitiesByDomain[domain] = entitiesInDomain.map { it.entityId }
-            computedAllEntitiesByDomain[domain] = entitiesInDomain
+            computedItemsByDomain[domain] = entitiesInDomain
 
             // Filtered entities (without area, category, or hidden status)
             val entitiesInDomainFiltered = entitiesInDomain.filter { entity ->
@@ -491,16 +405,15 @@ class MainViewModel @Inject constructor(
         // Update UiState in a single shot
         updateUiState { uiState ->
             uiState.copy(
-                entities = entities,
                 entitiesByArea = computedEntitiesByArea,
                 areas = areasList,
                 entitiesByDomainFilteredOrder = filteredDomainsList,
                 entitiesByDomainFiltered = computedEntitiesByDomainFiltered,
                 entitiesByDomain = computedEntitiesByDomain,
-                allEntitiesByDomain = computedAllEntitiesByDomain,
+                allDisplayItemsByDomain = computedItemsByDomain,
                 domainNames = computedDomainNames,
                 entityListNavigation = uiState.entityListNavigation.copy(
-                    entityLists = uiState.entityListNavigation.entityListIds.resolveEntities(entities),
+                    entityLists = uiState.entityListNavigation.entityListIds.resolveEntities(items),
                 ),
             )
         }
@@ -701,11 +614,8 @@ class MainViewModel @Inject constructor(
 
     private fun addCachedFavorite(entityId: String) {
         viewModelScope.launch {
-            val entity = mainViewUiState.value.entities[entityId]
-            val attributes = entity?.attributes as Map<*, *>
-            val icon = attributes["icon"] as String?
-            val name = attributes["friendly_name"]?.toString() ?: entityId
-            favoriteCachesDao.add(FavoriteCaches(entityId, name, icon))
+            val item = mainViewUiState.value.displayItems[entityId] ?: return@launch
+            favoriteCachesDao.add(FavoriteCaches(entityId, item.name, item.statelessIcon.mdiName))
         }
     }
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/DetailsPanelView.kt
@@ -27,17 +27,12 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
-import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.ColorTemperatureControl
 import io.homeassistant.companion.android.common.data.integration.EntityExt
-import io.homeassistant.companion.android.common.data.integration.friendlyName
-import io.homeassistant.companion.android.common.data.integration.getFanSpeed
-import io.homeassistant.companion.android.common.data.integration.getFanSteps
-import io.homeassistant.companion.android.common.data.integration.getIcon
-import io.homeassistant.companion.android.common.data.integration.getLightBrightness
-import io.homeassistant.companion.android.common.data.integration.isActive
-import io.homeassistant.companion.android.common.data.integration.supportsFanSetSpeed
-import io.homeassistant.companion.android.common.data.integration.supportsLightBrightness
-import io.homeassistant.companion.android.common.data.integration.supportsLightColorTemperature
+import io.homeassistant.companion.android.common.data.integration.EntityPosition
+import io.homeassistant.companion.android.common.data.integration.FanControls
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.common.util.formatForLocal
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getInlineSliderDefaultColors
@@ -54,7 +49,7 @@ import java.time.format.FormatStyle
 
 @Composable
 fun DetailsPanelView(
-    entity: Entity,
+    entity: EntityDisplay,
     onEntityToggled: (String, String) -> Unit,
     onFanSpeedChanged: (Float) -> Unit,
     onBrightnessChanged: (Float) -> Unit,
@@ -67,21 +62,19 @@ fun DetailsPanelView(
 
     WearAppTheme {
         ThemeLazyColumn {
-            val attributes = entity.attributes as Map<*, *>
-
             item {
                 // Style similar to icon on frontend tile card
-                val isChecked = entity.isActive()
+                val isChecked = entity.isActive
                 if (entity.domain in EntityExt.DOMAINS_TOGGLE) {
                     IconToggleButton(
                         checked = isChecked,
                         onCheckedChange = {
-                            onEntityToggled(entity.entityId, entity.state)
+                            onEntityToggled(entity.entityId, entity.rawState)
                             onEntityClickedFeedback(
                                 isToastEnabled,
                                 isHapticEnabled,
                                 context,
-                                entity.friendlyName,
+                                entity.name,
                                 haptic,
                             )
                         },
@@ -92,7 +85,7 @@ fun DetailsPanelView(
                         modifier = Modifier.touchTargetAwareSize(IconButtonDefaults.SmallButtonSize),
                     ) {
                         Image(
-                            asset = entity.getIcon(),
+                            asset = entity.icon,
                             colorFilter = ColorFilter.tint(
                                 if (isChecked) wearColorScheme.tertiary else wearColorScheme.onSurface,
                             ),
@@ -104,35 +97,28 @@ fun DetailsPanelView(
                     }
                 } else {
                     Image(
-                        asset = entity.getIcon(),
+                        asset = entity.icon,
                         colorFilter = ColorFilter.tint(wearColorScheme.onSurface),
                     )
                 }
             }
             item {
-                ListHeader(entity.friendlyName)
+                ListHeader(entity.name)
             }
 
-            if (entity.domain == "fan") {
-                if (entity.supportsFanSetSpeed()) {
-                    item {
-                        FanSpeedSlider(entity, onFanSpeedChanged, isToastEnabled, isHapticEnabled)
-                    }
+            entity.fanControls?.let { fanControls ->
+                item {
+                    FanSpeedSlider(fanControls, onFanSpeedChanged, isToastEnabled, isHapticEnabled)
                 }
             }
-            if (entity.domain == "light") {
-                if (entity.supportsLightBrightness()) {
-                    item {
-                        BrightnessSlider(entity, onBrightnessChanged, isToastEnabled, isHapticEnabled)
-                    }
+            entity.lightControls?.brightness?.let { brightness ->
+                item {
+                    BrightnessSlider(brightness, onBrightnessChanged, isToastEnabled, isHapticEnabled)
                 }
-
-                if (entity.supportsLightColorTemperature() &&
-                    attributes["color_mode"] == EntityExt.LIGHT_MODE_COLOR_TEMP
-                ) {
-                    item {
-                        ColorTempSlider(attributes, onColorTempChanged, isToastEnabled, isHapticEnabled)
-                    }
+            }
+            entity.lightControls?.colorTemperature?.let { colorTemperature ->
+                item {
+                    ColorTempSlider(colorTemperature, onColorTempChanged, isToastEnabled, isHapticEnabled)
                 }
             }
 
@@ -141,14 +127,14 @@ fun DetailsPanelView(
             }
             item {
                 Text(
-                    stringResource(R.string.state_name, entity.state),
+                    stringResource(R.string.state_name, entity.rawState),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 8.dp),
                 )
             }
             item {
-                val lastChanged = entity.lastChanged.formatForLocal(FormatStyle.MEDIUM)
+                val lastChanged = entity.lastChanged?.formatForLocal(FormatStyle.MEDIUM).orEmpty()
                 Text(
                     stringResource(R.string.last_changed, lastChanged),
                     modifier = Modifier
@@ -157,7 +143,7 @@ fun DetailsPanelView(
                 )
             }
             item {
-                val lastUpdated = entity.lastUpdated.formatForLocal(FormatStyle.MEDIUM)
+                val lastUpdated = entity.lastUpdated?.formatForLocal(FormatStyle.MEDIUM).orEmpty()
                 Text(
                     stringResource(R.string.last_updated, lastUpdated),
                     modifier = Modifier
@@ -179,15 +165,15 @@ fun DetailsPanelView(
 
 @Composable
 fun FanSpeedSlider(
-    entity: Entity,
+    controls: FanControls,
     onFanSpeedChanged: (Float) -> Unit,
     isToastEnabled: Boolean,
     isHapticEnabled: Boolean,
 ) {
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
-    val position = entity.getFanSpeed() ?: return
-    val steps = entity.getFanSteps() ?: return
+    val position = controls.speed
+    val steps = controls.steps
 
     Column {
         Text(
@@ -233,14 +219,13 @@ fun FanSpeedSlider(
 
 @Composable
 fun BrightnessSlider(
-    entity: Entity,
+    position: EntityPosition,
     onBrightnessChanged: (Float) -> Unit,
     isToastEnabled: Boolean,
     isHapticEnabled: Boolean,
 ) {
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
-    val position = entity.getLightBrightness() ?: return
 
     Column {
         Text(
@@ -286,7 +271,7 @@ fun BrightnessSlider(
 
 @Composable
 fun ColorTempSlider(
-    attributes: Map<*, *>,
+    controls: ColorTemperatureControl,
     onColorTempChanged: (Float, Boolean) -> Unit,
     isToastEnabled: Boolean,
     isHapticEnabled: Boolean,
@@ -294,20 +279,10 @@ fun ColorTempSlider(
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
 
-    val useKelvin = attributes.containsKey("color_temp_kelvin") // Added in 2022.11
-
-    val minValue =
-        ((if (useKelvin) attributes["min_color_temp_kelvin"] else attributes["min_mireds"]) as? Number)?.toFloat() ?: 0f
-    val maxValue =
-        ((if (useKelvin) attributes["max_color_temp_kelvin"] else attributes["max_mireds"]) as? Number)?.toFloat() ?: 0f
-    var currentValue =
-        ((if (useKelvin) attributes["color_temp_kelvin"] else attributes["color_temp"]) as? Number)?.toFloat() ?: 0f
-    if (currentValue < minValue) {
-        currentValue = minValue
-    }
-    if (currentValue > maxValue) {
-        currentValue = maxValue
-    }
+    val useKelvin = controls.isKelvin
+    val minValue = controls.min
+    val maxValue = controls.max
+    val currentValue = controls.current
 
     Column {
         Text(
@@ -388,7 +363,7 @@ private fun onSliderChangedFeedback(
 private fun PreviewDetailsPaneViewEntityFanOn() {
     CompositionLocalProvider {
         DetailsPanelView(
-            entity = previewEntity4,
+            entity = EntityDisplayWithoutContext(previewEntity4),
             onEntityToggled = { _, _ -> },
             onFanSpeedChanged = {},
             onBrightnessChanged = {},
@@ -404,7 +379,7 @@ private fun PreviewDetailsPaneViewEntityFanOn() {
 private fun PreviewDetailsPaneViewEntityLightOn() {
     CompositionLocalProvider {
         DetailsPanelView(
-            entity = previewEntity1,
+            entity = EntityDisplayWithoutContext(previewEntity1),
             onEntityToggled = { _, _ -> },
             onFanSpeedChanged = {},
             onBrightnessChanged = {},
@@ -420,7 +395,7 @@ private fun PreviewDetailsPaneViewEntityLightOn() {
 private fun PreviewDetailsPaneViewEntityLightOff() {
     CompositionLocalProvider {
         DetailsPanelView(
-            entity = previewEntity2,
+            entity = EntityDisplayWithoutContext(previewEntity2),
             onEntityToggled = { _, _ -> },
             onFanSpeedChanged = {},
             onBrightnessChanged = {},

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/EntityListView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/EntityListView.kt
@@ -10,7 +10,8 @@ import androidx.wear.compose.material3.Button
 import androidx.wear.compose.material3.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getPrimaryButtonColors
 import io.homeassistant.companion.android.util.playPreviewEntityScene1
@@ -25,9 +26,9 @@ import io.homeassistant.companion.android.views.rememberExpandedStates
 
 @Composable
 fun EntityViewList(
-    entityLists: Map<String, List<Entity>>,
+    entityLists: Map<String, List<EntityDisplay>>,
     entityListsOrder: List<String>,
-    entityListFilter: (Entity) -> Boolean,
+    entityListFilter: (EntityDisplay) -> Boolean,
     onEntityClicked: (String, String) -> Unit,
     onEntityLongClicked: (String) -> Unit,
     isHapticEnabled: Boolean,
@@ -90,7 +91,10 @@ fun EntityViewList(
 @Composable
 private fun PreviewEntityListView() {
     EntityViewList(
-        entityLists = mapOf(stringResource(commonR.string.lights) to listOf(previewEntity1, previewEntity2)),
+        entityLists = mapOf(
+            stringResource(commonR.string.lights) to
+                listOf(EntityDisplayWithoutContext(previewEntity1), EntityDisplayWithoutContext(previewEntity2)),
+        ),
         entityListsOrder = listOf(stringResource(commonR.string.lights)),
         entityListFilter = { true },
         onEntityClicked = { _, _ -> },
@@ -106,7 +110,11 @@ private fun PreviewEntityListScenes() {
     EntityViewList(
         entityLists = mapOf(
             stringResource(commonR.string.scenes) to
-                listOf(playPreviewEntityScene1, playPreviewEntityScene2, playPreviewEntityScene3),
+                listOf(
+                    EntityDisplayWithoutContext(playPreviewEntityScene1),
+                    EntityDisplayWithoutContext(playPreviewEntityScene2),
+                    EntityDisplayWithoutContext(playPreviewEntityScene3),
+                ),
         ),
         entityListsOrder = listOf(stringResource(commonR.string.scenes)),
         entityListFilter = { true },
@@ -121,7 +129,9 @@ private fun PreviewEntityListScenes() {
 @Composable
 private fun PreviewEntityListEmpty() {
     EntityViewList(
-        entityLists = mapOf(stringResource(commonR.string.scenes) to listOf(playPreviewEntityScene1)),
+        entityLists = mapOf(
+            stringResource(commonR.string.scenes) to listOf(EntityDisplayWithoutContext(playPreviewEntityScene1)),
+        ),
         entityListsOrder = listOf(stringResource(commonR.string.scenes)),
         entityListFilter = { false },
         onEntityClicked = { _, _ -> },

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/EntityUi.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/EntityUi.kt
@@ -21,10 +21,9 @@ import androidx.wear.compose.material3.MaterialTheme
 import androidx.wear.compose.material3.Text
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.mikepenz.iconics.compose.Image
-import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityExt
-import io.homeassistant.companion.android.common.data.integration.getIcon
-import io.homeassistant.companion.android.common.data.integration.isActive
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
 import io.homeassistant.companion.android.theme.getFilledTonalButtonColors
 import io.homeassistant.companion.android.theme.wearColorScheme
@@ -36,7 +35,7 @@ import io.homeassistant.companion.android.util.previewEntity4
 
 @Composable
 fun EntityUi(
-    entity: Entity,
+    entity: EntityDisplay,
     onEntityClicked: (String, String) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
@@ -44,20 +43,19 @@ fun EntityUi(
 ) {
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
-    val attributes = entity.attributes as Map<*, *>
-    val iconBitmap = entity.getIcon()
-    val friendlyName = attributes["friendly_name"].toString()
+    val iconBitmap = entity.icon
+    val name = entity.name
     val nameModifier = Modifier
         .fillMaxWidth()
         .pointerInput(Unit) {
             detectTapGestures(
                 onTap = {
-                    onEntityClicked(entity.entityId, entity.state)
+                    onEntityClicked(entity.entityId, entity.rawState)
                     onEntityClickedFeedback(
                         isToastEnabled,
                         isHapticEnabled,
                         context,
-                        friendlyName,
+                        name,
                         haptic,
                     )
                 },
@@ -68,14 +66,14 @@ fun EntityUi(
         }
 
     if (entity.domain in EntityExt.DOMAINS_TOGGLE) {
-        val isChecked = entity.isActive()
-        val isEnabled = entity.state != STATE_UNAVAILABLE
+        val isChecked = entity.isActive
+        val isEnabled = entity.rawState != STATE_UNAVAILABLE
         val colors = WearToggleChip.entityToggleChipBackgroundColors(entity, isChecked)
         ToggleChip(
             checked = isChecked,
             onCheckedChange = {
-                onEntityClicked(entity.entityId, entity.state)
-                onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, friendlyName, haptic)
+                onEntityClicked(entity.entityId, entity.rawState)
+                onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, name, haptic)
             },
             modifier = Modifier.fillMaxWidth(),
             appIcon = {
@@ -90,7 +88,7 @@ fun EntityUi(
                     LocalContentColor provides colors.contentColor(enabled = isEnabled, checked = isChecked).value,
                 ) {
                     Text(
-                        text = friendlyName,
+                        text = name,
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         modifier = nameModifier,
@@ -112,16 +110,16 @@ fun EntityUi(
             },
             label = {
                 Text(
-                    text = friendlyName,
+                    text = name,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                     modifier = nameModifier,
                 )
             },
-            enabled = entity.state != STATE_UNAVAILABLE,
+            enabled = entity.rawState != STATE_UNAVAILABLE,
             onClick = {
-                onEntityClicked(entity.entityId, entity.state)
-                onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, friendlyName, haptic)
+                onEntityClicked(entity.entityId, entity.rawState)
+                onEntityClickedFeedback(isToastEnabled, isHapticEnabled, context, name, haptic)
             },
             colors = getFilledTonalButtonColors(),
         )
@@ -133,21 +131,21 @@ fun EntityUi(
 private fun PreviewEntityUI() {
     Column {
         EntityUi(
-            entity = previewEntity1,
+            entity = EntityDisplayWithoutContext(previewEntity1),
             onEntityClicked = { _, _ -> },
             isHapticEnabled = true,
             isToastEnabled = false,
             onEntityLongPressed = { },
         )
         EntityUi(
-            entity = previewEntity3,
+            entity = EntityDisplayWithoutContext(previewEntity3),
             onEntityClicked = { _, _ -> },
             isHapticEnabled = false,
             isToastEnabled = true,
             onEntityLongPressed = { },
         )
         EntityUi(
-            entity = previewEntity4,
+            entity = EntityDisplayWithoutContext(previewEntity4),
             onEntityClicked = { _, _ -> },
             isHapticEnabled = false,
             isToastEnabled = true,

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/HomeView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/HomeView.kt
@@ -96,7 +96,7 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 )
             }
             composable("$SCREEN_ENTITY_DETAIL/{entityId}") {
-                val entity = uiState.entities[it.arguments?.getString("entityId")]
+                val entity = uiState.displayItems[it.arguments?.getString("entityId")]
                 if (entity != null) {
                     DetailsPanelView(
                         entity = entity,
@@ -198,7 +198,7 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
             }
             composable(SCREEN_SET_FAVORITES) {
                 SetFavoritesView(
-                    entitiesByDomain = uiState.allEntitiesByDomain,
+                    entitiesByDomain = uiState.allDisplayItemsByDomain,
                     domainNames = uiState.domainNames,
                     favoriteEntityIds = uiState.favoriteEntityIds,
                     onFavoriteSelected = { entityId, isSelected ->
@@ -230,9 +230,10 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 ),
             ) { backStackEntry ->
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_CAMERA_TILE_ID)
+                val cameraTile = mainViewModel.cameraTiles.value.firstOrNull { it.id == tileId }
                 SetCameraTileView(
-                    tile = mainViewModel.cameraTiles.value.firstOrNull { it.id == tileId },
-                    entities = uiState.cameraEntities,
+                    tile = cameraTile,
+                    entityItem = cameraTile?.entityId?.let { uiState.displayItems[it] },
                     onSelectEntity = {
                         swipeDismissableNavController.navigate(
                             "$ROUTE_CAMERA_TILE/$tileId/$SCREEN_SET_CAMERA_TILE_ENTITY",
@@ -256,7 +257,7 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_CAMERA_TILE_ID)
                 ChooseEntityView(
                     entitiesByDomainOrder = listOf(CAMERA_DOMAIN),
-                    entitiesByDomain = mapOf(CAMERA_DOMAIN to uiState.cameraEntities),
+                    entitiesByDomain = mapOf(CAMERA_DOMAIN to uiState.cameraItems),
                     favoriteEntityIds = emptyList(),
                     onNoneClicked = {},
                     onEntitySelected = { entity ->
@@ -315,9 +316,10 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 ),
             ) { backStackEntry ->
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_THERMOSTAT_TILE_ID)
+                val thermostatTile = mainViewModel.thermostatTiles.value.firstOrNull { it.id == tileId }
                 SetThermostatTileView(
-                    tile = mainViewModel.thermostatTiles.value.firstOrNull { it.id == tileId },
-                    entities = uiState.climateEntities,
+                    tile = thermostatTile,
+                    entityItem = thermostatTile?.entityId?.let { uiState.displayItems[it] },
                     onSelectEntity = {
                         swipeDismissableNavController.navigate(
                             "$ROUTE_THERMOSTAT_TILE/$tileId/$SCREEN_SET_THERMOSTAT_TILE_ENTITY",
@@ -344,7 +346,7 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 val tileId = backStackEntry.arguments?.getInt(ARG_SCREEN_THERMOSTAT_TILE_ID)
                 ChooseEntityView(
                     entitiesByDomainOrder = listOf(CLIMATE_DOMAIN),
-                    entitiesByDomain = mapOf(CLIMATE_DOMAIN to uiState.climateEntities),
+                    entitiesByDomain = mapOf(CLIMATE_DOMAIN to uiState.climateItems),
                     favoriteEntityIds = emptyList(),
                     onNoneClicked = {},
                     onEntitySelected = { entity ->
@@ -433,8 +435,8 @@ fun LoadHomePage(mainViewModel: MainViewModel) {
                 val entityIndex = backStackEntry.arguments!!.getInt(ARG_SCREEN_SHORTCUTS_TILE_ENTITY_INDEX)
                 val tileId = backStackEntry.arguments!!.getString(ARG_SCREEN_SHORTCUTS_TILE_ID)!!.toIntOrNull()
                 ChooseEntityView(
-                    entitiesByDomainOrder = uiState.allEntitiesByDomain.keys.toList(),
-                    entitiesByDomain = uiState.allEntitiesByDomain,
+                    entitiesByDomainOrder = uiState.allDisplayItemsByDomain.keys.toList(),
+                    entitiesByDomain = uiState.allDisplayItemsByDomain,
                     favoriteEntityIds = uiState.favoriteEntityIds,
                     onNoneClicked = {
                         mainViewModel.clearTileShortcut(tileId, entityIndex)

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/MainView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/MainView.kt
@@ -32,7 +32,7 @@ import androidx.wear.compose.material3.Text
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import io.homeassistant.companion.android.home.MainViewModel
 import io.homeassistant.companion.android.theme.WearAppTheme
@@ -56,7 +56,7 @@ fun MainView(
     onNavigationClicked: (
         entityIdLists: Map<String, List<String>>,
         listOrder: List<String>,
-        filter: (Entity) -> Boolean,
+        filter: (EntityDisplay) -> Boolean,
     ) -> Unit,
     isHapticEnabled: Boolean,
     isToastEnabled: Boolean,
@@ -85,7 +85,7 @@ fun MainView(
                 if (expandedFavorites) {
                     items(favoriteEntityIds.size) { index ->
                         val favoriteEntityID = favoriteEntityIds[index].split(",")[0]
-                        if (uiState.entities.isEmpty()) {
+                        if (uiState.displayItems.isEmpty()) {
                             // when we don't have the state of the entity, create a Chip from cache as we don't have the state yet
                             val cached = uiState.favoriteCaches.find { it.id == favoriteEntityID }
                             Button(
@@ -99,7 +99,7 @@ fun MainView(
                                 },
                                 label = {
                                     Text(
-                                        text = cached?.friendlyName ?: favoriteEntityID,
+                                        text = cached?.name ?: favoriteEntityID,
                                         maxLines = 2,
                                         overflow = TextOverflow.Ellipsis,
                                     )
@@ -117,7 +117,7 @@ fun MainView(
                                 colors = getFilledTonalButtonColors(),
                             )
                         } else {
-                            uiState.entities[favoriteEntityID]?.let {
+                            uiState.displayItems[favoriteEntityID]?.let {
                                 EntityUi(
                                     it,
                                     onEntityClicked,
@@ -181,7 +181,7 @@ fun MainView(
                         }
                     }
                     MainViewModel.LoadingState.READY -> {
-                        if (uiState.entities.isEmpty()) {
+                        if (uiState.displayItems.isEmpty()) {
                             item {
                                 Column(
                                     modifier = Modifier.fillMaxSize(),
@@ -213,7 +213,7 @@ fun MainView(
                                 ListHeader(id = commonR.string.areas)
                             }
                             for (area in uiState.areas) {
-                                val areaEntityIds = uiState.entitiesByArea[area.areaId]
+                                val areaEntityIds = uiState.entitiesByArea[area]
                                 val entitiesToShow = areaEntityIds?.filter { entityId ->
                                     entityId !in entitiesWithCategory &&
                                         entityId !in entitiesHidden
@@ -222,11 +222,11 @@ fun MainView(
                                     item {
                                         Button(
                                             modifier = Modifier.fillMaxWidth(),
-                                            label = { Text(area.name) },
+                                            label = { Text(area) },
                                             onClick = {
                                                 onNavigationClicked(
-                                                    mapOf(area.name to areaEntityIds),
-                                                    listOf(area.name),
+                                                    mapOf(area to areaEntityIds),
+                                                    listOf(area),
                                                 ) {
                                                     it.entityId !in entitiesWithCategory &&
                                                         it.entityId !in entitiesHidden
@@ -276,7 +276,7 @@ fun MainView(
                             Spacer(modifier = Modifier.height(32.dp))
                         }
                         // All entities regardless of area
-                        if (uiState.entities.isNotEmpty()) {
+                        if (uiState.displayItems.isNotEmpty()) {
                             item {
                                 Button(
                                     modifier = Modifier

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetCameraTileView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetCameraTileView.kt
@@ -12,9 +12,7 @@ import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
-import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.database.wear.CameraTile
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getFilledTonalButtonColors
@@ -27,7 +25,7 @@ import io.homeassistant.companion.android.views.ThemeLazyColumn
 @Composable
 fun SetCameraTileView(
     tile: CameraTile?,
-    entities: List<Entity>?,
+    entityItem: EntityDisplay?,
     onSelectEntity: () -> Unit,
     onSelectRefreshInterval: () -> Unit,
 ) {
@@ -37,10 +35,7 @@ fun SetCameraTileView(
                 ListHeader(commonR.string.camera_tile)
             }
             item {
-                val entity = tile?.entityId?.let { tileEntityId ->
-                    entities?.firstOrNull { it.entityId == tileEntityId }
-                }
-                val icon = entity?.getIcon() ?: CommunityMaterial.Icon3.cmd_video
+                val icon = entityItem?.icon ?: CommunityMaterial.Icon3.cmd_video
                 Button(
                     modifier = Modifier.fillMaxWidth(),
                     icon = {
@@ -56,7 +51,7 @@ fun SetCameraTileView(
                         )
                     },
                     secondaryLabel = {
-                        Text(entity?.friendlyName ?: tile?.entityId ?: "")
+                        Text(entityItem?.name ?: tile?.entityId ?: "")
                     },
                     onClick = onSelectEntity,
                 )

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetFavoriteView.kt
@@ -10,8 +10,7 @@ import androidx.wear.compose.material3.SwitchButton
 import androidx.wear.compose.material3.Text
 import com.mikepenz.iconics.compose.Image
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getSwitchButtonColors
 import io.homeassistant.companion.android.theme.wearColorScheme
@@ -22,7 +21,7 @@ import io.homeassistant.companion.android.views.rememberExpandedStates
 
 @Composable
 fun SetFavoritesView(
-    entitiesByDomain: Map<String, List<Entity>>,
+    entitiesByDomain: Map<String, List<EntityDisplay>>,
     domainNames: Map<String, String>,
     favoriteEntityIds: List<String>,
     onFavoriteSelected: (entityId: String, isSelected: Boolean) -> Unit,
@@ -61,12 +60,11 @@ fun SetFavoritesView(
 
 @Composable
 private fun FavoriteToggleChip(
-    entity: Entity,
+    entity: EntityDisplay,
     favoriteEntityIds: List<String>,
     onFavoriteSelected: (entityId: String, isSelected: Boolean) -> Unit,
 ) {
-    val attributes = entity.attributes as Map<*, *>
-    val iconBitmap = entity.getIcon()
+    val iconBitmap = entity.icon
 
     val entityId = entity.entityId
     val checked = favoriteEntityIds.contains(entityId)
@@ -85,7 +83,7 @@ private fun FavoriteToggleChip(
         },
         label = {
             Text(
-                text = attributes["friendly_name"].toString(),
+                text = entity.name,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetShortcutsTileView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetShortcutsTileView.kt
@@ -60,7 +60,7 @@ fun SetShortcutsTileView(shortcutEntities: List<SimplifiedEntity>, onShortcutEnt
                     },
                     secondaryLabel = {
                         Text(
-                            text = shortcutEntities[index].friendlyName,
+                            text = shortcutEntities[index].name,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetThermostatTileView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/home/views/SetThermostatTileView.kt
@@ -13,9 +13,7 @@ import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
-import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.database.wear.ThermostatTile
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getFilledTonalButtonColors
@@ -29,7 +27,7 @@ import io.homeassistant.companion.android.views.ThemeLazyColumn
 @Composable
 fun SetThermostatTileView(
     tile: ThermostatTile?,
-    entities: List<Entity>?,
+    entityItem: EntityDisplay?,
     onSelectEntity: () -> Unit,
     onSelectRefreshInterval: () -> Unit,
     onNameEnabled: (Int, Boolean) -> Unit,
@@ -40,10 +38,7 @@ fun SetThermostatTileView(
                 ListHeader(commonR.string.thermostat_tile)
             }
             item {
-                val entity = tile?.entityId?.let { tileEntityId ->
-                    entities?.firstOrNull { it.entityId == tileEntityId }
-                }
-                val icon = entity?.getIcon() ?: CommunityMaterial.Icon3.cmd_thermostat
+                val icon = entityItem?.icon ?: CommunityMaterial.Icon3.cmd_thermostat
                 Button(
                     modifier = Modifier.fillMaxWidth(),
                     icon = {
@@ -59,7 +54,7 @@ fun SetThermostatTileView(
                         )
                     },
                     secondaryLabel = {
-                        Text(entity?.friendlyName ?: tile?.entityId ?: "")
+                        Text(entityItem?.name ?: tile?.entityId ?: "")
                     },
                     onClick = onSelectEntity,
                 )

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ShortcutsTile.kt
@@ -261,7 +261,7 @@ class ShortcutsTile : TileService() {
                 LayoutElementBuilders.Arc.Builder()
                     .addContent(
                         LayoutElementBuilders.ArcText.Builder()
-                            .setText(entity.friendlyName)
+                            .setText(entity.name)
                             .setFontStyle(
                                 LayoutElementBuilders.FontStyle.Builder()
                                     .setSize(sp(TEXT_SIZE))

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
@@ -20,8 +20,9 @@ import com.google.common.util.concurrent.ListenableFuture
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.R
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.friendlyName
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.awaitLoadedOrNull
 import io.homeassistant.companion.android.common.data.prefs.WearPrefsRepository
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.database.wear.ThermostatTile
@@ -59,6 +60,9 @@ class ThermostatTile : TileService() {
 
     @Inject
     lateinit var thermostatTileDao: ThermostatTileDao
+
+    @Inject
+    lateinit var entitiesForDisplayManager: EntitiesForDisplayManager
 
     override fun onTileRequest(requestParams: RequestBuilders.TileRequest): ListenableFuture<Tile> =
         serviceScope.future {
@@ -101,20 +105,22 @@ class ThermostatTile : TileService() {
                 } else {
                     try {
                         val entity = tileConfig.entityId?.let {
-                            serverManager.integrationRepository().getEntity(it)
+                            entitiesForDisplayManager.snapshot(ServerManager.SERVER_ID_ACTIVE, listOf(it))
+                                .awaitLoadedOrNull()
+                                ?.entity(it)
                         }
                         check(entity != null)
+                        val climateControls = entity.climateControls
 
                         val lastId = requestParams.currentState.lastClickableId
-                        var targetTemp =
-                            tileConfig.targetTemperature ?: entity.attributes["temperature"]?.toString()?.toFloat()
+                        var targetTemp = tileConfig.targetTemperature ?: climateControls?.targetTemperature
 
                         val config = serverManager.webSocketRepository().getConfig()
                         val temperatureUnit = config?.unitSystem?.getValue("temperature").toString()
 
                         if (targetTemp != null && (lastId == TAP_ACTION_UP || lastId == TAP_ACTION_DOWN)) {
-                            val attrStepSize = (entity.attributes["target_temp_step"] as? Number)?.toFloat()
-                            val stepSize = attrStepSize ?: if (temperatureUnit == "°F") 1.0f else 0.5f
+                            val stepSize = climateControls?.targetTemperatureStep
+                                ?: if (temperatureUnit == "°F") 1.0f else 0.5f
                             val updatedTargetTemp = targetTemp + if (lastId == TAP_ACTION_UP) +stepSize else -stepSize
 
                             serverManager.integrationRepository().callAction(
@@ -133,10 +139,13 @@ class ThermostatTile : TileService() {
                             thermostatTileDao.add(updated)
                         }
 
+                        val name = if (tileConfig.showEntityName == true) entity.name else ""
+
                         tile.setTileTimeline(
                             timeline(
                                 tileConfig,
                                 entity,
+                                name,
                                 targetTemp,
                                 temperatureUnit,
                             ),
@@ -196,13 +205,14 @@ class ThermostatTile : TileService() {
 
     private fun timeline(
         tileConfig: ThermostatTile,
-        entity: Entity,
+        entity: EntityDisplay,
+        entityName: String,
         targetTemperature: Float?,
         temperatureUnit: String,
     ): Timeline = Timeline.fromLayoutElement(
         LayoutElementBuilders.Box.Builder().apply {
-            val currentTemperature = entity.attributes["current_temperature"]
-            val hvacAction = entity.attributes["hvac_action"].toString()
+            val currentTemperature = entity.climateControls?.currentTemperature
+            val hvacAction = entity.climateControls?.hvacAction.toString()
 
             val hvacActionColor = when (hvacAction) {
                 "heating" -> getColor(commonR.color.colorDeviceControlsThermostatHeat)
@@ -263,14 +273,14 @@ class ThermostatTile : TileService() {
                     .addContent(
                         LayoutElementBuilders.Row.Builder()
                             .addContent(
-                                getTempButton(hvacAction != "off" && entity.state != "unavailable", TAP_ACTION_DOWN),
+                                getTempButton(hvacAction != "off" && entity.rawState != "unavailable", TAP_ACTION_DOWN),
                             )
                             .addContent(
                                 LayoutElementBuilders.Spacer.Builder()
                                     .setWidth(DimensionBuilders.dp(20f)).build(),
                             )
                             .addContent(
-                                getTempButton(hvacAction != "off" && entity.state != "unavailable", TAP_ACTION_UP),
+                                getTempButton(hvacAction != "off" && entity.rawState != "unavailable", TAP_ACTION_UP),
                             )
                             .build(),
                     )
@@ -303,7 +313,7 @@ class ThermostatTile : TileService() {
                         )
                         .addContent(
                             LayoutElementBuilders.ArcText.Builder()
-                                .setText(entity.friendlyName)
+                                .setText(entityName)
                                 .build(),
                         )
                         .build(),

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/tiles/ThermostatTile.kt
@@ -30,6 +30,7 @@ import io.homeassistant.companion.android.database.wear.ThermostatTileDao
 import io.homeassistant.companion.android.home.HomeActivity
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -150,6 +151,8 @@ class ThermostatTile : TileService() {
                                 temperatureUnit,
                             ),
                         ).build()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.e(e, "Unable to fetch entity ${tileConfig.entityId}")
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/util/CommonFunctions.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/util/CommonFunctions.kt
@@ -47,10 +47,10 @@ fun onEntityClickedFeedback(
     isToastEnabled: Boolean,
     isHapticEnabled: Boolean,
     context: Context,
-    friendlyName: String,
+    name: String,
     haptic: HapticFeedback,
 ) {
-    val message = context.getString(commonR.string.toast_message, friendlyName)
+    val message = context.getString(commonR.string.toast_message, name)
     onEntityFeedback(isToastEnabled, isHapticEnabled, message, context, haptic)
 }
 

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/util/WearToggleChip.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/util/WearToggleChip.kt
@@ -15,12 +15,11 @@ import androidx.compose.ui.unit.LayoutDirection
 import androidx.wear.compose.material.ToggleChipColors
 import androidx.wear.compose.material.ToggleChipDefaults
 import androidx.wear.compose.material3.contentColorFor
-import io.homeassistant.companion.android.common.data.integration.Entity
 import io.homeassistant.companion.android.common.data.integration.EntityPosition
-import io.homeassistant.companion.android.common.data.integration.getCoverPosition
-import io.homeassistant.companion.android.common.data.integration.getFanSpeed
-import io.homeassistant.companion.android.common.data.integration.getLightBrightness
-import io.homeassistant.companion.android.common.data.integration.getLightColor
+import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.COVER_DOMAIN
+import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.FAN_DOMAIN
+import io.homeassistant.companion.android.common.data.integration.IntegrationDomains.LIGHT_DOMAIN
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
 import io.homeassistant.companion.android.theme.wearColorScheme
 
 object WearToggleChip {
@@ -34,7 +33,7 @@ object WearToggleChip {
      * @param entity The entity state on which the background for the active state should be based
      */
     @Composable
-    fun entityToggleChipBackgroundColors(entity: Entity, checked: Boolean): ToggleChipColors {
+    fun entityToggleChipBackgroundColors(entity: EntityDisplay, checked: Boolean): ToggleChipColors {
         // For a toggleable entity, a custom background should only be used if it has:
         // a. a position (eg. fan speed, light brightness)
         // b. a custom color (eg. light color)
@@ -43,16 +42,15 @@ object WearToggleChip {
         // If it doesn't have either or is 'off', it should use the default off (surfaceDim) background.
 
         val hasPosition = when (entity.domain) {
-            "cover" -> entity.state != "closed" && entity.getCoverPosition() != null
-            "fan" -> checked && entity.getFanSpeed() != null
-            "light" -> checked && entity.getLightBrightness() != null
+            COVER_DOMAIN -> entity.rawState != "closed" && entity.position != null
+            FAN_DOMAIN, LIGHT_DOMAIN -> checked && entity.position != null
             else -> false
         }
-        val hasColor = entity.getLightColor() != null
+        val hasColor = entity.color != null
         val gradientDirection = LocalLayoutDirection.current
 
         val contentBackgroundColor = if (hasColor) {
-            val entityColor = entity.getLightColor()
+            val entityColor = entity.color
             if (entityColor != null) Color(entityColor) else wearColorScheme.surfaceContainerHigh
         } else {
             wearColorScheme.surfaceContainerHigh
@@ -109,12 +107,8 @@ object WearToggleChip {
 
                     // Use position info to provide stop points
                     // Minimum/maximum stops are not set to 0f/1f to make 1%/100% values visible
-                    val position = when (entity.domain) {
-                        "cover" -> entity.getCoverPosition()
-                        "fan" -> entity.getFanSpeed()
-                        "light" -> entity.getLightBrightness()
-                        else -> null
-                    } ?: EntityPosition(value = 1f, min = 0f, max = 2f) // This should never happen
+                    // Null should never happen: hasPosition is only true when the position is set
+                    val position = entity.position ?: EntityPosition(value = 1f, min = 0f, max = 2f)
                     val positionValueRelative = if (gradientDirection == LayoutDirection.Ltr) {
                         ((position.value - position.min) / (position.max - position.min))
                     } else {

--- a/wear/src/main/kotlin/io/homeassistant/companion/android/views/ChooseEntityView.kt
+++ b/wear/src/main/kotlin/io/homeassistant/companion/android/views/ChooseEntityView.kt
@@ -23,9 +23,10 @@ import androidx.wear.tooling.preview.devices.WearDevices
 import com.mikepenz.iconics.compose.Image
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
 import io.homeassistant.companion.android.common.R as commonR
-import io.homeassistant.companion.android.common.data.integration.Entity
-import io.homeassistant.companion.android.common.data.integration.getIcon
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplay
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.common.util.capitalize
+import io.homeassistant.companion.android.common.util.mdiName
 import io.homeassistant.companion.android.data.SimplifiedEntity
 import io.homeassistant.companion.android.theme.WearAppTheme
 import io.homeassistant.companion.android.theme.getFilledTonalButtonColors
@@ -37,7 +38,7 @@ import java.util.Locale
 @Composable
 fun ChooseEntityView(
     entitiesByDomainOrder: List<String>,
-    entitiesByDomain: Map<String, List<Entity>>,
+    entitiesByDomain: Map<String, List<EntityDisplay>>,
     favoriteEntityIds: List<String>,
     onNoneClicked: () -> Unit,
     onEntitySelected: (entity: SimplifiedEntity) -> Unit,
@@ -118,9 +119,8 @@ fun ChooseEntityView(
 }
 
 @Composable
-private fun ChooseEntityChip(entity: Entity, onEntitySelected: (entity: SimplifiedEntity) -> Unit) {
-    val attributes = entity.attributes as Map<*, *>
-    val iconBitmap = entity.getIcon()
+private fun ChooseEntityChip(entity: EntityDisplay, onEntitySelected: (entity: SimplifiedEntity) -> Unit) {
+    val iconBitmap = entity.icon
     Button(
         modifier = Modifier
             .fillMaxWidth(),
@@ -132,7 +132,7 @@ private fun ChooseEntityChip(entity: Entity, onEntitySelected: (entity: Simplifi
         },
         label = {
             Text(
-                text = attributes["friendly_name"].toString(),
+                text = entity.name,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
@@ -141,8 +141,8 @@ private fun ChooseEntityChip(entity: Entity, onEntitySelected: (entity: Simplifi
             onEntitySelected(
                 SimplifiedEntity(
                     entity.entityId,
-                    attributes["friendly_name"] as String? ?: entity.entityId,
-                    attributes["icon"] as String? ?: "",
+                    entity.name,
+                    entity.statelessIcon.mdiName,
                 ),
             )
         },
@@ -172,8 +172,8 @@ fun ChooseEntityViewWithDataPreview() {
             playPreviewEntityScene2.entityId,
         ),
         entitiesByDomain = mapOf(
-            playPreviewEntityScene1.entityId to listOf(playPreviewEntityScene1),
-            playPreviewEntityScene2.entityId to listOf(playPreviewEntityScene2),
+            playPreviewEntityScene1.entityId to listOf(EntityDisplayWithoutContext(playPreviewEntityScene1)),
+            playPreviewEntityScene2.entityId to listOf(EntityDisplayWithoutContext(playPreviewEntityScene2)),
         ),
         favoriteEntityIds = listOf(playPreviewEntityScene1.entityId),
         onNoneClicked = {},

--- a/wear/src/screenshotTest/kotlin/io/homeassistant/companion/android/EntityListViewPreviewsTest.kt
+++ b/wear/src/screenshotTest/kotlin/io/homeassistant/companion/android/EntityListViewPreviewsTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.wear.tooling.preview.devices.WearDevices
 import com.android.tools.screenshot.PreviewTest
 import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayWithoutContext
 import io.homeassistant.companion.android.home.views.EntityViewList
 import io.homeassistant.companion.android.util.previewEntity1
 import io.homeassistant.companion.android.util.previewEntity2
@@ -17,7 +18,12 @@ class EntityListViewPreviewsTest {
     @Composable
     private fun PreviewEntityListView() {
         EntityViewList(
-            entityLists = mapOf(stringResource(R.string.lights) to listOf(previewEntity1, previewEntity2)),
+            entityLists = mapOf(
+                stringResource(R.string.lights) to listOf(
+                    EntityDisplayWithoutContext(previewEntity1),
+                    EntityDisplayWithoutContext(previewEntity2),
+                ),
+            ),
             entityListsOrder = listOf(stringResource(R.string.lights)),
             entityListFilter = { true },
             onEntityClicked = { _, _ -> },


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR replace the usage of friendly name within the wear module by using the `EntitiesDisplayManager`.

Based on #7246

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.