### PR TITLE
Add an sensor for the tonal palette for dynamic colors

### DIFF
--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KtfmtSettings">
+    <option name="enableKtfmt" value="Disabled" />
+  </component>
+</project>

--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KtfmtSettings">
-    <option name="enableKtfmt" value="Disabled" />
-  </component>
-</project>

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
@@ -29,14 +29,16 @@ class DynamicColorSensorManager @Inject constructor(
     companion object {
         // See https://source.android.com/docs/core/display/dynamic-color#dynamic-13
         private val TONAL_PALETTE_STYLES = listOf(
-            "TONAL_SPOT",
-            "SPRITZ",
-            "MONOCHROMATIC",
-            "VIBRANT",
             "EXPRESSIVE",
             "FRUIT_SALAD",
+            "MONOCHROMATIC",
             "RAINBOW",
-        ).sorted()
+            "SPRITZ",
+            "TONAL_SPOT",
+            "VIBRANT",
+        )
+        private const val THEME_OVERLAY_JSON = "theme_customization_overlay_packages"
+        private const val THEME_STYLE = "android.theme.customization.theme_style"
 
         @ProvidesSensor
         val accentColorSensor = SensorManager.BasicSensor(
@@ -122,20 +124,16 @@ class DynamicColorSensorManager @Inject constructor(
             )
         }
 
-        // See https://source.android.com/docs/core/display/dynamic-color#dynamic-13
-        val jsonKey = "theme_customization_overlay_packages"
-        val styleKey = "android.theme.customization.theme_style"
-
         val jsonString = try {
-            Settings.Secure.getString(applicationContext.contentResolver, jsonKey)
+            Settings.Secure.getString(applicationContext.contentResolver, THEME_OVERLAY_JSON)
         } catch (ex: Exception) {
-            Timber.w(ex, "Exception reading %s", jsonKey)
+            Timber.w(ex, "Exception reading %s", THEME_OVERLAY_JSON)
             updateState(STATE_UNAVAILABLE)
             return
         }
 
         if (jsonString == null) {
-            Timber.w("No value found for %s", jsonKey)
+            Timber.w("No value found for %s", THEME_OVERLAY_JSON)
             updateState(STATE_UNAVAILABLE)
             return
         }
@@ -143,15 +141,15 @@ class DynamicColorSensorManager @Inject constructor(
         val jsonObject = try {
             JSONObject(jsonString)
         } catch (ex: JSONException) {
-            Timber.w(ex, "Exception parsing JSON for %s", jsonKey)
+            Timber.w(ex, "Exception parsing JSON for %s", THEME_OVERLAY_JSON)
             updateState(STATE_UNKNOWN)
             return
         }
 
         val themeStyle = try {
-            jsonObject.getString(styleKey)
+            jsonObject.getString(THEME_STYLE)
         } catch (ex: JSONException) {
-            Timber.w(ex, "Missing %s in JSON for %s", styleKey, jsonKey)
+            Timber.w(ex, "Missing %s in JSON for %s", THEME_STYLE, THEME_OVERLAY_JSON)
             updateState(STATE_UNKNOWN)
             return
         }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManager.kt
@@ -1,6 +1,7 @@
 package io.homeassistant.companion.android.sensors
 
 import android.content.Context
+import android.provider.Settings
 import androidx.core.graphics.blue
 import androidx.core.graphics.green
 import androidx.core.graphics.red
@@ -11,8 +12,13 @@ import io.homeassistant.companion.android.common.data.servers.ServerManager
 import io.homeassistant.companion.android.common.sensors.ProvidesSensor
 import io.homeassistant.companion.android.common.sensors.SensorManager
 import io.homeassistant.companion.android.common.sensors.SensorRepository
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
 import javax.inject.Inject
 import javax.inject.Singleton
+import org.json.JSONException
+import org.json.JSONObject
+import timber.log.Timber
 
 @Singleton
 class DynamicColorSensorManager @Inject constructor(
@@ -21,6 +27,17 @@ class DynamicColorSensorManager @Inject constructor(
     override val serverManager: ServerManager,
 ) : SensorManager {
     companion object {
+        // See https://source.android.com/docs/core/display/dynamic-color#dynamic-13
+        private val TONAL_PALETTE_STYLES = listOf(
+            "TONAL_SPOT",
+            "SPRITZ",
+            "MONOCHROMATIC",
+            "VIBRANT",
+            "EXPRESSIVE",
+            "FRUIT_SALAD",
+            "RAINBOW",
+        ).sorted()
+
         @ProvidesSensor
         val accentColorSensor = SensorManager.BasicSensor(
             "accent_color",
@@ -30,16 +47,28 @@ class DynamicColorSensorManager @Inject constructor(
             "mdi:palette",
             entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
         )
+
+        @ProvidesSensor
+        val tonalPaletteSensor = SensorManager.BasicSensor(
+            "tonal_palette",
+            "sensor",
+            commonR.string.sensor_name_tonal_palette_sensor,
+            commonR.string.sensor_description_tonal_palette_sensor,
+            "mdi:palette",
+            deviceClass = "enum",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
     }
 
     override fun docsLink(): String {
         return "https://companion.home-assistant.io/docs/core/sensors#dynamic-color-sensor"
     }
+
     override val name: Int
         get() = commonR.string.sensor_name_dynamic_color
 
     override suspend fun getAvailableSensors(): List<SensorManager.BasicSensor> {
-        return listOf(accentColorSensor)
+        return listOf(accentColorSensor, tonalPaletteSensor)
     }
 
     override fun requiredPermissions(sensorId: String): Array<String> {
@@ -48,6 +77,7 @@ class DynamicColorSensorManager @Inject constructor(
 
     override suspend fun requestSensorUpdate() {
         updateAccentColor(applicationContext)
+        updateTonalPalette(applicationContext)
     }
 
     override fun hasSensor(): Boolean {
@@ -76,5 +106,56 @@ class DynamicColorSensorManager @Inject constructor(
                 "rgb_color" to listOf(accent.red, accent.green, accent.blue),
             ),
         )
+    }
+
+    private suspend fun updateTonalPalette(applicationContext: Context) {
+        if (!isEnabled(tonalPaletteSensor)) {
+            return
+        }
+
+        suspend fun updateState(state: String) {
+            onSensorUpdated(
+                tonalPaletteSensor,
+                state,
+                tonalPaletteSensor.statelessIcon,
+                mapOf("options" to TONAL_PALETTE_STYLES),
+            )
+        }
+
+        // See https://source.android.com/docs/core/display/dynamic-color#dynamic-13
+        val jsonKey = "theme_customization_overlay_packages"
+        val styleKey = "android.theme.customization.theme_style"
+
+        val jsonString = try {
+            Settings.Secure.getString(applicationContext.contentResolver, jsonKey)
+        } catch (ex: Exception) {
+            Timber.w(ex, "Exception reading %s", jsonKey)
+            updateState(STATE_UNAVAILABLE)
+            return
+        }
+
+        if (jsonString == null) {
+            Timber.w("No value found for %s", jsonKey)
+            updateState(STATE_UNAVAILABLE)
+            return
+        }
+
+        val jsonObject = try {
+            JSONObject(jsonString)
+        } catch (ex: JSONException) {
+            Timber.w(ex, "Exception parsing JSON for %s", jsonKey)
+            updateState(STATE_UNKNOWN)
+            return
+        }
+
+        val themeStyle = try {
+            jsonObject.getString(styleKey)
+        } catch (ex: JSONException) {
+            Timber.w(ex, "Missing %s in JSON for %s", styleKey, jsonKey)
+            updateState(STATE_UNKNOWN)
+            return
+        }
+
+        updateState(themeStyle)
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
@@ -1,0 +1,208 @@
+package io.homeassistant.companion.android.sensors
+
+import android.content.Context
+import android.os.Build
+import android.provider.Settings
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import dagger.hilt.android.testing.HiltTestApplication
+import io.homeassistant.companion.android.common.sensors.SensorRepository
+import io.homeassistant.companion.android.common.util.STATE_UNAVAILABLE
+import io.homeassistant.companion.android.common.util.STATE_UNKNOWN
+import io.homeassistant.companion.android.common.util.kotlinJsonMapper
+import io.homeassistant.companion.android.database.sensor.Attribute
+import io.homeassistant.companion.android.testing.unit.seedFakeAndroidId
+import javax.inject.Inject
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.jupiter.api.assertNotNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@HiltAndroidTest
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class DynamicColorSensorManagerTest {
+    @get:Rule(order = 0)
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    internal lateinit var dynamicColorSensor: DynamicColorSensorManager
+
+    @Inject
+    internal lateinit var sensorRepository: SensorRepository
+
+    @Before
+    fun setUp() {
+        getApplicationContext<Context>().seedFakeAndroidId()
+        hiltRule.inject()
+    }
+
+    @Config(maxSdk = Build.VERSION_CODES.R)
+    @Test
+    fun `Given SDK is lower than Android 12 sensor is absent`() {
+        assertFalse(dynamicColorSensor.hasSensor())
+    }
+
+    @Config(minSdk = Build.VERSION_CODES.S)
+    @Test
+    fun `Given SDK is at least Android 12 sensor is present`() {
+        assertTrue(dynamicColorSensor.hasSensor())
+    }
+
+    @Test
+    fun `Available sensors includes color sensor`() = runTest {
+        val availableSensors = dynamicColorSensor.getAvailableSensors()
+        assertTrue(availableSensors.contains(DynamicColorSensorManager.accentColorSensor))
+    }
+
+    @Test
+    fun `Available sensors includes palette sensor`() = runTest {
+        val availableSensors = dynamicColorSensor.getAvailableSensors()
+        assertTrue(availableSensors.contains(DynamicColorSensorManager.tonalPaletteSensor))
+    }
+
+    @Test
+    fun `Color sensor does not require any special permissions`() {
+        assertArrayEquals(
+            emptyArray<String>(),
+            dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.accentColorSensor.id),
+        )
+    }
+
+    @Test
+    fun `Palette sensor does not require any special permissions`() {
+        assertArrayEquals(
+            emptyArray<String>(),
+            dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.tonalPaletteSensor.id),
+        )
+    }
+
+    @Test
+    fun `Given color sensor is enabled then request update sets theme color`() = runTest {
+        val id = DynamicColorSensorManager.accentColorSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        val state = sensorRepository.get(id).single().state
+
+        // Default accent color for Robolectric
+        assertEquals("#475D92", state)
+    }
+
+    @Test
+    fun `Given color sensor is enabled then request update sets rgb color attribute`() = runTest {
+        val id = DynamicColorSensorManager.accentColorSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        val attrs = getSensorAttributes(id)
+        val rgbColor = attrs.find { it.name == "rgb_color" }
+        assertNotNull(rgbColor)
+
+        // Fixed accent color for Robolectric is 475D92
+        assertEquals("[71,93,146]", rgbColor.value)
+    }
+
+    @Test
+    fun `Given color sensor is disabled then request update does not update state`() = runTest {
+        val id = DynamicColorSensorManager.accentColorSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), false)
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        assertEquals("", sensorRepository.get(id).single().state)
+    }
+
+    @Test
+    fun `Given palette sensor is enabled then request update sets palette variant`() = runTest {
+        val id = DynamicColorSensorManager.tonalPaletteSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        Settings.Secure.putString(
+            getApplicationContext<Context>().contentResolver,
+            "theme_customization_overlay_packages",
+            """{ "android.theme.customization.theme_style": "VIBRANT" }""",
+        )
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        assertEquals("VIBRANT", sensorRepository.get(id).single().state)
+    }
+
+    @Test
+    fun `Given palette sensor receives malformed input then state unknown`() = runTest {
+        val id = DynamicColorSensorManager.tonalPaletteSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        Settings.Secure.putString(
+            getApplicationContext<Context>().contentResolver,
+            "theme_customization_overlay_packages",
+            """android.theme.customization.theme_style""",
+        )
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        assertEquals(STATE_UNKNOWN, sensorRepository.get(id).single().state)
+    }
+
+    @Test
+    fun `Given palette sensor receives null input then state is unavailable`() = runTest {
+        val id = DynamicColorSensorManager.tonalPaletteSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        Settings.Secure.putString(
+            getApplicationContext<Context>().contentResolver,
+            "theme_customization_overlay_packages",
+            null,
+        )
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        assertEquals(STATE_UNAVAILABLE, sensorRepository.get(id).single().state)
+    }
+
+    @Test
+    fun `Given palette sensor is updated then options are exhaustive`() = runTest {
+        val id = DynamicColorSensorManager.tonalPaletteSensor.id
+        sensorRepository.setSensorEnabled(id, listOf(1), true)
+
+        dynamicColorSensor.requestSensorUpdate()
+
+        val attrs = getSensorAttributes(id)
+        val options = attrs.find { it.name == "options" }?.value
+        assertNotNull(options)
+
+        // Serialized as ["EXPRESSIVE","RAINBOW",...]
+        val optionsUnwrapped = kotlinJsonMapper.decodeFromString<List<String>>(options)
+
+        assertEquals(
+            listOf(
+                "EXPRESSIVE",
+                "FRUIT_SALAD",
+                "MONOCHROMATIC",
+                "RAINBOW",
+                "SPRITZ",
+                "TONAL_SPOT",
+                "VIBRANT",
+            ).sorted(),
+            optionsUnwrapped.sorted(),
+        )
+    }
+
+    private suspend fun getSensorAttributes(id: String): List<Attribute> {
+        val map = sensorRepository.getFull(id)
+        assertEquals(1, map.size)
+        return map.values.single()
+    }
+}

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
@@ -48,30 +48,30 @@ class DynamicColorSensorManagerTest {
 
     @Config(maxSdk = Build.VERSION_CODES.R)
     @Test
-    fun `Given SDK is lower than Android 12 sensor is absent`() {
+    fun `Given SDK is lower than Android 12 then sensor is absent`() {
         assertFalse(dynamicColorSensor.hasSensor())
     }
 
     @Config(minSdk = Build.VERSION_CODES.S)
     @Test
-    fun `Given SDK is at least Android 12 sensor is present`() {
+    fun `Given SDK is at least Android 12 then sensor is present`() {
         assertTrue(dynamicColorSensor.hasSensor())
     }
 
     @Test
-    fun `Available sensors includes color sensor`() = runTest {
+    fun `Given dynamic color sensor when available sensors then includes color sensor`() = runTest {
         val availableSensors = dynamicColorSensor.getAvailableSensors()
         assertTrue(availableSensors.contains(DynamicColorSensorManager.accentColorSensor))
     }
 
     @Test
-    fun `Available sensors includes palette sensor`() = runTest {
+    fun `Given dynamic color sensor when available sensors then includes palette sensor`() = runTest {
         val availableSensors = dynamicColorSensor.getAvailableSensors()
         assertTrue(availableSensors.contains(DynamicColorSensorManager.tonalPaletteSensor))
     }
 
     @Test
-    fun `Color sensor does not require any special permissions`() {
+    fun `Given accent color sensor when required permissions then none specified`() {
         assertArrayEquals(
             emptyArray<String>(),
             dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.accentColorSensor.id),
@@ -79,7 +79,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Palette sensor does not require any special permissions`() {
+    fun `Given tonal palette sensor when required permissions then none specified`() {
         assertArrayEquals(
             emptyArray<String>(),
             dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.tonalPaletteSensor.id),
@@ -87,7 +87,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given color sensor is enabled then request update sets theme color`() = runTest {
+    fun `Given enabled color sensor when request update then sets theme color`() = runTest {
         val id = DynamicColorSensorManager.accentColorSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
@@ -100,7 +100,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given color sensor is enabled then request update sets rgb color attribute`() = runTest {
+    fun `Given enabled accent color sensor when request update then sets rgb color attribute`() = runTest {
         val id = DynamicColorSensorManager.accentColorSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
@@ -115,7 +115,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given color sensor is disabled then request update does not update state`() = runTest {
+    fun `Given disabled color sensor when request update then does not update state`() = runTest {
         val id = DynamicColorSensorManager.accentColorSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), false)
 
@@ -125,7 +125,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given palette sensor is enabled then request update sets palette variant`() = runTest {
+    fun `Given palette sensor when request update then sets palette variant`() = runTest {
         val id = DynamicColorSensorManager.tonalPaletteSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
@@ -141,7 +141,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given palette sensor receives malformed input then state unknown`() = runTest {
+    fun `Given palette sensor when receives malformed input then state is unknown`() = runTest {
         val id = DynamicColorSensorManager.tonalPaletteSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
@@ -157,7 +157,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given palette sensor receives null input then state is unavailable`() = runTest {
+    fun `Given palette sensor when receives null input then state is unavailable`() = runTest {
         val id = DynamicColorSensorManager.tonalPaletteSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
@@ -173,7 +173,7 @@ class DynamicColorSensorManagerTest {
     }
 
     @Test
-    fun `Given palette sensor is updated then options are exhaustive`() = runTest {
+    fun `Given palette sensor when updated then options are exhaustive`() = runTest {
         val id = DynamicColorSensorManager.tonalPaletteSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/DynamicColorSensorManagerTest.kt
@@ -29,13 +29,13 @@ import org.robolectric.annotation.Config
 
 @HiltAndroidTest
 @RunWith(RobolectricTestRunner::class)
-@Config(application = HiltTestApplication::class)
+@Config(sdk = [36], application = HiltTestApplication::class)
 class DynamicColorSensorManagerTest {
     @get:Rule(order = 0)
     val hiltRule = HiltAndroidRule(this)
 
     @Inject
-    internal lateinit var dynamicColorSensor: DynamicColorSensorManager
+    internal lateinit var sensorManager: DynamicColorSensorManager
 
     @Inject
     internal lateinit var sensorRepository: SensorRepository
@@ -48,25 +48,20 @@ class DynamicColorSensorManagerTest {
 
     @Config(maxSdk = Build.VERSION_CODES.R)
     @Test
-    fun `Given SDK is lower than Android 12 then sensor is absent`() {
-        assertFalse(dynamicColorSensor.hasSensor())
+    fun `Given SDK is lower than Android 12 then sensor manager is absent`() {
+        assertFalse(sensorManager.hasSensor())
     }
 
     @Config(minSdk = Build.VERSION_CODES.S)
     @Test
-    fun `Given SDK is at least Android 12 then sensor is present`() {
-        assertTrue(dynamicColorSensor.hasSensor())
+    fun `Given SDK is at least Android 12 then sensor manager is present`() {
+        assertTrue(sensorManager.hasSensor())
     }
 
     @Test
-    fun `Given dynamic color sensor when available sensors then includes color sensor`() = runTest {
-        val availableSensors = dynamicColorSensor.getAvailableSensors()
+    fun `Given dynamic color sensor when available sensors then includes color and palette sensors`() = runTest {
+        val availableSensors = sensorManager.getAvailableSensors()
         assertTrue(availableSensors.contains(DynamicColorSensorManager.accentColorSensor))
-    }
-
-    @Test
-    fun `Given dynamic color sensor when available sensors then includes palette sensor`() = runTest {
-        val availableSensors = dynamicColorSensor.getAvailableSensors()
         assertTrue(availableSensors.contains(DynamicColorSensorManager.tonalPaletteSensor))
     }
 
@@ -74,7 +69,7 @@ class DynamicColorSensorManagerTest {
     fun `Given accent color sensor when required permissions then none specified`() {
         assertArrayEquals(
             emptyArray<String>(),
-            dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.accentColorSensor.id),
+            sensorManager.requiredPermissions(DynamicColorSensorManager.accentColorSensor.id),
         )
     }
 
@@ -82,7 +77,7 @@ class DynamicColorSensorManagerTest {
     fun `Given tonal palette sensor when required permissions then none specified`() {
         assertArrayEquals(
             emptyArray<String>(),
-            dynamicColorSensor.requiredPermissions(DynamicColorSensorManager.tonalPaletteSensor.id),
+            sensorManager.requiredPermissions(DynamicColorSensorManager.tonalPaletteSensor.id),
         )
     }
 
@@ -91,20 +86,12 @@ class DynamicColorSensorManagerTest {
         val id = DynamicColorSensorManager.accentColorSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         val state = sensorRepository.get(id).single().state
 
         // Default accent color for Robolectric
         assertEquals("#475D92", state)
-    }
-
-    @Test
-    fun `Given enabled accent color sensor when request update then sets rgb color attribute`() = runTest {
-        val id = DynamicColorSensorManager.accentColorSensor.id
-        sensorRepository.setSensorEnabled(id, listOf(1), true)
-
-        dynamicColorSensor.requestSensorUpdate()
 
         val attrs = getSensorAttributes(id)
         val rgbColor = attrs.find { it.name == "rgb_color" }
@@ -119,7 +106,7 @@ class DynamicColorSensorManagerTest {
         val id = DynamicColorSensorManager.accentColorSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), false)
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         assertEquals("", sensorRepository.get(id).single().state)
     }
@@ -135,7 +122,7 @@ class DynamicColorSensorManagerTest {
             """{ "android.theme.customization.theme_style": "VIBRANT" }""",
         )
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         assertEquals("VIBRANT", sensorRepository.get(id).single().state)
     }
@@ -151,7 +138,7 @@ class DynamicColorSensorManagerTest {
             """android.theme.customization.theme_style""",
         )
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         assertEquals(STATE_UNKNOWN, sensorRepository.get(id).single().state)
     }
@@ -167,7 +154,7 @@ class DynamicColorSensorManagerTest {
             null,
         )
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         assertEquals(STATE_UNAVAILABLE, sensorRepository.get(id).single().state)
     }
@@ -177,7 +164,7 @@ class DynamicColorSensorManagerTest {
         val id = DynamicColorSensorManager.tonalPaletteSensor.id
         sensorRepository.setSensorEnabled(id, listOf(1), true)
 
-        dynamicColorSensor.requestSensorUpdate()
+        sensorManager.requestSensorUpdate()
 
         val attrs = getSensorAttributes(id)
         val options = attrs.find { it.name == "options" }?.value

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -1167,6 +1167,8 @@
     <string name="sensor_description_battery_power">The current wattage of the device. To get the most out of this sensor consider using the \"Fast while charging\" sensor update frequency setting.\n\nIf the sensor\'s state or attributes are not as expected, you may need to adjust the current or voltage divisor to get a correct value. Some devices report these values in a different unit.\n- The "Battery current divisor" will convert from microamperes to amperes by default.\n- The "Battery voltage divisor" will convert from millivolts to volts by default.</string>
     <string name="sensor_name_accent_color_sensor">Accent color</string>
     <string name="sensor_description_accent_color_sensor">A hexadecimal color value for the dynamic accent color used in the device theme</string>
+    <string name="sensor_name_tonal_palette_sensor">Tonal palette</string>
+    <string name="sensor_description_tonal_palette_sensor">The name of the dynamic color palette theme currently in use</string>
     <string name="sensor_name_dynamic_color">Dynamic color</string>
     <string name="basic_sensor_name_screen_brightness">Screen brightness</string>
     <string name="sensor_description_screen_brightness">The current screen brightness on the device, an attribute also indicates if auto-brightness is enabled</string>


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

This adds an additional sensor to the current Dynamic Color sensor for the tonal palette variant. In conjunction with the seed color, this is used to determine the generated color palette.

This combination allows for shared color definitions between Home Assistant and the phone's theme. The motivation here was that I was creating a theme that would use the [Material Color Utilities](https://github.com/material-foundation/material-color-utilities) library to create a color palette that would align with the phone's theme. This allows the app to blend in with native applications more effectively. 

The seed color (already exposed as a sensor) is not entirely sufficient, since the generated palette can vary widely based on the selected theme style.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

<img width="336" height="748" alt="as_sensor_entity" src="https://github.com/user-attachments/assets/519c2791-2e04-4a77-8787-1a28324c2eb9" />
<img width="336" height="748" alt="sensor_enabled" src="https://github.com/user-attachments/assets/0e93705b-fe1c-430a-8b2f-0fbf53ea87ee" />
<img width="336" height="748" alt="sensor_in_list" src="https://github.com/user-attachments/assets/b7affaa1-9619-4287-a185-7a6e7ced343d" />


## Link to pull request in documentation repositories
<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#1403

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
