### PR TITLE
Adjust RAM settings for Kotlin compiler and the deamon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,10 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+# Dex merging (D8) runs as in-process workers in the Gradle daemon and needs most of the heap;
+# the Kotlin daemon is pinned below so it no longer inherits this value.
+org.gradle.jvmargs=-Xmx6g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+kotlin.daemon.jvmargs=-Xmx3g
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
CI builds regularly fails with `java.lang.OutOfMemoryError: Java heap space` inside D8
(`DexMergingWorkAction` in `:app:mergeExtDexFullRelease`). Dex merging runs as in-process workers in the Gradle daemon, so all concurrent merges of the five release variants share the daemon's 4 GB heap. 

* Raise the Gradle daemon heap to 6 GB, since that is the process that OOMs. 
* Pin the Kotlin daemon to 3 GB via `kotlin.daemon.jvmargs`. It previously inherited the Gradle value, so this change moves the total heap ceilings from an implicit 4+4 GB to an explicit  6+3 GB: only 1 GB more on the 16 GB runner, with the headroom where it is needed.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.

## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->
The information have been given by Claude and I asked to do some local benchmark to validate the information about the fact that the worker are sharing the XMX, I initially thought it was per worker.