### PR TITLE
Mark one more server URL load as sensitive

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
@@ -153,7 +153,7 @@ class FrontendUrlManager @Inject constructor(
             .build()
             .toString()
 
-        Timber.d("Loading server URL: ${ sensitive(urlWithAuth) }")
+        Timber.d("Loading server URL: ${sensitive(urlWithAuth)}")
         return UrlLoadResult.Success(url = urlWithAuth, serverId = serverId, moreInfoEntityId = moreInfoEntityIdForJs)
     }
 

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/url/FrontendUrlManager.kt
@@ -6,6 +6,7 @@ import io.homeassistant.companion.android.common.data.servers.UrlState
 import io.homeassistant.companion.android.frontend.navigation.FrontendTarget
 import io.homeassistant.companion.android.frontend.session.ServerSessionManager
 import io.homeassistant.companion.android.util.UrlUtil
+import io.homeassistant.companion.android.util.sensitive
 import java.net.URL
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
@@ -152,7 +153,7 @@ class FrontendUrlManager @Inject constructor(
             .build()
             .toString()
 
-        Timber.d("Loading server URL: $urlWithAuth")
+        Timber.d("Loading server URL: ${ sensitive(urlWithAuth) }")
         return UrlLoadResult.Success(url = urlWithAuth, serverId = serverId, moreInfoEntityId = moreInfoEntityIdForJs)
     }
 


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Tiny fix: marks one more server URL during loading as sensitive to avoid logging in production. I don't think we need to add code to know the query parameter for more-info-entity-id was included.

Log excerpt from current production (last line):

```
2026-08-28 10:52:07.878 11624-11624 HAWebViewKt             io.homeassistant.companion.android   D  Webview started
2026-08-28 10:52:07.889 11624-11624 FrontendJsBridge        io.homeassistant.companion.android   D  JS externalAppV2 listener added
2026-08-28 10:52:07.889 11624-11624 FrontendSc...iewEffects io.homeassistant.companion.android   V  Load url HIDDEN
2026-08-28 10:52:07.892 11624-11641 ServerConn...oviderImpl io.homeassistant.companion.android   D  usesInternalSsid is: false, usesWifi is: false
2026-08-28 10:52:07.897 11624-11734 NetworkCha...workChange io.homeassistant.companion.android   D  Register network callback
2026-08-28 10:52:07.905 11624-11624 ServerConn...oviderImpl io.homeassistant.companion.android   D  usesInternalSsid is: false, usesWifi is: false
2026-08-28 10:52:07.906 11624-11624 ServerConn...iderImplKt io.homeassistant.companion.android   D  Using external URL
2026-08-28 10:52:07.908 11624-11624 FrontendUrlManager      io.homeassistant.companion.android   D  Loading server URL: https://ha.example.com/?external_auth=1
```

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Screenshots
<!--
    If this is a user-facing change not in the frontend, please include screenshots in light and dark mode.

    Note: Remove this section if there are no screenshots.
-->
n/a

## Link to pull request in documentation repositories
n/a

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->