### PR TITLE
Adjust NFC writing AAR records to better fit tag size

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -100,15 +100,13 @@ object NFCUtil {
     @Throws(IllegalArgumentException::class, IOException::class, Exception::class)
     private fun writeMessageToTag(nfcMessages: List<NdefMessage>, tag: Tag?): Boolean {
         val nDefTag = Ndef.get(tag)
-
-        nDefTag?.let {
+        nDefTag?.use {
             it.connect()
             val messageToWrite = nfcMessages.firstOrNull { message ->
                 message.toByteArray().size <= it.maxSize
             } ?: throw IllegalArgumentException("Message is too large")
             return if (it.isWritable) {
                 it.writeNdefMessage(messageToWrite)
-                it.close()
                 // Message is written to tag
                 true
             } else {
@@ -121,15 +119,16 @@ object NFCUtil {
             var caughtException: IOException? = null
             // Tag wasn't Ndef yet, so we don't know the size. Try all messages until the last one fails.
             for (message in nfcMessages) {
-                try {
-                    it.connect()
-                    it.format(message)
-                    it.close()
-                    // The data is written to the tag
-                    return true
-                } catch (e: IOException) {
-                    // Failed to format tag with message, try next
-                    caughtException = IOException("Failed to format tag", e)
+                it.use { formatableTag ->
+                    try {
+                        formatableTag.connect()
+                        formatableTag.format(message)
+                        // The data is written to the tag
+                        return true
+                    } catch (e: IOException) {
+                        // Failed to format tag with message, try next
+                        caughtException = IOException("Failed to format tag", e)
+                    }
                 }
             }
             caughtException?.let { e -> throw e }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -46,14 +46,14 @@ object NFCUtil {
     @Throws(IllegalArgumentException::class, IOException::class, Exception::class)
     fun createNFCMessage(url: String, intent: Intent?): Boolean {
         val nfcRecord = NdefRecord.createUri(url)
-        val applicationRecords = BuildConfig.APPLICATION_IDS.map {
+        val applicationFlavorsRecords = BuildConfig.APPLICATION_IDS.map {
             NdefRecord.createApplicationRecord(it)
         }
-        val packageRecord = NdefRecord.createApplicationRecord(BuildConfig.APPLICATION_ID)
+        val thisApplicationRecord = NdefRecord.createApplicationRecord(BuildConfig.APPLICATION_ID)
 
         val nfcMessages = listOf(
-            NdefMessage(arrayOf(nfcRecord) + applicationRecords),
-            NdefMessage(arrayOf(nfcRecord, packageRecord)),
+            NdefMessage(arrayOf(nfcRecord) + applicationFlavorsRecords),
+            NdefMessage(arrayOf(nfcRecord, thisApplicationRecord)),
             NdefMessage(arrayOf(nfcRecord)),
         )
         intent?.let {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -30,7 +30,20 @@ object NFCUtil {
         return ndefMessage?.records?.get(0)?.toUri()
     }
 
-    @Throws(Exception::class)
+    /**
+     * Write the given [url] to the tag in [intent].
+     *
+     * @param url URL to write to the tag.
+     * @param intent Tag to write to, in an intent which holds the extra [NfcAdapter.EXTRA_TAG].
+     *
+     * @throws IllegalArgumentException if the url doesn't fit on the tag.
+     * @throws IOException if the tag is NDEF and the url would fit, but it cannot be written to.
+     * @throws Exception for other tag operation exceptions.
+     *
+     * @return `true` if the tag was successfully written to, `false` if the tag doesn't support NDEF messages,
+     * throws if writing wasn't possible.
+     */
+    @Throws(IllegalArgumentException::class, IOException::class, Exception::class)
     fun createNFCMessage(url: String, intent: Intent?): Boolean {
         val nfcRecord = NdefRecord.createUri(url)
         val applicationRecords = BuildConfig.APPLICATION_IDS.map {
@@ -77,12 +90,12 @@ object NFCUtil {
      * written, later messages should be smaller and serve as fallback messages.
      * @param tag The NFC tag to write the message to.
      *
-     * @throws IllegalArgumentException if no messages fit on the tag
-     * @throws IOException if the tag is NDEF and a message would fit, but it cannot be written to
-     * @throws Exception for other tag operation exceptions
+     * @throws IllegalArgumentException if none of the messages fit on the tag.
+     * @throws IOException if the tag is NDEF and a message would fit, but it cannot be written to.
+     * @throws Exception for other tag operation exceptions.
      *
-     * @return `true` if a tag was successfully written, `false` if the tag doesn't support NDEF, throws if writing
-     * isn't possible
+     * @return `true` if the tag was successfully written to, `false` if the tag doesn't support NDEF messages,
+     * throws if writing wasn't possible.
      */
     @Throws(IllegalArgumentException::class, IOException::class, Exception::class)
     private fun writeMessageToTag(nfcMessages: List<NdefMessage>, tag: Tag?): Boolean {

--- a/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/nfc/NFCUtil.kt
@@ -36,12 +36,16 @@ object NFCUtil {
         val applicationRecords = BuildConfig.APPLICATION_IDS.map {
             NdefRecord.createApplicationRecord(it)
         }
+        val packageRecord = NdefRecord.createApplicationRecord(BuildConfig.APPLICATION_ID)
 
-        val nfcMessage = NdefMessage(arrayOf(nfcRecord) + applicationRecords)
-        val nfcFallbackMessage = NdefMessage(arrayOf(nfcRecord))
+        val nfcMessages = listOf(
+            NdefMessage(arrayOf(nfcRecord) + applicationRecords),
+            NdefMessage(arrayOf(nfcRecord, packageRecord)),
+            NdefMessage(arrayOf(nfcRecord)),
+        )
         intent?.let {
             val tag = IntentCompat.getParcelableExtra(it, NfcAdapter.EXTRA_TAG, Tag::class.java)
-            return writeMessageToTag(nfcMessage, nfcFallbackMessage, tag)
+            return writeMessageToTag(nfcMessages, tag)
         }
         return false
     }
@@ -65,43 +69,60 @@ object NFCUtil {
         nfcAdapter.enableForegroundDispatch(activity, pendingIntent, filters, techLists)
     }
 
-    @Throws(Exception::class)
-    private fun writeMessageToTag(nfcMessage: NdefMessage, fallbackMessage: NdefMessage, tag: Tag?): Boolean {
+    /**
+     * Write a message to an NFC tag. The first message in [nfcMessages] that fits on the given [tag] will
+     * be written to the tag.
+     *
+     * @param nfcMessages List of available messages to write to a NFC tag. The first message that fits (size) will be
+     * written, later messages should be smaller and serve as fallback messages.
+     * @param tag The NFC tag to write the message to.
+     *
+     * @throws IllegalArgumentException if no messages fit on the tag
+     * @throws IOException if the tag is NDEF and a message would fit, but it cannot be written to
+     * @throws Exception for other tag operation exceptions
+     *
+     * @return `true` if a tag was successfully written, `false` if the tag doesn't support NDEF, throws if writing
+     * isn't possible
+     */
+    @Throws(IllegalArgumentException::class, IOException::class, Exception::class)
+    private fun writeMessageToTag(nfcMessages: List<NdefMessage>, tag: Tag?): Boolean {
         val nDefTag = Ndef.get(tag)
 
         nDefTag?.let {
             it.connect()
-            var messageToWrite = nfcMessage
-            if (it.maxSize < nfcMessage.toByteArray().size) {
-                messageToWrite = fallbackMessage
-            }
-            if (it.maxSize < fallbackMessage.toByteArray().size) {
-                // Message to large to write to NFC tag
-                throw Exception("Message is too large")
-            }
+            val messageToWrite = nfcMessages.firstOrNull { message ->
+                message.toByteArray().size <= it.maxSize
+            } ?: throw IllegalArgumentException("Message is too large")
             return if (it.isWritable) {
                 it.writeNdefMessage(messageToWrite)
                 it.close()
                 // Message is written to tag
                 true
             } else {
-                throw Exception("NFC tag is read-only")
+                throw IOException("NFC tag is read-only")
             }
         }
 
         val nDefFormatableTag = NdefFormatable.get(tag)
-
         nDefFormatableTag?.let {
-            try {
-                it.connect()
-                it.format(nfcMessage)
-                it.close()
-                // The data is written to the tag
-            } catch (e: IOException) {
-                // Failed to format tag
-                throw Exception("Failed to format tag", e)
+            var caughtException: IOException? = null
+            // Tag wasn't Ndef yet, so we don't know the size. Try all messages until the last one fails.
+            for (message in nfcMessages) {
+                try {
+                    it.connect()
+                    it.format(message)
+                    it.close()
+                    // The data is written to the tag
+                    return true
+                } catch (e: IOException) {
+                    // Failed to format tag with message, try next
+                    caughtException = IOException("Failed to format tag", e)
+                }
             }
+            caughtException?.let { e -> throw e }
         }
-        return true
+
+        // Not already Ndef or Ndef Formatable
+        return false
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
@@ -33,13 +33,6 @@ private const val SMALL_TAG_SIZE_IN_BYTES = 100
 private const val NTAG213_TAG_SIZE_IN_BYTES = 144
 private const val NTAG215_TAG_SIZE_IN_BYTES = 504
 
-/** List of test cases with tag size to expected number of records to be written */
-private val TAG_CASES = listOf(
-    SMALL_TAG_SIZE_IN_BYTES to 1, // URL only
-    NTAG213_TAG_SIZE_IN_BYTES to 2, // URL and one app ID
-    NTAG215_TAG_SIZE_IN_BYTES to (BuildConfig.APPLICATION_IDS.size + 1), // URL and all app IDs
-)
-
 /**
  * Tests for writing tags with NFCUtil.
  *
@@ -48,6 +41,13 @@ private val TAG_CASES = listOf(
  */
 @RunWith(RobolectricTestRunner::class)
 class NFCUtilTest {
+
+    /** List of test cases with tag size to expected number of records to be written */
+    private val tagCases = listOf(
+        SMALL_TAG_SIZE_IN_BYTES to 1, // URL only
+        NTAG213_TAG_SIZE_IN_BYTES to 2, // URL and one app ID
+        NTAG215_TAG_SIZE_IN_BYTES to (BuildConfig.APPLICATION_IDS.size + 1), // URL and all app IDs
+    )
 
     private lateinit var tagDiscoveredIntent: Intent
     private lateinit var tag: Tag
@@ -72,7 +72,7 @@ class NFCUtilTest {
         val ndefMock = mockNdef(messageSlot)
 
         // Loop through cases as JUnit 4 can only parametrize the entire class
-        TAG_CASES.forEach { (tagSize, expectedNumberOfRecords) ->
+        tagCases.forEach { (tagSize, expectedNumberOfRecords) ->
             every { ndefMock.maxSize } returns tagSize
             messageSlot.clear()
 
@@ -119,7 +119,7 @@ class NFCUtilTest {
         val ndefFormatableMock = mockNdefFormatable()
 
         // Loop through cases as JUnit 4 can only parametrize the entire class
-        TAG_CASES.forEach { (tagSize, expectedNumberOfRecords) ->
+        tagCases.forEach { (tagSize, expectedNumberOfRecords) ->
             val messageSlot = slot<NdefMessage>()
             every { ndefFormatableMock.format(capture(messageSlot)) } answers {
                 if (messageSlot.captured.toByteArray().size <= tagSize) {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
@@ -1,0 +1,193 @@
+package io.homeassistant.companion.android.nfc
+
+import android.content.Intent
+import android.net.Uri
+import android.nfc.NdefMessage
+import android.nfc.Tag
+import android.nfc.tech.Ndef
+import android.nfc.tech.NdefFormatable
+import androidx.core.content.IntentCompat
+import io.homeassistant.companion.android.BuildConfig
+import io.mockk.CapturingSlot
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkAll
+import java.io.IOException
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.fail
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private const val TAG_URL = "https://www.home-assistant.io/tag/123e4567-e89b-12d3-a456-426614174000"
+
+private const val TINY_TAG_SIZE_IN_BYTES = 32
+private const val SMALL_TAG_SIZE_IN_BYTES = 100
+private const val NTAG213_TAG_SIZE_IN_BYTES = 144
+private const val NTAG215_TAG_SIZE_IN_BYTES = 504
+
+/** List of test cases with tag size to expected number of records to be written */
+private val TAG_CASES = listOf(
+    SMALL_TAG_SIZE_IN_BYTES to 1, // URL only
+    NTAG213_TAG_SIZE_IN_BYTES to 2, // URL and one app ID
+    NTAG215_TAG_SIZE_IN_BYTES to (BuildConfig.APPLICATION_IDS.size + 1), // URL and all app IDs
+)
+
+/**
+ * Tests for writing tags with NFCUtil.
+ *
+ * This test class uses Robolectric (JUnit 4) because anything NFC related and its use of [Uri]
+ * are Android framework classes.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NFCUtilTest {
+
+    private lateinit var tagDiscoveredIntent: Intent
+    private lateinit var tag: Tag
+
+    @Before
+    fun setup() {
+        tagDiscoveredIntent = mockk(relaxed = true)
+        tag = mockk()
+
+        mockkStatic(IntentCompat::class)
+        every { IntentCompat.getParcelableExtra(tagDiscoveredIntent, any(), Tag::class.java) } returns tag
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `Given NDEF tag with sufficient size when writing then writes expected number of records`() {
+        val messageSlot = slot<NdefMessage>()
+        val ndefMock = mockNdef(messageSlot)
+
+        // Loop through cases as JUnit 4 can only parametrize the entire class
+        TAG_CASES.forEach { (tagSize, expectedNumberOfRecords) ->
+            every { ndefMock.maxSize } returns tagSize
+            messageSlot.clear()
+
+            val success = NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
+
+            assertEquals(true, success)
+            val message = messageSlot.captured
+            assertNotNull(message.records)
+            assertEquals(expectedNumberOfRecords, message.records.size)
+            assertEquals(TAG_URL, message.records[0].toUri().toString())
+        }
+    }
+
+    @Test
+    fun `Given NDEF tag with tiny size when writing then throws message too large exception`() {
+        val messageSlot = slot<NdefMessage>()
+        val ndefMock = mockNdef(messageSlot)
+        every { ndefMock.maxSize } returns TINY_TAG_SIZE_IN_BYTES
+
+        try {
+            NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
+            fail("Expected IllegalArgumentException to be thrown")
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Message is too large", e.message)
+        }
+    }
+
+    @Test
+    fun `Given NDEF tag non-writable when writing then throws non-writable exception`() {
+        val messageSlot = slot<NdefMessage>()
+        val ndefMock = mockNdef(messageSlot, canWrite = false)
+        every { ndefMock.maxSize } returns NTAG215_TAG_SIZE_IN_BYTES
+
+        try {
+            NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
+            fail("Expected IOException to be thrown")
+        } catch (e: IOException) {
+            assertEquals("NFC tag is read-only", e.message)
+        }
+    }
+
+    @Test
+    fun `Given NDEF formatable tag with sufficient size when writing then writes expected number of records`() {
+        val ndefFormatableMock = mockNdefFormatable()
+
+        // Loop through cases as JUnit 4 can only parametrize the entire class
+        TAG_CASES.forEach { (tagSize, expectedNumberOfRecords) ->
+            val messageSlot = slot<NdefMessage>()
+            every { ndefFormatableMock.format(capture(messageSlot)) } answers {
+                if (messageSlot.captured.toByteArray().size <= tagSize) {
+                    Unit
+                } else {
+                    throw IOException()
+                }
+            }
+
+            val success = NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
+
+            assertEquals(true, success)
+            val message = messageSlot.captured
+            assertNotNull(message.records)
+            assertEquals(expectedNumberOfRecords, message.records.size)
+            assertEquals(TAG_URL, message.records[0].toUri().toString())
+        }
+    }
+
+    @Test
+    fun `Given NDEF formatable tag non-functional when writing then throws message too large exception`() {
+        // Non-functional can mean: the message is too big, formatting exception, tag lost, ...
+        // The specifics are inside the platforms API so we don't care about it here, but any failures
+        // for NDEF formatable are expected to throw.
+        val ndefFormatableMock = mockNdefFormatable()
+        every { ndefFormatableMock.format(any()) } throws IOException()
+
+        try {
+            NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
+            fail("Expected IOException to be thrown")
+        } catch (e: IOException) {
+            assertEquals("Failed to format tag", e.message)
+        }
+    }
+
+    @Test
+    fun `Given tag without NDEF support when writing then returns no success`() {
+        mockkStatic(Ndef::class)
+        every { Ndef.get(tag) } returns null
+        mockkStatic(NdefFormatable::class)
+        every { NdefFormatable.get(tag) } returns null
+
+        assertEquals(false, NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent))
+    }
+
+    private fun mockNdef(writeSlot: CapturingSlot<NdefMessage>, canWrite: Boolean = true): Ndef {
+        val ndefMock = mockk<Ndef>(relaxed = true) {
+            every { isWritable } returns canWrite
+        }
+
+        mockkStatic(Ndef::class)
+        every { Ndef.get(tag) } returns ndefMock
+        every { ndefMock.writeNdefMessage(capture(writeSlot)) } just Runs
+
+        return ndefMock
+    }
+
+    private fun mockNdefFormatable(): NdefFormatable {
+        // First mock Ndef, if it can be formatted that means it is not already Ndef
+        mockkStatic(Ndef::class)
+        every { Ndef.get(tag) } returns null
+
+        // Then mock NdefFormatable
+        val ndefFormatableMock = mockk<NdefFormatable>(relaxed = true)
+
+        mockkStatic(NdefFormatable::class)
+        every { NdefFormatable.get(tag) } returns ndefFormatableMock
+
+        return ndefFormatableMock
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/nfc/NFCUtilTest.kt
@@ -7,6 +7,7 @@ import android.nfc.Tag
 import android.nfc.tech.Ndef
 import android.nfc.tech.NdefFormatable
 import androidx.core.content.IntentCompat
+import dagger.hilt.android.testing.HiltTestApplication
 import io.homeassistant.companion.android.BuildConfig
 import io.mockk.CapturingSlot
 import io.mockk.Runs
@@ -19,12 +20,14 @@ import io.mockk.unmockkAll
 import java.io.IOException
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertTrue
 import junit.framework.TestCase.fail
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 private const val TAG_URL = "https://www.home-assistant.io/tag/123e4567-e89b-12d3-a456-426614174000"
 
@@ -40,6 +43,7 @@ private const val NTAG215_TAG_SIZE_IN_BYTES = 504
  * are Android framework classes.
  */
 @RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
 class NFCUtilTest {
 
     /** List of test cases with tag size to expected number of records to be written */
@@ -78,7 +82,7 @@ class NFCUtilTest {
 
             val success = NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
 
-            assertEquals(true, success)
+            assertTrue(success)
             val message = messageSlot.captured
             assertNotNull(message.records)
             assertEquals(expectedNumberOfRecords, message.records.size)
@@ -131,7 +135,7 @@ class NFCUtilTest {
 
             val success = NFCUtil.createNFCMessage(TAG_URL, tagDiscoveredIntent)
 
-            assertEquals(true, success)
+            assertTrue(success)
             val message = messageSlot.captured
             assertNotNull(message.records)
             assertEquals(expectedNumberOfRecords, message.records.size)

--- a/common/src/test/kotlin/io/homeassistant/companion/android/util/UriExtensionsTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/util/UriExtensionsTest.kt
@@ -1,12 +1,14 @@
 package io.homeassistant.companion.android.util
 
 import android.net.Uri
+import dagger.hilt.android.testing.HiltTestApplication
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
 /**
  * Tests for [Uri] extension functions defined in UrlUtil.kt.
@@ -16,6 +18,7 @@ import org.robolectric.RobolectricTestRunner
  * JUnit 5 for tests that don't require Android classes.
  */
 @RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
 class UriExtensionsTest {
 
     @Test


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
When writing NFC tags, the app tries to [include Android Application Records (AAR)](https://developer.android.com/develop/connectivity/nfc/nfc#aar) for `io.homeassistant.companion.android` and `io.homeassistant.companion.android.minimal` alongside the URL. If those don't fit on the tag, it falls back to **no** AARs to reduce the message size. This PR:
- adjusts behavior so that when all AARs don't fit on the tag, it will fall back to one AAR with the current application ID first*, before falling back to no AARs
- updates behavior for tags that supported NDEF records but weren't already formatted to also try messages with less/no AARs when formatting, instead of immediately failing

This might help with later comments in #7095 as some users reported manually writing one application record to the tag as a workaround/fix.

For the functions that were touched documentation (KDoc) and tests were added.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution. _To figure out JUnit 4 doesn't support parametrized tests per function and what was the easiest alternative._
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
n/a

## Link to pull request in documentation repositories
n/a, technical implementation detail

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
Note that when testing the application ID contains the `.debug` suffix. With the previous implementation that suffix would never be written to NFC tags, as it either had the production IDs hardcoded or none. With these changes, in the situation with 1 AAR you get the current application ID which will contain `.debug` if using a debug variant.

\* Related: the [iOS companion app implementation](https://github.com/home-assistant/iOS/blob/12452d630a7dc5fe6b3c95615ecdc5a4051c7378/Sources/App/Settings/NFC/iOSTagManager.swift#L110) always writes one AAR for `io.homeassistant.companion.android`.