### PR TITLE
Avoid collision with Intent message_id from FCM

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NfcSetupActivity.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NfcSetupActivity.kt
@@ -36,7 +36,8 @@ class NfcSetupActivity : BaseActivity() {
 
     companion object {
         private const val EXTRA_TAG_VALUE = "tag_value"
-        private const val EXTRA_MESSAGE_ID = "message_id"
+
+        private const val EXTRA_MESSAGE_ID = "io.homeassistant.companion.android.extra.MESSAGE_ID"
 
         const val NAV_WELCOME = "nfc_welcome"
         const val NAV_READ = "nfc_read"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
The NFCWriteActivity was using an extra `message_id` that collide with the internals of FCM messaging analytics interface. We are not using the interface since the analytics are not enabled but it still throw a log at us

```
2026-07-31 09:40:05.720  9716-9716  Bundle                  io....stant.companion.android.debug  W  Key message_id expected String but value was a java.lang.Integer.  The default value <null> was returned.
  2026-07-31 09:40:05.720  9716-9716  Bundle                  io....stant.companion.android.debug  W  Attempt to cast generated internal exception:
  java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.String
      at android.os.BaseBundle.getString(BaseBundle.java:1454)
      at com.google.firebase.messaging.MessagingAnalytics.getMessageId(MessagingAnalytics.java:422)
      at com.google.firebase.messaging.FcmLifecycleCallbacks.logNotificationOpen(FcmLifecycleCallbacks.java:83)
      at com.google.firebase.messaging.FcmLifecycleCallbacks.onActivityCreated(FcmLifecycleCallbacks.java:56)
      at android.app.Application.dispatchActivityCreated(Application.java:382)
      at android.app.Activity.dispatchActivityCreated(Activity.java:1604)
      at android.app.Activity.onCreate(Activity.java:1929)
      at androidx.core.app.ComponentActivity.onCreate(ComponentActivity.kt:68)
      at androidx.activity.ComponentActivity.onCreate(ComponentActivity.kt:343)
      at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:216)
      at io.homeassistant.companion.android.Hilt_BaseActivity.onCreate(Hilt_BaseActivity.java:55)
      at io.homeassistant.companion.android.BaseActivity.onCreate(BaseActivity.kt:31)
      at io.homeassistant.companion.android.nfc.NfcSetupActivity.onCreate(NfcSetupActivity.kt:57)
      at android.app.Activity.performCreate(Activity.java:9327)
      at android.app.Activity.performCreate(Activity.java:9305)
      at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1541)
```

The PR change the name of the extra to be unique.