### PR TITLE
LinkHandler better management of params in deep link URI

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
@@ -38,10 +38,23 @@ internal fun navigateDeepLinkUri(target: FrontendTarget, serverId: Int): Uri {
         .authority(NAVIGATE_URL_PATH.removeSurrounding("/"))
     when (target) {
         is FrontendTarget.EntityMoreInfo -> builder.appendQueryParameter(MORE_INFO_ENTITY_ID_PARAM, target.entityId)
-        is FrontendTarget.Path -> builder.path(target.path)
+        is FrontendTarget.Path -> builder.encodedRawPath(target.path)
         FrontendTarget.Default -> Unit
     }
     return builder.appendQueryParameter(SERVER_ID_PARAM, serverId.toString()).build()
+}
+
+/**
+ * Sets [rawPath] — a frontend path in URL form, possibly carrying a query and fragment — on this
+ * builder component by component, so a query like `?kiosk` stays a query instead of being
+ * percent-encoded into the path ([Uri.Builder.path] would store it as `%3Fkiosk`).
+ */
+private fun Uri.Builder.encodedRawPath(rawPath: String): Uri.Builder {
+    val withoutFragment = rawPath.substringBefore('#')
+    encodedPath("/" + withoutFragment.substringBefore('?').removePrefix("/"))
+    if ('?' in withoutFragment) encodedQuery(withoutFragment.substringAfter('?'))
+    if ('#' in rawPath) encodedFragment(rawPath.substringAfter('#'))
+    return this
 }
 
 /**
@@ -234,9 +247,28 @@ class LinkHandlerImpl @Inject constructor(private val serverManager: ServerManag
         val target = if (moreInfoEntityId != null && uri.isNavigateRoot()) {
             FrontendTarget.EntityMoreInfo(moreInfoEntityId)
         } else {
-            FrontendTarget.Path(uri.toString())
+            FrontendTarget.fromRawPath(uri.toFrontendRawPath())
         }
         return webviewDestination(target, serverId)
+    }
+
+    /**
+     * Rebuilds the raw frontend path (including query and fragment) from a navigate deep link,
+     * dropping the app's server selection parameters. All components are kept encoded as written,
+     * so the path reaches the frontend exactly as it appears in the link.
+     */
+    private fun Uri.toFrontendRawPath(): String = buildString {
+        append(encodedPath.orEmpty().removePrefix("/"))
+        encodedQuery
+            ?.splitToSequence('&')
+            ?.filterNot { param ->
+                val name = param.substringBefore('=')
+                name == SERVER_ID_PARAM || name == SERVER_PARAM
+            }
+            ?.joinToString("&")
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { append('?').append(it) }
+        encodedFragment?.let { append('#').append(it) }
     }
 
     /**

--- a/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/launch/link/LinkHandler.kt
@@ -45,15 +45,38 @@ internal fun navigateDeepLinkUri(target: FrontendTarget, serverId: Int): Uri {
 }
 
 /**
+ * Characters that need no percent-encoding in a URI path (RFC 3986 pchar plus "/"), on top of
+ * [Uri.encode]'s unreserved set. "%" is kept so escapes already present pass through.
+ */
+private const val PATH_ALLOWED_CHARS = "/%:@!$&'()*+,;="
+
+/** Query and fragment additionally allow "?". */
+private const val QUERY_FRAGMENT_ALLOWED_CHARS = "$PATH_ALLOWED_CHARS?"
+
+/**
+ * Whether [rawPath] is already a compliant frontend path in URL form, i.e. the encoding performed
+ * by [Uri.Builder.encodedRawPath] would keep it unchanged. Used by input UIs (e.g. the shortcut
+ * editor) to reject paths before they are persisted.
+ */
+internal fun isValidFrontendRawPath(rawPath: String): Boolean =
+    rawPath == Uri.encode(rawPath, "$QUERY_FRAGMENT_ALLOWED_CHARS#")
+
+/**
  * Sets [rawPath] — a frontend path in URL form, possibly carrying a query and fragment — on this
  * builder component by component, so a query like `?kiosk` stays a query instead of being
  * percent-encoded into the path ([Uri.Builder.path] would store it as `%3Fkiosk`).
+ *
+ * Characters illegal in a component (e.g. spaces in a hand-typed shortcut path or deep link) are
+ * percent-encoded; reserved characters and escapes already present pass through untouched, so a
+ * literal percent must be written `%25`.
  */
 private fun Uri.Builder.encodedRawPath(rawPath: String): Uri.Builder {
     val withoutFragment = rawPath.substringBefore('#')
-    encodedPath("/" + withoutFragment.substringBefore('?').removePrefix("/"))
-    if ('?' in withoutFragment) encodedQuery(withoutFragment.substringAfter('?'))
-    if ('#' in rawPath) encodedFragment(rawPath.substringAfter('#'))
+    encodedPath("/" + Uri.encode(withoutFragment.substringBefore('?').removePrefix("/"), PATH_ALLOWED_CHARS))
+    if ('?' in withoutFragment) {
+        encodedQuery(Uri.encode(withoutFragment.substringAfter('?'), QUERY_FRAGMENT_ALLOWED_CHARS))
+    }
+    if ('#' in rawPath) encodedFragment(Uri.encode(rawPath.substringAfter('#'), QUERY_FRAGMENT_ALLOWED_CHARS))
     return this
 }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/views/ManageShortcutsView.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,6 +17,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
@@ -42,6 +44,7 @@ import io.homeassistant.companion.android.common.compose.theme.HATheme
 import io.homeassistant.companion.android.common.data.integration.display.EntityDisplayState
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget.Companion.toRawPath
+import io.homeassistant.companion.android.launch.link.isValidFrontendRawPath
 import io.homeassistant.companion.android.settings.shortcuts.legacy.ManageShortcutsSettingsFragment
 import io.homeassistant.companion.android.settings.shortcuts.legacy.ManageShortcutsViewModel
 import io.homeassistant.companion.android.util.compose.ServerExposedDropdownMenu
@@ -256,19 +259,29 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
     }
 
     if (viewModel.shortcuts[i].type.value == "lovelace") {
+        val path = viewModel.shortcuts[i].path.value
+        val pathValid = path.isEmpty() || isValidFrontendRawPath(path)
         TextField(
-            value = viewModel.shortcuts[i].path.value,
+            value = path,
             onValueChange = { viewModel.shortcuts[i].path.value = it },
             label = { Text(stringResource(id = R.string.lovelace_view_dashboard)) },
+            isError = !pathValid,
             keyboardOptions = KeyboardOptions(
                 imeAction = ImeAction.Done,
                 autoCorrectEnabled = false,
                 keyboardType = KeyboardType.Uri,
             ),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 16.dp),
+            modifier = Modifier.fillMaxWidth(),
         )
+        if (!pathValid) {
+            Text(
+                text = stringResource(id = R.string.shortcut_path_invalid),
+                color = MaterialTheme.colors.error,
+                fontSize = 12.sp,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
+        Spacer(modifier = Modifier.padding(bottom = 16.dp))
     } else {
         // TODO use new theme for Material3 components https://github.com/home-assistant/android/issues/6258
         HATheme {
@@ -314,6 +327,7 @@ private fun CreateShortcutView(i: Int, viewModel: ManageShortcutsViewModel, show
             shortcut.label.value.isNotEmpty() &&
             shortcut.desc.value.isNotEmpty() &&
             shortcut.path.value.isNotEmpty() &&
+            isValidFrontendRawPath(shortcut.path.value) &&
             viewModel.servers.any { it.id == shortcut.serverId.value },
     ) {
         Text(

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
@@ -13,6 +13,8 @@ import java.net.URL
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.assertNotNull
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -287,6 +289,34 @@ class LinkHandlerTest {
         val result = handler.handleLink(uri)
 
         assertEquals(LinkDestination.Webview(FrontendTarget.Path("dashboard-smartphone/0?kiosk"), 2), result)
+    }
+
+    @Test
+    fun `Given compliant and non-compliant raw paths when validating then only compliant ones pass`() {
+        assertTrue(isValidFrontendRawPath("lovelace/dashboard-1?kiosk&edit=1#section"))
+        assertTrue(isValidFrontendRawPath("dashboard/my%20room"))
+        assertFalse(isValidFrontendRawPath("lovelace/my room"))
+        assertFalse(isValidFrontendRawPath("lovelace/café"))
+    }
+
+    @Test
+    fun `Given a hand-typed path with spaces when building the navigate deep link then illegal characters are percent-encoded`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("lovelace/my room?tab=my tab#my view"), serverId = 2)
+
+        assertEquals("homeassistant://navigate/lovelace/my%20room?tab=my%20tab&server_id=2#my%20view", uri.toString())
+        assertEquals(
+            LinkDestination.Webview(FrontendTarget.Path("lovelace/my%20room?tab=my%20tab#my%20view"), 2),
+            handler.handleLink(uri),
+        )
+    }
+
+    @Test
+    fun `Given a path with existing escapes when building the navigate deep link then escapes are not double-encoded`() = runTest {
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("dashboard/my%20room?kiosk"), serverId = 2)
+
+        assertEquals("homeassistant://navigate/dashboard/my%20room?kiosk&server_id=2", uri.toString())
     }
 
     @Test

--- a/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/launch/link/LinkHandlerTest.kt
@@ -6,8 +6,10 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.util.FailFast
 import io.homeassistant.companion.android.database.server.Server
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
+import io.homeassistant.companion.android.util.UrlUtil
 import io.mockk.coEvery
 import io.mockk.mockk
+import java.net.URL
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -191,7 +193,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard"), 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 1), result)
     }
 
     @Test
@@ -204,7 +206,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=default".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=default"), 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 1), result)
     }
 
     @Test
@@ -217,7 +219,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server="), 1), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 1), result)
     }
 
     @Test
@@ -237,7 +239,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=Office".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=Office"), 2), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 2), result)
     }
 
     @Test
@@ -247,7 +249,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server_id=2".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server_id=2"), 2), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 2), result)
     }
 
     @Test
@@ -271,6 +273,79 @@ class LinkHandlerTest {
     }
 
     @Test
+    fun `Given a path with a query when building the navigate deep link then the query stays a query`() = runTest {
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("dashboard-smartphone/0?kiosk"), serverId = 2)
+
+        assertEquals("homeassistant://navigate/dashboard-smartphone/0?kiosk&server_id=2", uri.toString())
+    }
+
+    @Test
+    fun `Given a navigate deep link built for a path with a query when invoking handleLink then it round-trips to the same path`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("dashboard-smartphone/0?kiosk"), serverId = 2)
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("dashboard-smartphone/0?kiosk"), 2), result)
+    }
+
+    @Test
+    fun `Given a path with a question mark in the fragment when building the navigate deep link then it round-trips without inventing a query`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("lovelace/0#view?x=1"), serverId = 2)
+
+        assertEquals("homeassistant://navigate/lovelace/0?server_id=2#view?x=1", uri.toString())
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/0#view?x=1"), 2), handler.handleLink(uri))
+    }
+
+    @Test
+    fun `Given a navigate deep link built for an absolute URL path when invoking handleLink then it round-trips to the same URL`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = navigateDeepLinkUri(FrontendTarget.Path("http://192.168.1.5:8123/lovelace/0?kiosk"), serverId = 2)
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("http://192.168.1.5:8123/lovelace/0?kiosk"), 2), result)
+    }
+
+    @Test
+    fun `Given navigate deep link with a percent-encoded query in the path when invoking handleLink then it is kept encoded`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = "homeassistant://navigate/dashboard-smartphone/0%3Fkiosk?server_id=2".toUri()
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("dashboard-smartphone/0%3Fkiosk"), 2), result)
+    }
+
+    @Test
+    fun `Given navigate deep link with a percent-encoded space in the path when invoking handleLink then the encoding is preserved and resolves`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = "homeassistant://navigate/lovelace/my%20dashboard?server_id=2".toUri()
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/my%20dashboard"), 2), result)
+
+        val base = URL("http://homeassistant.local:8123/")
+        assertEquals(
+            "http://homeassistant.local:8123/lovelace/my%20dashboard",
+            UrlUtil.handle(base, "lovelace/my%20dashboard").toString(),
+        )
+    }
+
+    @Test
+    fun `Given navigate deep link with query and fragment when invoking handleLink then both are kept without server params`() = runTest {
+        coEvery { serverManager.isRegistered() } returns true
+
+        val uri = "homeassistant://navigate/lovelace/dashboard?kiosk&server_id=2&edit=1#section".toUri()
+        val result = handler.handleLink(uri)
+
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard?kiosk&edit=1#section"), 2), result)
+    }
+
+    @Test
     fun `Given navigate deep link with registered server and case-insensitive server name when invoking handleLink then returns Webview with matching server`() = runTest {
         coEvery { serverManager.isRegistered() } returns true
         coEvery { serverManager.servers() } returns listOf(
@@ -287,7 +362,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=office".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=office"), 2), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), 2), result)
     }
 
     @Test
@@ -303,7 +378,7 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard?server=NonExisting".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.Webview(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=NonExisting"), ServerManager.SERVER_ID_ACTIVE), result)
+        assertEquals(LinkDestination.Webview(FrontendTarget.Path("lovelace/dashboard"), ServerManager.SERVER_ID_ACTIVE), result)
     }
 
     /*
@@ -357,7 +432,7 @@ class LinkHandlerTest {
         val result = handler.handleLink(uri)
 
         assertEquals(
-            LinkDestination.ServerPicker(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard?server=NonExisting"), servers),
+            LinkDestination.ServerPicker(FrontendTarget.Path("lovelace/dashboard"), servers),
             result,
         )
     }
@@ -381,6 +456,6 @@ class LinkHandlerTest {
         val uri = "homeassistant://navigate/lovelace/dashboard".toUri()
         val result = handler.handleLink(uri)
 
-        assertEquals(LinkDestination.ServerPicker(FrontendTarget.Path("homeassistant://navigate/lovelace/dashboard"), servers), result)
+        assertEquals(LinkDestination.ServerPicker(FrontendTarget.Path("lovelace/dashboard"), servers), result)
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -819,6 +819,7 @@
     <string name="shortcut_pinned_list">Select a pinned shortcut ID to edit</string>
     <string name="shortcut_pinned_note">Make sure to change the ID below for each new shortcut you want to add otherwise the existing ID will be updated. There are no limits to the amount of pinned shortcuts you can create.</string>
     <string name="shortcut_type">Select shortcut type</string>
+    <string name="shortcut_path_invalid">The path contains characters that are not allowed in a URL</string>
     <string name="shortcut_updated">Shortcut updated</string>
     <string name="shortcut">Shortcut</string>
     <string name="shortcuts_choose">Choose shortcuts</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Fixes #7263                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  Shortcuts store their destination in a `homeassistant://navigate` deep link, and the builder                                                                                                                                                                                                                     
  percent-encoded the path's query into the path itself (`?kiosk` became `%3Fkiosk`), so the frontend                                                                                                                                                                                                              
  never received it. Introduced with the FrontendScreen migration, beta only.                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  - Build the deep link from path, query and fragment components so the query survives.                                                                                                                                                                                                                            
  - When parsing, rebuild the frontend path from the encoded components and drop the app's                                                                                                                                                                                                                         
    `server_id`/`server` parameters instead of forwarding the whole deep link string.                                                                                                                                                                                                                              
  - Links persisted by the affected betas are not healed; recreating the shortcut fixes them.                                                                                                                                                                                                                      
  - Round-trip tests for query, fragment, encoding and absolute URL cases.

Updated the UI of the shortcut edition to make sure the link is a valid URL to use (does not contains space for instance).

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
I'm always kind of scared when messing with URL encoding/decoding and hopefully I didn't miss anything. I spent more time challenging Claude on this than fixing the issue itself.