### PR TITLE
Fix EntityWidgetConfigure build

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreen.kt
@@ -507,7 +507,7 @@ private val previewEntityWidgetConfigureState = EntityWidgetConfigureState(
     serversDropdownItems = listOf(previewServer1, previewServer2).map {
         HADropdownItem(key = it.id, label = it.friendlyName)
     },
-    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem.from(previewEntity1))),
+    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem(previewEntity1))),
     selectedEntityId = previewEntity1.entityId,
     availableAttributes = listOf("brightness", "friendly_name"),
     selectedAttributeIds = listOf("brightness"),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModel.kt
@@ -219,7 +219,7 @@ class EntityWidgetConfigureViewModel @AssistedInject constructor(
                 _state.update { it.copy(entityDisplayState = EntityDisplayState.Loaded(emptyList())) }
                 return@launch
             }
-            getEntitiesForDisplay(serverId).collect { displayState ->
+            getEntitiesForDisplay.snapshot(serverId).collect { displayState ->
                 _state.update { it.copy(entityDisplayState = displayState) }
                 // The selection can be set before the entities resolve (preselected entity or
                 // restored widget), so the generated label is refreshed once they are available.

--- a/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreenshotTest.kt
+++ b/app/src/screenshotTest/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreenshotTest.kt
@@ -79,7 +79,7 @@ private val previewEntityWidgetConfigureState = EntityWidgetConfigureState(
     serversDropdownItems = listOf(previewServer1, previewServer2).map {
         HADropdownItem(key = it.id, label = it.friendlyName)
     },
-    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem.from(previewEntity1))),
+    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem(previewEntity1))),
     selectedEntityId = previewEntity1.entityId,
     availableAttributes = listOf("brightness", "friendly_name"),
     selectedAttributeIds = listOf("brightness"),

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreenTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreenTest.kt
@@ -325,7 +325,7 @@ class EntityWidgetConfigureScreenTest {
         val newWidgetState = EntityWidgetConfigureState(
             serversDropdownItems = listOf(HADropdownItem(key = 1, label = "Home")),
             selectedServerId = 1,
-            entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem.from(ENTITY))),
+            entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem(ENTITY))),
         )
 
         val configuredState = newWidgetState.copy(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModelTest.kt
@@ -60,7 +60,7 @@ class EntityWidgetConfigureViewModelTest {
         coEvery { serverManager.getServer() } returns server
         coEvery { serverManager.getServer(any<Int>()) } returns server
         coEvery { dao.get(any()) } returns null
-        every { getEntitiesForDisplay(any(), any<(Entity) -> Boolean>()) } returns flowOf(displayStateOf(entity.toDisplayItem("Office light")))
+        every { getEntitiesForDisplay.snapshot(any(), any<(Entity) -> Boolean>()) } returns flowOf(displayStateOf(entity.toDisplayItem("Office light")))
     }
 
     @Test
@@ -145,7 +145,7 @@ class EntityWidgetConfigureViewModelTest {
     fun `Given a generated label when entity changes then label follows the selected entity`() = runTest {
         val secondEntity = createEntity(entityId = "switch.fan", attributes = emptyMap())
         coEvery { integrationRepository.getEntity(secondEntity.entityId) } returns secondEntity
-        every { getEntitiesForDisplay(any(), any<(Entity) -> Boolean>()) } returns
+        every { getEntitiesForDisplay.snapshot(any(), any<(Entity) -> Boolean>()) } returns
             flowOf(displayStateOf(entity.toDisplayItem("Office light"), secondEntity.toDisplayItem("Fan")))
         val viewModel = createViewModel()
         advanceUntilIdle()
@@ -251,7 +251,7 @@ class EntityWidgetConfigureViewModelTest {
         private fun displayStateOf(vararg items: EntityDisplayItem) = EntityDisplayState.Loaded(items.toList())
 
         /** Display name comes from the entity registry in production, so it is set explicitly here. */
-        private fun Entity.toDisplayItem(name: String) = EntityDisplayItem.from(this).copy(name = name)
+        private fun Entity.toDisplayItem(name: String) = EntityDisplayItem(this).copy(name = name)
 
         private fun createEntity(entityId: String, attributes: Map<String, Any?>) = Entity(
             entityId = entityId,


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We've merged #7007 but it was not up to date on main and we end up into a build that is not building because of that. This Pr fix this by simply using the new methods available in the use case.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.