### PR TITLE
Return entity id when friendly name is blank

### DIFF
--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/Entity.kt
@@ -960,7 +960,7 @@ suspend fun onEntityPressedWithoutState(entityId: String, integrationRepository:
 }
 
 val Entity.friendlyName: String
-    get() = attributes["friendly_name"]?.toString() ?: entityId
+    get() = attributes["friendly_name"]?.toString()?.takeIf { it.isNotBlank() } ?: entityId
 
 /**
  * Formats the entity state for display without registry metadata, so no sensor display

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/EntityTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/EntityTest.kt
@@ -58,6 +58,40 @@ class EntityTest {
     }
 
     @Nested
+    inner class FriendlyNameProperty {
+        @Test
+        fun `Given friendly_name attribute when accessing friendlyName then returns it`() {
+            val entity = createEntity(attributes = mapOf("friendly_name" to "Living Room Light"))
+            assertEquals("Living Room Light", entity.friendlyName)
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = ["", "   "])
+        fun `Given blank friendly_name attribute when accessing friendlyName then returns entityId`(name: String) {
+            val entity = createEntity(attributes = mapOf("friendly_name" to name))
+            assertEquals("light.living_room", entity.friendlyName)
+        }
+
+        @Test
+        fun `Given no friendly_name attribute when accessing friendlyName then returns entityId`() {
+            val entity = createEntity(attributes = emptyMap())
+            assertEquals("light.living_room", entity.friendlyName)
+        }
+
+        @Test
+        fun `Given null friendly_name attribute when accessing friendlyName then returns entityId`() {
+            val entity = createEntity(attributes = mapOf("friendly_name" to null))
+            assertEquals("light.living_room", entity.friendlyName)
+        }
+
+        @Test
+        fun `Given non-string friendly_name attribute when accessing friendlyName then returns its string value`() {
+            val entity = createEntity(attributes = mapOf("friendly_name" to 42))
+            assertEquals("42", entity.friendlyName)
+        }
+    }
+
+    @Nested
     inner class Deserialization {
         private fun entityJson(stateValue: String) = """
             {


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Copilot captured this issue in https://github.com/home-assistant/android/pull/7191#discussion_r3639926784 and I decided to do it in the Entity ext directly.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.