### PR TITLE
Prevent emulator.wtf reruns from failing on expired artifacts

### DIFF
--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -12,18 +12,60 @@ concurrency:
 permissions: {}
 
 jobs:
+  # A partial re-run of "Pull Request" re-triggers this workflow without
+  # rebuilding the emulator.wtf inputs, so they may already be gone. Skip
+  # emulator_wtf rather than failing it, so no red check appears on the PR.
+  # No `environment:` here, so an unusable run never costs a ui-test approval.
+  check_inputs:
+    name: "Check emulator.wtf inputs"
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read  # Needed for listing the artifacts of the triggering run
+    outputs:
+      available: ${{ steps.inputs.outputs.available }}
+    steps:
+      - name: Check whether the inputs artifact is still available
+        id: inputs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          # Expired artifacts stay in the listing with `expired: true` rather than
+          # disappearing, so this covers both expiry and a missing upload.
+          available=$(gh api "repos/$REPO/actions/runs/$RUN_ID/artifacts?name=emulator-wtf-inputs" \
+            --jq '[.artifacts[] | select(.expired == false)] | length > 0')
+          echo "available=$available" >> "$GITHUB_OUTPUT"
+          if [ "$available" != "true" ]; then
+            echo "::warning::The emulator.wtf inputs from $RUN_URL are no longer available, so instrumentation tests were skipped. Re-run all jobs of that workflow to rebuild them."
+          fi
+
   emulator_wtf:
     name: "Instrumentation Test app"
     runs-on: ubuntu-latest
     environment: ui-test
-    if: >
-      github.event.workflow_run.event == 'pull_request'
-      && github.event.workflow_run.conclusion == 'success'
+    needs: [check_inputs]
+    if: needs.check_inputs.outputs.available == 'true'
     permissions:
       id-token: write  # Needed for OIDC authentication
       actions: read  # Needed for retrieving artifacts
       checks: write  # Needed to publish this job's status as a PR check
     steps:
+      # Kept ahead of the check run: the artifact can still expire while this job
+      # waits on the ui-test approval, and failing with no check run created yet
+      # leaves the PR clean, same as a check_inputs skip.
+      - name: Download emulator.wtf inputs
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: emulator-wtf-inputs
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: emulator-wtf-inputs
+
       # Surface this job's own success/failure as a check on the PR commit.
       # workflow_run jobs are detached from the PR, so the status is not shown
       # otherwise. A check run created via the API for a PR-head SHA gets grouped
@@ -86,14 +128,6 @@ jobs:
             echo "job_url=$JOB_URL"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Download emulator.wtf inputs
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: emulator-wtf-inputs
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: emulator-wtf-inputs
-
       - name: Load device list
         id: devices
         # The artifact comes from a PR build that may originate from a fork; validate
@@ -152,8 +186,8 @@ jobs:
           name: Instrumentation Test app reports
           path: build/test-results/**
 
-      # job.status reflects everything above (check creation, downloads, test runs) and is
-      # one of success/failure/cancelled, all valid check-run conclusions.
+      # job.status reflects everything above (input download, check creation, test
+      # runs) and is one of success/failure/cancelled, all valid check-run conclusions.
       # We re-send the same output.summary link so the completed check page
       # keeps the deep-link to the emulator.wtf job logs (see the Create step
       # for why this matters on PR-context check_suites).
@@ -188,14 +222,18 @@ jobs:
       actions: read
       contents: read
     steps:
+      # Exclude emulator-wtf-inputs (APKs, no test XML): it is the only artifact
+      # here with a short retention, and download-artifact errors on an expired
+      # one, which would sink the pr.yml results too. Minimatch reads "!" as negation.
       - name: Download artifacts from pr.yml run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          pattern: "!emulator-wtf-inputs"
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path: pr-artifacts
 
-      # If emulator_wtf was skipped (non-PR trigger or triggering workflow did not succeed) or
+      # If emulator_wtf was skipped (non-PR trigger, triggering workflow did not succeed, or inputs expired) or
       # cancelled/failed before running tests, it uploads no results artifact, and
       # downloading it by name errors. Tolerate that so we still publish the
       # pr.yml results below. We cannot gate on needs.emulator_wtf.result because

--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -15,7 +15,6 @@ jobs:
   # A partial re-run of "Pull Request" re-triggers this workflow without
   # rebuilding the emulator.wtf inputs, so they may already be gone. Skip
   # emulator_wtf rather than failing it, so no red check appears on the PR.
-  # No `environment:` here, so an unusable run never costs a ui-test approval.
   check_inputs:
     name: "Check emulator.wtf inputs"
     runs-on: ubuntu-latest
@@ -55,9 +54,9 @@ jobs:
       actions: read  # Needed for retrieving artifacts
       checks: write  # Needed to publish this job's status as a PR check
     steps:
-      # Kept ahead of the check run: the artifact can still expire while this job
-      # waits on the ui-test approval, and failing with no check run created yet
-      # leaves the PR clean, same as a check_inputs skip.
+      # Kept ahead of the check run: the artifact can still expire between the
+      # check_inputs preflight and this download, and failing before the check
+      # run exists leaves the PR clean, same as a check_inputs skip.
       - name: Download emulator.wtf inputs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pr-emulator-wtf.yml
+++ b/.github/workflows/pr-emulator-wtf.yml
@@ -40,7 +40,7 @@ jobs:
             --jq '[.artifacts[] | select(.expired == false)] | length > 0')
           echo "available=$available" >> "$GITHUB_OUTPUT"
           if [ "$available" != "true" ]; then
-            echo "::warning::The emulator.wtf inputs from $RUN_URL are no longer available, so instrumentation tests were skipped. Re-run all jobs of that workflow to rebuild them."
+            echo "::error title=Instrumentation tests skipped::The emulator.wtf inputs from $RUN_URL are no longer available. A maintainer needs to re-run all jobs of that workflow to rebuild them."
           fi
 
   emulator_wtf:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -353,8 +353,8 @@ jobs:
         with:
           name: emulator-wtf-inputs
           # A partial re-run re-triggers "PR Emulator.wtf" without rebuilding these
-          # APKs, so they must outlive the original run. Beyond a week it skips itself.
-          retention-days: 7
+          # APKs, so they must outlive the original run. Past that it skips itself.
+          retention-days: 3
           if-no-files-found: error
           path: |
             app/build/outputs/apk/full/debug/app-full-debug.apk

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -352,7 +352,9 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: emulator-wtf-inputs
-          retention-days: 1
+          # A partial re-run re-triggers "PR Emulator.wtf" without rebuilding these
+          # APKs, so they must outlive the original run. Beyond a week it skips itself.
+          retention-days: 7
           if-no-files-found: error
           path: |
             app/build/outputs/apk/full/debug/app-full-debug.apk


### PR DESCRIPTION
## Summary

`PR Emulator.wtf` runs on `workflow_run` and downloads the `emulator-wtf-inputs` artifact from the triggering `Pull Request` run. That artifact had `retention-days: 1`, but GitHub allows reruns for 30 days, and a *partial* rerun re-triggers the downstream workflow without rebuilding the APKs. Past the first day the download fails with `Artifact has expired`, and the PR gets a red "Instrumentation Test app" check that says nothing about the code under review. This happened on #7209: run `30712233663` attempt 2 reran one cancelled job a day later, and downstream run `30763712786` failed at the download.

Retention goes to 3 days, which covers the manual restarts maintainers actually do, including one that spans a weekend. Past that, a new `check_inputs` job skips `emulator_wtf` instead of failing it, so no check appears on the PR at all and the workflow log explains that re-running *all* jobs of `Pull Request` rebuilds the inputs. That mirrors what #7093 settled on for the "triggering workflow didn't succeed" case. I stopped at 3 rather than 30 days because the artifact is ~100 MB and `Pull Request` runs ~19 times a day, so every extra day of retention leaves ~2 GB standing permanently to serve a rare edge case.

Two smaller fixes fell out of the same failure:

- `emulator_wtf` now downloads the inputs *before* creating the check run. The preflight can't close the window entirely, since the artifact can expire between the check and the download. Downloading first means such a failure happens before any check run exists, so the PR still stays clean.
- `publish_test_results` had the same bug through another door: its download step had no `name` and no `pattern`, so it pulled *every* artifact including the expired one. It failed on the run above too, so the unit and screenshot results never published either. It now excludes `emulator-wtf-inputs` by pattern, which is lossless (that artifact holds only APKs and `devices.txt`) and saves 100 MB per run.

Fixes #7297

## Checklist

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Any other notes

No changelog entry (CI-only, not user-visible) and no tests (workflow YAML, no Kotlin surface), so the first box is unticked. Validated with `yamllint --strict`, the same check the `yamllint` job runs, plus checking the artifacts API query and `download-artifact`'s pattern matching against real runs of both workflows.