### PR TITLE
Rework IconDialog UI to Material 3

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ui/ManageTilesScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/qs/ui/ManageTilesScreen.kt
@@ -59,9 +59,8 @@ import io.homeassistant.companion.android.common.compose.theme.LocalHAColorSchem
 import io.homeassistant.companion.android.settings.qs.ManageTilesState
 import io.homeassistant.companion.android.settings.qs.ManageTilesViewModel
 import io.homeassistant.companion.android.settings.qs.TileId
-import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
 import io.homeassistant.companion.android.util.compose.entity.EntityPicker
-import io.homeassistant.companion.android.util.icondialog.IconDialog
+import io.homeassistant.companion.android.util.icondialog.IconDialogM3
 import io.homeassistant.companion.android.util.safeBottomWindowInsets
 
 @Composable
@@ -79,16 +78,13 @@ internal fun ManageTilesScreen(viewModel: ManageTilesViewModel, modifier: Modifi
     }
 
     if (showIconDialog) {
-        // TODO Migrate IconDialog to Material 3 https://github.com/home-assistant/android/issues/7156
-        HomeAssistantAppTheme {
-            IconDialog(
-                onSelect = { icon ->
-                    viewModel.selectIcon(icon)
-                    showIconDialog = false
-                },
-                onDismissRequest = { showIconDialog = false },
-            )
-        }
+        IconDialogM3(
+            onSelect = { icon ->
+                viewModel.selectIcon(icon)
+                showIconDialog = false
+            },
+            onDismissRequest = { showIconDialog = false },
+        )
     }
 
     ManageTilesContent(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsSettingsFragment.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/shortcuts/legacy/ManageShortcutsSettingsFragment.kt
@@ -16,10 +16,11 @@ import androidx.fragment.app.viewModels
 import com.mikepenz.iconics.typeface.IIcon
 import dagger.hilt.android.AndroidEntryPoint
 import io.homeassistant.companion.android.common.R as commonR
+import io.homeassistant.companion.android.common.compose.theme.HATheme
 import io.homeassistant.companion.android.settings.addHelpMenuProvider
 import io.homeassistant.companion.android.settings.shortcuts.legacy.views.ManageShortcutsView
 import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
-import io.homeassistant.companion.android.util.icondialog.IconDialog
+import io.homeassistant.companion.android.util.icondialog.IconDialogM3
 import timber.log.Timber
 
 @RequiresApi(Build.VERSION_CODES.N_MR1)
@@ -40,13 +41,15 @@ class ManageShortcutsSettingsFragment : Fragment() {
                 HomeAssistantAppTheme {
                     var showingTag by remember { mutableStateOf<String?>(null) }
                     showingTag?.let { tag ->
-                        IconDialog(
-                            onSelect = {
-                                onIconDialogIconsSelected(tag, it)
-                                showingTag = null
-                            },
-                            onDismissRequest = { showingTag = null },
-                        )
+                        HATheme {
+                            IconDialogM3(
+                                onSelect = {
+                                    onIconDialogIconsSelected(tag, it)
+                                    showingTag = null
+                                },
+                                onDismissRequest = { showingTag = null },
+                            )
+                        }
                     }
 
                     ManageShortcutsView(viewModel = viewModel, showIconDialog = { showingTag = it })

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialog.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialog.kt
@@ -37,7 +37,10 @@ fun IconDialogContent(
 }
 
 @Deprecated(
-    "Uses Material Design 2. Use IconDialogM3 (Material Design 3) instead.",
+    message = "Uses Material Design 2. Use IconDialogM3 (Material Design 3) instead.",
+    replaceWith = ReplaceWith(
+        "IconDialogM3(onSelect = onSelect, onDismissRequest = onDismissRequest, modifier = modifier, iconFilter = iconFilter)",
+    ),
 )
 @Composable
 fun IconDialog(

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogGridM3.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogGridM3.kt
@@ -1,0 +1,109 @@
+package io.homeassistant.companion.android.util.icondialog
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mikepenz.iconics.compose.Image
+import com.mikepenz.iconics.typeface.IIcon
+import com.mikepenz.iconics.typeface.ITypeface
+import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
+import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Display a grid of icons, letting the user select one.
+ * @param icons List of icons to display
+ * @param onClick Invoked when the user clicks on the given icon
+ */
+@Composable
+fun IconDialogGridM3(
+    icons: List<IIcon>,
+    modifier: Modifier = Modifier,
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: (IIcon) -> Unit,
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(minSize = 48.dp),
+        modifier = modifier.fillMaxSize(),
+    ) {
+        items(icons) { icon ->
+            IconButton(onClick = { onClick(icon) }) {
+                Image(
+                    asset = icon,
+                    colorFilter = ColorFilter.tint(tint),
+                    // https://material.io/design/iconography/system-icons.html#color
+                    alpha = 0.54f,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Display a grid of icons, letting the user select one.
+ * @param typeface Icon typeface that includes all possible icons.
+ * @param searchQuery Search term used to filter icons from the [typeface].
+ * @param iconFilter Adjust filtering logic for the search process.
+ * @param onClick Invoked when the user clicks on the given icon
+ */
+@Composable
+fun IconDialogGridM3(
+    typeface: ITypeface,
+    searchQuery: String,
+    modifier: Modifier = Modifier,
+    iconFilter: IconFilter = DefaultIconFilter(),
+    tint: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: (IIcon) -> Unit,
+) {
+    var icons by remember { mutableStateOf<List<IIcon>>(emptyList()) }
+    LaunchedEffect(typeface, searchQuery) {
+        icons = withContext(Dispatchers.IO) {
+            iconFilter.queryIcons(typeface, searchQuery)
+        }
+    }
+
+    IconDialogGridM3(
+        icons = icons,
+        modifier = modifier,
+        tint = tint,
+        onClick = onClick,
+    )
+}
+
+@Preview
+@Composable
+private fun IconDialogGridM3Preview() {
+    HAThemeForPreview {
+        Surface(
+            modifier = Modifier
+                .width(480.dp)
+                .height(500.dp),
+            shape = MaterialTheme.shapes.medium,
+        ) {
+            IconDialogGridM3(
+                icons = CommunityMaterial.icons.map { name ->
+                    CommunityMaterial.getIcon(name)
+                },
+                onClick = {},
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogGridM3.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogGridM3.kt
@@ -75,7 +75,7 @@ fun IconDialogGridM3(
 ) {
     var icons by remember { mutableStateOf<List<IIcon>>(emptyList()) }
     LaunchedEffect(typeface, searchQuery) {
-        icons = withContext(Dispatchers.IO) {
+        icons = withContext(Dispatchers.Default) {
             iconFilter.queryIcons(typeface, searchQuery)
         }
     }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogM3.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogM3.kt
@@ -3,8 +3,8 @@ package io.homeassistant.companion.android.util.icondialog
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -16,18 +16,21 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.mikepenz.iconics.typeface.IIcon
 import com.mikepenz.iconics.typeface.library.community.material.CommunityMaterial
-import io.homeassistant.companion.android.util.compose.HomeAssistantAppTheme
+import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
 
 @Composable
-fun IconDialogContent(
+fun IconDialogContentM3(
     modifier: Modifier = Modifier,
     iconFilter: IconFilter = DefaultIconFilter(),
     onSelect: (IIcon) -> Unit,
 ) {
     var searchQuery by remember { mutableStateOf("") }
     Column(modifier = modifier) {
-        IconDialogSearch(value = searchQuery, onValueChange = { searchQuery = it })
-        IconDialogGrid(
+        IconDialogSearchM3(
+            value = searchQuery,
+            onValueChange = { searchQuery = it },
+        )
+        IconDialogGridM3(
             typeface = CommunityMaterial,
             searchQuery = searchQuery,
             iconFilter = iconFilter,
@@ -36,11 +39,8 @@ fun IconDialogContent(
     }
 }
 
-@Deprecated(
-    "Uses Material Design 2. Use IconDialogM3 (Material Design 3) instead.",
-)
 @Composable
-fun IconDialog(
+fun IconDialogM3(
     onSelect: (IIcon) -> Unit,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
@@ -53,22 +53,25 @@ fun IconDialog(
                 .height(500.dp),
             shape = MaterialTheme.shapes.medium,
         ) {
-            IconDialogContent(iconFilter = iconFilter, onSelect = onSelect)
+            IconDialogContentM3(
+                iconFilter = iconFilter,
+                onSelect = onSelect,
+            )
         }
     }
 }
 
 @Preview
 @Composable
-private fun IconDialogPreview() {
-    HomeAssistantAppTheme {
+private fun IconDialogM3Preview() {
+    HAThemeForPreview {
         Surface(
             modifier = Modifier
                 .width(480.dp)
                 .height(500.dp),
             shape = MaterialTheme.shapes.medium,
         ) {
-            IconDialogContent(onSelect = {})
+            IconDialogContentM3(onSelect = {})
         }
     }
 }

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogSearchM3.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogSearchM3.kt
@@ -1,0 +1,74 @@
+package io.homeassistant.companion.android.util.icondialog
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.intl.Locale
+import androidx.compose.ui.tooling.preview.Preview
+import io.homeassistant.companion.android.common.R
+import io.homeassistant.companion.android.common.compose.theme.HAThemeForPreview
+
+@Composable
+fun IconDialogSearchM3(
+    value: String,
+    onValueChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val isEnglish by remember { mutableStateOf(Locale.current.language == "en") }
+    TextField(
+        modifier = modifier.fillMaxWidth(),
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        label = {
+            Text(
+                text = stringResource(
+                    if (isEnglish) R.string.search_icons else R.string.search_icons_in_english,
+                ),
+            )
+        },
+        leadingIcon = {
+            Icon(
+                Icons.Filled.Search,
+                contentDescription = null,
+            )
+        },
+        trailingIcon = if (value.isNotBlank()) {
+            {
+                IconButton(onClick = { onValueChange("") }) {
+                    Icon(
+                        Icons.Filled.Clear,
+                        contentDescription = stringResource(R.string.clear_search),
+                    )
+                }
+            }
+        } else {
+            null
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun IconDialogSearchM3Preview() {
+    HAThemeForPreview {
+        Surface {
+            IconDialogSearchM3(
+                value = "account",
+                onValueChange = {},
+            )
+        }
+    }
+}

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogSearchM3.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/icondialog/IconDialogSearchM3.kt
@@ -8,11 +8,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
+import io.homeassistant.companion.android.common.compose.composable.HATextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.intl.Locale
@@ -26,8 +23,8 @@ fun IconDialogSearchM3(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val isEnglish by remember { mutableStateOf(Locale.current.language == "en") }
-    TextField(
+    val isEnglish = Locale.current.language == "en"
+    HATextField(
         modifier = modifier.fillMaxWidth(),
         value = value,
         onValueChange = onValueChange,


### PR DESCRIPTION
## Summary

- Add a Material 3 version of `IconDialog`
- Migrate existing Material 3 callers to the new dialog
- Deprecate the existing Material 2 `IconDialog`

## Testing

- `./gradlew :app:compileFullDebugKotlin --exclude-task processFullDebugGoogleServices`

Build successful.

Fixes #7156