### PR TITLE
Add activity alias with DISPATCH_NFC_MESSAGE permission to fix tag scanning on Android 17

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -498,15 +498,6 @@
             android:theme="@style/Theme.HomeAssistant.TranslucentOverlay">
             <tools:validation testUrl="https://www.home-assistant.io/tag/123e4567-e89b-12d3-a456-426614174000" />
 
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="www.home-assistant.io"
-                    android:pathPrefix="/tag/" />
-            </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -518,6 +509,21 @@
                     android:pathPrefix="/tag/" />
             </intent-filter>
         </activity>
+        <activity-alias
+            android:name=".nfc.TagScannedActivity"
+            android:targetActivity=".nfc.TagReaderActivity"
+            android:exported="true"
+            android:permission="android.permission.DISPATCH_NFC_MESSAGE">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.home-assistant.io"
+                    android:pathPrefix="/tag/" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".nfc.NfcSetupActivity"
             android:exported="false"

--- a/automotive/src/main/AndroidManifest.xml
+++ b/automotive/src/main/AndroidManifest.xml
@@ -400,15 +400,6 @@
             android:theme="@style/Theme.HomeAssistant.TranslucentOverlay">
             <tools:validation testUrl="https://www.home-assistant.io/tag/123e4567-e89b-12d3-a456-426614174000" />
 
-            <intent-filter>
-                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data
-                    android:scheme="https"
-                    android:host="www.home-assistant.io"
-                    android:pathPrefix="/tag/" />
-            </intent-filter>
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -420,6 +411,21 @@
                     android:pathPrefix="/tag/" />
             </intent-filter>
         </activity>
+        <activity-alias
+            android:name=".nfc.TagScannedActivity"
+            android:targetActivity=".nfc.TagReaderActivity"
+            android:exported="true"
+            android:permission="android.permission.DISPATCH_NFC_MESSAGE">
+            <intent-filter>
+                <action android:name="android.nfc.action.NDEF_DISCOVERED" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="www.home-assistant.io"
+                    android:pathPrefix="/tag/" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name=".nfc.NfcSetupActivity"
             android:exported="false"


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
This PR adds an activity alias for the `TagReaderActivity` which has the `DISPATCH_NFC_MESSAGE` permission, and moves the `android.nfc.action.NDEF_DISCOVERED` intentfilter to this alias. This permission is [now required for apps targeting Android 17](https://developer.android.com/develop/connectivity/nfc/nfc#manifest:~:text=Starting%20Android,permission%2E,-This) to receive tag scanned intents but wasn't mentioned on the behavior changes page.

It is an activity alias and not an additonal permission on the existing `TagReaderActivity`, as the `TagReaderActivity` may also be launched when scanning a QR code which isn't coming from the system but usually from a camera app.

I had noticed that it was no longer scanning tags properly but hadn't figured out what caused it yet - but now fixed thanks to a hint from @YBOnline for #7095. Reviewed [Android source](https://cs.android.com/android/platform/superproject/+/bde42b56b84fb2f184f83f2a00fb00a1bd4db22e:frameworks/base/core/res/AndroidManifest.xml?q=android.permission.DISPATCH_NFC_MESSAGE&start=11) to verify that this permission was already included in Android 6, our currently supported minimum, fso no different behavior depending on Android version is needed. Tested on devices with Android 13 and Android 17.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->