### PR TITLE
Support BCP 47 folder for locales

### DIFF
--- a/.github/actions/download-translations/action.yml
+++ b/.github/actions/download-translations/action.yml
@@ -45,6 +45,8 @@ runs:
           FOLDER="$(basename $(dirname $i))"
           CODE="${FOLDER#*-}" # remove "values-"
           CODE="${CODE/-r/-}" # replace region "-rXX" with "-XX"
+          CODE="${CODE#b+}" # BCP 47 folder "b+xx+Yyyy" becomes "xx-Yyyy"
+          CODE="${CODE//+/-}"
           if [ "$CODE" == "values" ]; then CODE="en"; fi
           XML_LOCALES="$XML_LOCALES    <locale android:name=\"$CODE\"/>\n"
         done


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->
Serbian (Latin) was added to Lokalise. Android does not accept `values-sr-rLatn` as a resource folder (`-r` only takes a two letter region), the merger fails with `Invalid resource directory name`. Locales with a script must use the BCP 47 form `values-b+sr+Latn`, which is now the custom language code for that language in Lokalise.

This PR updates the `locales_config.xml` generator in the download translations action to convert a `b+xx+Yyyy` folder into the `xx-Yyyy` locale name, so `sr-Latn` shows up in the per-app language settings. Other folders are unaffected.

Verified locally by building an APK with a `values-b+sr+Latn` folder: the `b+sr+Latn` configuration and its strings are packaged, and the generator produces `<locale android:name="sr-Latn"/>`.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [ ] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [ ] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [x] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.