### PR TITLE
Avoid crashing when Bluetooth adapter is not available

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/FrontendImprovModule.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/FrontendImprovModule.kt
@@ -1,5 +1,6 @@
 package io.homeassistant.companion.android.frontend.improv
 
+import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.pm.PackageManager
 import com.wifi.improv.ImprovManager
@@ -32,6 +33,10 @@ abstract class FrontendImprovModule {
         @Provides
         @Singleton
         fun provideImprovManagerFactory(@ApplicationContext context: Context): ImprovManagerFactory =
-            ImprovManagerFactory { callback -> ImprovManager(context.applicationContext, callback) }
+            ImprovManagerFactory { callback ->
+                context.getSystemService(BluetoothManager::class.java)?.adapter?.let {
+                    ImprovManager(context.applicationContext, callback)
+                }
+            }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovManagerFactory.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovManagerFactory.kt
@@ -9,7 +9,10 @@ import com.wifi.improv.ImprovManagerCallback
  * Exists so the repository does not have to hold an Android `Context` — the factory closes over
  * the application context at the Hilt provision site, leaving the repository fully unit-testable
  * with a mock factory.
+ *
+ * Returns `null` on devices without a Bluetooth adapter: [ImprovManager] dereferences the adapter
+ * at construction and would crash.
  */
 fun interface ImprovManagerFactory {
-    fun create(callback: ImprovManagerCallback): ImprovManager
+    fun create(callback: ImprovManagerCallback): ImprovManager?
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImpl.kt
@@ -60,7 +60,8 @@ class ImprovRepositoryImpl @VisibleForTesting constructor(
         backgroundDispatcher = Dispatchers.IO,
     )
 
-    private val manager: ImprovManager = improvManagerFactory.create(this)
+    // Null on devices without a Bluetooth adapter; scanning and provisioning are then inert.
+    private val manager: ImprovManager? = improvManagerFactory.create(this)
 
     private val devices = MutableStateFlow(emptyList<ImprovDevice>())
     private val stateEvents = MutableSharedFlow<DeviceState>(extraBufferCapacity = 16)
@@ -98,6 +99,11 @@ class ImprovRepositoryImpl @VisibleForTesting constructor(
 
     override fun provisionDevice(device: ImprovDevice, ssid: String, password: String): Flow<ProvisioningEvent> =
         channelFlow {
+            val manager = manager ?: run {
+                Timber.w("Ignoring Improv provisioning: device has no Bluetooth adapter")
+                close()
+                return@channelFlow
+            }
             var credentialsSent = false
 
             // Forward error events for the duration of the session.
@@ -190,6 +196,7 @@ class ImprovRepositoryImpl @VisibleForTesting constructor(
     // endregion
 
     private suspend fun startScanInternal() = withContext(backgroundDispatcher) {
+        val manager = manager ?: return@withContext
         if (!hasPermissions()) return@withContext
         try {
             manager.findDevices()
@@ -206,7 +213,7 @@ class ImprovRepositoryImpl @VisibleForTesting constructor(
     // `ensureActive` and the BLE scan would never be torn down.
     private suspend fun stopScanInternal() = withContext(NonCancellable + backgroundDispatcher) {
         try {
-            manager.stopScan()
+            manager?.stopScan()
         } catch (e: Exception) {
             Timber.w(e, "Cannot stop scanning")
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImpl.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImpl.kt
@@ -100,7 +100,8 @@ class ImprovRepositoryImpl @VisibleForTesting constructor(
     override fun provisionDevice(device: ImprovDevice, ssid: String, password: String): Flow<ProvisioningEvent> =
         channelFlow {
             val manager = manager ?: run {
-                Timber.w("Ignoring Improv provisioning: device has no Bluetooth adapter")
+                Timber.i("Improv provisioning not available: device has no Bluetooth adapter")
+                send(ProvisioningEvent.ErrorOccurred(ErrorState.UNABLE_TO_CONNECT))
                 close()
                 return@channelFlow
             }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImplTest.kt
@@ -36,11 +36,12 @@ class ImprovRepositoryImplTest {
         sdkInt: Int = Build.VERSION_CODES.S,
         scope: CoroutineScope = backgroundScope,
         ioDispatcher: CoroutineDispatcher = StandardTestDispatcher(testScheduler),
+        factory: ImprovManagerFactory = improvManagerFactory,
     ): ImprovRepositoryImpl {
         SdkVersion.sdkInt = sdkInt
         return ImprovRepositoryImpl(
             permissionChecker = permissionChecker,
-            improvManagerFactory = improvManagerFactory,
+            improvManagerFactory = factory,
             shareInScope = scope,
             backgroundDispatcher = ioDispatcher,
         )
@@ -345,6 +346,32 @@ class ImprovRepositoryImplTest {
                 val error = awaitError()
                 assertInstanceOf(SecurityException::class.java, error)
                 assertEquals("wifi-denied", error.message)
+            }
+        }
+    }
+
+    @Nested
+    inner class WithoutBluetoothAdapter {
+
+        @Test
+        fun `Given no Bluetooth adapter when scanDevices subscribed then scan stays inert`() = runTest {
+            every { permissionChecker.hasPermission(any()) } returns true
+            val repository = createRepository(factory = { null })
+
+            repository.scanDevices().test {
+                assertEquals(emptyList<ImprovDevice>(), awaitItem())
+                cancelAndIgnoreRemainingEvents()
+            }
+            // Also covers the teardown path: stopScan on a missing manager must not throw.
+            advanceTimeBy(SCAN_IDLE_WINDOW_MS + 1)
+        }
+
+        @Test
+        fun `Given no Bluetooth adapter when provisionDevice then flow completes without events`() = runTest {
+            val repository = createRepository(factory = { null })
+
+            repository.provisionDevice(ImprovDevice("d", "AA"), "wifi", "pwd").test {
+                awaitComplete()
             }
         }
     }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImplTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/improv/ImprovRepositoryImplTest.kt
@@ -367,10 +367,11 @@ class ImprovRepositoryImplTest {
         }
 
         @Test
-        fun `Given no Bluetooth adapter when provisionDevice then flow completes without events`() = runTest {
+        fun `Given no Bluetooth adapter when provisionDevice then flow emits error and completes`() = runTest {
             val repository = createRepository(factory = { null })
 
             repository.provisionDevice(ImprovDevice("d", "AA"), "wifi", "pwd").test {
+                assertEquals(ProvisioningEvent.ErrorOccurred(ErrorState.UNABLE_TO_CONNECT), awaitItem())
                 awaitComplete()
             }
         }


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
While working on the #7035 I found out that we are currently crashing the app when the device doesn't have a Bluetooth adapter which could happen. This PR handle this case.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.