### PR TITLE
Limit workflows to only run on the official repo to avoid forks unnecessary usage

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -8,6 +8,7 @@ jobs:
   tag:
     name: Tag Monthly Release
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/onPush.yml
+++ b/.github/workflows/onPush.yml
@@ -18,6 +18,7 @@ jobs:
   app_build:
     name: Github, Firebase, and Sentry Release
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     permissions:
       contents: write
     steps:
@@ -158,6 +159,7 @@ jobs:
   play_publish:
     name: Play Publish
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     concurrency:
       group: playstore_deploy
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
   play_promote_production:
     name: Play Publish Production
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/renovate-lockfiles.yml
+++ b/.github/workflows/renovate-lockfiles.yml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   update-lockfiles:
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     permissions:
       contents: write # To push to the current branch
     steps:

--- a/.github/workflows/restrict-task-creation.yml
+++ b/.github/workflows/restrict-task-creation.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     # Only run if this is a Task issue type (from the issue form)
-    if: github.event.issue.type.name == 'Task'
+    if: github.repository == 'home-assistant/android' && github.event.issue.type.name == 'Task'
     steps:
       - name: Check if user is authorized
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -8,6 +8,7 @@ jobs:
   tag:
     name: Tag Weekly Release
     runs-on: ubuntu-latest
+    if: github.repository == 'home-assistant/android'
     permissions:
       actions: write # Start workflows onPush and prepareNextRelease
       contents: write # Allow pushing tags


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
I had some forks cloned locally and I noticed that some forks where running some workflows like the weekly workflow. It doesn't make sense and waste resources. On top of that the contributors might not even know that it runs there.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [ ] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [ ] The changes have been thoroughly tested, and edge cases have been considered.
- [ ] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [ ] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.