### PR TITLE
Fix Ktlint exemption for flavor tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,5 +26,5 @@ ij_kotlin_allow_trailing_comma = true
 ktlint_standard_function-expression-body = disabled
 max_line_length = 120
 
-[**/test/**.kt]
+[**/src/test*/**.kt]
 max_line_length = off

--- a/app/src/testFull/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImplTest.kt
+++ b/app/src/testFull/kotlin/io/homeassistant/companion/android/thread/ThreadManagerImplTest.kt
@@ -256,39 +256,37 @@ class ThreadManagerImplTest {
         }
 
         @Test
-        fun `Given only the server has a dataset and import succeeds when sync then returns OnlyOnServer imported`() =
-            runTest {
-                stubServerSupport(coreSupports = true)
-                mockOrphanCleanup()
-                mockPreferredCredentials(intentSender = null)
-                coEvery { webSocketRepository.getThreadDatasets() } returns
-                    listOf(dataset(datasetId = "server", preferred = true))
-                // No TLV on the server, so the import is a no-op that completes successfully
-                coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
+        fun `Given only the server has a dataset and import succeeds when sync then returns OnlyOnServer imported`() = runTest {
+            stubServerSupport(coreSupports = true)
+            mockOrphanCleanup()
+            mockPreferredCredentials(intentSender = null)
+            coEvery { webSocketRepository.getThreadDatasets() } returns
+                listOf(dataset(datasetId = "server", preferred = true))
+            // No TLV on the server, so the import is a no-op that completes successfully
+            coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
 
-                val result = assertInstanceOf(
-                    ThreadManager.SyncResult.OnlyOnServer::class.java,
-                    createManager().syncPreferredDataset(serverId = 1, scope = this),
-                )
-                assertTrue(result.imported)
-            }
+            val result = assertInstanceOf(
+                ThreadManager.SyncResult.OnlyOnServer::class.java,
+                createManager().syncPreferredDataset(serverId = 1, scope = this),
+            )
+            assertTrue(result.imported)
+        }
 
         @Test
-        fun `Given only the server has a dataset and import fails when sync then returns OnlyOnServer not imported`() =
-            runTest {
-                stubServerSupport(coreSupports = true)
-                mockOrphanCleanup()
-                mockPreferredCredentials(intentSender = null)
-                coEvery { webSocketRepository.getThreadDatasets() } returns
-                    listOf(dataset(datasetId = "server", preferred = true))
-                coEvery { webSocketRepository.getThreadDatasetTlv(any()) } throws RuntimeException("import boom")
+        fun `Given only the server has a dataset and import fails when sync then returns OnlyOnServer not imported`() = runTest {
+            stubServerSupport(coreSupports = true)
+            mockOrphanCleanup()
+            mockPreferredCredentials(intentSender = null)
+            coEvery { webSocketRepository.getThreadDatasets() } returns
+                listOf(dataset(datasetId = "server", preferred = true))
+            coEvery { webSocketRepository.getThreadDatasetTlv(any()) } throws RuntimeException("import boom")
 
-                val result = assertInstanceOf(
-                    ThreadManager.SyncResult.OnlyOnServer::class.java,
-                    createManager().syncPreferredDataset(serverId = 1, scope = this),
-                )
-                assertFalse(result.imported)
-            }
+            val result = assertInstanceOf(
+                ThreadManager.SyncResult.OnlyOnServer::class.java,
+                createManager().syncPreferredDataset(serverId = 1, scope = this),
+            )
+            assertFalse(result.imported)
+        }
 
         @Test
         fun `Given only the device has a dataset when sync then returns OnlyOnDevice with intent`() = runTest {
@@ -328,24 +326,23 @@ class ThreadManagerImplTest {
         }
 
         @Test
-        fun `Given both have datasets and the comparison fails when sync then returns AllHaveCredentials with nulls`() =
-            runTest {
-                stubServerSupport(coreSupports = true)
-                mockOrphanCleanup()
-                mockPreferredCredentials(intentSender = mockk())
-                coEvery { webSocketRepository.getThreadDatasets() } returns
-                    listOf(dataset(datasetId = "server", preferred = true))
-                coEvery { webSocketRepository.getThreadDatasetTlv(any()) } throws RuntimeException("compare boom")
+        fun `Given both have datasets and the comparison fails when sync then returns AllHaveCredentials with nulls`() = runTest {
+            stubServerSupport(coreSupports = true)
+            mockOrphanCleanup()
+            mockPreferredCredentials(intentSender = mockk())
+            coEvery { webSocketRepository.getThreadDatasets() } returns
+                listOf(dataset(datasetId = "server", preferred = true))
+            coEvery { webSocketRepository.getThreadDatasetTlv(any()) } throws RuntimeException("compare boom")
 
-                val result = assertInstanceOf(
-                    ThreadManager.SyncResult.AllHaveCredentials::class.java,
-                    createManager().syncPreferredDataset(serverId = 1, scope = this),
-                )
-                assertNull(result.matches)
-                assertNull(result.fromApp)
-                assertNull(result.updated)
-                assertNull(result.exportIntent)
-            }
+            val result = assertInstanceOf(
+                ThreadManager.SyncResult.AllHaveCredentials::class.java,
+                createManager().syncPreferredDataset(serverId = 1, scope = this),
+            )
+            assertNull(result.matches)
+            assertNull(result.fromApp)
+            assertNull(result.updated)
+            assertNull(result.exportIntent)
+        }
 
         @Test
         fun `Given the device already prefers the server dataset when sync then matches without exporting`() = runTest {
@@ -375,65 +372,62 @@ class ThreadManagerImplTest {
         }
 
         @Test
-        fun `Given the device prefers an app-added dataset when sync then updates the device to the server dataset`() =
-            runTest {
-                stubServerSupport(coreSupports = true)
-                mockOrphanCleanup()
-                mockPreferredCredentials(intentSender = mockk())
-                coEvery { webSocketRepository.getThreadDatasets() } returns
-                    listOf(dataset(datasetId = "server", preferred = true))
-                // No TLV, so the device does not prefer the server dataset directly...
-                coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
-                // ...but it does prefer a credential this app added previously
-                mockDeviceCredentialPrefersApp()
+        fun `Given the device prefers an app-added dataset when sync then updates the device to the server dataset`() = runTest {
+            stubServerSupport(coreSupports = true)
+            mockOrphanCleanup()
+            mockPreferredCredentials(intentSender = mockk())
+            coEvery { webSocketRepository.getThreadDatasets() } returns
+                listOf(dataset(datasetId = "server", preferred = true))
+            // No TLV, so the device does not prefer the server dataset directly...
+            coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
+            // ...but it does prefer a credential this app added previously
+            mockDeviceCredentialPrefersApp()
 
-                val result = assertInstanceOf(
-                    ThreadManager.SyncResult.AllHaveCredentials::class.java,
-                    createManager().syncPreferredDataset(serverId = 1, scope = this),
-                )
-                assertEquals(false, result.matches)
-                assertEquals(true, result.fromApp)
-                assertEquals(true, result.updated)
-                assertNull(result.exportIntent)
-            }
+            val result = assertInstanceOf(
+                ThreadManager.SyncResult.AllHaveCredentials::class.java,
+                createManager().syncPreferredDataset(serverId = 1, scope = this),
+            )
+            assertEquals(false, result.matches)
+            assertEquals(true, result.fromApp)
+            assertEquals(true, result.updated)
+            assertNull(result.exportIntent)
+        }
 
         @Test
-        fun `Given a foreign-sourced server dataset preferred via an app credential when sync then removes it`() =
-            runTest {
-                stubServerSupport(coreSupports = true)
-                mockOrphanCleanup()
-                mockPreferredCredentials(intentSender = mockk())
-                // The server's preferred dataset reports it originated from another app (not HA), so HA
-                // should stop managing it: remove its own contributed credential without re-importing.
-                coEvery { webSocketRepository.getThreadDatasets() } returns
-                    listOf(dataset(datasetId = "server", preferred = true, source = "Google"))
-                // No TLV, so the device does not prefer the server dataset directly...
-                coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
-                // ...but it does prefer a credential this app added previously, which is what lets HA
-                // remove it. A credential added by another app could not be removed here (see the
-                // "neither is device-preferred" test, which exports instead of removing).
-                mockDeviceCredentialPrefersApp()
+        fun `Given a foreign-sourced server dataset preferred via an app credential when sync then removes it`() = runTest {
+            stubServerSupport(coreSupports = true)
+            mockOrphanCleanup()
+            mockPreferredCredentials(intentSender = mockk())
+            // The server's preferred dataset reports it originated from another app (not HA), so HA
+            // should stop managing it: remove its own contributed credential without re-importing.
+            coEvery { webSocketRepository.getThreadDatasets() } returns
+                listOf(dataset(datasetId = "server", preferred = true, source = "Google"))
+            // No TLV, so the device does not prefer the server dataset directly...
+            coEvery { webSocketRepository.getThreadDatasetTlv(any()) } returns null
+            // ...but it does prefer a credential this app added previously, which is what lets HA
+            // remove it. A credential added by another app could not be removed here (see the
+            // "neither is device-preferred" test, which exports instead of removing).
+            mockDeviceCredentialPrefersApp()
 
-                val result = assertInstanceOf(
-                    ThreadManager.SyncResult.AllHaveCredentials::class.java,
-                    createManager().syncPreferredDataset(serverId = 1, scope = this),
-                )
-                assertEquals(false, result.matches)
-                assertEquals(true, result.fromApp)
-                assertEquals(false, result.updated)
-                assertNull(result.exportIntent)
-            }
+            val result = assertInstanceOf(
+                ThreadManager.SyncResult.AllHaveCredentials::class.java,
+                createManager().syncPreferredDataset(serverId = 1, scope = this),
+            )
+            assertEquals(false, result.matches)
+            assertEquals(true, result.fromApp)
+            assertEquals(false, result.updated)
+            assertNull(result.exportIntent)
+        }
     }
 
-    private fun dataset(datasetId: String, preferred: Boolean, source: String = "HomeAssistant") =
-        ThreadDatasetResponse(
-            datasetId = datasetId,
-            extendedPanId = "extended-pan-id",
-            networkName = "network-$datasetId",
-            panId = "pan-id",
-            preferred = preferred,
-            source = source,
-        )
+    private fun dataset(datasetId: String, preferred: Boolean, source: String = "HomeAssistant") = ThreadDatasetResponse(
+        datasetId = datasetId,
+        extendedPanId = "extended-pan-id",
+        networkName = "network-$datasetId",
+        panId = "pan-id",
+        preferred = preferred,
+        source = source,
+    )
 
     private fun stubServerSupport(coreSupports: Boolean) {
         coEvery { serverManager.isRegistered() } returns true


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

Expand the test-source Ktlint line-length exemption from conventional `src/test` sources to flavor-specific unit-test source sets such as `src/testFull`.

The pattern is scoped to `src/test*` so it does not unintentionally match module directories such as `testing-unit`. The `ThreadManagerImplTest` changes are mechanical output from running the repository formatter with the corrected convention.

This is prerequisite cleanup discovered while working on #7344; it does not resolve that issue.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->

Not applicable.

## Link to pull request in documentation repositories
<!--
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant# N/A

<!--
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.

    Note: Remove this section if there is no PR.
-->
Developer Documentation: home-assistant/developers.home-assistant# N/A

## Any other notes
<!--
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->

Validation:

- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :build-logic:convention:ktlintFormat ktlintFormat`
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew ktlintCheck :build-logic:convention:ktlintCheck --continue`
