### PR TITLE
Report add matter status to frontend

### DIFF
--- a/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -1,10 +1,14 @@
 package io.homeassistant.companion.android.matter
 
+import android.app.Activity
 import android.content.ComponentName
 import android.os.Build
+import androidx.activity.result.ActivityResult
 import androidx.annotation.ChecksSdkIntAtLeast
+import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.home.matter.commissioning.CommissioningClient
 import com.google.android.gms.home.matter.commissioning.CommissioningRequest
+import com.google.android.gms.home.matter.commissioning.CommissioningResult
 import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.MatterCommissionResponse
 import io.homeassistant.companion.android.common.util.SdkVersion
@@ -63,6 +67,23 @@ class MatterManagerImpl @Inject constructor(
                 .addOnFailureListener { exception ->
                     if (cont.isActive) cont.resume(MatterManager.CommissioningResult.Error(exception))
                 }
+        }
+    }
+
+    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningFlowOutcome {
+        if (result.resultCode != Activity.RESULT_OK) {
+            return MatterManager.CommissioningFlowOutcome.Failed
+        }
+        return try {
+            val commissioningResult = CommissioningResult.fromIntentSenderResult(result.resultCode, result.data)
+            MatterManager.CommissioningFlowOutcome.Success(
+                deviceName = commissioningResult.deviceName?.takeIf { it.isNotBlank() },
+            )
+        } catch (e: ApiException) {
+            // RESULT_OK means our commissioning service completed, so the device was added even
+            // when the result payload cannot be read; only the user-entered name is lost.
+            Timber.w(e, "Commissioning succeeded but its result could not be parsed")
+            MatterManager.CommissioningFlowOutcome.Success(deviceName = null)
         }
     }
 

--- a/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/full/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -70,23 +70,6 @@ class MatterManagerImpl @Inject constructor(
         }
     }
 
-    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningFlowOutcome {
-        if (result.resultCode != Activity.RESULT_OK) {
-            return MatterManager.CommissioningFlowOutcome.Failed
-        }
-        return try {
-            val commissioningResult = CommissioningResult.fromIntentSenderResult(result.resultCode, result.data)
-            MatterManager.CommissioningFlowOutcome.Success(
-                deviceName = commissioningResult.deviceName?.takeIf { it.isNotBlank() },
-            )
-        } catch (e: ApiException) {
-            // RESULT_OK means our commissioning service completed, so the device was added even
-            // when the result payload cannot be read; only the user-entered name is lost.
-            Timber.w(e, "Commissioning succeeded but its result could not be parsed")
-            MatterManager.CommissioningFlowOutcome.Success(deviceName = null)
-        }
-    }
-
     override suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse? {
         return try {
             serverManager.webSocketRepository(serverId).commissionMatterDevice(code)
@@ -106,6 +89,23 @@ class MatterManagerImpl @Inject constructor(
         } catch (e: Exception) {
             Timber.e(e, "Error while executing server commissioning request")
             null
+        }
+    }
+
+    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningRequestResult {
+        if (result.resultCode != Activity.RESULT_OK) {
+            return MatterManager.CommissioningRequestResult.Failed
+        }
+        return try {
+            val commissioningResult = CommissioningResult.fromIntentSenderResult(result.resultCode, result.data)
+            MatterManager.CommissioningRequestResult.Success(
+                deviceName = commissioningResult.deviceName.takeIf { it.isNotBlank() },
+            )
+        } catch (e: ApiException) {
+            // RESULT_OK means our commissioning service completed, so the device was added even
+            // when the result payload cannot be read; only the user-entered name is lost.
+            Timber.w(e, "Commissioning succeeded but its result could not be parsed")
+            MatterManager.CommissioningRequestResult.Success(deviceName = null)
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/incoming/IncomingExternalBusMessage.kt
@@ -290,7 +290,7 @@ data class EntityAddToPayload(
  * The app is expected to run the commissioning flow.
  *
  * Will not be sent by the frontend when the device reports
- * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResult.canCommissionMatter] = `false`.
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResultMessage.ConfigResult.canCommissionMatter] = `false`.
  */
 @Serializable
 @SerialName("matter/commission")
@@ -305,7 +305,7 @@ data class MatterCommissionMessage(override val id: Int? = null) : IncomingExter
  * [id] (success or failure).
  *
  * Will not be sent by the frontend when the device reports
- * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResult.canImportThreadCredentials] = `false`.
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResultMessage.ConfigResult.canImportThreadCredentials] = `false`.
  */
 @Serializable
 @SerialName("thread/import_credentials")

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
@@ -96,6 +96,41 @@ object ImprovDiscoveredDeviceMessage {
 val ImprovDeviceSetupDoneMessage: OutgoingExternalBusMessage = CommandMessage(command = "improv/device_setup_done")
 
 /**
+ * Reports the outcome of the platform Matter commissioning flow to the frontend.
+ *
+ * Sent after the flow launched for a
+ * [io.homeassistant.companion.android.frontend.externalbus.incoming.MatterCommissionMessage]
+ * finishes, on every outcome: the frontend keeps the add-device dialog on its spinner until this
+ * message arrives (see `hasMatterStatusReport` in
+ * [io.homeassistant.companion.android.frontend.externalbus.outgoing.ConfigResultMessage.ConfigResult]).
+ *
+ * @param name The device name the user entered during the flow, prefilled by the frontend in the
+ *   rename step. `null` when the flow failed or provided no name.
+ * @param success Whether the device was commissioned. On `false` the frontend shows its own
+ *   failure feedback and closes the add-device dialog.
+ *
+ * @see CommandMessage
+ */
+object MatterCommissionFinishMessage {
+    operator fun invoke(name: String?, success: Boolean): OutgoingExternalBusMessage = CommandMessage(
+        command = "matter/commission/finish",
+        payload = frontendExternalBusJson.encodeToJsonElement(
+            CommissionFinishPayload(name = name, success = success),
+        ),
+    )
+
+    /**
+     * Whether the frontend acts on this message. Supported since Home Assistant 2026.7; older
+     * frontends ignore it and show no feedback of their own, so the app must surface failures
+     * itself.
+     */
+    fun isHandledByFrontend(version: HomeAssistantVersion?): Boolean = version?.isAtLeast(2026, 7, 0) == true
+
+    @Serializable
+    private data class CommissionFinishPayload(val name: String?, val success: Boolean)
+}
+
+/**
  * Notifies the frontend that the user scanned a code.
  *
  * Sent in response to a [io.homeassistant.companion.android.frontend.externalbus.incoming.BarcodeScanMessage].

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessage.kt
@@ -119,12 +119,7 @@ object MatterCommissionFinishMessage {
         ),
     )
 
-    /**
-     * Whether the frontend acts on this message. Supported since Home Assistant 2026.7; older
-     * frontends ignore it and show no feedback of their own, so the app must surface failures
-     * itself.
-     */
-    fun isHandledByFrontend(version: HomeAssistantVersion?): Boolean = version?.isAtLeast(2026, 7, 0) == true
+    fun isAvailable(version: HomeAssistantVersion?): Boolean = version?.isAtLeast(2026, 7, 0) == true
 
     @Serializable
     private data class CommissionFinishPayload(val name: String?, val success: Boolean)

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/OutgoingExternalBusMessage.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/OutgoingExternalBusMessage.kt
@@ -100,6 +100,7 @@ object ConfigResultMessage {
         val hasEntityAddTo: Boolean = true,
         val hasAssistSettings: Boolean = true,
         val hasSplashscreen: Boolean = true,
+        val hasMatterStatusReport: Boolean = true,
     ) {
         companion object {
             fun create(
@@ -121,44 +122,6 @@ object ConfigResultMessage {
     }
 }
 
-/**
- * Configuration result payload for config/get requests.
- *
- * Contains the app's capabilities that the frontend needs to know about.
- */
-@Serializable
-data class ConfigResult(
-    val hasSettingsScreen: Boolean = true,
-    val canWriteTag: Boolean,
-    val hasExoPlayer: Boolean = true,
-    val canCommissionMatter: Boolean,
-    val canImportThreadCredentials: Boolean,
-    val hasAssist: Boolean = true,
-    val hasBarCodeScanner: Int,
-    val canSetupImprov: Boolean = true,
-    val downloadFileSupported: Boolean = true,
-    val appVersion: String,
-    val hasEntityAddTo: Boolean = true,
-    val hasAssistSettings: Boolean = true,
-) {
-    companion object {
-        fun create(
-            hasNfc: Boolean,
-            canCommissionMatter: Boolean,
-            canExportThread: Boolean,
-            hasBarCodeScanner: Int,
-            canSetupImprov: Boolean,
-            appVersion: AppVersion,
-        ) = ConfigResult(
-            canWriteTag = hasNfc,
-            canCommissionMatter = canCommissionMatter,
-            canImportThreadCredentials = canExportThread,
-            hasBarCodeScanner = hasBarCodeScanner,
-            canSetupImprov = canSetupImprov,
-            appVersion = appVersion.value,
-        )
-    }
-}
 object EntityAddToActionsResultMessage {
     /**
      * Creates a response with available EntityAddTo actions.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandler.kt
@@ -1,10 +1,12 @@
 package io.homeassistant.companion.android.frontend.matterthread
 
-import android.app.Activity
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import dagger.hilt.android.scopes.ViewModelScoped
+import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
+import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
+import io.homeassistant.companion.android.frontend.externalbus.outgoing.MatterCommissionFinishMessage
 import io.homeassistant.companion.android.matter.MatterManager
 import io.homeassistant.companion.android.thread.ThreadManager
 import java.util.concurrent.atomic.AtomicReference
@@ -41,13 +43,17 @@ import timber.log.Timber
  *    [onMatterThreadIntentResult].
  *  - [Event.ShowSnackbar] for transient feedback.
  *
- * The handler does not send any external-bus response messages.
+ * The only external-bus message the handler sends is [MatterCommissionFinishMessage], reporting
+ * the outcome of the Matter commissioning flow on every outcome so the frontend's add-device
+ * dialog can leave its spinner.
  */
 @ViewModelScoped
 internal class FrontendMatterThreadHandler @Inject constructor(
     private val matterManager: MatterManager,
     private val threadManager: ThreadManager,
     private val dialogManager: FrontendDialogManager,
+    private val externalBusRepository: FrontendExternalBusRepository,
+    private val serverManager: ServerManager,
 ) {
 
     /**
@@ -168,8 +174,9 @@ internal class FrontendMatterThreadHandler @Inject constructor(
 
     /**
      * Process the result of the Play Services intent launched in response to [Event.LaunchIntent].
-     * Dispatches based on what's [inFlight] — Matter just surfaces a "cancelled" snackbar on
-     * non-OK, Thread forwards the dataset to the server and reports success / no-dataset.
+     * Dispatches based on what's [inFlight] — Matter reports the outcome (and the user-entered
+     * device name) to the frontend via [MatterCommissionFinishMessage], Thread forwards the
+     * dataset to the server and reports success / no-dataset.
      *
      * Silently ignores stale results when nothing is in-flight (shouldn't happen in practice
      * since only one launcher exists, but guards against bugs).
@@ -190,11 +197,21 @@ internal class FrontendMatterThreadHandler @Inject constructor(
     }
 
     private suspend fun handleMatterIntentResult(result: ActivityResult) {
-        if (result.resultCode == Activity.RESULT_OK) {
-            Timber.d("Matter commissioning returned success")
-        } else {
-            Timber.d("Matter commissioning returned with non-OK code ${result.resultCode}")
-            showTerminal(MatterThreadTerminal.Snackbar.MatterCancelled)
+        when (val outcome = matterManager.parseCommissioningIntentResult(result)) {
+            is MatterManager.CommissioningFlowOutcome.Success -> {
+                Timber.d("Matter commissioning returned success")
+                externalBusRepository.send(MatterCommissionFinishMessage(name = outcome.deviceName, success = true))
+            }
+
+            is MatterManager.CommissioningFlowOutcome.Failed -> {
+                Timber.d("Matter commissioning was cancelled or failed")
+                externalBusRepository.send(MatterCommissionFinishMessage(name = null, success = false))
+                // Frontends that handle the finish message show their own failure feedback and
+                // close the add-device dialog; older ones show nothing, so keep the snackbar.
+                if (!MatterCommissionFinishMessage.isHandledByFrontend(serverManager.getServer()?.version)) {
+                    showTerminal(MatterThreadTerminal.Snackbar.MatterCancelled)
+                }
+            }
         }
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandler.kt
@@ -45,7 +45,7 @@ import timber.log.Timber
  *
  * The only external-bus message the handler sends is [MatterCommissionFinishMessage], reporting
  * the outcome of the Matter commissioning flow on every outcome so the frontend's add-device
- * dialog can leave its spinner.
+ * dialog can hide its spinner.
  */
 @ViewModelScoped
 internal class FrontendMatterThreadHandler @Inject constructor(
@@ -198,17 +198,17 @@ internal class FrontendMatterThreadHandler @Inject constructor(
 
     private suspend fun handleMatterIntentResult(result: ActivityResult) {
         when (val outcome = matterManager.parseCommissioningIntentResult(result)) {
-            is MatterManager.CommissioningFlowOutcome.Success -> {
+            is MatterManager.CommissioningRequestResult.Success -> {
                 Timber.d("Matter commissioning returned success")
                 externalBusRepository.send(MatterCommissionFinishMessage(name = outcome.deviceName, success = true))
             }
 
-            is MatterManager.CommissioningFlowOutcome.Failed -> {
+            is MatterManager.CommissioningRequestResult.Failed -> {
                 Timber.d("Matter commissioning was cancelled or failed")
                 externalBusRepository.send(MatterCommissionFinishMessage(name = null, success = false))
                 // Frontends that handle the finish message show their own failure feedback and
-                // close the add-device dialog; older ones show nothing, so keep the snackbar.
-                if (!MatterCommissionFinishMessage.isHandledByFrontend(serverManager.getServer()?.version)) {
+                // close the add-device dialog; older ones show nothing, so show a simple Snackbar.
+                if (!MatterCommissionFinishMessage.isAvailable(serverManager.getServer()?.version)) {
                     showTerminal(MatterThreadTerminal.Snackbar.MatterCancelled)
                 }
             }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.matter
 
 import android.content.IntentSender
+import androidx.activity.result.ActivityResult
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.MatterCommissionResponse
 
 interface MatterManager {
@@ -28,9 +29,32 @@ interface MatterManager {
     }
 
     /**
+     * Terminal outcome of the platform commissioning flow launched from
+     * [CommissioningResult.Ready.intentSender], derived from its `ActivityResult` by
+     * [parseCommissioningIntentResult].
+     */
+    sealed interface CommissioningFlowOutcome {
+
+        /**
+         * The device was commissioned. [deviceName] is the name the user entered during the
+         * platform flow, or `null` when none was provided.
+         */
+        data class Success(val deviceName: String?) : CommissioningFlowOutcome
+
+        /** The flow was cancelled by the user or failed before the device was commissioned. */
+        data object Failed : CommissioningFlowOutcome
+    }
+
+    /**
      * Indicates if the app on this device supports Matter commissioning.
      */
     fun appSupportsCommissioning(): Boolean
+
+    /**
+     * Interpret the `ActivityResult` of the commissioning flow launched from
+     * [CommissioningResult.Ready.intentSender].
+     */
+    fun parseCommissioningIntentResult(result: ActivityResult): CommissioningFlowOutcome
 
     /**
      * Indicates if the server supports Matter commissioning.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -29,20 +29,20 @@ interface MatterManager {
     }
 
     /**
-     * Terminal outcome of the platform commissioning flow launched from
+     * Terminal outcome of the platform commissioning request launched from
      * [CommissioningResult.Ready.intentSender], derived from its `ActivityResult` by
      * [parseCommissioningIntentResult].
      */
-    sealed interface CommissioningFlowOutcome {
+    sealed interface CommissioningRequestResult {
 
         /**
          * The device was commissioned. [deviceName] is the name the user entered during the
-         * platform flow, or `null` when none was provided.
+         * platform request, or `null` when none was provided.
          */
-        data class Success(val deviceName: String?) : CommissioningFlowOutcome
+        data class Success(val deviceName: String?) : CommissioningRequestResult
 
-        /** The flow was cancelled by the user or failed before the device was commissioned. */
-        data object Failed : CommissioningFlowOutcome
+        /** The request was cancelled by the user or failed before the device was commissioned. */
+        data object Failed : CommissioningRequestResult
     }
 
     /**
@@ -54,7 +54,7 @@ interface MatterManager {
      * Interpret the `ActivityResult` of the commissioning flow launched from
      * [CommissioningResult.Ready.intentSender].
      */
-    fun parseCommissioningIntentResult(result: ActivityResult): CommissioningFlowOutcome
+    fun parseCommissioningIntentResult(result: ActivityResult): CommissioningRequestResult
 
     /**
      * Indicates if the server supports Matter commissioning.

--- a/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/matter/MatterManager.kt
@@ -51,12 +51,6 @@ interface MatterManager {
     fun appSupportsCommissioning(): Boolean
 
     /**
-     * Interpret the `ActivityResult` of the commissioning flow launched from
-     * [CommissioningResult.Ready.intentSender].
-     */
-    fun parseCommissioningIntentResult(result: ActivityResult): CommissioningRequestResult
-
-    /**
      * Indicates if the server supports Matter commissioning.
      */
     suspend fun coreSupportsCommissioning(serverId: Int): Boolean
@@ -88,4 +82,10 @@ interface MatterManager {
      * @return [MatterCommissionResponse], or `null` if it wasn't possible to complete the request.
      */
     suspend fun commissionOnNetworkDevice(pin: Long, ip: String, serverId: Int): MatterCommissionResponse?
+
+    /**
+     * Interpret the `ActivityResult` of the commissioning flow launched from
+     * [CommissioningResult.Ready.intentSender].
+     */
+    fun parseCommissioningIntentResult(result: ActivityResult): CommissioningRequestResult
 }

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.matter
 
+import androidx.activity.result.ActivityResult
 import io.homeassistant.companion.android.common.data.websocket.impl.entities.MatterCommissionResponse
 import javax.inject.Inject
 
@@ -20,6 +21,9 @@ class MatterManagerImpl @Inject constructor() : MatterManager {
         MatterManager.CommissioningResult.Error(
             IllegalStateException("Matter commissioning is not supported with the minimal flavor"),
         )
+
+    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningFlowOutcome =
+        MatterManager.CommissioningFlowOutcome.Failed
 
     override suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse? = null
 

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -22,11 +22,10 @@ class MatterManagerImpl @Inject constructor() : MatterManager {
             IllegalStateException("Matter commissioning is not supported with the minimal flavor"),
         )
 
-    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningRequestResult =
-        MatterManager.CommissioningRequestResult.Failed
-
     override suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse? = null
-
     override suspend fun commissionOnNetworkDevice(pin: Long, ip: String, serverId: Int): MatterCommissionResponse? =
         null
+
+    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningRequestResult =
+        MatterManager.CommissioningRequestResult.Failed
 }

--- a/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
+++ b/app/src/minimal/kotlin/io/homeassistant/companion/android/matter/MatterManagerImpl.kt
@@ -22,8 +22,8 @@ class MatterManagerImpl @Inject constructor() : MatterManager {
             IllegalStateException("Matter commissioning is not supported with the minimal flavor"),
         )
 
-    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningFlowOutcome =
-        MatterManager.CommissioningFlowOutcome.Failed
+    override fun parseCommissioningIntentResult(result: ActivityResult): MatterManager.CommissioningRequestResult =
+        MatterManager.CommissioningRequestResult.Failed
 
     override suspend fun commissionDevice(code: String, serverId: Int): MatterCommissionResponse? = null
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.frontend.externalbus.outgoing
 
+import io.homeassistant.companion.android.common.data.HomeAssistantVersion
 import io.homeassistant.companion.android.frontend.externalbus.frontendExternalBusJson
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -28,6 +29,37 @@ class CommandMessageTest {
             """{"type":"command","id":null,"command":"navigate","payload":{"path":"/lovelace/dashboard","options":{"replace":false}}}""",
             json,
         )
+    }
+
+    @Test
+    fun `Given MatterCommissionFinishMessage with name when serializing then produces command with payload`() {
+        val message = MatterCommissionFinishMessage(name = "Kitchen light", success = true)
+
+        val json = frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(message)
+
+        assertEquals(
+            """{"type":"command","id":null,"command":"matter/commission/finish","payload":{"name":"Kitchen light","success":true}}""",
+            json,
+        )
+    }
+
+    @Test
+    fun `Given failed MatterCommissionFinishMessage when serializing then payload contains explicit null name`() {
+        val message = MatterCommissionFinishMessage(name = null, success = false)
+
+        val json = frontendExternalBusJson.encodeToString<OutgoingExternalBusMessage>(message)
+
+        assertEquals(
+            """{"type":"command","id":null,"command":"matter/commission/finish","payload":{"name":null,"success":false}}""",
+            json,
+        )
+    }
+
+    @Test
+    fun `Given server version when isHandledByFrontend then only 2026_7 and later handle the finish message`() {
+        assertEquals(false, MatterCommissionFinishMessage.isHandledByFrontend(null))
+        assertEquals(false, MatterCommissionFinishMessage.isHandledByFrontend(HomeAssistantVersion(2026, 6, 9)))
+        assertEquals(true, MatterCommissionFinishMessage.isHandledByFrontend(HomeAssistantVersion(2026, 7, 0)))
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/CommandMessageTest.kt
@@ -56,10 +56,10 @@ class CommandMessageTest {
     }
 
     @Test
-    fun `Given server version when isHandledByFrontend then only 2026_7 and later handle the finish message`() {
-        assertEquals(false, MatterCommissionFinishMessage.isHandledByFrontend(null))
-        assertEquals(false, MatterCommissionFinishMessage.isHandledByFrontend(HomeAssistantVersion(2026, 6, 9)))
-        assertEquals(true, MatterCommissionFinishMessage.isHandledByFrontend(HomeAssistantVersion(2026, 7, 0)))
+    fun `Given server version when isAvailable then only 2026_7 and later handle the finish message`() {
+        assertEquals(false, MatterCommissionFinishMessage.isAvailable(null))
+        assertEquals(false, MatterCommissionFinishMessage.isAvailable(HomeAssistantVersion(2026, 6, 9)))
+        assertEquals(true, MatterCommissionFinishMessage.isAvailable(HomeAssistantVersion(2026, 7, 0)))
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/OutgoingExternalBusMessageTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/externalbus/outgoing/OutgoingExternalBusMessageTest.kt
@@ -23,7 +23,7 @@ class OutgoingExternalBusMessageTest {
             ),
         )
         assertEquals(
-            """{"type":"result","id":1,"success":true,"result":{"hasSettingsScreen":true,"canWriteTag":true,"hasExoPlayer":true,"canCommissionMatter":true,"canImportThreadCredentials":true,"hasAssist":true,"hasBarCodeScanner":0,"canSetupImprov":true,"downloadFileSupported":true,"appVersion":"1.0.0 (1)","hasEntityAddTo":true,"hasAssistSettings":true,"hasSplashscreen":true},"error":null}""",
+            """{"type":"result","id":1,"success":true,"result":{"hasSettingsScreen":true,"canWriteTag":true,"hasExoPlayer":true,"canCommissionMatter":true,"canImportThreadCredentials":true,"hasAssist":true,"hasBarCodeScanner":0,"canSetupImprov":true,"downloadFileSupported":true,"appVersion":"1.0.0 (1)","hasEntityAddTo":true,"hasAssistSettings":true,"hasSplashscreen":true,"hasMatterStatusReport":true},"error":null}""",
             json,
         )
     }
@@ -63,6 +63,7 @@ class OutgoingExternalBusMessageTest {
         assertTrue(config.hasEntityAddTo)
         assertTrue(config.hasAssistSettings)
         assertTrue(config.hasSplashscreen)
+        assertTrue(config.hasMatterStatusReport)
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandlerTest.kt
@@ -4,11 +4,17 @@ import android.app.Activity
 import android.content.IntentSender
 import androidx.activity.result.ActivityResult
 import app.cash.turbine.test
+import io.homeassistant.companion.android.common.data.HomeAssistantVersion
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.frontend.dialog.FrontendDialogManager
+import io.homeassistant.companion.android.frontend.externalbus.FrontendExternalBusRepository
+import io.homeassistant.companion.android.frontend.externalbus.outgoing.MatterCommissionFinishMessage
 import io.homeassistant.companion.android.matter.MatterManager
 import io.homeassistant.companion.android.thread.ThreadManager
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.awaitCancellation
@@ -28,12 +34,23 @@ class FrontendMatterThreadHandlerTest {
         // Default: progress dialog suspends forever (caller must cancel to dismiss).
         coEvery { showMatterThreadProgress() } coAnswers { awaitCancellation() }
     }
+    private val externalBusRepository: FrontendExternalBusRepository = mockk(relaxed = true)
+    private val serverManager: ServerManager = mockk(relaxed = true)
 
     private fun createHandler() = FrontendMatterThreadHandler(
         matterManager = matterManager,
         threadManager = threadManager,
         dialogManager = dialogManager,
+        externalBusRepository = externalBusRepository,
+        serverManager = serverManager,
     )
+
+    private fun givenServerVersion(version: HomeAssistantVersion?) {
+        val server: Server = mockk {
+            every { this@mockk.version } returns version
+        }
+        coEvery { serverManager.getServer() } returns server
+    }
 
     @Test
     fun `Given Matter Ready result when onStartMatterCommissioning then emits LaunchIntent`() = runTest {
@@ -84,8 +101,10 @@ class FrontendMatterThreadHandlerTest {
     }
 
     @Test
-    fun `Given Matter is in-flight and RESULT_OK when onMatterThreadIntentResult then no event is emitted`() = runTest {
+    fun `Given Matter is in-flight and commissioning succeeded when onMatterThreadIntentResult then reports success with device name`() = runTest {
         coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
+        every { matterManager.parseCommissioningIntentResult(any()) } returns
+            MatterManager.CommissioningFlowOutcome.Success(deviceName = "Kitchen light")
         val handler = createHandler()
         // Drive the handler to the awaiting-intent-result state.
         handler.onStartMatterCommissioning()
@@ -94,12 +113,15 @@ class FrontendMatterThreadHandlerTest {
             handler.onMatterThreadIntentResult(ActivityResult(Activity.RESULT_OK, null))
             expectNoEvents()
         }
+        coVerify { externalBusRepository.send(MatterCommissionFinishMessage(name = "Kitchen light", success = true)) }
         coVerify(exactly = 0) { dialogManager.showMatterThreadTerminal(any()) }
     }
 
     @Test
-    fun `Given Matter is in-flight and RESULT_CANCELED when onMatterThreadIntentResult then emits MatterCancelled snackbar`() = runTest {
+    fun `Given Matter is in-flight and commissioning failed on old server when onMatterThreadIntentResult then reports failure and emits MatterCancelled snackbar`() = runTest {
         coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
+        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningFlowOutcome.Failed
+        givenServerVersion(HomeAssistantVersion(2026, 6, 0))
         val handler = createHandler()
         handler.onStartMatterCommissioning()
 
@@ -113,6 +135,23 @@ class FrontendMatterThreadHandlerTest {
             )
             cancelAndIgnoreRemainingEvents()
         }
+        coVerify { externalBusRepository.send(MatterCommissionFinishMessage(name = null, success = false)) }
+    }
+
+    @Test
+    fun `Given Matter is in-flight and commissioning failed on 2026_7 server when onMatterThreadIntentResult then reports failure without snackbar`() = runTest {
+        coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
+        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningFlowOutcome.Failed
+        givenServerVersion(HomeAssistantVersion(2026, 7, 0))
+        val handler = createHandler()
+        handler.onStartMatterCommissioning()
+
+        handler.events.test {
+            handler.onMatterThreadIntentResult(ActivityResult(Activity.RESULT_CANCELED, null))
+            expectNoEvents()
+        }
+        coVerify { externalBusRepository.send(MatterCommissionFinishMessage(name = null, success = false)) }
+        coVerify(exactly = 0) { dialogManager.showMatterThreadTerminal(any()) }
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/matterthread/FrontendMatterThreadHandlerTest.kt
@@ -104,7 +104,7 @@ class FrontendMatterThreadHandlerTest {
     fun `Given Matter is in-flight and commissioning succeeded when onMatterThreadIntentResult then reports success with device name`() = runTest {
         coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
         every { matterManager.parseCommissioningIntentResult(any()) } returns
-            MatterManager.CommissioningFlowOutcome.Success(deviceName = "Kitchen light")
+            MatterManager.CommissioningRequestResult.Success(deviceName = "Kitchen light")
         val handler = createHandler()
         // Drive the handler to the awaiting-intent-result state.
         handler.onStartMatterCommissioning()
@@ -120,7 +120,7 @@ class FrontendMatterThreadHandlerTest {
     @Test
     fun `Given Matter is in-flight and commissioning failed on old server when onMatterThreadIntentResult then reports failure and emits MatterCancelled snackbar`() = runTest {
         coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
-        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningFlowOutcome.Failed
+        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningRequestResult.Failed
         givenServerVersion(HomeAssistantVersion(2026, 6, 0))
         val handler = createHandler()
         handler.onStartMatterCommissioning()
@@ -141,7 +141,7 @@ class FrontendMatterThreadHandlerTest {
     @Test
     fun `Given Matter is in-flight and commissioning failed on 2026_7 server when onMatterThreadIntentResult then reports failure without snackbar`() = runTest {
         coEvery { matterManager.prepareMatterDeviceCommissioning() } returns MatterManager.CommissioningResult.Ready(mockk())
-        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningFlowOutcome.Failed
+        every { matterManager.parseCommissioningIntentResult(any()) } returns MatterManager.CommissioningRequestResult.Failed
         givenServerVersion(HomeAssistantVersion(2026, 7, 0))
         val handler = createHandler()
         handler.onStartMatterCommissioning()


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Align with iOS https://github.com/home-assistant/iOS/pull/4684 by sending the finish commissioning event.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.