### PR TITLE
Fix entity widget configuration after merge

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreen.kt
@@ -507,7 +507,7 @@ private val previewEntityWidgetConfigureState = EntityWidgetConfigureState(
     serversDropdownItems = listOf(previewServer1, previewServer2).map {
         HADropdownItem(key = it.id, label = it.friendlyName)
     },
-    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem.from(previewEntity1))),
+    entityDisplayState = EntityDisplayState.Loaded(listOf(EntityDisplayItem(previewEntity1))),
     selectedEntityId = previewEntity1.entityId,
     availableAttributes = listOf("brightness", "friendly_name"),
     selectedAttributeIds = listOf("brightness"),

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModel.kt
@@ -219,7 +219,7 @@ class EntityWidgetConfigureViewModel @AssistedInject constructor(
                 _state.update { it.copy(entityDisplayState = EntityDisplayState.Loaded(emptyList())) }
                 return@launch
             }
-            getEntitiesForDisplay(serverId).collect { displayState ->
+            getEntitiesForDisplay.snapshot(serverId).collect { displayState ->
                 _state.update { it.copy(entityDisplayState = displayState) }
                 // The selection can be set before the entities resolve (preselected entity or
                 // restored widget), so the generated label is refreshed once they are available.


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes main [build failure](https://github.com/home-assistant/android/actions/runs/30296856669/job/90079917517) after merging #7007 which wasn't adjusted to the changes in #7189.

```
e: file:///home/runner/work/android/android/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureScreen.kt:510:77 Unresolved reference 'from'.
e: file:///home/runner/work/android/android/app/src/main/kotlin/io/homeassistant/companion/android/widgets/entity/EntityWidgetConfigureViewModel.kt:222:13 Unresolved reference 'getEntitiesForDisplay'.
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->