### PR TITLE
Load frontend when app is resumed from a state where it was not connected

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -421,8 +421,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         viewModelScope.launch {
             _viewState.collect { state ->
                 Timber.d("Frontend state: ${state.logDescription()}")
-                // LoadServer is the request to (re)load, so acting on it here is what guarantees
-                // that setting the state and starting the load can never drift apart.
                 if (state is FrontendViewState.LoadServer) loadServer(state.serverId, state.target)
                 releaseExoPlayerIfLeavingContent(state)
             }
@@ -557,7 +555,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         )
 
     fun onScreenStartedChanged(started: Boolean) {
-        // Gates the loading watchdog, so this marks when the timeout countdown can run.
         Timber.d("Frontend screen started: $started")
         val resumed = started && !isScreenStarted.value
         isScreenStarted.value = started

--- a/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModel.kt
@@ -420,6 +420,10 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     init {
         viewModelScope.launch {
             _viewState.collect { state ->
+                Timber.d("Frontend state: ${state.logDescription()}")
+                // LoadServer is the request to (re)load, so acting on it here is what guarantees
+                // that setting the state and starting the load can never drift apart.
+                if (state is FrontendViewState.LoadServer) loadServer(state.serverId, state.target)
                 releaseExoPlayerIfLeavingContent(state)
             }
         }
@@ -473,12 +477,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
             improvHandler.events.collect { event ->
                 when (event) {
                     is FrontendImprovHandler.Event.ReloadAtPath -> {
-                        _viewState.update {
-                            FrontendViewState.LoadServer(
-                                serverId = event.serverId,
-                                target = FrontendTarget.Path(event.path),
-                            )
-                        }
+                        startLoad(serverId = event.serverId, target = FrontendTarget.Path(event.path))
                     }
                 }
             }
@@ -497,8 +496,6 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
 
         collectMatterThreadEvents()
-
-        loadServer()
     }
 
     override fun onCleared() {
@@ -560,14 +557,27 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         )
 
     fun onScreenStartedChanged(started: Boolean) {
+        // Gates the loading watchdog, so this marks when the timeout countdown can run.
+        Timber.d("Frontend screen started: $started")
+        val resumed = started && !isScreenStarted.value
         isScreenStarted.value = started
+        if (resumed) restartInterruptedLoad()
+    }
+
+    /**
+     * Restarts the load when the screen resumes while the external-bus handshake is still pending.
+     * A frontend whose connection attempt failed while the app was in the background never retries
+     * on its own, so only a new navigation to the same [FrontendViewState.Loading.target] can
+     * complete the handshake.
+     */
+    private fun restartInterruptedLoad() {
+        val state = _viewState.value
+        if (state !is FrontendViewState.Loading || state.connected) return
+        startLoad(serverId = state.serverId, target = state.target)
     }
 
     fun onRetry() {
-        _viewState.update {
-            FrontendViewState.LoadServer(serverId = it.serverId)
-        }
-        loadServer()
+        startLoad()
     }
 
     /**
@@ -620,10 +630,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     }
 
     fun switchServer(serverId: Int) {
-        _viewState.update {
-            FrontendViewState.LoadServer(serverId = serverId)
-        }
-        loadServer()
+        startLoad(serverId = serverId)
     }
 
     /**
@@ -633,10 +640,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
     fun onSecurityLevelDone() {
         val serverId = _viewState.value.serverId
         urlManager.onSecurityLevelShown(serverId)
-        _viewState.update {
-            FrontendViewState.LoadServer(serverId = serverId)
-        }
-        loadServer()
+        startLoad(serverId = serverId)
     }
 
     /**
@@ -827,20 +831,15 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
     }
 
-    private fun loadServer() {
+    private fun startLoad(serverId: Int = _viewState.value.serverId, target: FrontendTarget = FrontendTarget.Default) {
+        _viewState.update { FrontendViewState.LoadServer(serverId = serverId, target = target) }
+    }
+
+    private fun loadServer(serverId: Int, target: FrontendTarget) {
         urlFlowJob?.cancel()
         urlFlowJob = viewModelScope.launch {
             permissionManager.checkLocalNetworkPermission()
-            val currentState = _viewState.value
-            val target = when (currentState) {
-                is FrontendViewState.LoadServer -> currentState.target
-                is FrontendViewState.Loading -> currentState.target
-                else -> FrontendTarget.Default
-            }
-            urlManager.serverUrlFlow(
-                serverId = currentState.serverId,
-                target = target,
-            ).collect { result ->
+            urlManager.serverUrlFlow(serverId = serverId, target = target).collect { result ->
                 handleUrlResult(result)
             }
         }
@@ -879,6 +878,7 @@ internal class FrontendViewModel @VisibleForTesting constructor(
 
             is FrontendHandlerEvent.Disconnected -> {
                 // Disconnection handling not yet implemented
+                Timber.d("Frontend external bus disconnected")
             }
             is FrontendHandlerEvent.Loaded -> showContent()
 
@@ -1002,11 +1002,11 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         when (result) {
             is UrlLoadResult.Success -> {
                 pendingMoreInfoEntityId = result.moreInfoEntityId
-                _viewState.update {
+                _viewState.update { currentState ->
                     FrontendViewState.Loading(
                         serverId = result.serverId,
                         url = result.url,
-                        target = FrontendTarget.Default,
+                        target = currentState.pendingTarget,
                     )
                 }
             }
@@ -1105,7 +1105,29 @@ internal class FrontendViewModel @VisibleForTesting constructor(
         }
     }
 
+    /**
+     * The frontend page the current load was started for, [FrontendTarget.Default] once the
+     * content is shown.
+     */
+    private val FrontendViewState.pendingTarget: FrontendTarget
+        get() = when (this) {
+            is FrontendViewState.LoadServer -> target
+            is FrontendViewState.Loading -> target
+            else -> FrontendTarget.Default
+        }
+
+    /**
+     * Short description of a state for logging. Deliberately omits the URL, which carries the
+     * server address.
+     */
+    private fun FrontendViewState.logDescription(): String = when (this) {
+        is FrontendViewState.Loading -> "Loading(connected=$connected)"
+        is FrontendViewState.Error -> "Error(${error::class.simpleName})"
+        else -> this::class.simpleName.orEmpty()
+    }
+
     private fun onError(error: FrontendConnectionError) {
+        Timber.w("Frontend error: ${error::class.simpleName}")
         // Resolve the connection type so the error screen can label the "Refresh" action, then
         // build the recovery actions for the screen to render.
         viewModelScope.launch {

--- a/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
+++ b/app/src/test/kotlin/io/homeassistant/companion/android/frontend/FrontendViewModelTest.kt
@@ -73,6 +73,7 @@ import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -651,6 +652,79 @@ class FrontendViewModelTest {
             messageFlow.emit(FrontendHandlerEvent.Loaded)
             advanceUntilIdle()
             assertInstanceOf(FrontendViewState.Content::class.java, viewModel.viewState.value)
+        }
+
+        @Test
+        fun `Given loading when the screen is backgrounded and resumed then the load is restarted`() = runTest {
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(1.seconds)
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+
+            // Backgrounded mid-load. The watchdog is cancelled, so the state simply stays Loading
+            // however long the app stays away.
+            viewModel.onScreenStartedChanged(false)
+            advanceTimeBy(5.minutes)
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+
+            viewModel.onScreenStartedChanged(true)
+            advanceTimeBy(CONNECTION_TIMEOUT + 1.seconds)
+
+            // Resuming restarts the timeout countdown, so it must also restart the load. The paused
+            // WebView never resumes a navigation on its own, and the already-loaded frontend never
+            // repeats its external-bus handshake, so without a reload the countdown can only expire.
+            verify(exactly = 2) { urlManager.serverUrlFlow(any(), any()) }
+        }
+
+        @Test
+        fun `Given loading a deep link when the screen is backgrounded and resumed then the load is restarted at the same target`() = runTest {
+            val target = FrontendTarget.Path("/dashboard")
+            every { urlManager.serverUrlFlow(serverId, target) } returns flowOf(
+                UrlLoadResult.Success(url = "https://example.com/dashboard?external_auth=1", serverId = serverId),
+            )
+
+            val viewModel = createViewModel(path = "/dashboard")
+            advanceTimeBy(1.seconds)
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+
+            viewModel.onScreenStartedChanged(false)
+            viewModel.onScreenStartedChanged(true)
+            advanceTimeBy(1.seconds)
+
+            verify(exactly = 2) { urlManager.serverUrlFlow(serverId, target) }
+        }
+
+        @Test
+        fun `Given loading with the handshake done when the screen is backgrounded and resumed then the load is not restarted`() = runTest {
+            val messageFlow = MutableSharedFlow<FrontendHandlerEvent>()
+            every { frontendBusObserver.messageResults() } returns messageFlow
+            every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
+                UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
+            )
+            coEvery { serverManager.getServer(serverId) } returns mockServer(
+                url = "https://ha.test",
+                name = "t",
+                haVersion = HomeAssistantVersion(2026, 8, 0),
+                serverId = serverId,
+            )
+
+            val viewModel = createViewModel()
+            advanceTimeBy(1.seconds)
+            messageFlow.emit(FrontendHandlerEvent.Connected)
+            advanceTimeBy(1.seconds)
+            val state = assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
+            assertTrue(state.connected)
+
+            // The frontend reconnects on its own once the handshake is done, so restarting would
+            // only discard a finished load.
+            viewModel.onScreenStartedChanged(false)
+            viewModel.onScreenStartedChanged(true)
+            advanceTimeBy(1.seconds)
+
+            verify(exactly = 1) { urlManager.serverUrlFlow(any(), any()) }
         }
 
         @Test
@@ -2721,7 +2795,8 @@ class FrontendViewModelTest {
         }
 
         @Test
-        fun `Given handler emits ReloadAtPath event when collected then state transitions to LoadServer`() = runTest {
+        fun `Given handler emits ReloadAtPath event when collected then the frontend is reloaded at that path`() = runTest {
+            val path = "/_my_redirect/config_flow_start?domain=acme"
             every { urlManager.serverUrlFlow(any(), any()) } returns flowOf(
                 UrlLoadResult.Success(url = testUrlWithAuth, serverId = serverId),
             )
@@ -2730,18 +2805,14 @@ class FrontendViewModelTest {
             advanceTimeBy(CONNECTION_TIMEOUT - 1.seconds)
 
             improvEventsFlow.emit(
-                FrontendImprovHandler.Event.ReloadAtPath(
-                    path = "/_my_redirect/config_flow_start?domain=acme",
-                    serverId = serverId,
-                ),
+                FrontendImprovHandler.Event.ReloadAtPath(path = path, serverId = serverId),
             )
             advanceTimeBy(1.seconds)
 
-            val state = assertInstanceOf(FrontendViewState.LoadServer::class.java, viewModel.viewState.value)
-            assertEquals(
-                FrontendTarget.Path("/_my_redirect/config_flow_start?domain=acme"),
-                state.target,
-            )
+            // Transitioning to LoadServer is not enough: nothing else starts a load, so without
+            // this the WebView would sit on the blank URL forever.
+            verify { urlManager.serverUrlFlow(serverId, FrontendTarget.Path(path)) }
+            assertInstanceOf(FrontendViewState.Loading::class.java, viewModel.viewState.value)
         }
 
         @Test


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

Description from Claude analysis with my logs:

Returning to the app after it was backgrounded mid-load showed the connection error screen instead of the dashboard, even though the server was reachable the whole time. Pressing Retry fixed it instantly.                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  FrontendViewState.Loading means two things at once: the WebView is navigating, and we are waiting for the frontend's external-bus handshake. Those coincide on a cold load and come apart on resume. Backgrounding during a load parks the state at Loading, and resuming restarts the 10 second watchdog from   
  zero without re-navigating, so a page frozen mid-load by onPause() can never complete its handshake and the timeout is guaranteed to expire.                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                   
  Resuming while Loading and not yet connected now restarts the load, which is what Retry did by hand. Loads are also started from a single place: the LoadServer state collector, so setting that state and starting the load can no longer drift apart.                                                          
                                                                                                                                                                                                                                                                                                                   
  That drift was already happening. Improv's ReloadAtPath set LoadServer without calling loadServer(), leaving the WebView on the blank URL forever after provisioning on older Home Assistant versions. It is fixed here as a side effect, and its test now asserts the reload rather than just the state         
  transition.                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                   
  Also adds logging for the frontend state machine, which was previously invisible: state transitions, the FrontendConnectionError subtype behind the error screen, external-bus disconnects, and when the watchdog is allowed to run. Diagnosing this from a user log took two wrong hypotheses without it. The   
  log lines deliberately omit the URL and errorDetails, which carry the server address.                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                   
  Reproduction (deterministic, do not touch the radios: a network change causes the very reload that is missing and hides the bug):                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                                   
  - start the app and put it in background before it leaves the loading screen
  - put the phone in doze mode (wait few minutes)
  - open the app again
  - It shows timetout                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                   
  Before: ExternalBusTimeout exactly 10s after resume, with no Load url in between. After: the load restarts and the dashboard appears.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.


## Any other notes
<!-- 
    If there is any other information of note, like if this Pull Request is part of a bigger change, please include it here.
-->