### PR TITLE
Remove leftover from prepareNextRelease workflow

### DIFF
--- a/.github/workflows/monthly.yml
+++ b/.github/workflows/monthly.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'home-assistant/android'
     permissions:
-      actions: write
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,14 +25,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.current-time.outputs.year }}.${{ steps.current-time.outputs.month }}.0
-
-      - name: Trigger Prepare Next Release
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'prepareNextRelease.yml',
-              ref: 'main',
-            })

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'home-assistant/android'
     permissions:
-      actions: write # Start workflows onPush and prepareNextRelease
+      actions: write # Start workflows onPush
       contents: write # Allow pushing tags
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
We recently remove the prepareNextRelease workflow since we don't need anymore, but we forgot to remove some reference to it from other workflow like monthly and weekly.