### PR TITLE
Health connect sleep stages

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -1118,27 +1118,21 @@ class HealthConnectSensorManager @Inject constructor(
     ): Map<String, Any?> = mapOf(
         "startTime" to sleepRecord.startTime,
         "endTime" to sleepRecord.endTime,
-        "startZoneOffset" to sleepRecord.startZoneOffset?.toString(),
-        "endZoneOffset" to sleepRecord.endZoneOffset?.toString(),
-        "title" to sleepRecord.title,
-        "notes" to sleepRecord.notes,
         "sources" to sleepRecord.metadata.dataOrigin.packageName,
-        "recordId" to sleepRecord.metadata.id,
-        "lastModifiedTime" to sleepRecord.metadata.lastModifiedTime,
-        "clientRecordId" to sleepRecord.metadata.clientRecordId,
-        "clientRecordVersion" to sleepRecord.metadata.clientRecordVersion,
-        "recordingMethod" to sleepRecord.metadata.recordingMethod,
-        "deviceType" to sleepRecord.metadata.device?.type,
-        "deviceManufacturer" to sleepRecord.metadata.device?.manufacturer,
-        "deviceModel" to sleepRecord.metadata.device?.model,
-        "stages" to analysis.timeline,
+        "stageTypes" to analysis.stageTypes,
+        "stageTypeIds" to analysis.stageTypeIds,
+        "stageStartTimes" to analysis.stageStartTimes,
+        "stageEndTimes" to analysis.stageEndTimes,
     )
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal data class SleepStageAnalysis(
         val sleepDurationInMinutes: Long,
         val durationInMinutesByStage: Map<Int, Long>,
-        val timeline: List<Map<String, Any>>,
+        val stageTypes: List<String>,
+        val stageTypeIds: List<Int>,
+        val stageStartTimes: List<String>,
+        val stageEndTimes: List<String>,
     )
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
@@ -1162,14 +1156,10 @@ class HealthConnectSensorManager @Inject constructor(
             durationInMinutesByStage = durationSecondsByStage.mapValues { (_, durationSeconds) ->
                 durationSeconds.toDuration(DurationUnit.SECONDS).inWholeMinutes
             },
-            timeline = stages.map { stage ->
-                mapOf(
-                    "type" to getSleepStageType(stage.stage),
-                    "stageType" to stage.stage,
-                    "startTime" to stage.startTime,
-                    "endTime" to stage.endTime,
-                )
-            },
+            stageTypes = stages.map { stage -> getSleepStageType(stage.stage) },
+            stageTypeIds = stages.map { stage -> stage.stage },
+            stageStartTimes = stages.map { stage -> stage.startTime.toString() },
+            stageEndTimes = stages.map { stage -> stage.endTime.toString() },
         )
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -1232,7 +1232,7 @@ class HealthConnectSensorManager @Inject constructor(
             vo2Max.statelessIcon,
             attributes = mapOf(
                 "date" to response.records.last().time,
-"measurementMethod" to getMeasurementMethod(response.records.last().measurementMethod),
+                "measurementMethod" to getMeasurementMethod(response.records.last().measurementMethod),
                 "source" to response.records.last().metadata.dataOrigin.packageName,
             ),
         )
@@ -1461,4 +1461,3 @@ class HealthConnectSensorManager @Inject constructor(
         }
     }
 }
-

--- a/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManager.kt
@@ -327,6 +327,124 @@ class HealthConnectSensorManager @Inject constructor(
         )
 
         @ProvidesSensor
+        val sleepStart = SensorManager.BasicSensor(
+            id = "health_connect_sleep_start",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_start,
+            commonR.string.sensor_description_sleep_start,
+            "mdi:sleep",
+            deviceClass = "timestamp",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepEnd = SensorManager.BasicSensor(
+            id = "health_connect_sleep_end",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_end,
+            commonR.string.sensor_description_sleep_end,
+            "mdi:sleep",
+            deviceClass = "timestamp",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepLightDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_light_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_light_duration,
+            commonR.string.sensor_description_sleep_light_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepDeepDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_deep_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_deep_duration,
+            commonR.string.sensor_description_sleep_deep_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepRemDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_rem_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_rem_duration,
+            commonR.string.sensor_description_sleep_rem_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepAwakeDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_awake_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_awake_duration,
+            commonR.string.sensor_description_sleep_awake_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepAwakeInBedDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_awake_in_bed_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_awake_in_bed_duration,
+            commonR.string.sensor_description_sleep_awake_in_bed_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepOutOfBedDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_out_of_bed_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_out_of_bed_duration,
+            commonR.string.sensor_description_sleep_out_of_bed_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepUnspecifiedDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_unspecified_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_unspecified_duration,
+            commonR.string.sensor_description_sleep_unspecified_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
+        val sleepUnknownDuration = SensorManager.BasicSensor(
+            id = "health_connect_sleep_unknown_duration",
+            type = "sensor",
+            commonR.string.basic_sensor_name_sleep_unknown_duration,
+            commonR.string.sensor_description_sleep_unknown_duration,
+            "mdi:sleep",
+            deviceClass = "duration",
+            unitOfMeasurement = "min",
+            entityCategory = SensorManager.ENTITY_CATEGORY_DIAGNOSTIC,
+        )
+
+        @ProvidesSensor
         val steps = SensorManager.BasicSensor(
             id = "health_connect_steps",
             type = "sensor",
@@ -408,6 +526,16 @@ class HealthConnectSensorManager @Inject constructor(
             respiratoryRate.id to RespiratoryRateRecord::class,
             restingHeartRate.id to RestingHeartRateRecord::class,
             sleepDuration.id to SleepSessionRecord::class,
+            sleepStart.id to SleepSessionRecord::class,
+            sleepEnd.id to SleepSessionRecord::class,
+            sleepLightDuration.id to SleepSessionRecord::class,
+            sleepDeepDuration.id to SleepSessionRecord::class,
+            sleepRemDuration.id to SleepSessionRecord::class,
+            sleepAwakeDuration.id to SleepSessionRecord::class,
+            sleepAwakeInBedDuration.id to SleepSessionRecord::class,
+            sleepOutOfBedDuration.id to SleepSessionRecord::class,
+            sleepUnspecifiedDuration.id to SleepSessionRecord::class,
+            sleepUnknownDuration.id to SleepSessionRecord::class,
             steps.id to StepsRecord::class,
             systolicBloodPressure.id to BloodPressureRecord::class,
             totalCaloriesBurned.id to TotalCaloriesBurnedRecord::class,
@@ -498,8 +626,20 @@ class HealthConnectSensorManager @Inject constructor(
         if (isEnabled(restingHeartRate)) {
             updateRestingHeartRateSensor()
         }
-        if (isEnabled(sleepDuration)) {
-            updateSleepDurationSensor()
+        if (
+            isEnabled(sleepDuration) ||
+            isEnabled(sleepStart) ||
+            isEnabled(sleepEnd) ||
+            isEnabled(sleepLightDuration) ||
+            isEnabled(sleepDeepDuration) ||
+            isEnabled(sleepRemDuration) ||
+            isEnabled(sleepAwakeDuration) ||
+            isEnabled(sleepAwakeInBedDuration) ||
+            isEnabled(sleepOutOfBedDuration) ||
+            isEnabled(sleepUnspecifiedDuration) ||
+            isEnabled(sleepUnknownDuration)
+        ) {
+            updateSleepSensors()
         }
         if (isEnabled(steps)) {
             updateStepsSensor()
@@ -872,39 +1012,185 @@ class HealthConnectSensorManager @Inject constructor(
         )
     }
 
-    private suspend fun updateSleepDurationSensor() {
+    private suspend fun updateSleepSensors() {
         val healthConnectClient = getOrCreateHealthConnectClient() ?: return
         val sleepRequest = buildReadRecordsRequest(SleepSessionRecord::class)
         val sleepRecords = healthConnectClient.readRecordsOrNull(sleepRequest)
         if (sleepRecords == null || sleepRecords.records.isEmpty()) {
             return
         }
+
         val lastSleepRecord = sleepRecords.records.last()
-        val sleepRecordDuration = calculateSleepDurationInMinutes(lastSleepRecord.stages)
+        val analysis = analyzeSleepStages(lastSleepRecord.stages)
+        val sessionAttributes = buildSleepSessionAttributes(lastSleepRecord, analysis)
+        val basicAttributes = mapOf(
+            "endTime" to lastSleepRecord.endTime,
+            "startTime" to lastSleepRecord.startTime,
+            "sources" to lastSleepRecord.metadata.dataOrigin.packageName,
+        )
+
+        if (isEnabled(sleepDuration)) {
+            onSensorUpdated(
+                sleepDuration,
+                analysis.sleepDurationInMinutes,
+                sleepDuration.statelessIcon,
+                attributes = sessionAttributes,
+            )
+        }
+        if (isEnabled(sleepStart)) {
+            onSensorUpdated(
+                sleepStart,
+                lastSleepRecord.startTime.toString(),
+                sleepStart.statelessIcon,
+                attributes = basicAttributes,
+            )
+        }
+        if (isEnabled(sleepEnd)) {
+            onSensorUpdated(
+                sleepEnd,
+                lastSleepRecord.endTime.toString(),
+                sleepEnd.statelessIcon,
+                attributes = basicAttributes,
+            )
+        }
+
+        updateSleepStageDurationSensor(
+            sleepLightDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_LIGHT],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepDeepDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_DEEP],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepRemDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_REM],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepAwakeDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_AWAKE],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepAwakeInBedDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepOutOfBedDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_OUT_OF_BED],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepUnspecifiedDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_SLEEPING],
+            basicAttributes,
+        )
+        updateSleepStageDurationSensor(
+            sleepUnknownDuration,
+            analysis.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_UNKNOWN],
+            basicAttributes,
+        )
+    }
+
+    private suspend fun updateSleepStageDurationSensor(
+        sensor: SensorManager.BasicSensor,
+        durationInMinutes: Long?,
+        attributes: Map<String, Any?>,
+    ) {
+        if (!isEnabled(sensor)) {
+            return
+        }
         onSensorUpdated(
-            sleepDuration,
-            sleepRecordDuration,
-            sleepDuration.statelessIcon,
-            attributes = mapOf(
-                "endTime" to lastSleepRecord.endTime,
-                "startTime" to lastSleepRecord.startTime,
-                "sources" to lastSleepRecord.metadata.dataOrigin.packageName,
-            ),
+            sensor,
+            durationInMinutes ?: STATE_UNKNOWN,
+            sensor.statelessIcon,
+            attributes = attributes,
+        )
+    }
+
+    private fun buildSleepSessionAttributes(
+        sleepRecord: SleepSessionRecord,
+        analysis: SleepStageAnalysis,
+    ): Map<String, Any?> = mapOf(
+        "startTime" to sleepRecord.startTime,
+        "endTime" to sleepRecord.endTime,
+        "startZoneOffset" to sleepRecord.startZoneOffset?.toString(),
+        "endZoneOffset" to sleepRecord.endZoneOffset?.toString(),
+        "title" to sleepRecord.title,
+        "notes" to sleepRecord.notes,
+        "sources" to sleepRecord.metadata.dataOrigin.packageName,
+        "recordId" to sleepRecord.metadata.id,
+        "lastModifiedTime" to sleepRecord.metadata.lastModifiedTime,
+        "clientRecordId" to sleepRecord.metadata.clientRecordId,
+        "clientRecordVersion" to sleepRecord.metadata.clientRecordVersion,
+        "recordingMethod" to sleepRecord.metadata.recordingMethod,
+        "deviceType" to sleepRecord.metadata.device?.type,
+        "deviceManufacturer" to sleepRecord.metadata.device?.manufacturer,
+        "deviceModel" to sleepRecord.metadata.device?.model,
+        "stages" to analysis.timeline,
+    )
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal data class SleepStageAnalysis(
+        val sleepDurationInMinutes: Long,
+        val durationInMinutesByStage: Map<Int, Long>,
+        val timeline: List<Map<String, Any>>,
+    )
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun analyzeSleepStages(stages: List<SleepSessionRecord.Stage>): SleepStageAnalysis {
+        val durationSecondsByStage = stages
+            .groupingBy { it.stage }
+            .fold(0L) { durationSeconds, stage ->
+                durationSeconds + Duration.between(stage.startTime, stage.endTime).seconds
+            }
+        val sleepDurationSeconds = durationSecondsByStage
+            .filterKeys {
+                it != SleepSessionRecord.STAGE_TYPE_AWAKE &&
+                    it != SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED &&
+                    it != SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
+            }
+            .values
+            .sum()
+
+        return SleepStageAnalysis(
+            sleepDurationInMinutes = sleepDurationSeconds.toDuration(DurationUnit.SECONDS).inWholeMinutes,
+            durationInMinutesByStage = durationSecondsByStage.mapValues { (_, durationSeconds) ->
+                durationSeconds.toDuration(DurationUnit.SECONDS).inWholeMinutes
+            },
+            timeline = stages.map { stage ->
+                mapOf(
+                    "type" to getSleepStageType(stage.stage),
+                    "stageType" to stage.stage,
+                    "startTime" to stage.startTime,
+                    "endTime" to stage.endTime,
+                )
+            },
         )
     }
 
     /** @return Sleep duration based on the stages, excluding awake (+ in bed) and out of bed */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    internal fun calculateSleepDurationInMinutes(stages: List<SleepSessionRecord.Stage>): Long = stages
-        .filter {
-            it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE &&
-                it.stage != SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED &&
-                it.stage != SleepSessionRecord.STAGE_TYPE_OUT_OF_BED
+    internal fun calculateSleepDurationInMinutes(stages: List<SleepSessionRecord.Stage>): Long =
+        analyzeSleepStages(stages).sleepDurationInMinutes
+
+    private fun getSleepStageType(stageType: Int): String {
+        return when (stageType) {
+            SleepSessionRecord.STAGE_TYPE_UNKNOWN -> "unknown"
+            SleepSessionRecord.STAGE_TYPE_AWAKE -> "awake"
+            SleepSessionRecord.STAGE_TYPE_SLEEPING -> "sleeping"
+            SleepSessionRecord.STAGE_TYPE_OUT_OF_BED -> "out_of_bed"
+            SleepSessionRecord.STAGE_TYPE_LIGHT -> "light"
+            SleepSessionRecord.STAGE_TYPE_DEEP -> "deep"
+            SleepSessionRecord.STAGE_TYPE_REM -> "rem"
+            SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED -> "awake_in_bed"
+            else -> STATE_UNKNOWN
         }
-        .sumOf { Duration.between(it.startTime, it.endTime).seconds }
-        .toDuration(DurationUnit.SECONDS)
-        // Don't convert to minutes until the end to avoid losing detail
-        .inWholeMinutes
+    }
 
     private suspend fun updateStepsSensor() {
         val healthConnectClient = getOrCreateHealthConnectClient() ?: return
@@ -946,7 +1232,7 @@ class HealthConnectSensorManager @Inject constructor(
             vo2Max.statelessIcon,
             attributes = mapOf(
                 "date" to response.records.last().time,
-                "measurementMethod" to getMeasurementMethod(response.records.last().measurementMethod),
+"measurementMethod" to getMeasurementMethod(response.records.last().measurementMethod),
                 "source" to response.records.last().metadata.dataOrigin.packageName,
             ),
         )
@@ -998,6 +1284,16 @@ class HealthConnectSensorManager @Inject constructor(
                 respiratoryRate,
                 restingHeartRate,
                 sleepDuration,
+                sleepStart,
+                sleepEnd,
+                sleepLightDuration,
+                sleepDeepDuration,
+                sleepRemDuration,
+                sleepAwakeDuration,
+                sleepAwakeInBedDuration,
+                sleepOutOfBedDuration,
+                sleepUnspecifiedDuration,
+                sleepUnknownDuration,
                 steps,
                 systolicBloodPressure,
                 totalCaloriesBurned,
@@ -1165,3 +1461,4 @@ class HealthConnectSensorManager @Inject constructor(
         }
     }
 }
+

--- a/app/src/main/res/xml/changelog_master.xml
+++ b/app/src/main/res/xml/changelog_master.xml
@@ -4,6 +4,7 @@
     <release version="2026.8.4 - Main" versioncode="3">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
         <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
+        <change>Health Connect now exposes sleep start/end times and individual sleep stage durations</change>
         <change>Modernized settings for entity widgets and tiles</change>
         <change>Bug fixes and dependency updates</change>
     </release>
@@ -14,6 +15,7 @@
     <release version="2026.8.4 - Automotive" versioncode="1">
         <change>Android 17: added assistant volume level sensor + notification command for control</change>
         <change>Health Connect sleep duration sensor now ignores awake and out of bed time</change>
+        <change>Health Connect now exposes sleep start/end times and individual sleep stage durations</change>
         <change>Bug fixes and dependency updates</change>
     </release>
 </changelog>

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkObject
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -105,5 +106,112 @@ class HealthConnectSensorManagerTest {
 
         val result = sensorManager.calculateSleepDurationInMinutes(mockSleepStages)
         assertEquals(300L, result)
+    }
+
+    @Test
+    fun `Given repeated sleep stages when analyzed then durations are summed by stage type`() {
+        val midnight = Instant.parse("2026-07-01T00:00:00Z")
+        val stages = listOf(
+            SleepSessionRecord.Stage(
+                startTime = midnight,
+                endTime = midnight.plus(30, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_LIGHT,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(30, ChronoUnit.MINUTES),
+                endTime = midnight.plus(90, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_DEEP,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(90, ChronoUnit.MINUTES),
+                endTime = midnight.plus(150, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_LIGHT,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(150, ChronoUnit.MINUTES),
+                endTime = midnight.plus(180, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_REM,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(180, ChronoUnit.MINUTES),
+                endTime = midnight.plus(195, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_AWAKE,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(195, ChronoUnit.MINUTES),
+                endTime = midnight.plus(205, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(205, ChronoUnit.MINUTES),
+                endTime = midnight.plus(215, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_OUT_OF_BED,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(215, ChronoUnit.MINUTES),
+                endTime = midnight.plus(245, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_SLEEPING,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(245, ChronoUnit.MINUTES),
+                endTime = midnight.plus(260, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_UNKNOWN,
+            ),
+        )
+
+        val result = sensorManager.analyzeSleepStages(stages)
+
+        assertEquals(90L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_LIGHT])
+        assertEquals(60L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_DEEP])
+        assertEquals(30L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_REM])
+        assertEquals(15L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_AWAKE])
+        assertEquals(10L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_AWAKE_IN_BED])
+        assertEquals(10L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_OUT_OF_BED])
+        assertEquals(30L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_SLEEPING])
+        assertEquals(15L, result.durationInMinutesByStage[SleepSessionRecord.STAGE_TYPE_UNKNOWN])
+        assertEquals(225L, result.sleepDurationInMinutes)
+    }
+
+    @Test
+    fun `Given a missing sleep stage when analyzed then no duration is created for that stage`() {
+        val midnight = Instant.parse("2026-07-01T00:00:00Z")
+        val stages = listOf(
+            SleepSessionRecord.Stage(
+                startTime = midnight,
+                endTime = midnight.plus(1, ChronoUnit.HOURS),
+                stage = SleepSessionRecord.STAGE_TYPE_LIGHT,
+            ),
+        )
+
+        val result = sensorManager.analyzeSleepStages(stages)
+
+        assertFalse(result.durationInMinutesByStage.containsKey(SleepSessionRecord.STAGE_TYPE_DEEP))
+    }
+
+    @Test
+    fun `Given sleep stages when analyzed then complete ordered timeline is preserved`() {
+        val midnight = Instant.parse("2026-07-01T00:00:00Z")
+        val stages = listOf(
+            SleepSessionRecord.Stage(
+                startTime = midnight,
+                endTime = midnight.plus(30, ChronoUnit.MINUTES),
+                stage = SleepSessionRecord.STAGE_TYPE_LIGHT,
+            ),
+            SleepSessionRecord.Stage(
+                startTime = midnight.plus(30, ChronoUnit.MINUTES),
+                endTime = midnight.plus(1, ChronoUnit.HOURS),
+                stage = SleepSessionRecord.STAGE_TYPE_DEEP,
+            ),
+        )
+
+        val result = sensorManager.analyzeSleepStages(stages)
+
+        assertEquals(2, result.timeline.size)
+        assertEquals("light", result.timeline[0]["type"])
+        assertEquals(SleepSessionRecord.STAGE_TYPE_LIGHT, result.timeline[0]["stageType"])
+        assertEquals(midnight, result.timeline[0]["startTime"])
+        assertEquals(midnight.plus(30, ChronoUnit.MINUTES), result.timeline[0]["endTime"])
+        assertEquals("deep", result.timeline[1]["type"])
+        assertEquals(SleepSessionRecord.STAGE_TYPE_DEEP, result.timeline[1]["stageType"])
     }
 }

--- a/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/sensors/HealthConnectSensorManagerTest.kt
@@ -189,7 +189,7 @@ class HealthConnectSensorManagerTest {
     }
 
     @Test
-    fun `Given sleep stages when analyzed then complete ordered timeline is preserved`() {
+    fun `Given sleep stages when analyzed then complete ordered timeline is preserved as primitive lists`() {
         val midnight = Instant.parse("2026-07-01T00:00:00Z")
         val stages = listOf(
             SleepSessionRecord.Stage(
@@ -206,12 +206,24 @@ class HealthConnectSensorManagerTest {
 
         val result = sensorManager.analyzeSleepStages(stages)
 
-        assertEquals(2, result.timeline.size)
-        assertEquals("light", result.timeline[0]["type"])
-        assertEquals(SleepSessionRecord.STAGE_TYPE_LIGHT, result.timeline[0]["stageType"])
-        assertEquals(midnight, result.timeline[0]["startTime"])
-        assertEquals(midnight.plus(30, ChronoUnit.MINUTES), result.timeline[0]["endTime"])
-        assertEquals("deep", result.timeline[1]["type"])
-        assertEquals(SleepSessionRecord.STAGE_TYPE_DEEP, result.timeline[1]["stageType"])
+        assertEquals(listOf("light", "deep"), result.stageTypes)
+        assertEquals(
+            listOf(SleepSessionRecord.STAGE_TYPE_LIGHT, SleepSessionRecord.STAGE_TYPE_DEEP),
+            result.stageTypeIds,
+        )
+        assertEquals(
+            listOf(
+                midnight.toString(),
+                midnight.plus(30, ChronoUnit.MINUTES).toString(),
+            ),
+            result.stageStartTimes,
+        )
+        assertEquals(
+            listOf(
+                midnight.plus(30, ChronoUnit.MINUTES).toString(),
+                midnight.plus(1, ChronoUnit.HOURS).toString(),
+            ),
+            result.stageEndTimes,
+        )
     }
 }

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -946,7 +946,7 @@
     <string name="tile_4">Tile 4</string>
     <string name="tile_40">Tile 40</string>
     <string name="tile_5">Tile 5</string>
-    <string name="tile_6">Tile 6</string>
+<string name="tile_6">Tile 6</string>
     <string name="tile_7">Tile 7</string>
     <string name="tile_8">Tile 8</string>
     <string name="tile_9">Tile 9</string>
@@ -1353,6 +1353,26 @@
     <string name="sensor_description_floors_climbed">Total floors climbed since midnight from Health Connect</string>
     <string name="basic_sensor_name_sleep_duration">Sleep duration</string>
     <string name="sensor_description_sleep_duration">Last recorded sleep duration in minutes from Health Connect</string>
+    <string name="basic_sensor_name_sleep_start">Sleep start</string>
+    <string name="sensor_description_sleep_start">Start time of the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_end">Sleep end</string>
+    <string name="sensor_description_sleep_end">End time of the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_light_duration">Light sleep duration</string>
+    <string name="sensor_description_sleep_light_duration">Duration of light sleep in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_deep_duration">Deep sleep duration</string>
+    <string name="sensor_description_sleep_deep_duration">Duration of deep sleep in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_rem_duration">REM sleep duration</string>
+    <string name="sensor_description_sleep_rem_duration">Duration of REM sleep in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_awake_duration">Awake duration</string>
+    <string name="sensor_description_sleep_awake_duration">Duration reported as awake in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_awake_in_bed_duration">Awake in bed duration</string>
+    <string name="sensor_description_sleep_awake_in_bed_duration">Duration reported as awake in bed in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_out_of_bed_duration">Out of bed duration</string>
+    <string name="sensor_description_sleep_out_of_bed_duration">Duration reported as out of bed in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_unspecified_duration">Unspecified sleep duration</string>
+    <string name="sensor_description_sleep_unspecified_duration">Duration reported as sleeping without a specific sleep stage in the latest sleep session from Health Connect</string>
+    <string name="basic_sensor_name_sleep_unknown_duration">Unknown sleep stage duration</string>
+    <string name="sensor_description_sleep_unknown_duration">Duration reported with an unknown sleep stage in the latest sleep session from Health Connect</string>
     <string name="sensor_description_steps">Total steps taken since midnight from Health Connect</string>
     <string name="basic_sensor_name_blood_glucose">Blood glucose</string>
     <string name="sensor_description_blood_glucose">Last recorded blood glucose reading in milligrams per deciliter from Health Connect</string>
@@ -1512,3 +1532,4 @@
     <string name="default_assistant_required">Home Assistant must be your default assistant to perform %s.</string>
     <string name="hidden_entity">Hidden entity</string>
 </resources>
+

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -946,7 +946,7 @@
     <string name="tile_4">Tile 4</string>
     <string name="tile_40">Tile 40</string>
     <string name="tile_5">Tile 5</string>
-<string name="tile_6">Tile 6</string>
+    <string name="tile_6">Tile 6</string>
     <string name="tile_7">Tile 7</string>
     <string name="tile_8">Tile 8</string>
     <string name="tile_9">Tile 9</string>


### PR DESCRIPTION
## Summary

Adds richer Health Connect sleep session data to the Android Companion App by exposing the individual standardized sleep stages already available through `SleepSessionRecord`.

The existing Health Connect sleep duration sensor remains unchanged for backward compatibility. This change adds sensors for sleep start/end times and the duration of each standardized Health Connect sleep stage, including Light, Deep, REM, Awake, Awake in bed, Out of bed, Sleeping/unspecified, and Unknown.

The latest `SleepSessionRecord` is read once per sensor update and its stages are analyzed once, avoiding duplicate Health Connect queries when multiple sleep sensors are enabled.

The existing Sleep Duration sensor also preserves the ordered sleep-stage timeline as structured attributes containing each stage's type, start time, and end time, allowing Home Assistant consumers to use the original Health Connect stage data for dashboards and analysis.

The implementation is provider-neutral. It does not contain Samsung-, Fitbit-, or device-specific logic and does not attempt to merge separate `SleepSessionRecord` entries.

Missing stage data is kept unavailable/unknown rather than being converted to zero, because a provider not supplying a stage is semantically different from reporting zero duration.

Related feature request:
https://github.com/home-assistant/feature-requests/discussions/4080

## Checklist

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [x] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Link to pull request in documentation repositories

<!-- 
    This pull request introduces, changes, or removes user-facing functionality.
    A corresponding update to the Companion App documentation in the documentation repository (https://github.com/home-assistant/companion.home-assistant) is required.

    Instructions:
    1. Create a pull request in the documentation repository.
    2. Add the documentation pull request number after the "#" below.
    3. Add the `<span class='beta'>BETA</span> ` flag in the documentation to mark it as such.

    Note: Remove this section if there is no PR.
-->
User Documentation: home-assistant/companion.home-assistant#1407

<!-- 
    This pull request introduces, changes, or removes developer-facing functionality.
    A corresponding update to the Developer documentation in the documentation repository (https://github.com/home-assistant/developers.home-assistant) is required. 
 
    Instructions: 
    1. Create a pull request in the documentation repository. 
    2. Add the documentation pull request number after the "#" below. 
 
    Note: Remove this section if there is no PR. 
--> 
Developer Documentation: home-assistant/developers.home-assistant#

## Any other notes

Targeted `HealthConnectSensorManagerTest`: 6/6 tests passed.

`:app:lintFullDebug`: passed.

`ktlintCheck :build-logic:convention:ktlintCheck --continue`: passed.

The full `:app:testFullDebugUnitTest` run completed 1,530 tests with two unrelated failures in `WearOnboardingNavigationTest` and `ServerDiscoveryNavigationTest`. Both failures were reproduced independently when those test classes were run in isolation.