### PR TITLE
Simplify subtitle API of EntityDisplay

### DIFF
--- a/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/settings/controls/views/ManageControlsView.kt
@@ -43,7 +43,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontStyle
@@ -336,7 +335,7 @@ fun ManageControlsEntity(
             modifier = Modifier.weight(1f),
         ) {
             Text(text = entity.name, style = MaterialTheme.typography.body1)
-            entity.subtitle(LocalLayoutDirection.current)?.let {
+            entity.subtitle()?.let {
                 CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                     Text(
                         text = it,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/FavoriteEntityRow.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/FavoriteEntityRow.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.github.timoptr.mdiicons.Mdi
@@ -75,7 +74,7 @@ fun ReorderableCollectionItemScope.FavoriteEntityRow(
                 CompositionLocalProvider(LocalContentAlpha provides ContentAlpha.medium) {
                     Text(
                         text =
-                        (entity as? EntityDisplayWithContext)?.subtitle(LocalLayoutDirection.current)
+                        (entity as? EntityDisplayWithContext)?.subtitle()
                             ?: entity.entityId,
                         style = MaterialTheme.typography.body2,
                     )

--- a/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPicker.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/util/compose/entity/EntityPicker.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -350,7 +349,7 @@ private fun RowScope.EntityContent(entity: EntityDisplay, showHiddenIndicator: B
             overflow = TextOverflow.Ellipsis,
         )
 
-        (entity as? EntityDisplayWithContext)?.subtitle(LocalLayoutDirection.current)?.let { subtitle ->
+        (entity as? EntityDisplayWithContext)?.subtitle()?.let { subtitle ->
             Text(
                 text = subtitle,
                 style = HATextStyle.BodyMedium,

--- a/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureScreen.kt
+++ b/app/src/main/kotlin/io/homeassistant/companion/android/widgets/mediaplayer/MediaPlayerControlsWidgetConfigureScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
@@ -374,7 +373,7 @@ private fun SelectedEntityRow(entity: EntityDisplayWithContext, onRemove: () -> 
                 overflow = TextOverflow.Ellipsis,
             )
 
-            entity.subtitle(LocalLayoutDirection.current)?.let { subtitle ->
+            entity.subtitle()?.let { subtitle ->
                 Text(
                     text = subtitle,
                     style = HATextStyle.BodyMedium,

--- a/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplay.kt
+++ b/common/src/main/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplay.kt
@@ -1,6 +1,9 @@
 package io.homeassistant.companion.android.common.data.integration.display
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import io.github.timoptr.mdiicons.MdiIcon
 import io.homeassistant.companion.android.common.data.integration.CameraControls
@@ -272,4 +275,9 @@ data class EntityDisplayWithContext(
         .takeIf { it.isNotEmpty() }
         ?.joinToString(if (layoutDirection == LayoutDirection.Ltr) " ▸ " else " ◂ ")
         ?.takeIf { it != name }
+
+    /** [subtitle] resolved against the layout direction the composition is in. */
+    @Composable
+    @ReadOnlyComposable
+    fun subtitle(): String? = subtitle(LocalLayoutDirection.current)
 }

--- a/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayWithContextTest.kt
+++ b/common/src/test/kotlin/io/homeassistant/companion/android/common/data/integration/display/EntityDisplayWithContextTest.kt
@@ -1,0 +1,51 @@
+package io.homeassistant.companion.android.common.data.integration.display
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.unit.LayoutDirection
+import dagger.hilt.android.testing.HiltTestApplication
+import io.github.timoptr.mdiicons.Mdi
+import io.github.timoptr.mdiicons.generated.Bookmark
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = HiltTestApplication::class)
+class EntityDisplayWithContextTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val item = EntityDisplayWithContext(
+        item = EntityDisplayWithoutContext(
+            entityId = "light.bed",
+            name = "Bed",
+            icon = Mdi.Bookmark,
+        ),
+        areaName = "Bedroom",
+        deviceName = "Hub",
+    )
+
+    @Test
+    fun `Given a layout direction in the composition when reading the subtitle then it follows that direction`() {
+        var ltrSubtitle: String? = null
+        var rtlSubtitle: String? = null
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Ltr) {
+                ltrSubtitle = item.subtitle()
+            }
+            CompositionLocalProvider(LocalLayoutDirection provides LayoutDirection.Rtl) {
+                rtlSubtitle = item.subtitle()
+            }
+        }
+
+        assertEquals("Bedroom ▸ Hub", ltrSubtitle)
+        assertEquals("Bedroom ◂ Hub", rtlSubtitle)
+    }
+}


### PR DESCRIPTION
<!--
    Please review the contributing guide before submitting: https://developers.home-assistant.io/docs/android/submit
    Please, complete the following sections to help the processing and review of your changes.
    Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).

    Thank you for submitting a Pull Request and helping to improve Home Assistant. You are amazing!
-->

## Summary
<!--
    Provide a brief summary of the changes you have made and most importantly what they aim to achieve.
    Don't forget any links that could be useful to the reader. (Github issues, PRs, documentation, articles, ...)

    * What was the motivation behind this change?
    * What is the impact of the changes on the application?
-->

Small quality of life improvement that allow getting the subtitle of an `EntityDisplay` without having to give the `LayoutDirection`. I hesitated to move it out of the class but this class is made for Compose anyway.

## Checklist
<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.
-->

- [x] New or updated tests have been added to cover the changes following the testing [guidelines](https://developers.home-assistant.io/docs/android/testing/introduction).
- [x] The code follows the project's [code style](https://developers.home-assistant.io/docs/android/codestyle) and [best_practices](https://developers.home-assistant.io/docs/android/best_practices).
- [x] The changes have been thoroughly tested, and edge cases have been considered.
- [x] Changes are backward compatible whenever feasible. Any breaking changes are documented in the changelog for users and/or in the code for developers depending on the relevance.
- [x] I have read the [Open Home Foundation AI Policy](https://developers.home-assistant.io/docs/ai_policy).

Select exactly one option that describes AI usage in this contribution:

- [x] I have not used AI for this contribution.
- [ ] AI assistance was used for this contribution.
- [ ] AI fully generated the code for this contribution, but I've reviewed and understood it before submitting and will respond without AI during review.