### PR TITLE
Avoid crashing when Shortcuts are using reserved string

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsSettingsFragment.kt
@@ -28,6 +28,7 @@ class ManageShortcutsSettingsFragment : Fragment() {
 
     companion object {
         const val MAX_SHORTCUTS = 5
+        const val PINNED_SHORTCUT_INDEX = MAX_SHORTCUTS + 1
         const val SHORTCUT_PREFIX = "shortcut"
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
@@ -111,9 +111,10 @@ internal class ManageShortcutsViewModel @Inject constructor(
                 Timber.d("We have ${pinnedShortcuts.size} pinned shortcuts")
             }
 
-            if (dynamicShortcuts.isNotEmpty()) {
-                for (i in 0 until dynamicShortcuts.size) {
-                    setDynamicShortcutData(dynamicShortcuts[i].id, i)
+            dynamicShortcuts.forEach { item ->
+                dynamicSlotIndex(item.id)?.let { index ->
+                    Timber.d("setting ${item.id} data")
+                    shortcuts[index].setData(item)
                 }
             }
         }
@@ -137,7 +138,7 @@ internal class ManageShortcutsViewModel @Inject constructor(
             icon = icon,
         )
 
-        if (shortcutId.startsWith("shortcut")) {
+        if (dynamicSlotIndex(shortcutId) != null) {
             ShortcutManagerCompat.addDynamicShortcuts(app, listOf(shortcut))
             updateDynamicShortcuts()
         } else {
@@ -181,16 +182,16 @@ internal class ManageShortcutsViewModel @Inject constructor(
             }.toMutableList()
     }
 
-    private fun setDynamicShortcutData(shortcutId: String, index: Int) = viewModelScope.launch {
-        if (dynamicShortcuts.isNotEmpty()) {
-            for (item in dynamicShortcuts) {
-                if (item.id == shortcutId) {
-                    Timber.d("setting ${item.id} data")
-                    shortcuts[index].setData(item)
-                }
-            }
-        }
-    }
+    /** Returns whether [shortcutId] is reserved for a dynamic shortcut slot and can't be used for a pinned shortcut. */
+    fun isReservedShortcutId(shortcutId: String): Boolean = dynamicSlotIndex(shortcutId) != null
+
+    /**
+     * Returns the zero-based slot index for a dynamic shortcut ID managed by this screen
+     * (exactly "shortcut_1".."shortcut_5"), or null for any other ID such as a pinned shortcut.
+     */
+    private fun dynamicSlotIndex(shortcutId: String): Int? = (1..ManageShortcutsSettingsFragment.MAX_SHORTCUTS)
+        .firstOrNull { slot -> "${ManageShortcutsSettingsFragment.SHORTCUT_PREFIX}_$slot" == shortcutId }
+        ?.minus(1)
 
     private suspend fun Shortcut.setData(item: ShortcutInfoCompat) {
         val currentServerId = currentServerId()

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModel.kt
@@ -71,7 +71,7 @@ internal class ManageShortcutsViewModel @Inject constructor(
     )
 
     var shortcuts = mutableStateListOf<Shortcut>().apply {
-        repeat(6) {
+        repeat(ManageShortcutsSettingsFragment.MAX_SHORTCUTS + 1) {
             add(
                 Shortcut(
                     id = mutableStateOf(""),
@@ -187,7 +187,8 @@ internal class ManageShortcutsViewModel @Inject constructor(
 
     /**
      * Returns the zero-based slot index for a dynamic shortcut ID managed by this screen
-     * (exactly "shortcut_1".."shortcut_5"), or null for any other ID such as a pinned shortcut.
+     * (exactly "${ManageShortcutsSettingsFragment.SHORTCUT_PREFIX}_<slot>" where slot is 1..MAX_SHORTCUTS),
+     * or null for any other ID such as a pinned shortcut.
      */
     private fun dynamicSlotIndex(shortcutId: String): Int? = (1..ManageShortcutsSettingsFragment.MAX_SHORTCUTS)
         .firstOrNull { slot -> "${ManageShortcutsSettingsFragment.SHORTCUT_PREFIX}_$slot" == shortcutId }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
@@ -94,6 +95,7 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
     val index = i + 1
     val shortcut = viewModel.shortcuts[i]
     val shortcutId = ManageShortcutsSettingsFragment.SHORTCUT_PREFIX + "_" + index
+    val pinnedIdReserved = index == 6 && viewModel.isReservedShortcutId(shortcut.id.value.orEmpty())
     Text(
         text = if (index < 6) {
             stringResource(id = R.string.shortcut) + " $index"
@@ -170,8 +172,16 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
             label = {
                 Text(stringResource(id = R.string.shortcut_pinned_id))
             },
+            isError = pinnedIdReserved,
             modifier = Modifier.fillMaxWidth(),
         )
+        if (pinnedIdReserved) {
+            Text(
+                text = stringResource(id = R.string.shortcut_pinned_id_reserved),
+                fontSize = 12.sp,
+                color = MaterialTheme.colors.error,
+            )
+        }
     }
 
     Row(verticalAlignment = Alignment.CenterVertically) {
@@ -310,7 +320,7 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
             )
         },
         enabled =
-        (index < 6 || !shortcut.id.value.isNullOrEmpty()) &&
+        (index < 6 || (!shortcut.id.value.isNullOrEmpty() && !pinnedIdReserved)) &&
             shortcut.label.value.isNotEmpty() &&
             shortcut.desc.value.isNotEmpty() &&
             shortcut.path.value.isNotEmpty() &&

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
@@ -95,9 +95,11 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
     val index = i + 1
     val shortcut = viewModel.shortcuts[i]
     val shortcutId = ManageShortcutsSettingsFragment.SHORTCUT_PREFIX + "_" + index
-    val pinnedIdReserved = index == 6 && viewModel.isReservedShortcutId(shortcut.id.value.orEmpty())
+    val pinnedIdReserved =
+        index == ManageShortcutsSettingsFragment.PINNED_SHORTCUT_INDEX &&
+            viewModel.isReservedShortcutId(shortcut.id.value.orEmpty())
     Text(
-        text = if (index < 6) {
+        text = if (index < ManageShortcutsSettingsFragment.PINNED_SHORTCUT_INDEX) {
             stringResource(id = R.string.shortcut) + " $index"
         } else {
             stringResource(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModelTest.kt
@@ -1,0 +1,162 @@
+package io.homeassistant.companion.android.settings.shortcuts.legacy
+
+import android.app.Application
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.pm.ShortcutInfoCompat
+import androidx.core.content.pm.ShortcutManagerCompat
+import androidx.test.core.app.ApplicationProvider
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.data.integration.display.EntitiesForDisplayManager
+import io.homeassistant.companion.android.common.data.servers.ServerManager
+import io.homeassistant.companion.android.database.server.Server
+import io.homeassistant.companion.android.database.server.ServerConnectionInfo
+import io.homeassistant.companion.android.database.server.ServerSessionInfo
+import io.homeassistant.companion.android.database.server.ServerUserInfo
+import io.homeassistant.companion.android.settings.shortcuts.HaShortcutManager
+import io.homeassistant.companion.android.settings.shortcuts.SHORTCUT_EXTRA_PATH
+import io.homeassistant.companion.android.settings.shortcuts.SHORTCUT_EXTRA_SERVER
+import io.homeassistant.companion.android.testing.unit.MainDispatcherJUnit4Rule
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class, sdk = [Build.VERSION_CODES.TIRAMISU])
+@OptIn(ExperimentalCoroutinesApi::class)
+class ManageShortcutsViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherJUnit4Rule()
+
+    private lateinit var application: Application
+
+    private val serverManager: ServerManager = mockk()
+    private val shortcutManager: HaShortcutManager = mockk()
+    private val entitiesForDisplayManager: EntitiesForDisplayManager = mockk()
+
+    @Before
+    fun setUp() {
+        application = ApplicationProvider.getApplicationContext()
+        coEvery { serverManager.getServer(any<Int>()) } returns fakeServer(0)
+        coEvery { serverManager.servers() } returns listOf(fakeServer(0))
+        every { entitiesForDisplayManager.snapshotInContext(serverId = any()) } returns emptyFlow()
+        coEvery { shortcutManager.resolveIconFromIntent(any()) } returns null
+    }
+
+    private fun fakeServer(id: Int) = Server(
+        id = id,
+        _name = "Server $id",
+        connection = ServerConnectionInfo(externalUrl = "https://example.com"),
+        session = ServerSessionInfo(),
+        user = ServerUserInfo(),
+    )
+
+    private fun fakeShortcutInfo(id: String, path: String = "path_$id") = ShortcutInfoCompat.Builder(application, id)
+        .setShortLabel("Label $id")
+        .setLongLabel("Description $id")
+        .setIntent(
+            Intent(Intent.ACTION_VIEW)
+                .putExtra(SHORTCUT_EXTRA_SERVER, 0)
+                .putExtra(SHORTCUT_EXTRA_PATH, path),
+        )
+        .build()
+
+    private fun createViewModel() = ManageShortcutsViewModel(
+        serverManager = serverManager,
+        shortcutManager = shortcutManager,
+        entitiesForDisplayManager = entitiesForDisplayManager,
+        application = application,
+    )
+
+    @Test
+    fun `Given more dynamic shortcuts than slots when creating the view model then extra shortcuts are ignored`() = runTest {
+        val slotShortcuts = (1..5).map { fakeShortcutInfo("shortcut_$it") }
+        val strayShortcuts = listOf(
+            fakeShortcutInfo("shortcutStray1"),
+            fakeShortcutInfo("shortcutStray2"),
+            fakeShortcutInfo("1"),
+            fakeShortcutInfo("shortcut_05"),
+        )
+        ShortcutManagerCompat.addDynamicShortcuts(application, slotShortcuts + strayShortcuts)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        (1..5).forEach { index ->
+            assertEquals("path_shortcut_$index", viewModel.shortcuts[index - 1].path.value)
+        }
+        assertEquals("", viewModel.shortcuts.last().path.value)
+    }
+
+    @Test
+    fun `Given a single dynamic shortcut when creating the view model then it fills the slot matching its id`() = runTest {
+        ShortcutManagerCompat.addDynamicShortcuts(application, listOf(fakeShortcutInfo("shortcut_3")))
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals("path_shortcut_3", viewModel.shortcuts[2].path.value)
+        assertEquals("", viewModel.shortcuts[0].path.value)
+    }
+
+    @Test
+    fun `Given a pinned id that is not exactly a slot id when creating the shortcut then it is not added as dynamic`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        listOf("shortcut for lights", "1", "shortcut_05").forEach { pinnedId ->
+            every {
+                shortcutManager.buildShortcutInfo(any(), any(), any(), any(), any(), any())
+            } returns fakeShortcutInfo(pinnedId)
+
+            viewModel.createShortcut(pinnedId, 0, "Label", "Description", "path", null)
+        }
+
+        assertTrue(
+            ShortcutManagerCompat.getShortcuts(application, ShortcutManagerCompat.FLAG_MATCH_DYNAMIC).isEmpty(),
+        )
+    }
+
+    @Test
+    fun `Given shortcut ids when checking if reserved then only exact slot ids are reserved`() = runTest {
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        (1..5).forEach { slot ->
+            assertTrue(viewModel.isReservedShortcutId("shortcut_$slot"))
+        }
+        listOf("", "1", "shortcutA", "shortcut_0", "shortcut_6", "shortcut_05", "shortcut_1x").forEach { id ->
+            assertFalse(viewModel.isReservedShortcutId(id))
+        }
+    }
+
+    @Test
+    fun `Given a slot id when creating the shortcut then it is added as dynamic`() = runTest {
+        every {
+            shortcutManager.buildShortcutInfo(any(), any(), any(), any(), any(), any())
+        } returns fakeShortcutInfo("shortcut_2")
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        viewModel.createShortcut("shortcut_2", 0, "Label", "Description", "path", null)
+
+        assertEquals(
+            listOf("shortcut_2"),
+            ShortcutManagerCompat.getShortcuts(application, ShortcutManagerCompat.FLAG_MATCH_DYNAMIC).map { it.id },
+        )
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsViewModelTest.kt
@@ -51,6 +51,15 @@ class ManageShortcutsViewModelTest {
     @Before
     fun setUp() {
         application = ApplicationProvider.getApplicationContext()
+
+        val dynamicIds = ShortcutManagerCompat.getShortcuts(
+            application,
+            ShortcutManagerCompat.FLAG_MATCH_DYNAMIC,
+        ).map { it.id }
+        if (dynamicIds.isNotEmpty()) {
+            ShortcutManagerCompat.removeDynamicShortcuts(application, dynamicIds)
+        }
+
         coEvery { serverManager.getServer(any<Int>()) } returns fakeServer(0)
         coEvery { serverManager.servers() } returns listOf(fakeServer(0))
         every { entitiesForDisplayManager.snapshotInContext(serverId = any()) } returns emptyFlow()

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -815,6 +815,7 @@
     <string name="shortcut_n">Shortcut %d</string>
     <string name="shortcut_pinned_desc">Pinned shortcut description</string>
     <string name="shortcut_pinned_id">Pinned shortcut ID</string>
+    <string name="shortcut_pinned_id_reserved">This ID is reserved for dynamic shortcuts</string>
     <string name="shortcut_pinned_label">Pinned shortcut label</string>
     <string name="shortcut_pinned_list">Select a pinned shortcut ID to edit</string>
     <string name="shortcut_pinned_note">Make sure to change the ID below for each new shortcut you want to add otherwise the existing ID will be updated. There are no limits to the amount of pinned shortcuts you can create.</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fix #7270.

Opening the shortcuts settings screen crashed with `IndexOutOfBoundsException` when the system reported more dynamic shortcuts than the 5 slots the screen manages. The ViewModel mapped the system's dynamic shortcut list positionally into a fixed 6-slot list, and `createShortcut` treated any ID starting with "shortcut" as dynamic, so a pinned shortcut with a user-typed ID like "shortcutA" was silently registered as an extra dynamic shortcut. Two of those and the screen crashed on every open.

To avoid future problem we forbid the usage of shortcut_x in the ID of pinned shortcut. It comes with a downside that if a dynamic shortcut is moved to a pinned shortcut from the launcher it is going to appear in the list of pinned shortcut to edit but we block it from the UI, the edition is still from the dynamic section.

Step to reproduce the crash, set all the dynamic shortcut and then add a pinned shortcut with an ID that starts with `shortcut`. This PR is going to avoid the crashes on existing install.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.